### PR TITLE
Idiomatic assertion now correctly verifies fields

### DIFF
--- a/Src/Idioms/IdiomaticAssertion.cs
+++ b/Src/Idioms/IdiomaticAssertion.cs
@@ -99,6 +99,7 @@ namespace Ploeh.AutoFixture.Idioms
             this.Verify(type.GetConstructors());
             this.Verify(IdiomaticAssertion.GetMethodsExceptPropertyAccessors(type));
             this.Verify(type.GetProperties());
+            this.Verify(type.GetFields());
         }
 
         /// <summary>

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -403,6 +403,20 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             // Teardown
         }
 
+        [Fact]
+        public void VerifyTypeWithPublicReadOnlyFieldsNotInitialisedViaConstructorThrows()
+        {
+            // Fixture setup
+            var dummyComposer = new Fixture();
+            var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
+            var typeToVerify = typeof (DoubleFieldHolder<int, int>);
+            // Exercise system and verify outcome
+            var e = Assert.Throws<ConstructorInitializedMemberException>(() => sut.Verify(typeToVerify));
+            var expectedFailingField = typeToVerify.GetFields().First();
+            AssertExceptionPropertiesEqual(e, expectedFailingField);
+            // Teardown
+        }
+
         static void AssertExceptionPropertiesEqual(ConstructorInitializedMemberException ex, ConstructorInfo ctor, ParameterInfo param)
         {
             Assert.Equal(param, ex.MissingParameter);

--- a/Src/IdiomsUnitTest/IdiomaticAssertionTest.cs
+++ b/Src/IdiomsUnitTest/IdiomaticAssertionTest.cs
@@ -205,6 +205,23 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             // Teardown
         }
 
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(System.Runtime.Remoting.Messaging.Header))]
+        public void VerifyTypeCorrectlyInvokesFieldsVerify(Type type)
+        {
+            // Fixture setup
+            var expectedFields = type.GetFields();
+            var mockVerified = false;
+            var sut = new DelegatingIdiomaticAssertion { OnFieldInfoArrayVerify = p => mockVerified = expectedFields.IsEquivalentTo(p) };
+            // Exercise system
+            sut.Verify(type);
+            // Verify outcome
+            Assert.True(mockVerified, "Mock verified.");
+            // Teardown
+        }
+
         [Fact]
         public void VerifyNullMemberInfoArrayThrows()
         {
@@ -299,6 +316,22 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var member = type.GetProperties().Cast<MemberInfo>().First();
             var mockVerified = false;
             var sut = new DelegatingIdiomaticAssertion { OnPropertyInfoVerify = p => mockVerified = p.Equals(member) };
+            // Exercise system
+            sut.Verify(member);
+            // Verify outcome
+            Assert.True(mockVerified, "Mock verified.");
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(System.Runtime.Remoting.Messaging.Header))]
+        public void VerifyMemberInfoCorrectlyInvokesFieldInfoVerify(Type type)
+        {
+            // Fixture setup
+            var member = type.GetFields().Cast<MemberInfo>().First();
+            var mockVerified = false;
+            var sut = new DelegatingIdiomaticAssertion { OnFieldInfoVerify = f => mockVerified = f.Equals(member) };
             // Exercise system
             sut.Verify(member);
             // Verify outcome


### PR DESCRIPTION
This fixes #161 by making sure `IdiomaticAssertion.Verify(Type)` correctly verifies the fields of the type.
