### PR TITLE
Added support for IReadOnlyCollection creations

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ploeh.AutoFixture</RootNamespace>
     <AssemblyName>Ploeh.AutoFixture</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>
@@ -56,6 +56,7 @@
     <CodeAnalysisRules>
     </CodeAnalysisRules>
     <CodeAnalysisRuleSet>Migrated rules for AutoFixture.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -70,6 +71,7 @@
     <DocumentationFile>bin\Release\Ploeh.AutoFixture.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>AutoFixture.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Verify|AnyCPU' ">
     <OutputPath>bin\Verify\</OutputPath>
@@ -86,6 +88,7 @@
     <ErrorReport>prompt</ErrorReport>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -98,6 +101,7 @@
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
     <Compile Include="Kernel\IRecursionHandler.cs" />
+    <Compile Include="Kernel\ReadOnlyCollectionRelay.cs" />
     <Compile Include="Kernel\TerminatingWithPathSpecimenBuilder.cs" />
     <Compile Include="Kernel\ObservableCollectionSpecification.cs" />
     <Compile Include="MapCreateManyToEnumerable.cs" />

--- a/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Relays a request for an <see cref="IReadOnlyCollection{T}" /> to a request for a
+    /// <see cref="List{T}"/> and retuns the result.
+    /// </summary>
+    public class ReadOnlyCollectionRelay : ISpecimenBuilder
+    {
+        /// <summary>
+        /// Creates a new specimen based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// A populated <see cref="IReadOnlyCollection{T}"/> of the appropriate item type if possible; otherwise
+        /// a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// If <paramref name="request"/> is a request for an <see cref="IReadOnlyCollection{T}"/> and
+        /// <paramref name="context"/> can satisfy a request for a populated specimen of that type,
+        /// this value will be returned. If not, the return value is a <see cref="NoSpecimen"/>
+        /// instance.
+        /// </para>
+        /// </remarks>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context");
+
+            var t = request as Type;
+            if (t == null)
+                return new NoSpecimen(request);
+
+            var typeArguments = t.GetGenericArguments();
+            if (typeArguments.Length != 1 ||
+                typeof(IReadOnlyCollection<>) != t.GetGenericTypeDefinition())
+                return new NoSpecimen(request);
+
+            return context.Resolve(
+                typeof(List<>).MakeGenericType(typeArguments));
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ploeh.AutoFixtureUnitTest</RootNamespace>
     <AssemblyName>Ploeh.AutoFixtureUnitTest</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -43,6 +43,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,6 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Verify|AnyCPU' ">
     <OutputPath>bin\Verify\</OutputPath>
@@ -63,6 +65,7 @@
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Ploeh.Albedo">
@@ -90,6 +93,7 @@
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />
+    <Compile Include="Kernel\ReadOnlyCollectionRelayTest.cs" />
     <Compile Include="Kernel\ObservableCollectionSpecificationTest.cs" />
     <Compile Include="Kernel\TerminatingWithPathSpecimenBuilderTest.cs" />
     <Compile Include="MapCreateManyToEnumerableTests.cs" />

--- a/Src/AutoFixtureUnitTest/Kernel/ReadOnlyCollectionRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ReadOnlyCollectionRelayTest.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest.Kernel
+{
+    public class ReadOnlyCollectionRelayTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new ReadOnlyCollectionRelay();
+            // Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            // Fixture setup
+            var sut = new ReadOnlyCollectionRelay();
+            var dummyRequest = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(dummyRequest, null));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(Version))]
+        [InlineData(typeof(object[]))]
+        [InlineData(typeof(string[]))]
+        [InlineData(typeof(int[]))]
+        [InlineData(typeof(Version[]))]
+        [InlineData(typeof(IEnumerable<object>))]
+        [InlineData(typeof(IEnumerable<string>))]
+        [InlineData(typeof(IEnumerable<int>))]
+        [InlineData(typeof(IEnumerable<Version>))]
+        public void CreateWithNonListRequestReturnsCorrectResult(object request)
+        {
+            // Fixture setup
+            var sut = new ReadOnlyCollectionRelay();
+            // Exercise system
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(request, dummyContext);
+            // Verify outcome
+            var expectedResult = new NoSpecimen(request);
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(IReadOnlyCollection<object>), typeof(object))]
+        [InlineData(typeof(IReadOnlyCollection<string>), typeof(string))]
+        [InlineData(typeof(IReadOnlyCollection<int>), typeof(int))]
+        [InlineData(typeof(IReadOnlyCollection<Version>), typeof(Version))]
+        public void CreateWithListRequestReturnsCorrectResult(Type request, Type itemType)
+        {
+            // Fixture setup
+            var expectedRequest = typeof(List<>).MakeGenericType(itemType);
+            object contextResult = typeof(List<>).MakeGenericType(itemType).GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen(r) };
+
+            var sut = new ReadOnlyCollectionRelay();
+            // Exercise system
+            var result = sut.Create(request, context);
+            // Verify outcome
+            Assert.Equal(contextResult, result);
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
Added support for IReadOnlyCollection creations, which basically is a copy of ListRelay.

Unfortunately the interface IReadOnlyCollection is defined in .NET 4.5, which I'm not sure you are ready to upgrade to yet.
