### PR TITLE
Performance improvement for RandomNumericSequenceGenerator

### DIFF
--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -13,7 +13,7 @@ namespace Ploeh.AutoFixture
         private readonly long[] limits;
         private readonly object syncRoot;
         private readonly Random random;
-        private readonly List<long> numbers;
+        private readonly HashSet<long> numbers;
         private long lower;
         private long upper;
         private long count;
@@ -59,7 +59,7 @@ namespace Ploeh.AutoFixture
             this.limits = limits;
             this.syncRoot = new object();
             this.random = new Random();
-            this.numbers = new List<long>();
+            this.numbers = new HashSet<long>();
             this.CreateRange();
         }
 


### PR DESCRIPTION
When doing performance tests AutoFixture is a valuable tool for generating large amounts of random data. However when you generate large amount of numeric data AutoFixture slows down as the amount of data generated grows.

Below you can see a single run of the test included with this pull-request. Here the y-axis is runtime in seconds and x-axis is amount of requests. Pretty steep increase around the 30000 mark.

![image](https://f.cloud.github.com/assets/574189/1252223/76c755c2-2b44-11e3-967b-4e2641549b4a.png)

If you do a performance profile of the code it looks like this before and after the fix, as it is evident a lot of less time is spend in the `GetNextRandom` method:

![image](https://f.cloud.github.com/assets/574189/1252230/bb0066d4-2b44-11e3-8a46-df55f167d126.png)

The fix is however simple, in `RandomNumericSequenceGenerator` the list of already generated numbers can be replaced by a HashSet and we have a traditional cpu/memory-usage trade-off. In my opinion in this situation the usage of some additional amount of memory is of no matter taking the performance increase into account. By using a HashSet the runtime of generating random numbers no longer grows with the amount of requests and it have sped up our performance tests considerably.

I hope you find this change useful. I expect that you will want to delete the test if you decide to merge my pull-request.

Best regards,

Simon
