### PR TITLE
Correctness fix for DelegatingEqualityComparer in Test Suite

### DIFF
--- a/Src/AutoFixtureUnitTest/DelegatingEqualityComparer.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingEqualityComparer.cs
@@ -18,7 +18,10 @@ namespace Ploeh.AutoFixtureUnitTest
 
         int IEqualityComparer.GetHashCode(object obj)
         {
-            return obj.GetHashCode();
+            // It's not safe to assume anything about how OnEquals is going to [effectively] 
+            // 'bucket' results, so make no assumtions that could lead to false negatives. 
+            // See http://stackoverflow.com/a/3719617
+            return 0;
         }
 
         internal Func<object, object, bool> OnEquals { get; set; }
@@ -38,7 +41,10 @@ namespace Ploeh.AutoFixtureUnitTest
 
         int IEqualityComparer<T>.GetHashCode(T obj)
         {
-            return obj.GetHashCode();
+            // It's not safe to assume anything about how OnEquals is going to [effectively] 
+            // 'bucket' results, so make no assumtions that could lead to false negatives. 
+            // See http://stackoverflow.com/a/3719617
+            return 0;
         }
 
         internal Func<T, T, bool> OnEquals { get; set; }


### PR DESCRIPTION
The code is likely influenced by a classes of the same name in SemanticComparison, which don't [directly/ at present] fall into the same trap as the default ctors assign a [correctly] conservative default impl.

Will leave it to others to consider whether that code should bear warning comments or simply not expose an OnGetHashCode and have a safe impl with a comment as to why (the non-generic variant is the only consumer of OnGetHashCode and the generic one seems to have escaped that scrutiny).

Just noticed typo: assumtions
Will fix iff any followups
