### PR TITLE
Removed test case(s) that behaved erratically

### DIFF
--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -102,7 +102,6 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return new object[] { "in[du]" };
                 yield return new object[] { "x[0-9A-Z]" };
                 yield return new object[] { "[^A-M]in" };
-                yield return new object[] { ".gr" };
                 yield return new object[] { "W*in" };
                 yield return new object[] { "[xX][0-9a-z]" };
                 yield return new object[] { @"\(\(\(ab\)*c\)*d\)\(ef\)*\(gh\)\{2\}\(ij\)*\(kl\)*\(mn\)*\(op\)*\(qr\)*" };


### PR DESCRIPTION
The reason is that by default the [RegularExpression] attribute validates regular expressions matching any character except '\n' and the test could produce that character.
