### PR TITLE
Incompatible Albedo version

### DIFF
--- a/Nuget/Ploeh.AutoFixture.Idioms.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Idioms.nuspec
@@ -8,7 +8,7 @@
         <owners>Mark Seemann</owners>
         <dependencies>
             <dependency id="autofixture" version="2.2" />
-            <dependency id="Albedo" version="0.1" />
+            <dependency id="Albedo" version="0.1.1" />
         </dependencies>
         <summary>Extension to AutoFixture that contains unit testing idioms.</summary>
         <description>Ubiquitous use of AutoFixture for unit testing has given rise to a number of idiomatic unit tests - unit tests that tend to follow common templates. The AutoFixture Idioms library encapsulates these idioms into reusable classes and methods.</description>


### PR DESCRIPTION
Current AutoFixture.Idioms library(v3.18.0) have had a bug as following, due to incompatible Albedo versioning.

```
Assembly 'Ploeh.AutoFixture.Idioms, Version=3.18.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f' uses 'Ploeh.Albedo, Version=0.1.1.0, Culture=neutral, PublicKeyToken=179ef6dd03497bbd' which has a higher version than referenced assembly 'Ploeh.Albedo, Version=0.1.0.0, Culture=neutral, PublicKeyToken=179ef6dd03497bbd'    d:\users\jin-wook\documents\visual studio 2013\Projects\ClassLibrary11\packages\AutoFixture.Idioms.3.18.0\lib\net40\Ploeh.AutoFixture.Idioms.dll    ClassLibrary11
```

This PR addressed this incompatibility.
