### PR TITLE
Enhanced `ObjectCreationException` with specimen request path

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -97,6 +97,7 @@
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
     <Compile Include="Kernel\IRecursionHandler.cs" />
+    <Compile Include="Kernel\TerminatingWithPathSpecimenBuilder.cs" />
     <Compile Include="Kernel\ObservableCollectionSpecification.cs" />
     <Compile Include="MapCreateManyToEnumerable.cs" />
     <Compile Include="Kernel\MultipleToEnumerableRelay.cs" />

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -61,7 +61,7 @@ namespace Ploeh.AutoFixture
 
             this.graph =
                 new BehaviorRoot(
-                    new CompositeSpecimenBuilder(
+                    new TerminatingWithPathSpecimenBuilder(new TracingBuilder(new CompositeSpecimenBuilder(
                         new CustomizationNode(
                             new CompositeSpecimenBuilder(
                                 new FilteringSpecimenBuilder(
@@ -119,8 +119,7 @@ namespace Ploeh.AutoFixture
                             new MutableValueTypeWarningThrower(),
                             new AndRequestSpecification(
                                 new ValueTypeSpecification(), 
-                                new NoConstructorsSpecification())),
-                        new TerminatingSpecimenBuilder()));
+                                new NoConstructorsSpecification()))))));
 
             this.UpdateCustomizer();
             this.UpdateResidueCollector();

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Decorates an <see cref="ISpecimenBuilder"/> with a node which tracks specimen requests, and
+    /// when <see cref="NoSpecimen"/> is detected, throws an <see cref="ObjectCreationException"/>, which
+    /// includes a description of the request path.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix",
+        Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
+    public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
+    {
+        private readonly TracingBuilder tracer;
+        private readonly Stack<object> path = new Stack<object>();
+
+        /// <summary>
+        /// Creates a new <see cref="TerminatingWithPathSpecimenBuilder"/> using the
+        /// supplied <see cref="TracingBuilder"/> to track specimen requests.
+        /// </summary>
+        /// <param name="tracer"></param>
+        public TerminatingWithPathSpecimenBuilder(TracingBuilder tracer)
+        {
+            if (tracer == null)
+                throw new ArgumentNullException("tracer");
+
+            this.tracer = tracer;
+            this.tracer.SpecimenRequested += OnSpecimenRequested;
+            this.tracer.SpecimenCreated += OnSpecimenCreated;
+        }
+
+        private void OnSpecimenCreated(object sender, SpecimenCreatedEventArgs e)
+        {
+            // Keep the final NoSpecimen in the list, even though we're about to throw
+            if (!(e.Specimen is NoSpecimen))
+                path.Pop();
+        }
+
+        private void OnSpecimenRequested(object sender, RequestTraceEventArgs e)
+        {
+            path.Push(e.Request);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="TracingBuilder"/> decorated by this instance.
+        /// </summary>
+        public TracingBuilder Tracer
+        {
+            get { return this.tracer; }
+        }
+
+        /// <summary>
+        /// Gets the observed specimen requests, in the order they were requested.
+        /// </summary>
+        public IEnumerable<object> SpecimenRequests
+        {
+            get { return this.path.Reverse(); }
+        }
+
+        /// <summary>
+        /// Creates a new specimen based on a request by delegating to its decorated builder.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        public object Create(object request, ISpecimenContext context)
+        {
+            var result = this.tracer.Create(request, context);
+            if (result is NoSpecimen)
+            {
+                throw new ObjectCreationException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    "AutoFixture was unable to create an instance from {0}, most likely because it has no " +
+                        "public constructor, is an abstract or non-public type.{1}{1}Request path:{1}{2}",
+                    request,
+                    Environment.NewLine,
+                    BuildRequestPathText(this.SpecimenRequests)));
+            }
+            return result;
+        }
+
+        private static string BuildRequestPathText(IEnumerable<object> recordedRequests)
+        {
+            var thisAssembly = MethodBase.GetCurrentMethod().DeclaringType.Assembly;
+            return recordedRequests
+                .Where(r => r.GetType().Assembly != thisAssembly)
+                .Select((r, i) => string.Format(CultureInfo.CurrentCulture, "\t{0} {1}", " ".PadLeft(i+1), r))
+                .Aggregate((s1, s2) => s1 + " --> " + Environment.NewLine + s2);
+        }
+
+        internal static ISpecimenBuilder ComposeIfMultiple(IEnumerable<ISpecimenBuilder> builders)
+        {
+            var isSingle = builders.Take(2).Count() == 1;
+            if (isSingle)
+                return builders.Single();
+
+            return new CompositeSpecimenBuilder(builders);
+        }
+
+        /// <summary>Composes the supplied builders.</summary>
+        /// <param name="builders">The builders to compose.</param>
+        /// <returns>
+        /// A new <see cref="ISpecimenBuilderNode" /> instance containing
+        /// <paramref name="builders" /> as child nodes.
+        /// </returns>
+        public virtual ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
+        {
+            var builder = ComposeIfMultiple(builders);
+            return new TerminatingWithPathSpecimenBuilder(new TracingBuilder(builder));
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="IEnumerator{ISpecimenBuilder}" /> that can be used to
+        /// iterate through the collection.
+        /// </returns>
+        public IEnumerator<ISpecimenBuilder> GetEnumerator()
+        {
+            yield return this.tracer.Builder;
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -87,6 +87,7 @@
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />
     <Compile Include="Kernel\ObservableCollectionSpecificationTest.cs" />
+    <Compile Include="Kernel\TerminatingWithPathSpecimenBuilderTest.cs" />
     <Compile Include="MapCreateManyToEnumerableTests.cs" />
     <Compile Include="Kernel\MultipleToEnumerableRelayTests.cs" />
     <Compile Include="Kernel\NoConstructorsSpecificationTest.cs" />

--- a/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection.Emit;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest.Kernel
+{
+    public class TerminatingWithPathSpecimenBuilderTest
+    {
+        [Fact]
+        public void SutIsISpecimenBuilder()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new TerminatingWithPathSpecimenBuilder(new DelegatingTracingBuilder());
+            // Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsISpecimenBuilderNode()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new TerminatingWithPathSpecimenBuilder(new DelegatingTracingBuilder());
+            // Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilderNode>(sut);
+            // Teardown
+        }
+        
+        [Fact]
+        public void InitializeWithNullBuilderWillThrow()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new TerminatingWithPathSpecimenBuilder(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void TracerIsCorrect()
+        {
+            // Fixture setup
+            var expected = new DelegatingTracingBuilder();
+            // Exercise system
+            var sut = new TerminatingWithPathSpecimenBuilder(expected);
+            // Verify outcome
+            Assert.Same(expected, sut.Tracer);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutYieldsCorrectSequence()
+        {
+            // Fixture setup
+            var expected = new DelegatingSpecimenBuilder();
+            var tracer = new DelegatingTracingBuilder(expected);
+            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            // Exercise system
+            // Verify outcome
+            Assert.Equal(expected, sut.Single());
+            Assert.Equal(expected, sut.Cast<object>().Single());
+            // Teardown
+        }
+
+        [Fact]
+        public void ComposeReturnsCorrectResult()
+        {
+            // Fixture setup
+            var tracer = new DelegatingTracingBuilder();
+            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            // Exercise system
+            var expectedBuilders = new[]
+            {
+                new DelegatingSpecimenBuilder(),
+                new DelegatingSpecimenBuilder(),
+                new DelegatingSpecimenBuilder()
+            };
+            var actual = sut.Compose(expectedBuilders);
+            // Verify outcome
+            var tw = Assert.IsAssignableFrom<TerminatingWithPathSpecimenBuilder>(actual);
+            var composite = Assert.IsAssignableFrom<CompositeSpecimenBuilder>(tw.Tracer.Builder);
+            Assert.True(expectedBuilders.SequenceEqual(composite));
+            // Teardown
+        }
+
+        [Fact]
+        public void ComposeSingleItemReturnsCorrectResult()
+        {
+            // Fixture setup
+            var tracer = new DelegatingTracingBuilder();
+            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            // Exercise system
+            var expected = new DelegatingSpecimenBuilder();
+            var actual = sut.Compose(new[] { expected });
+            // Verify outcome
+            var tw = Assert.IsAssignableFrom<TerminatingWithPathSpecimenBuilder>(actual);
+            Assert.Equal(expected, tw.Tracer.Builder);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWillReturnCorrectResult()
+        {
+            // Fixture setup
+            var expectedSpecimen = new object();
+            var stubBuilder = new TracingBuilder(new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expectedSpecimen
+            });
+
+            var sut = new TerminatingWithPathSpecimenBuilder(stubBuilder);
+            // Exercise system
+            var dummyRequest = new object();
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = sut.Create(dummyRequest, dummyContainer);
+            // Verify outcome
+            Assert.Equal(expectedSpecimen, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWillInvokeDecoratedBuilderWithCorrectParameters()
+        {
+            // Fixture setup
+            var expectedRequest = new object();
+            var expectedContainer = new DelegatingSpecimenContext();
+
+            var verified = false;
+            var mockBuilder = new TracingBuilder(new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => verified = expectedRequest == r && expectedContainer == c
+            });
+
+            var sut = new TerminatingWithPathSpecimenBuilder(mockBuilder);
+            // Exercise system
+            sut.Create(expectedRequest, expectedContainer);
+            // Verify outcome
+            Assert.True(verified, "Mock verified");
+            // Teardown
+        }
+
+        [Fact]
+        public void SpecimenRequestsWillInitiallyBeEmpty()
+        {
+            // Fixture setup
+            var tracer = new DelegatingTracingBuilder();
+            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            // Exercise system and verify outcome
+            Assert.Empty(sut.SpecimenRequests);
+            // Teardown
+        }
+
+        [Fact]
+        public void SpecimenRequestsRaisedFromTracerAreRecordedCorrectly()
+        {
+            // Fixture setup
+            var tracer = new DelegatingTracingBuilder();
+            var specimens = new[] { new object(), new object(), new object() };
+            var requestEvents = specimens.Select((o, i) => new RequestTraceEventArgs(o, i)).ToList();
+            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            // Exercise system
+            requestEvents.ForEach(tracer.RaiseSpecimenRequested);
+            // Verify outcome
+            Assert.True(specimens.SequenceEqual(sut.SpecimenRequests));
+            // Teardown
+        }
+
+        [Fact]
+        public void SpecimenRequestsAreEmptyWhenAllThatWereRequestedAreCreated()
+        {
+            // Fixture setup
+            var tracer = new DelegatingTracingBuilder();
+            var specimens = new[] { new object(), new object(), new object() };
+            var requestEvents = specimens.Select(
+                (o, i) => new RequestTraceEventArgs(o, i)).ToList();
+            var createdEvents = specimens.Reverse().Select(
+                (o, i) => new SpecimenCreatedEventArgs(o, null, i)).ToList();
+            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            // Exercise system
+            requestEvents.ForEach(tracer.RaiseSpecimenRequested);
+            createdEvents.ForEach(tracer.RaiseSpecimenCreated);
+            // Verify outcome
+            Assert.Empty(sut.SpecimenRequests);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateThrowsWhenNoSpecimenIsReturnedFromTheDecoratedGraph()
+        {
+            // Fixture setup
+            var requests = new[] {new object(), new object(), new object()};
+            var tracer = new DelegatingTracingBuilder(new DelegatingSpecimenBuilder
+            {
+                // Returns NoSpecimen only on the last specimen request
+                OnCreate = (r, c) => (r == requests[2]) ? new NoSpecimen() : new object(),
+            });
+
+            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var container = new SpecimenContext(sut);
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.Create(requests[0], container));
+            Assert.DoesNotThrow(() => sut.Create(requests[1], container));
+            Assert.Throws<ObjectCreationException>(() => sut.Create(requests[2], container));
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
This fixes #173 by enhancing the message contained within an `ObjectCreationException` to include a 'specimen request path'. See #173 for information regarding how this solution was chosen.

Assuming the following test:

``` csharp
[Fact]
public void CreateThrowsObjectCreationException()
{
    var fixture = new Fixture();

    var oce = Assert.Throws<ObjectCreationException>(() =>
        fixture.Create<AbstractParametersInConstructor>());

    Console.WriteLine(oce.Message);
}

class AbstractParametersInConstructor
{
    public AbstractParametersInConstructor(AbstractClass abstractClass)
    {
    }
}

abstract class AbstractClass
{
}
```

The message printed before this change is:

```
AutoFixture was unable to create an instance from X, most likely because
it has no public constructor, is an abstract or non-public type.
```

And, the message printed after this change is:

```
AutoFixture was unable to create an instance from 
Test.TerminatingWithPathSpecimenBuilderTest+AbstractClass, most likely because it has no 
public constructor, is an abstract or non-public type.

Request path:
      Test.TerminatingWithPathSpecimenBuilderTest+AbstractParametersInConstructor --> 
       AbstractClass abstractClass --> 
        Test.TerminatingWithPathSpecimenBuilderTest+AbstractClass
```
