### PR TITLE
publish symbol packages

### DIFF
--- a/BuildRelease.msbuild
+++ b/BuildRelease.msbuild
@@ -20,31 +20,43 @@
         <ProjectToBuild Include="Src\*.sln" />
     </ItemGroup>
     <ItemGroup>
-        <BuildOutput Include="Src\AutoFixture\bin\Release\Ploeh.AutoFixture.dll" />
-        <BuildOutput Include="Src\AutoFixture\bin\Release\Ploeh.AutoFixture.XML" />
-        <BuildOutput Include="Src\SemanticComparison\bin\Release\Ploeh.SemanticComparison.dll" />
-        <BuildOutput Include="Src\SemanticComparison\bin\Release\Ploeh.SemanticComparison.XML" />
-        <BuildOutput Include="Src\AutoMoq\bin\Release\Ploeh.AutoFixture.AutoMoq.dll" />
-        <BuildOutput Include="Src\AutoMoq\bin\Release\Ploeh.AutoFixture.AutoMoq.XML" />
-        <BuildOutput Include="Src\AutoRhinoMock\bin\Release\Ploeh.AutoFixture.AutoRhinoMock.dll" />
-        <BuildOutput Include="Src\AutoRhinoMock\bin\Release\Ploeh.AutoFixture.AutoRhinoMock.XML" />
-        <BuildOutput Include="Src\AutoFakeItEasy\bin\Release\Ploeh.AutoFixture.AutoFakeItEasy.dll" />
-        <BuildOutput Include="Src\AutoFakeItEasy\bin\Release\Ploeh.AutoFixture.AutoFakeItEasy.XML" />
-        <BuildOutput Include="Src\AutoNSubstitute\bin\Release\Ploeh.AutoFixture.AutoNSubstitute.dll" />
-        <BuildOutput Include="Src\AutoNSubstitute\bin\Release\Ploeh.AutoFixture.AutoNSubstitute.XML" />
-        <BuildOutput Include="Src\AutoFoq\bin\Release\Ploeh.AutoFixture.AutoFoq.dll" />
-        <BuildOutput Include="Src\AutoFoq\bin\Release\Ploeh.AutoFixture.AutoFoq.XML" />
-        <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.dll" />
-        <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.XML" />
-        <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.dll" />
-        <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.XML" />
-        <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.dll" />
-        <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.XML" />
-        <BuildOutput Include="Src\Idioms\bin\Release\Ploeh.AutoFixture.Idioms.dll" />
-        <BuildOutput Include="Src\Idioms\bin\Release\Ploeh.AutoFixture.Idioms.XML" />
-        <BuildOutput Include="Src\Idioms.FsCheck\bin\Release\Ploeh.AutoFixture.Idioms.FsCheck.dll" />
-        <BuildOutput Include="Src\Idioms.FsCheck\bin\Release\Ploeh.AutoFixture.Idioms.FsCheck.XML" />
-        <BuildOutput Include="$(NUnitToolsFolder)\lib\nunit.core.interfaces.dll" />
+      <BuildOutput Include="Src\AutoFixture\bin\Release\Ploeh.AutoFixture.dll" />
+      <BuildOutput Include="Src\AutoFixture\bin\Release\Ploeh.AutoFixture.pdb" />
+      <BuildOutput Include="Src\AutoFixture\bin\Release\Ploeh.AutoFixture.XML" />
+      <BuildOutput Include="Src\SemanticComparison\bin\Release\Ploeh.SemanticComparison.dll" />
+      <BuildOutput Include="Src\SemanticComparison\bin\Release\Ploeh.SemanticComparison.pdb" />
+      <BuildOutput Include="Src\SemanticComparison\bin\Release\Ploeh.SemanticComparison.XML" />
+      <BuildOutput Include="Src\AutoMoq\bin\Release\Ploeh.AutoFixture.AutoMoq.dll" />
+      <BuildOutput Include="Src\AutoMoq\bin\Release\Ploeh.AutoFixture.AutoMoq.pdb" />
+      <BuildOutput Include="Src\AutoMoq\bin\Release\Ploeh.AutoFixture.AutoMoq.XML" />
+      <BuildOutput Include="Src\AutoRhinoMock\bin\Release\Ploeh.AutoFixture.AutoRhinoMock.dll" />
+      <BuildOutput Include="Src\AutoRhinoMock\bin\Release\Ploeh.AutoFixture.AutoRhinoMock.pdb" />
+      <BuildOutput Include="Src\AutoRhinoMock\bin\Release\Ploeh.AutoFixture.AutoRhinoMock.XML" />
+      <BuildOutput Include="Src\AutoFakeItEasy\bin\Release\Ploeh.AutoFixture.AutoFakeItEasy.dll" />
+      <BuildOutput Include="Src\AutoFakeItEasy\bin\Release\Ploeh.AutoFixture.AutoFakeItEasy.pdb" />
+      <BuildOutput Include="Src\AutoFakeItEasy\bin\Release\Ploeh.AutoFixture.AutoFakeItEasy.XML" />
+      <BuildOutput Include="Src\AutoNSubstitute\bin\Release\Ploeh.AutoFixture.AutoNSubstitute.dll" />
+      <BuildOutput Include="Src\AutoNSubstitute\bin\Release\Ploeh.AutoFixture.AutoNSubstitute.pdb" />
+      <BuildOutput Include="Src\AutoNSubstitute\bin\Release\Ploeh.AutoFixture.AutoNSubstitute.XML" />
+      <BuildOutput Include="Src\AutoFoq\bin\Release\Ploeh.AutoFixture.AutoFoq.dll" />
+      <BuildOutput Include="Src\AutoFoq\bin\Release\Ploeh.AutoFixture.AutoFoq.pdb" />
+      <BuildOutput Include="Src\AutoFoq\bin\Release\Ploeh.AutoFixture.AutoFoq.XML" />
+      <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.dll" />
+      <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.pdb" />
+      <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.XML" />
+      <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.dll" />
+      <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.pdb" />
+      <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.XML" />
+      <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.dll" />
+      <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.pdb" />
+      <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.XML" />
+      <BuildOutput Include="Src\Idioms\bin\Release\Ploeh.AutoFixture.Idioms.dll" />
+      <BuildOutput Include="Src\Idioms\bin\Release\Ploeh.AutoFixture.Idioms.pdb" />
+      <BuildOutput Include="Src\Idioms\bin\Release\Ploeh.AutoFixture.Idioms.XML" />
+      <BuildOutput Include="Src\Idioms.FsCheck\bin\Release\Ploeh.AutoFixture.Idioms.FsCheck.dll" />
+      <BuildOutput Include="Src\Idioms.FsCheck\bin\Release\Ploeh.AutoFixture.Idioms.FsCheck.pdb" />
+      <BuildOutput Include="Src\Idioms.FsCheck\bin\Release\Ploeh.AutoFixture.Idioms.FsCheck.XML" />
+      <BuildOutput Include="$(NUnitToolsFolder)\lib\nunit.core.interfaces.dll" />
     </ItemGroup>
     <ItemGroup>
     	<NUnitAddinFiles Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.dll" />
@@ -131,7 +143,7 @@
                  Value="$(SemanticVersion)" />
     </Target>
     <Target Name="NuGetPack" DependsOnTargets="NuGetPrepare">
-        <Exec Command="Lib\NuGet\nuget.exe pack %(TempNuspecFiles.FullPath) -BasePath $(ReleaseFolder) -OutputDirectory $(NuGetOutputFolder)" />
+        <Exec Command="Lib\NuGet\nuget.exe pack %(TempNuspecFiles.FullPath) -Symbols -BasePath $(ReleaseFolder) -OutputDirectory $(NuGetOutputFolder)" />
     </Target>
     <Target Name="CleanTemporaryNuGetSpecFiles" DependsOnTargets="NuGetPack">
         <Delete Files="@(TempNuspecFiles)" />

--- a/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
@@ -19,7 +19,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.AutoFakeItEasy.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.AutoFakeItEasy.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.AutoFakeItEasy.XML" target="lib\net40" />
+        <file src="..\Src\AutoFakeItEasy\**\*.cs" target="src" />
         <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.AutoFoq.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoFoq.nuspec
@@ -19,7 +19,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.AutoFoq.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.AutoFoq.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.AutoFoq.XML" target="lib\net40" />
+        <file src="..\Src\AutoFoq\**\*.fs" target="src" />
         <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.AutoMoq.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoMoq.nuspec
@@ -19,7 +19,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.AutoMoq.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.AutoMoq.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.AutoMoq.XML" target="lib\net40" />
+        <file src="..\Src\AutoMoq\**\*.cs" target="src" />
         <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.AutoNSubstitute.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoNSubstitute.nuspec
@@ -19,7 +19,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.AutoNSubstitute.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.AutoNSubstitute.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.AutoNSubstitute.XML" target="lib\net40" />
+        <file src="..\Src\AutoNSubstitute\**\*.cs" target="src" />
         <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.AutoRhinoMock.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoRhinoMock.nuspec
@@ -19,7 +19,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.AutoRhinoMock.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.AutoRhinoMock.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.AutoRhinoMock.XML" target="lib\net40" />
+        <file src="..\Src\AutoRhinoMock\**\*.cs" target="src" />
         <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.Idioms.FsCheck.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Idioms.FsCheck.nuspec
@@ -20,6 +20,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.Idioms.FsCheck.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.Idioms.FsCheck.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.Idioms.FsCheck.XML" target="lib\net40" />
+        <file src="..\Src\Idioms.FsCheck\**\*.fs" target="src" />
+        <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.Idioms.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Idioms.nuspec
@@ -19,6 +19,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.Idioms.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.Idioms.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.Idioms.XML" target="lib\net40" />
+        <file src="..\Src\Idioms\**\*.cs" target="src" />
+        <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.NUnit2.nuspec
+++ b/Nuget/Ploeh.AutoFixture.NUnit2.nuspec
@@ -20,10 +20,14 @@
     <files>
         <file src="Ploeh.AutoFixture.NUnit2.Readme.txt" target="readme.txt" />
         <file src="Ploeh.AutoFixture.NUnit2.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.NUnit2.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.NUnit2.XML" target="lib\net40" />
         <file src="Ploeh.AutoFixture.NUnit2.Addins.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.NUnit2.Addins.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.NUnit2.Addins.XML" target="lib\net40" />
         <file src="nunit.core.interfaces.dll" target="lib\net40" />
         <file src="Ploeh.AutoFixture.NUnit2.Addins.LocalAddin.cs.pp" target="content\LocalAddin.cs.pp" />
+        <file src="..\Src\AutoFixture.NUnit2*\**\*.cs" exclude="..\Src\*UnitTest\**\*.cs" target="src" />
+        <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.Xunit.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Xunit.nuspec
@@ -19,7 +19,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.Xunit.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.Xunit.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.Xunit.XML" target="lib\net40" />
+        <file src="..\Src\AutoFixture.xUnit.net\**\*.cs" target="src" />
         <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.AutoFixture.nuspec
+++ b/Nuget/Ploeh.AutoFixture.nuspec
@@ -14,6 +14,9 @@
     </metadata>
     <files>
         <file src="Ploeh.AutoFixture.dll" target="lib\net40" />
+        <file src="Ploeh.AutoFixture.pdb" target="lib\net40" />
         <file src="Ploeh.AutoFixture.XML" target="lib\net40" />
+        <file src="..\Src\AutoFixture\**\*.cs" target="src" />
+        <file src="Install.ps1" target="tools" />
     </files>
 </package>

--- a/Nuget/Ploeh.SemanticComparison.nuspec
+++ b/Nuget/Ploeh.SemanticComparison.nuspec
@@ -14,6 +14,9 @@
     </metadata>
     <files>
         <file src="Ploeh.SemanticComparison.dll" target="lib\net40" />
+        <file src="Ploeh.SemanticComparison.pdb" target="lib\net40" />
         <file src="Ploeh.SemanticComparison.XML" target="lib\net40" />
+        <file src="..\Src\SemanticComparison\**\*.cs" target="src" />
+        <file src="Install.ps1" target="tools" />
     </files>
 </package>


### PR DESCRIPTION
This PR has resolved #65.

To correctly work this implementation on the AutoFixture CI server, the modification of the BuildRelease.msbuild script would have to be applied to the CI script. For more details, please refer to the [Creating and Publishing a Symbol Package](http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-symbol-package) document.
