### PR TITLE
Added check for parameter name in GuardClauseAssertion.

### DIFF
--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -328,6 +328,11 @@ See e.g. http://msmvps.com/blogs/jon_skeet/archive/2008/03/02/c-4-idea-iterator-
                 get { return this.command.RequestedType; }
             }
 
+            public string RequestedParameterName
+            {
+                get { return this.command.RequestedParameterName; }
+            }
+
             public void Execute(object value)
             {
                 this.command.Execute(value);

--- a/Src/Idioms/IGuardClauseCommand.cs
+++ b/Src/Idioms/IGuardClauseCommand.cs
@@ -26,6 +26,17 @@ namespace Ploeh.AutoFixture.Idioms
         Type RequestedType { get; }
 
         /// <summary>
+        /// Gets the name of the requested parameter.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The RequestedParameterName property identifies the name of parameter which should be supplied to
+        /// the <see cref="Execute" /> method.
+        /// </para>
+        /// </remarks>
+        string RequestedParameterName { get; }
+
+        /// <summary>
         /// Executes the action with the specified value.
         /// </summary>
         /// <param name="value">The value with wich the action is executed.</param>

--- a/Src/Idioms/MethodInvokeCommand.cs
+++ b/Src/Idioms/MethodInvokeCommand.cs
@@ -69,6 +69,19 @@ namespace Ploeh.AutoFixture.Idioms
         }
 
         /// <summary>
+        /// Gets the parameter name of the requested value.
+        /// </summary>
+        /// <remarks>
+        /// The RequestedParameterName property identifies the parameter name of object which should be supplied to
+        /// the <see cref="Execute"/> method - in this case the name of the
+        /// <see cref="ParameterInfo" />.
+        /// </remarks>
+        public string RequestedParameterName
+        {
+            get { return this.ParameterInfo.Name; }
+        }
+
+        /// <summary>
         /// Invokes the mthod with the specified value.
         /// </summary>
         /// <param name="value">The value with wich the method is executed.</param>

--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -25,8 +25,8 @@ namespace Ploeh.AutoFixture.Idioms
         /// <para>
         /// The Verify method attempts to invoke the <paramref name="command" /> instance's
         /// <see cref="IGuardClauseCommand.Execute" /> with <see langword="null" />. The expected
-        /// result is that this action throws an <see cref="ArgumentNullException" />, in which
-        /// case the expected behavior is considered verified. If any other exception is thrown, or
+        /// result is that this action throws an <see cref="ArgumentNullException" /> with proper parameter name, 
+        /// in which case the expected behavior is considered verified. If any other exception is thrown, or
         /// if no exception is thrown at all, the verification fails and an exception is thrown.
         /// </para>
         /// <para>
@@ -50,9 +50,11 @@ namespace Ploeh.AutoFixture.Idioms
             {
                 command.Execute(null);
             }
-            catch (ArgumentNullException)
+            catch (ArgumentNullException e)
             {
-                return;
+                if (e.ParamName == command.RequestedParameterName)
+                    return;
+                throw command.CreateException("null", e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/PropertySetCommand.cs
+++ b/Src/Idioms/PropertySetCommand.cs
@@ -60,6 +60,19 @@ namespace Ploeh.AutoFixture.Idioms
             get { return this.propertyInfo.PropertyType; }
         }
 
+
+        /// <summary>
+        /// Gets the parameter name of the requested value.
+        /// </summary>
+        /// <value></value>
+        /// <remarks>
+        /// The RequestedParameterName always returns "value".
+        /// </remarks>
+        public string RequestedParameterName
+        {
+            get { return "value"; }
+        }
+
         /// <summary>
         /// Executes the action with the specified value.
         /// </summary>

--- a/Src/Idioms/ReflectionExceptionUnwrappingCommand.cs
+++ b/Src/Idioms/ReflectionExceptionUnwrappingCommand.cs
@@ -44,6 +44,20 @@ namespace Ploeh.AutoFixture.Idioms
         }
 
         /// <summary>
+        /// Gets the parameter name of the requested value.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The return value is the return value of the decorated <see cref="Command" /> instance's
+        /// <see cref="IGuardClauseCommand.RequestedParameterName" /> property.
+        /// </para>
+        /// </remarks>
+        public string RequestedParameterName
+        {
+            get { return this.command.RequestedParameterName; }
+        }
+
+        /// <summary>
         /// Executes the action on the decorated <see cref="Command" />. If a
         /// <see cref="TargetInvocationException" /> is thrown, it's unwrapped and its
         /// <see cref="Exception.InnerException" /> is thrown instead.

--- a/Src/IdiomsUnitTest/DelegatingGuardClauseCommand.cs
+++ b/Src/IdiomsUnitTest/DelegatingGuardClauseCommand.cs
@@ -21,6 +21,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
 
         public Type RequestedType { get; set; }
 
+        public string RequestedParameterName { get; set; }
+
         public void Execute(object value)
         {
             this.OnExecute(value);

--- a/Src/IdiomsUnitTest/MethodInvokeCommandTest.cs
+++ b/Src/IdiomsUnitTest/MethodInvokeCommandTest.cs
@@ -104,6 +104,19 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
+        public void RequestedParameterNameIsCorrect()
+        {
+            var dummyMethod = new DelegatingMethod();
+            var dummyExpansion = new DelegatingExpansion<object>();
+            var parameter = MethodInvokeCommandTest.CreateAnonymousParameterInfo();
+            var sut = new MethodInvokeCommand(dummyMethod, dummyExpansion, parameter);
+
+            var actual = sut.RequestedParameterName;
+
+            Assert.Equal(parameter.Name, actual);
+        }
+
+        [Fact]
         public void CreateExceptionReturnsExceptionWithCorrectMessage()
         {
             // Fixture setup

--- a/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
@@ -78,7 +78,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
-        public void VerifySuccedsWhenCommandThrowsCorrectException()
+        public void VerifySucceedsWhenCommandThrowsCorrectException()
         {
             // Fixture setup
             var cmd = new DelegatingGuardClauseCommand { OnExecute = v => { throw new ArgumentNullException(); } };
@@ -87,6 +87,20 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             Assert.DoesNotThrow(() =>
                 sut.Verify(cmd));
             // Teardown
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("invalidParamName")]
+        public void VerifyThrowsWhenCommandThrowsArgumentNullExceptionWithInvalidParamName(string invalidParamName)
+        {
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => { throw new ArgumentNullException(invalidParamName); }
+            };
+            var sut = new NullReferenceBehaviorExpectation();
+            Assert.Throws<Exception>(() => 
+                sut.Verify(cmd));
         }
 
         [Fact]

--- a/Src/IdiomsUnitTest/PropertySetCommandTest.cs
+++ b/Src/IdiomsUnitTest/PropertySetCommandTest.cs
@@ -79,6 +79,17 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
+        public void RequestedParameterNameIsCorrect()
+        {
+            var dummyOwner = new PropertyHolder<object>();
+            var propertyDummy = dummyOwner.GetType().GetProperty("Property");
+
+            var sut = new PropertySetCommand(propertyDummy, dummyOwner);
+
+            Assert.Equal("value", sut.RequestedParameterName);
+        }
+
+        [Fact]
         public void CreateExceptionReturnsExceptionWithCorrectMessage()
         {
             // Fixture setup

--- a/Src/IdiomsUnitTest/ReflectionExceptionUnwrappingCommandTest.cs
+++ b/Src/IdiomsUnitTest/ReflectionExceptionUnwrappingCommandTest.cs
@@ -32,6 +32,18 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             Assert.Equal(expectedCommand, result);
             // Teardown
         }
+        
+        [Fact]
+        public void RequestedParamNameIsCorrect()
+        {
+            const string expected = "foo";
+            var commandStub = new DelegatingGuardClauseCommand { RequestedParameterName = expected };
+            var sut = new ReflectionExceptionUnwrappingCommand(commandStub);
+
+            var actual = sut.RequestedParameterName;
+
+            Assert.Equal(expected, actual);
+        }
 
         [Fact]
         public void ExecuteExecutesDecoratedCommand()


### PR DESCRIPTION
This pull request added new logic to NullReferenceBehaviorExpectation's Verify method. Now it verifies that command throws ArgumentNullException with proper parameter name. Inspired by [this]( http://stackoverflow.com/questions/15078400/autofixture-test-for-invalid-constructor-parameter/15083283]) question on StackOverflow.

This pull request contains breaking change for IGuardClauseCommand interface.