### PR TITLE
Include RegularExpressions matching every character — do not exclude '\n'

### DIFF
--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -41,7 +41,7 @@ namespace Ploeh.AutoFixture
             try
             {
                 string regex = new Xeger(pattern).Generate();
-                if (Regex.IsMatch(regex, pattern))
+                if (Regex.IsMatch(regex, pattern, RegexOptions.Singleline))
                 {
                     return regex;
                 }

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -59,7 +59,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-            Assert.True(Regex.IsMatch(result.ToString(), pattern), string.Format("result: {0}", result));
+            Assert.True(Regex.IsMatch(result.ToString(), pattern, RegexOptions.Singleline), string.Format("result: {0}", result));
             // Teardown
         }
 


### PR DESCRIPTION
The reported issue can be found [here](https://github.com/AutoFixture/AutoFixture/issues/30).
