### PR TITLE
#94 Throw an informative exception when trying to create an abstract type with a public constructor

### DIFF
--- a/Src/AutoFixture/Kernel/ConstructorMethod.cs
+++ b/Src/AutoFixture/Kernel/ConstructorMethod.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -83,9 +84,15 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (this.Constructor.DeclaringType.IsAbstract && this.Constructor.IsPublic)
             {
-                var message = @"abstract classes should never have public constructors, 
-                    see http://msdn.microsoft.com/en-us/library/vstudio/ms229047.aspx";
-                throw new ObjectCreationException(message);
+                throw new ObjectCreationException(
+                                string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    @"AutoFixture was unwilling to create an instance of {0}, since it is an abstract class with a public constructor. 
+An abstract class with a public constructor represents a design error. For more information please refer to: http://tinyurl.com/lg38t3g",
+                                    this.Constructor.DeclaringType.Name
+                                    )
+                                );
+
             }
             return this.constructor.Invoke(parameters.ToArray());
         }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -266,7 +266,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var sut = new Fixture();
             // Exercise system
             Assert.Throws<ObjectCreationException>(() =>
-                sut.Create<AbstractTypeWithPublicConstructor>());
+                sut.Create<AbstractClassWithPublicConstructor>());
         }
 
         [Fact]

--- a/Src/TestTypeFoundation/AbstractClassWithPublicConstructor.cs
+++ b/Src/TestTypeFoundation/AbstractClassWithPublicConstructor.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.TestTypeFoundation
+{
+    public abstract class AbstractClassWithPublicConstructor
+    {
+        public AbstractClassWithPublicConstructor() { }
+    }
+}

--- a/Src/TestTypeFoundation/AbstractTypeWithPublicConstructor.cs
+++ b/Src/TestTypeFoundation/AbstractTypeWithPublicConstructor.cs
@@ -1,7 +1,0 @@
-﻿namespace Ploeh.TestTypeFoundation
-{
-    public abstract class AbstractTypeWithPublicConstructor
-    {
-        public AbstractTypeWithPublicConstructor() { }
-    }
-}

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -67,7 +67,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AbstractTypeWithPublicConstructor.cs" />
+    <Compile Include="AbstractClassWithPublicConstructor.cs" />
     <Compile Include="AbstractGenericType.cs" />
     <Compile Include="AbstractType.cs" />
     <Compile Include="AbstractTypeWithConstructorWithMultipleParameters.cs" />


### PR DESCRIPTION
In order to make in simpler, keep it tidier and because of my git stupidity. I've created another branch with my changes based on the current master and created a new pull request. 

Sorry for causing confusion, hopefully, this will be straightforward now and we can simply close down the other pull request. 

I've ran BuildRelease.ps1 against this and there are no errors generated. 

Sorry again.
