### PR TITLE
Culture-dependent unit test fails when run in a thread set to a non-English culture

### DIFF
--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -157,6 +157,7 @@ namespace Ploeh.AutoFixtureUnitTest
         [InlineData(-30003, -10001)]
         [InlineData(-300.3, -100.1)]
         [InlineData("-3.3", "-1.1")]
+        [UseCulture("en-US")]
         public void CreateWithDifferentOperandTypeDoesNotThrowOnMultipleCall(object minimum, object maximum)
         {
             // Fixture setup
@@ -165,18 +166,18 @@ namespace Ploeh.AutoFixtureUnitTest
             {
                 new RangedNumberRequest(
                     typeof(decimal),
-                    Convert.ChangeType(minimum, typeof(decimal), CultureInfo.CurrentCulture), 
-                    Convert.ChangeType(maximum, typeof(decimal), CultureInfo.CurrentCulture)
+                    Convert.ChangeType(minimum, typeof(decimal)),
+                    Convert.ChangeType(maximum, typeof(decimal))
                     ),
                 new RangedNumberRequest(
                     typeof(double),
-                    Convert.ChangeType(minimum, typeof(double), CultureInfo.CurrentCulture), 
-                    Convert.ChangeType(maximum, typeof(double), CultureInfo.CurrentCulture)
+                    Convert.ChangeType(minimum, typeof(double)),
+                    Convert.ChangeType(maximum, typeof(double))
                     ),
                 new RangedNumberRequest(
                     typeof(decimal),
-                    Convert.ChangeType(minimum, typeof(decimal), CultureInfo.CurrentCulture), 
-                    Convert.ChangeType(maximum, typeof(decimal), CultureInfo.CurrentCulture)
+                    Convert.ChangeType(minimum, typeof(decimal)),
+                    Convert.ChangeType(maximum, typeof(decimal))
                     )
             };
             var context = new DelegatingSpecimenContext


### PR DESCRIPTION
The following unit test `Ploeh.AutoFixtureUnitTest.RangedNumberGeneratorTest.CreateWithDifferentOperandTypeDoesNotThrowOnMultipleCall` throws a [FormatException](http://msdn.microsoft.com/en-us/library/system.formatexception.aspx) when run in thread set to a non-English culture.

The stack trace is:

> System.FormatException: System.FormatException : The input string was not in a correct format.
>    vid System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
>    vid System.Number.ParseDecimal(String value, NumberStyles options, NumberFormatInfo numfmt)
>    vid System.Convert.ToDecimal(String value, IFormatProvider provider)
>    vid System.String.System.IConvertible.ToDecimal(IFormatProvider provider)
>    vid System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
>    vid Ploeh.AutoFixtureUnitTest.RangedNumberGeneratorTest.CreateWithDifferentOperandTypeDoesNotThrowOnMultipleCall(Object minimum, Object maximum) 

In this particular situation the [Convert.ChangeType](http://msdn.microsoft.com/en-us/library/system.convert.changetype.aspx) method fails to parse the numeric test values passed to it as strings. Forcing the conversion to use the `en-US` culture fixes the problem.
### Proposed solution

Culture information used for type conversion should be an invariant in the test.
