### PR TITLE
Proxied Likeness Improvement

### DIFF
--- a/Src/SemanticComparisonUnitTest/LikenessTest.cs
+++ b/Src/SemanticComparisonUnitTest/LikenessTest.cs
@@ -1321,6 +1321,25 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Teardown
         }
 
+        [Fact]
+        public void ProxyOfTypeWithUnorderedPropertiesCanBeCreated()
+        {
+            // Fixture setup
+            var value = new TypeWithUnorderedProperties(
+                new ConcreteType(),
+                new ConcreteType(),
+                new byte());
+
+            var sut = value
+                .AsSource()
+                .OfLikeness<TypeWithUnorderedProperties>();
+            // Exercise system
+            var result = sut.CreateProxy();
+            // Verify outcome
+            Assert.NotNull(result);
+            // Teardown
+        }
+
         private static void CompareLikenessToObject<TSource, TDestination>(TSource likenObject, TDestination comparee, bool expectedResult)
         {
             // Fixture setup
@@ -1497,6 +1516,35 @@ namespace Ploeh.SemanticComparison.UnitTest
             public byte Property3
             {
                 get { return this.value3; }
+            }
+        }
+
+        public class TypeWithUnorderedProperties
+        {
+            private readonly AbstractType value1;
+            private readonly AbstractType value2;
+            private readonly byte value3;
+
+            public TypeWithUnorderedProperties(ConcreteType a, AbstractType b, byte c)
+            {
+                this.value1 = a;
+                this.value2 = b;
+                this.value3 = c;
+            }
+
+            public byte Property3
+            {
+                get { return this.value3; }
+            }
+
+            public AbstractType Property1
+            {
+                get { return this.value1; }
+            }
+
+            public AbstractType Property2
+            {
+                get { return this.value2; }
             }
         }
     }


### PR DESCRIPTION
It is now possible to create proxies of types where their properties have not been declared with the same order as the corresponding constructor arguments.

The proposed changes originate from this [comment](https://github.com/AutoFixture/AutoFixture/issues/27#issuecomment-10886202).
