### PR TITLE
OCP-ify the ConstructorInitializedMemberAssertion

### DIFF
--- a/Src/Idioms/IParameterMemberMatcher.cs
+++ b/Src/Idioms/IParameterMemberMatcher.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Idioms
+{
+    /// <summary>
+    /// Determines if a parameter and member are 'matched' together.
+    /// </summary>
+    public interface IParameterMemberMatcher
+    {
+        /// <summary>
+        /// Determines if a parameter and member are 'matched' together.
+        /// </summary>
+        /// <param name="parameter">The parameter being tested</param>
+        /// <param name="member">The member (field or property) being tested</param>
+        /// <returns><c>true</c> for a match, <c>false</c> otherwise.</returns>
+        bool IsMatch(ParameterInfo parameter, MemberInfo member);
+    }
+}

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -83,6 +83,7 @@
     <Compile Include="EmptyGuidBehaviorExpectation.cs" />
     <Compile Include="IExpansion.cs" />
     <Compile Include="IndexedReplacement.cs" />
+    <Compile Include="IParameterMemberMatcher.cs" />
     <Compile Include="MethodInfoExtensions.cs" />
     <Compile Include="MethodInvokeCommand.cs" />
     <Compile Include="GuardClauseException.cs" />


### PR DESCRIPTION
This change attempts to address the issues raised in #167, by allowing a custom `IEqualityComparer' and a constructor-parameter-to-member matching predicate to be used.
