### PR TITLE
Fixes #315 by creating range validated unsigned numbers

### DIFF
--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -178,6 +178,9 @@ namespace Ploeh.AutoFixture
                 case TypeCode.Byte:
                     return (byte)a + (byte)b;
 
+                case TypeCode.SByte:
+                    return (sbyte)((sbyte)a + (sbyte)b);
+
                 case TypeCode.Single:
                     return (float)a + (float)b;
 

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedType.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedType.cs
@@ -47,6 +47,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         public ulong UnsignedLongProperty { get; set; }
 
         [Range(Minimum, Maximum)]
+        public sbyte SignedByteProperty { get; set; }
+
+        [Range(Minimum, Maximum)]
         public decimal? NullableTypeField;
 
         [Range(Minimum, Maximum)]

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -1475,6 +1475,21 @@ namespace Ploeh.AutoFixtureUnitTest
 
         [Fact]
         [UseCulture("en-US")]
+        public void CreateAnonymousWithRangeValidatedSignedBytePropertyReturnsCorrectResultForIntegerRange()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var result = fixture.Create<RangeValidatedType>();
+            // Verify outcome
+            Assert.InRange(
+                (int)result.SignedByteProperty,
+                RangeValidatedType.Minimum,
+                RangeValidatedType.Maximum);
+            // Teardown
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
         public void CreateAnonymousWithRangeValidatedDoublePropertyReturnsCorrectResultForDoubleWithMinimumDoubleMinValue()
         {
             // Fixture setup
@@ -1683,6 +1698,21 @@ namespace Ploeh.AutoFixtureUnitTest
             var fixture = new Fixture();
             // Exercise system
             var result = (from n in Enumerable.Range(1, 33).Select(i => fixture.Create<RangeValidatedType>().UnsignedLongProperty)
+                          where (n < RangeValidatedType.Minimum && n > RangeValidatedType.Maximum)
+                          select n);
+            // Verify outcome
+            Assert.False(result.Any());
+            // Teardown
+        }
+
+        [Fact]
+        [UseCulture("en-US")]
+        public void CreateAnonymousWithRangeValidatedSignedBytePropertyReturnsCorrectResultForIntegerRangeOnMultipleCall()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            // Exercise system
+            var result = (from n in Enumerable.Range(1, 33).Select(i => fixture.Create<RangeValidatedType>().SignedByteProperty)
                           where (n < RangeValidatedType.Minimum && n > RangeValidatedType.Maximum)
                           select n);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -435,6 +435,21 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue: new object(),
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(byte), 10, 20)));
 
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: -5, maximum: -1, contextValue:  1, expectedResult: (sbyte)-5);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: -5, maximum: -1, contextValue: -1, expectedResult: (sbyte)-1);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: -5, maximum: -1, contextValue:  0, expectedResult: (sbyte)-5);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum:  1, maximum:  3, contextValue: -9, expectedResult: (sbyte) 1);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue:  1, expectedResult: (sbyte)11);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue:  2, expectedResult: (sbyte)12);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue:  3, expectedResult: (sbyte)13);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: 10, expectedResult: (sbyte)10);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: 17, expectedResult: (sbyte)17);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: 20, expectedResult: (sbyte)20);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (sbyte)10);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 13, contextValue:  4, expectedResult: (sbyte)10);
+                yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: new object(),
+                    expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(sbyte), 10, 20)));
+
                 yield return CreateTestCase(operandType: typeof(float), minimum: -5.0f, maximum: -1.0f, contextValue:  1.0f, expectedResult: -5.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: -5.0f, maximum: -1.0f, contextValue: -1.0f, expectedResult: -1.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: -5.0f, maximum: -1.0f, contextValue:  0.0f, expectedResult: -5.0f);


### PR DESCRIPTION
Adds support for unsigned numbers as well as signed bytes similarly to 0c389d4. This resolves #315.
