### PR TITLE
Fix issue with throwing/path-capturing after exceptions

### DIFF
--- a/Src/AutoFixture/Kernel/RecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/RecursionGuard.cs
@@ -281,9 +281,14 @@ namespace Ploeh.AutoFixture.Kernel
             }
 
             requestsForCurrentThread.Push(request);
-            var specimen = this.builder.Create(request, context);
-            requestsForCurrentThread.Pop();
-            return specimen;
+            try
+            {
+                return this.builder.Create(request, context);
+            }
+            finally
+            {
+                requestsForCurrentThread.Pop();
+            }
         }
 
         /// <summary>Composes the supplied builders.</summary>

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -85,13 +85,20 @@ namespace Ploeh.AutoFixture.Kernel
             var result = this.tracer.Create(request, context);
             if (result is NoSpecimen)
             {
-                throw new ObjectCreationException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    "AutoFixture was unable to create an instance from {0}, most likely because it has no " +
+                try
+                {
+                    throw new ObjectCreationException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        "AutoFixture was unable to create an instance from {0}, most likely because it has no " +
                         "public constructor, is an abstract or non-public type.{1}{1}Request path:{1}{2}",
-                    request,
-                    Environment.NewLine,
-                    BuildRequestPathText(this.SpecimenRequests)));
+                        request,
+                        Environment.NewLine,
+                        BuildRequestPathText(this.SpecimenRequests)));
+                }
+                finally
+                {
+                    this.GetPathForCurrentThread().Clear();
+                }
             }
             return result;
         }

--- a/Src/AutoFixtureUnitTest/DelegatingRecursionGuard.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingRecursionGuard.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Linq;
 using Ploeh.AutoFixture.Kernel;
 using System.Collections.Generic;
 
@@ -37,6 +38,11 @@ namespace Ploeh.AutoFixtureUnitTest
         public override ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
             return new DelegatingRecursionGuard(new CompositeSpecimenBuilder(builders));
+        }
+
+        internal IEnumerable<Object> UnprotectedRecordedRequests
+        {
+            get { return this.RecordedRequests.Cast<object>(); }
         }
 
         internal Func<object, object> OnHandleRecursiveRequest { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
@@ -666,6 +666,27 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
+        [Fact]
+        public void CreateAbstractTypeThreeTimesGivesTheSameErrorMessage()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+
+            // Exercise system and verify outcome
+            var ocex1 = Assert.Throws<ObjectCreationException>(() =>
+                fixture.Create<PropertyHolder<AbstractType>>());
+
+            var ocex2 = Assert.Throws<ObjectCreationException>(() =>
+                fixture.Create<PropertyHolder<AbstractType>>());
+
+            var ocex3 = Assert.Throws<ObjectCreationException>(() =>
+                fixture.Create<PropertyHolder<AbstractType>>());
+
+            Assert.Equal(ocex1.Message, ocex2.Message);
+            Assert.Equal(ocex2.Message, ocex3.Message);
+            // Teardown
+        }
+
         private static SpecimenContext CreateContainer()
         {
             var builder = Scenario.CreateAutoPropertyBuilder();


### PR DESCRIPTION
In `RecursionGuard` and `TerminatingWithPathSpecimenBuilder`. Both of these classes incorrectly _remember_ the previous requests when `ObjectCreationException` (e.g. due to creating an abstract type) is throw.

This fixes #226.
