### PR TITLE
Excluded AutoFixture.AutoFoq from Strong-Name signing

### DIFF
--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
+++ b/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.Xunit.UnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
+++ b/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.Xunit</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>false</SignAssembly>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
     <SccProjectName>

--- a/Src/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
+++ b/Src/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixtureDocumentationTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoFoq</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <Name>AutoFoq</Name>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoFoq.UnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <Name>AutoFoqUnitTest</Name>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoMoq</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoMoq.UnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoNSubstitute</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
+++ b/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoNSubstitute.UnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Src/AutoRhinoMock/AutoRhinoMock.csproj
+++ b/Src/AutoRhinoMock/AutoRhinoMock.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoRhinoMock</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
+++ b/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.AutoRhinoMock.UnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.Idioms</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.AutoFixture.IdiomsUnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/SemanticComparison/SemanticComparison.csproj
+++ b/Src/SemanticComparison/SemanticComparison.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.SemanticComparison</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <SccProjectName>
     </SccProjectName>
     <SccLocalPath>

--- a/Src/SemanticComparisonUnitTest/SemanticComparisonUnitTest.csproj
+++ b/Src/SemanticComparisonUnitTest/SemanticComparisonUnitTest.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.SemanticComparison.UnitTest</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>Ploeh.TestTypeFoundation</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
     <SccProjectName>
     </SccProjectName>
     <SccLocalPath>


### PR DESCRIPTION
Resolves an issue on the CI server related to Foq and Strong-Name signing.

In order to run a successful build on the CI server the `/p:SignAssembly=true` must be removed from the command line parameters to MSBuild.exe (since it is now explicitly defined on each project file).

(Continuation of [#56](https://github.com/AutoFixture/AutoFixture/issues/56#issuecomment-24673680).)
