### PR TITLE
Fix exception message for non-deferred return types in GuardClauseAssertion,

### DIFF
--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -162,7 +162,7 @@ namespace Ploeh.AutoFixture.Idioms
                     : null;
 
             return t.IsArray ||
-                nonGenericCollectionTypes.Contains(t) ||
+                nonGenericCollectionTypes.Any(gt => gt.IsAssignableFrom(t)) ||
                 (isGeneric && (genericCollectionTypeGtds.Any(gtd => gtdInterfaces.Contains(gtd))));
         }
 

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -515,6 +515,9 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         [InlineData(typeof(ClassWithEnumerableNonDeferredIListMissingGuard))]
         [InlineData(typeof(ClassWithEnumerableNonDeferredICollectionMissingGuard))]
         [InlineData(typeof(ClassWithEnumerableNonDeferredIDictionaryMissingGuard))]
+        [InlineData(typeof(ClassWithEnumerableNonDeferredArrayListMissingGuard))]
+        [InlineData(typeof(ClassWithEnumerableNonDeferredStackMissingGuard))]
+        [InlineData(typeof(ClassWithEnumerableNonDeferredReadOnlyCollectionBaseMissingGuard))]
         public void VerifyMethodWithNonDeferredMissingGuardThrowsExceptionWithoutDeferredMessage(
             Type type)
         {
@@ -533,6 +536,38 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             public IList GetValues(string someString)
             {
                 return new System.Collections.ArrayList { someString, someString, someString };
+            }
+        }
+
+        class ClassWithEnumerableNonDeferredArrayListMissingGuard
+        {
+            public System.Collections.ArrayList GetValues(string someString)
+            {
+                return new System.Collections.ArrayList { someString, someString, someString };
+            }
+        }
+
+        class ClassWithEnumerableNonDeferredStackMissingGuard
+        {
+            public System.Collections.Stack GetValues(string someString)
+            {
+                return new System.Collections.Stack(new[] { someString, someString, someString });
+            }
+        }
+
+        class ClassWithEnumerableNonDeferredReadOnlyCollectionBaseMissingGuard
+        {
+            class ReadOnlyCollection : ReadOnlyCollectionBase
+            {
+                public ReadOnlyCollection(params object[] items)
+                {
+                    this.InnerList.AddRange(items);
+                }
+            }
+
+            public System.Collections.ReadOnlyCollectionBase GetValues(string someString)
+            {
+                return new ReadOnlyCollection(new[] { someString, someString, someString });
             }
         }
 


### PR DESCRIPTION
such that when it encounters `IEnumerable` return types, it will treat the known non-deferred enumerable types (such as `Array`, `IList`, `ICollection`, `IDictionary`, etc) as non-deferred, and therefore will not give a misleading exception message about them being deferred.

Note that this supports well-known generic and non-generic BCL collection types (and their interface counterparts) explicitly (aka. a white list).

This fixes #277.
