### PR TITLE
Filter out private ctors

### DIFF
--- a/Src/AutoMoq/MockType.cs
+++ b/Src/AutoMoq/MockType.cs
@@ -23,7 +23,8 @@ namespace Ploeh.AutoFixture.AutoMoq
 
         internal static IEnumerable<ConstructorInfo> GetPublicAndProtectedConstructors(this Type type)
         {
-            return type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            return type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(ctor => !ctor.IsPrivate);
         }
 
         internal static ConstructorInfo GetParamsConstructor(this Type type)

--- a/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
+++ b/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
@@ -104,5 +104,17 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             Assert.True(mockTypeCtorArgCounts.SequenceEqual(actualArgCounts));
             // Teardown
         }
+
+        [Fact]
+        public void FiltersOutPrivateConstructor()
+        {
+            // Fixture setup
+            var sut = new MockConstructorQuery();
+            // Exercise system
+            var result = sut.SelectMethods(typeof(Mock<ConcreteTypeWithPrivateParameterlessConstructor>));
+            // Verify outcome
+            Assert.Equal(1, result.Count());
+            // Teardown
+        }
     }
 }

--- a/Src/TestTypeFoundation/ConcreteTypeWithPrivateParameterlessConstructor.cs
+++ b/Src/TestTypeFoundation/ConcreteTypeWithPrivateParameterlessConstructor.cs
@@ -1,0 +1,13 @@
+﻿namespace Ploeh.TestTypeFoundation
+{
+    public class ConcreteTypeWithPrivateParameterlessConstructor
+    {
+        private ConcreteTypeWithPrivateParameterlessConstructor()
+        {
+        }
+
+        public ConcreteTypeWithPrivateParameterlessConstructor(object obj)
+        {
+        }
+    }
+}

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -78,6 +78,7 @@
     <Compile Include="CollectionHolder.cs" />
     <Compile Include="CompositeType.cs" />
     <Compile Include="ConcreteType.cs" />
+    <Compile Include="ConcreteTypeWithPrivateParameterlessConstructor.cs" />
     <Compile Include="DataErrorInfo.cs" />
     <Compile Include="DoubleFieldHolder.cs" />
     <Compile Include="DoubleParameterType.cs" />


### PR DESCRIPTION
During testing I ran into a class that had a declared private
parameterless constructor (don't ask me why, it's out of my hands).
AutoFixture.AutoMoq chose that one.

This fix excludes private constructors from consideration.
