### PR TITLE
AutoFixture throws an exception when it generates an anonymous string matching a regular expression that contains '@'

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -109,6 +109,7 @@
     <Compile Include="DataAnnotations\MinimizationOperations.cs" />
     <Compile Include="DataAnnotations\RangeAttributeRelay.cs" />
     <Compile Include="DataAnnotations\RegExp.cs" />
+    <Compile Include="DataAnnotations\RegExpSyntaxOptions.cs" />
     <Compile Include="DataAnnotations\RegularExpressionAttributeRelay.cs" />
     <Compile Include="DataAnnotations\SpecialOperations.cs" />
     <Compile Include="DataAnnotations\State.cs" />

--- a/Src/AutoFixture/DataAnnotations/RegExp.cs
+++ b/Src/AutoFixture/DataAnnotations/RegExp.cs
@@ -44,42 +44,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
     internal sealed class RegExp
     {
         private readonly string b;
-        private readonly int flags;
-
-        /// <summary>
-        ///   Syntax flag, enables intersection.
-        /// </summary>
-        private static int intersection = 0x0001;
-
-        /// <summary>
-        ///   Syntax flag, enables complement.
-        /// </summary>
-        private static int complement = 0x0002;
-
-        /// <summary>
-        ///   Syntax flag, enables empty language.
-        /// </summary>
-        private static int empty = 0x0004;
-
-        /// <summary>
-        ///   Syntax flag, enables anystring.
-        /// </summary>
-        private static int anystring = 0x0008;
-
-        /// <summary>
-        ///   Syntax flag, enables named automata.
-        /// </summary>
-        private static int automaton = 0x0010;
-
-        /// <summary>
-        ///   Syntax flag, enables numerical intervals.
-        /// </summary>
-        private static int interval = 0x0020;
-
-        /// <summary>
-        ///   Syntax flag, enables all optional regexp syntax.
-        /// </summary>
-        private static int all = 0xffff;
+        private readonly RegExpSyntaxOptions flags;
 
         private static bool allowMutation;
 
@@ -107,7 +72,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// </summary>
         /// <param name = "s">A string with the regular expression.</param>
         internal RegExp(string s)
-            : this(s, all)
+            : this(s, RegExpSyntaxOptions.All)
         {
         }
 
@@ -116,7 +81,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// </summary>
         /// <param name = "s">A string with the regular expression.</param>
         /// <param name = "syntaxFlags">Boolean 'or' of optional syntax constructs to be enabled.</param>
-        internal RegExp(string s, int syntaxFlags)
+        internal RegExp(string s, RegExpSyntaxOptions syntaxFlags)
         {
             this.b = s;
             this.flags = syntaxFlags;
@@ -729,7 +694,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         private RegExp ParseInterExp()
         {
             RegExp e = this.ParseConcatExp();
-            if (this.Check(intersection) && this.Match('&'))
+            if (this.Check(RegExpSyntaxOptions.Intersection) && this.Match('&'))
             {
                 e = RegExp.MakeIntersection(e, this.ParseInterExp());
             }
@@ -737,7 +702,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
             return e;
         }
 
-        private bool Check(int flag)
+        private bool Check(RegExpSyntaxOptions flag)
         {
             return (flags & flag) != 0;
         }
@@ -745,7 +710,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         private RegExp ParseConcatExp()
         {
             RegExp e = this.ParseRepeatExp();
-            if (this.More() && !this.Peek(")|") && (!this.Check(intersection) || !this.Peek("&")))
+            if (this.More() && !this.Peek(")|") && (!this.Check(RegExpSyntaxOptions.Intersection) || !this.Peek("&")))
             {
                 e = RegExp.MakeConcatenation(e, this.ParseConcatExp());
             }
@@ -837,7 +802,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
 
         private RegExp ParseComplExp()
         {
-            if (this.Check(complement) && this.Match('~'))
+            if (this.Check(RegExpSyntaxOptions.Complement) && this.Match('~'))
             {
                 return RegExp.MakeComplement(this.ParseComplExp());
             }
@@ -880,12 +845,12 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 return RegExp.MakeAnyChar();
             }
 
-            if (this.Check(empty) && this.Match('#'))
+            if (this.Check(RegExpSyntaxOptions.Empty) && this.Match('#'))
             {
                 return RegExp.MakeEmpty();
             }
 
-            if (this.Check(anystring) && this.Match('@'))
+            if (this.Check(RegExpSyntaxOptions.Anystring) && this.Match('@'))
             {
                 return RegExp.MakeAnyString();
             }
@@ -922,7 +887,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 return e;
             }
 
-            if ((this.Check(automaton) || this.Check(interval)) && this.Match('<'))
+            if ((this.Check(RegExpSyntaxOptions.Automaton) || this.Check(RegExpSyntaxOptions.Interval)) && this.Match('<'))
             {
                 int start = pos;
                 while (this.More() && !this.Peek(">"))
@@ -939,7 +904,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 int i = str.IndexOf('-');
                 if (i == -1)
                 {
-                    if (!this.Check(automaton))
+                    if (!this.Check(RegExpSyntaxOptions.Automaton))
                     {
                         throw new ArgumentException("interval syntax error at position " + (pos - 1));
                     }
@@ -947,7 +912,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
                     return RegExp.MakeAutomaton(str);
                 }
 
-                if (!this.Check(interval))
+                if (!this.Check(RegExpSyntaxOptions.Interval))
                 {
                     throw new ArgumentException("illegal identifier at position " + (pos - 1));
                 }

--- a/Src/AutoFixture/DataAnnotations/RegExpSyntaxOptions.cs
+++ b/Src/AutoFixture/DataAnnotations/RegExpSyntaxOptions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Ploeh.AutoFixture.DataAnnotations
+{
+    [Flags]
+    internal enum RegExpSyntaxOptions
+    {
+        /// <summary>
+        /// Enables intersection.
+        /// </summary>
+        Intersection = 0x0001,
+
+        /// <summary>
+        /// Enables complement.
+        /// </summary>
+        Complement = 0x0002,
+
+        /// <summary>
+        /// Enables empty language.
+        /// </summary>
+        Empty = 0x0004,
+
+        /// <summary>
+        /// Enables anystring.
+        /// </summary>
+        Anystring = 0x0008,
+
+        /// <summary>
+        /// Enables named automata.
+        /// </summary>
+        Automaton = 0x0010,
+
+        /// <summary>
+        /// Enables numerical intervals.
+        /// </summary>
+        Interval = 0x0020,
+
+        /// <summary>
+        /// Enables all optional regexp syntax.
+        /// </summary>
+        All = 0xffff
+    }
+}

--- a/Src/AutoFixture/DataAnnotations/Xeger.cs
+++ b/Src/AutoFixture/DataAnnotations/Xeger.cs
@@ -29,6 +29,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// </summary>
     internal sealed class Xeger
     {
+        private const RegExpSyntaxOptions AllExceptAnyString = RegExpSyntaxOptions.All & ~RegExpSyntaxOptions.Anystring;
+
         private readonly Automaton automaton;
         private readonly Random random;
 
@@ -49,7 +51,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 throw new ArgumentNullException("random");
             }
 
-            this.automaton = new RegExp(regex).ToAutomaton();
+            this.automaton = new RegExp(regex, AllExceptAnyString).ToAutomaton();
             this.random = random;
         }
 

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -120,6 +120,7 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return new object[] { "[A-Za-z]{11}" };
                 yield return new object[] { @"^[a-zA-Z''-'\s]{1,40}$" };
                 yield return new object[] { @"^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$" };
+                yield return new object[] { @"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$" };
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -132,7 +133,6 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[] { @"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$" };
                 yield return new object[] { "[" };
                 yield return new object[] { @"(?\[Test\]|\[Foo\]|\[Bar\])?(?:-)?(?\[[()a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?" };
             }


### PR DESCRIPTION
For example, given the following class containing a property decorated with the [RegularExpression](http://msdn.microsoft.com/en-us/library/system.componentmodel.dataannotations.regularexpressionattribute.aspx) data annotation attribute:

``` csharp
public class Foo
{
    [RegularExpression(@"^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$")]
    public string Email { get; set; }
}
```

Asking AutoFixture to generate an anonymous instance of `Foo` will result in the following exception:

> Ploeh.AutoFixture.ObjectCreationException: Ploeh.AutoFixture.ObjectCreationException : AutoFixture was unable to create an instance from Ploeh.AutoFixture.Kernel.RegularExpressionRequest, most likely because it has no public constructor, is an abstract or non-public type.
### The problem

I tracked down the exception and found that it's originated in the `RegularExpressionGenerator` specimen builder, which apparently returns a `NoSpecimen` for any regular expression that contains the `@` character:

``` csharp
private static object CreateAnonymous(RegularExpressionRequest request)
{
    string pattern = request.Pattern;

    try
    {
        string regex = new Xeger(pattern).Generate();

        if (Regex.IsMatch(regex, pattern))
        {
            return regex;
        }
    }
    catch (InvalidOperationException)
    {
        return new NoSpecimen(request);
    }
    catch (ArgumentException)
    {
        return new NoSpecimen(request);
    }

    return new NoSpecimen(request);
}
```

The reason is that the `Xeger` class returns a string that _does not contain_ the `@` character, substituting it with an _anonymous character_ instead.

Further investigation revealed that the `RegExp` class, which is used internally by `Xeger`, treats `@` as a _special character_ when parsing the regular expression and translates it into _any string_: 

``` csharp
private RegExp ParseSimpleExp()
{
    // ....

    if (this.Check(anystring) && this.Match('@'))
    {
        return RegExp.MakeAnyString();
    }

    // ...
}
```
### The workaround

The current workaround is to escape `@`, which forces `RegExp` to treat it as a _literal character_:

``` csharp
public class Foo
{
    [RegularExpression(@"^[A-Z0-9._%+-]+\@[A-Z0-9.-]+\.[A-Z]{2,4}$")]
    public string Email { get; set; }
}
```

This indeed yields the expected result. However, I believe this violates the [Principle of least astonishment](http://en.wikipedia.org/wiki/Principle_of_least_astonishment) in the sense that I wouldn't expect to have to escape `@`, since it's not a [special character](http://www.regular-expressions.info/characters.html) in the regular expression syntax. Also, the exception message doesn't provide any helpful information to resolve the issue. 
### Proposed solution

I suggest we **delete the code** in the `RegExp` class that's responsible for treating `@` as a special character meaning _any string_. I did this in a local branch and all tests pass.

Thoughts?
