### PR TITLE
Support for regular expressions with non-capturing subpatterns.

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -111,6 +111,7 @@
     <Compile Include="DataAnnotations\MinimizationOperations.cs" />
     <Compile Include="DataAnnotations\RangeAttributeRelay.cs" />
     <Compile Include="DataAnnotations\RegExp.cs" />
+    <Compile Include="DataAnnotations\RegExpMatchingOptions.cs" />
     <Compile Include="DataAnnotations\RegExpSyntaxOptions.cs" />
     <Compile Include="DataAnnotations\RegularExpressionAttributeRelay.cs" />
     <Compile Include="DataAnnotations\SpecialOperations.cs" />

--- a/Src/AutoFixture/DataAnnotations/RegExp.cs
+++ b/Src/AutoFixture/DataAnnotations/RegExp.cs
@@ -34,6 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Ploeh.AutoFixture.DataAnnotations
@@ -879,6 +880,11 @@ namespace Ploeh.AutoFixture.DataAnnotations
 
             if (this.Match('('))
             {
+                if (this.Match('?'))
+                {
+                    this.SkipNonCapturingSubpatternExp();
+                }
+
                 if (this.Match(')'))
                 {
                     return RegExp.MakeString(string.Empty);
@@ -951,6 +957,12 @@ namespace Ploeh.AutoFixture.DataAnnotations
             }
 
             return RegExp.MakeChar(this.ParseCharExp());
+        }
+
+        private void SkipNonCapturingSubpatternExp()
+        {
+            RegExpMatchingOptions.All().Any(this.Match);
+            this.Match(':');
         }
 
         private char ParseCharExp()

--- a/Src/AutoFixture/DataAnnotations/RegExpMatchingOptions.cs
+++ b/Src/AutoFixture/DataAnnotations/RegExpMatchingOptions.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.DataAnnotations
+{
+    internal static class RegExpMatchingOptions
+    {
+        /// <summary>
+        /// Uses case-insensitive matching.
+        /// </summary>
+        public const char IgnoreCase = 'i';
+
+        /// <summary>
+        /// Use single-line mode, where the period matches every character,
+        /// instead of every character except <code>\n</code>.
+        /// </summary>
+        public const char Singleline = 's';
+
+        /// <summary>
+        /// Use multiline mode, where <code>^</code> and <code>$</code> match
+        /// the beginning and end of each line, instead of the beginning and end of the input string.
+        /// </summary>
+        public const char Multiline = 'm';
+
+        /// <summary>
+        /// Do not capture unnamed groups.
+        /// </summary>
+        public const char ExplicitCapture = 'n';
+
+        /// <summary>
+        /// Exclude unescaped white space from the pattern
+        /// and enable comments after a hash sign <code>#</code>.
+        /// </summary>
+        public const char IgnorePatternWhitespace = 'x';
+
+        public static IEnumerable<char> All()
+        {
+            yield return IgnoreCase;
+            yield return Singleline;
+            yield return Multiline;
+            yield return ExplicitCapture;
+            yield return IgnorePatternWhitespace;
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -122,6 +122,12 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return new object[] { @"\d{8}" };
                 yield return new object[] { @"\d{5}(-\d{4})?" };
                 yield return new object[] { @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}" };
+                yield return new object[] { @"^(?:[a-z0-9])+$" };
+                yield return new object[] { @"^(?i:[a-z0-9])+$" };
+                yield return new object[] { @"^(?s:[a-z0-9])+$" };
+                yield return new object[] { @"^(?m:[a-z0-9])+$" };
+                yield return new object[] { @"^(?n:[a-z0-9])+$" };
+                yield return new object[] { @"^(?x:[a-z0-9])+$" };
             }
 
             IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
It seems that AutoFixture fails to generate anonymous strings for regular expressions that contain [non-capturing subpatterns](http://php.net/manual/en/regexp.reference.subpatterns.php).

The problem is similar to the one reported in issue #1, where AutoFixture treats certain regular expressions syntax tokens as _literals_ during the parsing process, thus generating invalid strings.

This pull request solves the problem by modifying the regular expression parsing algorithm to recognize and skip any non-capturing subpattern expressions `?:` after an opening parenthesis.
