### PR TITLE
Add support for ObservableCollection{T}

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -97,6 +97,7 @@
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
     <Compile Include="Kernel\IRecursionHandler.cs" />
+    <Compile Include="Kernel\ObservableCollectionSpecification.cs" />
     <Compile Include="MapCreateManyToEnumerable.cs" />
     <Compile Include="Kernel\MultipleToEnumerableRelay.cs" />
     <Compile Include="Kernel\NoConstructorsSpecification.cs" />

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -83,6 +83,10 @@ namespace Ploeh.AutoFixture
                                     new DictionarySpecification()),
                                 new FilteringSpecimenBuilder(
                                     new MethodInvoker(
+                                        new EnumerableFavoringConstructorQuery()),
+                                    new ObservableCollectionSpecification()),
+                                new FilteringSpecimenBuilder(
+                                    new MethodInvoker(
                                         new ListFavoringConstructorQuery()),
                                     new CollectionSpecification()),
                                 new FilteringSpecimenBuilder(

--- a/Src/AutoFixture/Kernel/ObservableCollectionSpecification.cs
+++ b/Src/AutoFixture/Kernel/ObservableCollectionSpecification.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.ObjectModel;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Encapsulates logic that determines whether a request is a request for a
+    /// <see cref="ObservableCollection{T}"/>.
+    /// </summary>
+    public class ObservableCollectionSpecification : IRequestSpecification
+    {
+        /// <summary>
+        /// Evaluates a request for a specimen to determine whether it's a request for a
+        /// <see cref="ObservableCollection{T}"/>.
+        /// </summary>
+        /// <param name="request">The specimen request.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="request"/> is a request for a
+        /// <see cref="ObservableCollection{T}" />; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool IsSatisfiedBy(object request)
+        {
+            var type = request as Type;
+            if (type == null)
+            {
+                return false;
+            }
+
+            return type.IsGenericType
+                && typeof(ObservableCollection<>) == type.GetGenericTypeDefinition();
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -86,6 +86,7 @@
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />
+    <Compile Include="Kernel\ObservableCollectionSpecificationTest.cs" />
     <Compile Include="MapCreateManyToEnumerableTests.cs" />
     <Compile Include="Kernel\MultipleToEnumerableRelayTests.cs" />
     <Compile Include="Kernel\NoConstructorsSpecificationTest.cs" />

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4641,6 +4641,18 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
+        public void CreateAnonymousObservableCollectionWithoutCustomizationWorks()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            // Exercise system
+            var result = sut.Create<ObservableCollection<decimal>>();
+            // Verify outcome
+            Assert.NotEmpty(result);
+            // Teardown
+        }
+
+        [Fact]
         public void CreateAnonymousEnumerableWhenEnumerableRelayIsPresentReturnsCorrectResult()
         {
             // Fixture setup
@@ -4907,6 +4919,7 @@ namespace Ploeh.AutoFixtureUnitTest
         [InlineData(typeof(ListSpecification), typeof(EnumerableFavoringConstructorQuery))]
         [InlineData(typeof(HashSetSpecification), typeof(EnumerableFavoringConstructorQuery))]
         [InlineData(typeof(CollectionSpecification), typeof(ListFavoringConstructorQuery))]
+        [InlineData(typeof(ObservableCollectionSpecification), typeof(EnumerableFavoringConstructorQuery))]
         public void CustomizationsContainBuilderForProperConcreteMultipleTypeByDefault(
             Type specificationType,
             Type queryType)

--- a/Src/AutoFixtureUnitTest/Kernel/ObservableCollectionSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ObservableCollectionSpecificationTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest.Kernel
+{
+    public class ObservableCollectionSpecificationTest
+    {
+        [Fact]
+        public void SutIsRequestSpecification()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new ObservableCollectionSpecification();
+            // Verify outcome
+            Assert.IsAssignableFrom<IRequestSpecification>(sut);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(Version))]
+        [InlineData(typeof(object[]))]
+        [InlineData(typeof(string[]))]
+        [InlineData(typeof(int[]))]
+        [InlineData(typeof(Version[]))]
+        public void IsSatisfiedByNonEnumerableRequestReturnsCorrectResult(object request)
+        {
+            // Fixture setup
+            var sut = new ObservableCollectionSpecification();
+            // Exercise system
+            var result = sut.IsSatisfiedBy(request);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(List<object>))]
+        [InlineData(typeof(Dictionary<string, string>))]
+        [InlineData(typeof(Stack<int>))]
+        [InlineData(typeof(Collection<Version>))]
+        public void IsSatisfiedByEnumerableNonObservableRequestReturnsCorrectResult(Type request)
+        {
+            // Fixture setup
+            var sut = new ObservableCollectionSpecification();
+            // Exercise system
+            var result = sut.IsSatisfiedBy(request);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(ObservableCollection<object>))]
+        [InlineData(typeof(ObservableCollection<string>))]
+        [InlineData(typeof(ObservableCollection<int>))]
+        [InlineData(typeof(ObservableCollection<Version>))]
+        public void IsSatisfiedByEnumerableRequestReturnsCorrectResult(Type request)
+        {
+            // Fixture setup
+            var sut = new ObservableCollectionSpecification();
+            // Exercise system
+            var result = sut.IsSatisfiedBy(request);
+            // Verify outcome
+            Assert.True(result);
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
This fixes #192 (from #191), by adding default support for `System.Collections.ObjectModel.ObservableCollection<T>`.
