### PR TITLE
Additional extension method to ease migration from AutoFixture v2 to AutoFixture v3 Edit

### DIFF
--- a/Src/AutoFixture/SpecimenFactory.cs
+++ b/Src/AutoFixture/SpecimenFactory.cs
@@ -33,6 +33,22 @@ namespace Ploeh.AutoFixture
         /// Creates an anonymous variable of the requested type.
         /// </summary>
         /// <typeparam name="T">The type of object to create.</typeparam>
+        /// <param name="fixture">
+        /// The fixture used to resolve the type request.
+        /// </param>
+        /// <returns>
+        /// An anonymous object of type <typeparamref name="T"/>.
+        /// </returns>
+        [Obsolete("For compatibility to AutoFixture version 2. This method will be removed, please move to using Create<T>()")]
+        public static T CreateAnonymous<T>(this IFixture fixture)
+        {
+            return fixture.Create<T>();
+        }
+
+        /// <summary>
+        /// Creates an anonymous variable of the requested type.
+        /// </summary>
+        /// <typeparam name="T">The type of object to create.</typeparam>
         /// <param name="builder">
         /// The builder used to resolve the type request.
         /// </param>

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -237,6 +237,18 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
+        public void CreateAnonymousCompatibilityExtensionWillCreateSimpleObject()
+        {
+            // Fixture setup
+            Fixture sut = new Fixture();
+            // Exercise system
+            object result = sut.CreateAnonymous<object>();
+            // Verify outcome
+            Assert.NotNull(result);
+            // Teardown
+        }
+
+        [Fact]
         public void CreateUnregisteredAbstractTypeWillThrow()
         {
             // Fixture setup


### PR DESCRIPTION
New extension method with `[Obsolete]` attribute and message so that the
user is informed that the extension is going away, also added a unit
test.
