### PR TITLE
Enhanced Likeness CreateProxy

### DIFF
--- a/Src/SemanticComparison/ProxyGenerator.cs
+++ b/Src/SemanticComparison/ProxyGenerator.cs
@@ -20,11 +20,11 @@ namespace Ploeh.SemanticComparison
             ProxyGenerator.BuildMethodEquals(builder, BuildFieldEqualsHasBeenCalled(builder), equals);
             ProxyGenerator.BuildMethodGetHashCode<TDestination>(builder);
 
-            IEnumerable<Type> parameterTypes = typeof(TDestination)
-                .GetCompatibleConstructor().GetParameters().Select(pi => pi.ParameterType);
+            List<Type> parameterTypes = typeof(TDestination)
+                .GetCompatibleConstructor().GetParameters().Select(pi => pi.ParameterType).ToList();
 
             var constructorArguments = (from mi in members
-                                        where parameterTypes.Contains(mi.ToUnderlyingType())
+                                        where parameterTypes.Matches(mi.ToUnderlyingType())
                                         select typeof(TSource).MatchProperty(mi.Name).GetValue(source, null))
                                         .Take(parameterTypes.Count())
                                         .Concat(new[] { comparer });

--- a/Src/SemanticComparison/ProxyType.cs
+++ b/Src/SemanticComparison/ProxyType.cs
@@ -14,9 +14,16 @@ namespace Ploeh.SemanticComparison
             return (from ci in type.GetConstructors(
                         BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance)
                     let parameterTypes = ci.GetParameters().Select(x => x.ParameterType).ToList()
-                    where parameterTypes.All(propertyTypes.Contains)
+                    where parameterTypes.All(t => Matches(propertyTypes, t))
                     orderby parameterTypes.Count ascending
                     select ci).First();
+        }
+
+        internal static bool Matches(this List<Type> publicTypes, Type type)
+        {
+            return publicTypes.Contains(type)
+                || publicTypes.Any(t => t.IsAssignableFrom(type)
+                    || type.IsAssignableFrom(t));
         }
 
         internal static PropertyInfo MatchProperty(this Type type, string name)

--- a/Src/SemanticComparisonUnitTest/LikenessTest.cs
+++ b/Src/SemanticComparisonUnitTest/LikenessTest.cs
@@ -1267,6 +1267,32 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Teardown
         }
 
+        [Fact]
+        public void ProxyOfTypeAcceptingConcreteTypeAndExposingAbstractTypeCanBeCreated()
+        {
+            // Fixture setup
+            var sut = new TypeAcceptingConcreteTypeAndExposingAbstractType(
+                new ConcreteType())
+                .AsSource()
+                .OfLikeness<TypeAcceptingConcreteTypeAndExposingAbstractType>();
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.CreateProxy());
+            // Teardown
+        }
+
+        [Fact]
+        public void ProxyOfTypeAcceptingConcreteAndAbstractTypeAndExposingAbstractTypeCanBeCreated()
+        {
+            // Fixture setup
+            var sut = new TypeAcceptingConcreteAndAbstractTypeAndExposingAbstractType(
+                new ConcreteType(), 2, new ConcreteType())
+                .AsSource()
+                .OfLikeness<TypeAcceptingConcreteAndAbstractTypeAndExposingAbstractType>();
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.CreateProxy());
+            // Teardown
+        }
+
         private static void CompareLikenessToObject<TSource, TDestination>(TSource likenObject, TDestination comparee, bool expectedResult)
         {
             // Fixture setup
@@ -1404,6 +1430,63 @@ namespace Ploeh.SemanticComparison.UnitTest
             public Guid Property4
             {
                 get { return this.field4; }
+            }
+        }
+
+        public class TypeAcceptingConcreteTypeAndExposingAbstractType
+        {
+            private readonly AbstractType value;
+
+            public TypeAcceptingConcreteTypeAndExposingAbstractType(
+                ConcreteType value)
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+
+                this.value = value;
+            }
+            
+            public AbstractType Property
+            {
+                get { return this.value; }
+            }
+        }
+
+        public class TypeAcceptingConcreteAndAbstractTypeAndExposingAbstractType
+        {
+            private readonly AbstractType field1;
+            private readonly int field2;
+            private readonly AbstractType field3;
+
+            public TypeAcceptingConcreteAndAbstractTypeAndExposingAbstractType(
+                ConcreteType value1,
+                int value2,
+                AbstractType value3)
+            {
+                if (value1 == null)
+                    throw new ArgumentNullException("value1");
+
+                if (value3 == null)
+                    throw new ArgumentNullException("value3");
+
+                this.field1 = value1;
+                this.field2 = value2;
+                this.field3 = value3;
+            }
+
+            public AbstractType Property1
+            {
+                get { return this.field1; }
+            }
+
+            public int Property2
+            {
+                get { return this.field2; }
+            }
+
+            public AbstractType Property3
+            {
+                get { return this.field3; }
             }
         }
     }


### PR DESCRIPTION
It is now possible to create proxies of types accepting a derived type in the constructor while exposing the derived type's base type through a public property.

The reported issue can be found [here](https://github.com/AutoFixture/AutoFixture/issues/27).
