### PR TITLE
Replace 'OmitOnRecursionGuard' with 'RecursionGuard' in xml comments

### DIFF
--- a/Src/AutoFixture/OmitOnRecursionBehavior.cs
+++ b/Src/AutoFixture/OmitOnRecursionBehavior.cs
@@ -8,13 +8,13 @@ namespace Ploeh.AutoFixture
 {
     /// <summary>
     /// Decorates an <see cref="ISpecimenBuilder" /> with a
-    /// <see cref="OmitOnRecursionGuard" />.
+    /// <see cref="RecursionGuard" />.
     /// </summary>
     public class OmitOnRecursionBehavior : ISpecimenBuilderTransformation
     {
         /// <summary>
         /// Decorates the supplied <see cref="ISpecimenBuilder" /> with an
-        /// <see cref="OmitOnRecursionGuard"/>.
+        /// <see cref="RecursionGuard"/>.
         /// </summary>
         /// <param name="builder">The builder to decorate.</param>
         /// <returns>


### PR DESCRIPTION
The use of OmitOnRecursionGuard class seems to have been replaced with the combined use of RecursionGuard and OmitOnRecursionHandler. The class level xml comments for the OmitOnRecursionBehavior class, as well as its Transform method are updated with this commit to replace the word 'OmitOnRecursionGuard' with 'RecursionGuard' in a total of [2] places.
