### PR TITLE
Modified RangedNumberGenerator in order to be compatible with random numbers that can be returned from the context

### DIFF
--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -79,7 +79,24 @@ namespace Ploeh.AutoFixture
 
                 if (this.rangedValue != null && (minimum.CompareTo(this.rangedValue) <= 0 && maximum.CompareTo(this.rangedValue) > 0))
                 {
-                    this.rangedValue = RangedNumberGenerator.Add(this.rangedValue, Convert.ChangeType(1, range.OperandType, CultureInfo.CurrentCulture));
+                    this.rangedValue =
+                        Convert.ChangeType(
+                            RangedNumberGenerator.Add(
+                                this.rangedValue,
+                                Convert.ChangeType(
+                                    1,
+                                    range.OperandType,
+                                    CultureInfo.CurrentCulture)),
+                            range.OperandType,
+                            CultureInfo.CurrentCulture);
+
+                    if (maximum.CompareTo(this.rangedValue) < 0)
+                    {
+                        this.rangedValue = Convert.ChangeType(
+                            maximum, 
+                            range.OperandType,
+                            CultureInfo.CurrentCulture);
+                    }
                 }
                 else if (minimum.CompareTo(value) == 0)
                 {


### PR DESCRIPTION
Now that in _v3.0_ the default generator for numbers is the `RandomNumericSequenceGenerator`, there are times that the context can return a value which once gets added to the `Minimum` can result in an out-of-bounds result.

This Pull Request is related to #66. However, I am thinking that we could actually take advantage of the `RandomNumericSequenceGenerator` type inside the `RangedNumberGenerator`. That way this [method](https://github.com/AutoFixture/AutoFixture/blob/master/Src/AutoFixture/RangedNumberGenerator.cs#L68) could be simplified a lot since we could simply tell the `RandomNumericSequenceGenerator` instance to create a number inside the given range. This could be done as a separate work item after the _v3.0_ is merged with _master_.
