### PR TITLE
Stopped VehicleTest from behaving erratically

### DIFF
--- a/Src/AutoFixtureDocumentationTest/Simple/VechicleTest.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/VechicleTest.cs
@@ -14,6 +14,8 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
         {
             // Fixture setup
             var fixture = new Fixture();
+            fixture.Customizations.Add(new RandomNumericSequenceGenerator(5, byte.MaxValue));
+
             var sut = fixture.Create<Vehicle>();
             // Exercise system
             var result = sut.Wheels;


### PR DESCRIPTION
... by ensuring the `Fixture` cannot return `4`; the default value that would indicate the property was _not_ populated.
