### PR TITLE
Enhancement to the OOTB behaviour for AutoFixture.NUnit2

### DIFF
--- a/BuildRelease.msbuild
+++ b/BuildRelease.msbuild
@@ -44,6 +44,7 @@
         <BuildOutput Include="Src\Idioms\bin\Release\Ploeh.AutoFixture.Idioms.XML" />
         <BuildOutput Include="Src\Idioms.FsCheck\bin\Release\Ploeh.AutoFixture.Idioms.FsCheck.dll" />
         <BuildOutput Include="Src\Idioms.FsCheck\bin\Release\Ploeh.AutoFixture.Idioms.FsCheck.XML" />
+        <BuildOutput Include="$(NUnitToolsFolder)\lib\nunit.core.interfaces.dll" />
     </ItemGroup>
     <ItemGroup>
     	<NUnitAddinFiles Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.dll" />

--- a/Nuget/Ploeh.AutoFixture.NUnit2.Readme.txt
+++ b/Nuget/Ploeh.AutoFixture.NUnit2.Readme.txt
@@ -13,3 +13,12 @@ public void IntroductoryTest(
     int result = sut.Echo(expectedNumber);
     Assert.Equal(expectedNumber, result);
 }
+
+Known Issues
+
+* Resharper >= 8.1 uses NUnit 2.6.3 under the covers, need to manually add binding redirect to [web|app].config
+
+<dependentAssembly>
+	<assemblyIdentity name="nunit.core.interfaces" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
+	<bindingRedirect oldVersion="0.0.0.0-2.6.3.13283" newVersion="2.6.3.13283" />
+</dependentAssembly>

--- a/Nuget/Ploeh.AutoFixture.NUnit2.nuspec
+++ b/Nuget/Ploeh.AutoFixture.NUnit2.nuspec
@@ -23,6 +23,7 @@
         <file src="Ploeh.AutoFixture.NUnit2.XML" target="lib\net40" />
         <file src="Ploeh.AutoFixture.NUnit2.Addins.dll" target="lib\net40" />
         <file src="Ploeh.AutoFixture.NUnit2.Addins.XML" target="lib\net40" />
+        <file src="nunit.core.interfaces.dll" target="lib\net40" />
         <file src="Ploeh.AutoFixture.NUnit2.Addins.LocalAddin.cs.pp" target="content\LocalAddin.cs.pp" />
     </files>
 </package>


### PR DESCRIPTION
Manually adding binding redirect for `nunit.core.interfaces.dll` fixes the issue with Resharper 8.1 and greater this resolves #246

Included `nunit.core.interfaces.dll` similar to [NUnitTestAdapter](http://www.nuget.org/packages/NUnitTestAdapter/) this fixes the OOTB and resolves #275
