### PR TITLE
Likeness CreateProxy errors on private ctor

### DIFF
--- a/Src/SemanticComparison/ProxyGenerator.cs
+++ b/Src/SemanticComparison/ProxyGenerator.cs
@@ -256,7 +256,7 @@ namespace Ploeh.SemanticComparison
             this Type type)
         {
             return type.GetConstructors(
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(x => x.IsPublic || x.IsFamily);
         }
 
         private static IEnumerable<Type> GetParameterTypes(

--- a/Src/SemanticComparisonUnitTest/LikenessTest.cs
+++ b/Src/SemanticComparisonUnitTest/LikenessTest.cs
@@ -1024,6 +1024,17 @@ namespace Ploeh.SemanticComparison.UnitTest
         }
 
         [Fact]
+        public void ProxyOfTypeWithPrivateAndOtherCtorDoesNotThrow()
+        {
+            // Fixture setup
+            var value = new PropertyHolder<string>();
+            value.Property = "Foo";
+            var sut = value.AsSource().OfLikeness<TypeWithPrivateDefaultCtorAndOtherCtor<string>>();
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.CreateProxy());
+            // Teardown
+        }
+        [Fact]
         public void ProxyOfQuadrupleParameterTypeEqualsTripleParameterType()
         {
             // Fixture setup

--- a/Src/SemanticComparisonUnitTest/SemanticComparisonUnitTest.csproj
+++ b/Src/SemanticComparisonUnitTest/SemanticComparisonUnitTest.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProxyCreationExceptionTest.cs" />
     <Compile Include="SemanticComparerTest.cs" />
+    <Compile Include="TypeWithPrivateDefaultCtorAndOtherCtor.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SemanticComparison\SemanticComparison.csproj">

--- a/Src/SemanticComparisonUnitTest/TypeWithPrivateDefaultCtorAndOtherCtor.cs
+++ b/Src/SemanticComparisonUnitTest/TypeWithPrivateDefaultCtorAndOtherCtor.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Ploeh.SemanticComparison.UnitTest
+{
+    public class TypeWithPrivateDefaultCtorAndOtherCtor<T>
+    {
+        private readonly T property;
+
+        private TypeWithPrivateDefaultCtorAndOtherCtor()
+        {
+            
+        }
+        public TypeWithPrivateDefaultCtorAndOtherCtor(T value) : this()
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+
+            this.property = value;
+        }
+
+        public T Property
+        {
+            get { return this.property; }
+        }
+
+    }
+}


### PR DESCRIPTION
I guess family means protected so i went with that and public, could also have been !x.IsPrivate.
