### PR TITLE
Freeze on match data attribute

### DIFF
--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -58,7 +58,9 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         {
             // Fixture setup
             var registeredType = typeof(AbstractType);
+#pragma warning disable 0618
             var sut = new FrozenAttribute { As = registeredType };
+#pragma warning restore 0618
             var parameter = AParameter<ConcreteType>();
             // Exercise system
             var result = sut.GetCustomization(parameter);
@@ -73,7 +75,9 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         {
             // Fixture setup
             var registeredType = typeof(string);
+#pragma warning disable 0618
             var sut = new FrozenAttribute { As = registeredType };
+#pragma warning restore 0618
             var parameter = AParameter<ConcreteType>();
             // Exercise system and verify outcome
             Assert.Throws<ArgumentException>(() => sut.GetCustomization(parameter));

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationFromNullParamterThrows()
+        public void GetCustomizationFromNullParameterThrows()
         {
             // Fixture setup
             var sut = new FrozenAttribute();

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -142,20 +142,6 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationWithMatchingByPropertyNameShouldMatchByProperty()
-        {
-            // Fixture setup
-            var sut = new FrozenAttribute(Matching.PropertyName);
-            // Exercise system
-            var customization = sut.GetCustomization(AParameter<object>());
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            Assert.NotEmpty(matcher.Specifications.OfType<PropertySpecification>());
-            // Teardown
-        }
-
-        [Fact]
         public void GetCustomizationWithMatchingByFieldNameShouldMatchByField()
         {
             // Fixture setup

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -142,20 +142,6 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationWithMatchingByParameterNameShouldMatchByParameter()
-        {
-            // Fixture setup
-            var sut = new FrozenAttribute(Matching.ParameterName);
-            // Exercise system
-            var customization = sut.GetCustomization(AParameter<object>());
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            Assert.NotEmpty(matcher.Specifications.OfType<ParameterSpecification>());
-            // Teardown
-        }
-
-        [Fact]
         public void GetCustomizationWithMatchingByPropertyNameShouldMatchByProperty()
         {
             // Fixture setup

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -141,20 +141,6 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             // Teardown
         }
 
-        [Fact]
-        public void GetCustomizationWithMatchingByFieldNameShouldMatchByField()
-        {
-            // Fixture setup
-            var sut = new FrozenAttribute(Matching.FieldName);
-            // Exercise system
-            var customization = sut.GetCustomization(AParameter<object>());
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            Assert.NotEmpty(matcher.Specifications.OfType<FieldSpecification>());
-            // Teardown
-        }
-
         private static ParameterInfo AParameter<T>()
         {
             return typeof(SingleParameterType<T>)

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -111,13 +111,16 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByDirectBaseTypeShouldMatchByBaseType()
         {
             // Fixture setup
+            var parameter = AParameter<object>();
             var sut = new FrozenAttribute(Matching.DirectBaseType);
             // Exercise system
-            var customization = sut.GetCustomization(AParameter<object>());
+            var customization = sut.GetCustomization(parameter);
             // Verify outcome
             var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
             var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            Assert.NotEmpty(matcher.Specifications.OfType<DirectBaseTypeSpecification>());
+            var directBaseTypeMatcher = matcher.Specifications.OfType<DirectBaseTypeSpecification>().SingleOrDefault();
+            Assert.NotNull(directBaseTypeMatcher);
+            Assert.Equal(parameter.ParameterType, directBaseTypeMatcher.TargetType);
             // Teardown
         }
 
@@ -125,13 +128,16 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByImplementedInterfacesShouldMatchByImplementedInterfaces()
         {
             // Fixture setup
+            var parameter = AParameter<object>();
             var sut = new FrozenAttribute(Matching.ImplementedInterfaces);
             // Exercise system
-            var customization = sut.GetCustomization(AParameter<object>());
+            var customization = sut.GetCustomization(parameter);
             // Verify outcome
             var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
             var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            Assert.NotEmpty(matcher.Specifications.OfType<ImplementedInterfaceSpecification>());
+            var interfaceTypeMatcher = matcher.Specifications.OfType<ImplementedInterfaceSpecification>().SingleOrDefault();
+            Assert.NotNull(interfaceTypeMatcher);
+            Assert.Equal(parameter.ParameterType, interfaceTypeMatcher.TargetType);
             // Teardown
         }
 

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 
@@ -15,6 +17,28 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             var sut = new FrozenAttribute();
             // Verify outcome
             Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeShouldSetDefaultMatchingStrategy()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new FrozenAttribute();
+            // Verify outcome
+            Assert.Equal(Matching.ExactType, sut.By);
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeShouldSetDefaultTargetName()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new FrozenAttribute();
+            // Verify outcome
+            Assert.Null(sut.TargetName);
             // Teardown
         }
 
@@ -64,15 +88,12 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationWithSpecificRegisteredTypeReturnsCorrectResult()
+        public void GetCustomizationWithSpecificTypeShouldReturnCorrectResult()
         {
             // Fixture setup
             var registeredType = typeof(AbstractType);
             var sut = new FrozenAttribute { As = registeredType };
-            var parameter = typeof(TypeWithConcreteParameterMethod)
-                .GetMethod("DoSomething", new[] { typeof(ConcreteType) })
-                .GetParameters()
-                .Single();
+            var parameter = AParameter<ConcreteType>();
             // Exercise system
             var result = sut.GetCustomization(parameter);
             // Verify outcome
@@ -82,18 +103,127 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationWithIncompatibleRegisteredTypeThrowsArgumentException()
+        public void GetCustomizationWithIncompatibleSpecificTypeThrowsArgumentException()
         {
             // Fixture setup
             var registeredType = typeof(string);
             var sut = new FrozenAttribute { As = registeredType };
-            var parameter = typeof(TypeWithConcreteParameterMethod)
-                .GetMethod("DoSomething", new[] { typeof(ConcreteType) })
-                .GetParameters()
-                .Single();
+            var parameter = AParameter<ConcreteType>();
             // Exercise system and verify outcome
             Assert.Throws<ArgumentException>(() => sut.GetCustomization(parameter));
             // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationShouldMatchByExactParameterType()
+        {
+            // Fixture setup
+            var parameter = AParameter<object>();
+            var sut = new FrozenAttribute();
+            // Exercise system
+            var customization = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            var exactTypeMatcher = matcher.Specifications.OfType<ExactTypeSpecification>().SingleOrDefault();
+            Assert.NotNull(exactTypeMatcher);
+            Assert.Equal(parameter.ParameterType, exactTypeMatcher.TargetType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationShouldMatchBySeedRequestForParameterType()
+        {
+            // Fixture setup
+            var parameter = AParameter<object>();
+            var sut = new FrozenAttribute();
+            // Exercise system
+            var customization = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            var seedRequestMatcher = matcher.Specifications.OfType<SeedRequestSpecification>().SingleOrDefault();
+            Assert.NotNull(seedRequestMatcher);
+            Assert.Equal(parameter.ParameterType, seedRequestMatcher.TargetType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithMatchingByDirectBaseTypeShouldMatchByBaseType()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute { By = Matching.DirectBaseType };
+            // Exercise system
+            var customization = sut.GetCustomization(AParameter<object>());
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            Assert.NotEmpty(matcher.Specifications.OfType<DirectBaseTypeSpecification>());
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithMatchingByImplementedInterfacesShouldMatchByImplementedInterfaces()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute { By = Matching.ImplementedInterfaces };
+            // Exercise system
+            var customization = sut.GetCustomization(AParameter<object>());
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            Assert.NotEmpty(matcher.Specifications.OfType<ImplementedInterfaceSpecification>());
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithMatchingByParameterNameShouldMatchByParameter()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute { By = Matching.ParameterName, TargetName = "parameter" };
+            // Exercise system
+            var customization = sut.GetCustomization(AParameter<object>());
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            Assert.NotEmpty(matcher.Specifications.OfType<ParameterSpecification>());
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithMatchingByPropertyNameShouldMatchByProperty()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute { By = Matching.PropertyName, TargetName = "Property" };
+            // Exercise system
+            var customization = sut.GetCustomization(AParameter<object>());
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            Assert.NotEmpty(matcher.Specifications.OfType<PropertySpecification>());
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithMatchingByFieldNameShouldMatchByField()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute { By = Matching.FieldName, TargetName = "Field" };
+            // Exercise system
+            var customization = sut.GetCustomization(AParameter<object>());
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            Assert.NotEmpty(matcher.Specifications.OfType<FieldSpecification>());
+            // Teardown
+        }
+
+        private static ParameterInfo AParameter<T>()
+        {
+            return typeof(SingleParameterType<T>)
+                .GetConstructor(new[] { typeof(T) })
+                .GetParameters()
+                .Single(p => p.Name == "parameter");
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
-using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 
@@ -70,74 +69,6 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             var parameter = AParameter<ConcreteType>();
             // Exercise system and verify outcome
             Assert.Throws<ArgumentException>(() => sut.GetCustomization(parameter));
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationShouldMatchByExactParameterType()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute();
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var exactTypeMatcher = matcher.Specifications.OfType<ExactTypeSpecification>().SingleOrDefault();
-            Assert.NotNull(exactTypeMatcher);
-            Assert.Equal(parameter.ParameterType, exactTypeMatcher.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationShouldMatchBySeedRequestForParameterType()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute();
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var seedRequestMatcher = matcher.Specifications.OfType<SeedRequestSpecification>().SingleOrDefault();
-            Assert.NotNull(seedRequestMatcher);
-            Assert.Equal(parameter.ParameterType, seedRequestMatcher.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationWithMatchingByDirectBaseTypeShouldMatchByBaseType()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute(Matching.DirectBaseType);
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var directBaseTypeMatcher = matcher.Specifications.OfType<DirectBaseTypeSpecification>().SingleOrDefault();
-            Assert.NotNull(directBaseTypeMatcher);
-            Assert.Equal(parameter.ParameterType, directBaseTypeMatcher.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationWithMatchingByImplementedInterfacesShouldMatchByImplementedInterfaces()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute(Matching.ImplementedInterfaces);
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var interfaceTypeMatcher = matcher.Specifications.OfType<ImplementedInterfaceSpecification>().SingleOrDefault();
-            Assert.NotNull(interfaceTypeMatcher);
-            Assert.Equal(parameter.ParameterType, interfaceTypeMatcher.TargetType);
             // Teardown
         }
 

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -54,40 +54,6 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationReturnsCorrectResult()
-        {
-            // Fixture setup
-            var sut = new FrozenAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers)
-                .GetMethod("DoSomething", new[] { typeof(object) })
-                .GetParameters()
-                .Single();
-            // Exercise system
-            var result = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezingCustomization>(result);
-            Assert.Equal(parameter.ParameterType, freezer.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationReturnsTheRegisteredTypeEqualToTheParameterType()
-        {
-            // Fixture setup
-            var sut = new FrozenAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers)
-                .GetMethod("DoSomething", new[] { typeof(object) })
-                .GetParameters()
-                .Single();
-            // Exercise system
-            var result = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezingCustomization>(result);
-            Assert.Equal(parameter.ParameterType, freezer.RegisteredType);
-            // Teardown
-        }
-
-        [Fact]
         public void GetCustomizationWithSpecificTypeShouldReturnCorrectResult()
         {
             // Fixture setup

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -122,7 +122,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByDirectBaseTypeShouldMatchByBaseType()
         {
             // Fixture setup
-            var sut = new FrozenAttribute { By = Matching.DirectBaseType };
+            var sut = new FrozenAttribute(Matching.DirectBaseType);
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome
@@ -136,7 +136,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByImplementedInterfacesShouldMatchByImplementedInterfaces()
         {
             // Fixture setup
-            var sut = new FrozenAttribute { By = Matching.ImplementedInterfaces };
+            var sut = new FrozenAttribute(Matching.ImplementedInterfaces);
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome
@@ -150,7 +150,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByParameterNameShouldMatchByParameter()
         {
             // Fixture setup
-            var sut = new FrozenAttribute { By = Matching.ParameterName, TargetName = "parameter" };
+            var sut = new FrozenAttribute(Matching.ParameterName, "parameter");
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome
@@ -164,7 +164,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByPropertyNameShouldMatchByProperty()
         {
             // Fixture setup
-            var sut = new FrozenAttribute { By = Matching.PropertyName, TargetName = "Property" };
+            var sut = new FrozenAttribute(Matching.PropertyName, "Property");
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome
@@ -178,7 +178,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByFieldNameShouldMatchByField()
         {
             // Fixture setup
-            var sut = new FrozenAttribute { By = Matching.FieldName, TargetName = "Field" };
+            var sut = new FrozenAttribute(Matching.FieldName, "Field");
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome

--- a/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/FrozenAttributeTest.cs
@@ -32,17 +32,6 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Fact]
-        public void InitializeShouldSetDefaultTargetName()
-        {
-            // Fixture setup
-            // Exercise system
-            var sut = new FrozenAttribute();
-            // Verify outcome
-            Assert.Null(sut.TargetName);
-            // Teardown
-        }
-
-        [Fact]
         public void GetCustomizationFromNullParameterThrows()
         {
             // Fixture setup
@@ -150,7 +139,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByParameterNameShouldMatchByParameter()
         {
             // Fixture setup
-            var sut = new FrozenAttribute(Matching.ParameterName, "parameter");
+            var sut = new FrozenAttribute(Matching.ParameterName);
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome
@@ -164,7 +153,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByPropertyNameShouldMatchByProperty()
         {
             // Fixture setup
-            var sut = new FrozenAttribute(Matching.PropertyName, "Property");
+            var sut = new FrozenAttribute(Matching.PropertyName);
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome
@@ -178,7 +167,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         public void GetCustomizationWithMatchingByFieldNameShouldMatchByField()
         {
             // Fixture setup
-            var sut = new FrozenAttribute(Matching.FieldName, "Field");
+            var sut = new FrozenAttribute(Matching.FieldName);
             // Exercise system
             var customization = sut.GetCustomization(AParameter<object>());
             // Verify outcome

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -129,7 +129,9 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterAsBaseTypeAssignsSameInstanceToSecondParameterOfThatBaseType(
+#pragma warning disable 0618
             [Frozen(As = typeof(AbstractType))]ConcreteType p1,
+#pragma warning restore 0618
             AbstractType p2)
         {
             Assert.Equal(p1, p2);
@@ -137,7 +139,9 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterAsNullTypeAssignsSameInstanceToSecondParameterOfSameType(
+#pragma warning disable 0618
             [Frozen(As = null)]ConcreteType p1,
+#pragma warning restore 0618
             ConcreteType p2)
         {
             Assert.Equal(p1, p2);

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -188,11 +188,27 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByParameterWithSameNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.ParameterName)]string parameter,
+            SingleParameterType<object> p2)
+        {
+            Assert.Equal(parameter, p2.Parameter);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByPropertyNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.PropertyName, "Property")]string p1,
             PropertyHolder<object> p2)
         {
             Assert.Equal(p1, p2.Property);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByPropertyWithSameNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.PropertyName)]string property,
+            PropertyHolder<object> p2)
+        {
+            Assert.Equal(property, p2.Property);
         }
 
         [Theory, AutoData]
@@ -204,11 +220,27 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByFieldWithSameNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.FieldName)]string field,
+            FieldHolder<object> p2)
+        {
+            Assert.Equal(field, p2.Field);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingParameter(
             [Frozen(Matching.MemberName, "parameter")]string p1,
             SingleParameterType<object> p2)
         {
             Assert.Equal(p1, p2.Parameter);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingParameter(
+            [Frozen(Matching.MemberName)]string parameter,
+            SingleParameterType<object> p2)
+        {
+            Assert.Equal(parameter, p2.Parameter);
         }
 
         [Theory, AutoData]
@@ -220,11 +252,27 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingProperty(
+            [Frozen(Matching.MemberName)]string property,
+            PropertyHolder<object> p2)
+        {
+            Assert.Equal(property, p2.Property);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingField(
             [Frozen(Matching.MemberName, "Field")]string p1,
             FieldHolder<object> p2)
         {
             Assert.Equal(p1, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingField(
+            [Frozen(Matching.MemberName)]string field,
+            FieldHolder<object> p2)
+        {
+            Assert.Equal(field, p2.Field);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -164,11 +164,27 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByExactTypeShouldNotAssignSameInstanceToSecondParameterOfDifferentType(
+            [Frozen(Matching.ExactType)]ConcreteType p1,
+            object p2)
+        {
+            Assert.NotEqual(p1, p2);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByDirectBaseTypeShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.DirectBaseType)]ConcreteType p1,
             AbstractType p2)
         {
             Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByDirectBaseTypeShouldNotAssignSameInstanceToSecondParameterOfIndirectBaseType(
+            [Frozen(Matching.DirectBaseType)]ConcreteType p1,
+            object p2)
+        {
+            Assert.NotEqual(p1, p2);
         }
 
         [Theory, AutoData]
@@ -180,11 +196,27 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByInterfaceShouldNotAssignSameInstanceToSecondParameterOfNonInterfaceType(
+            [Frozen(Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
+            object p2)
+        {
+            Assert.NotEqual(p1, p2);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByParameterWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.ParameterName)]string parameter,
             SingleParameterType<object> p2)
         {
             Assert.Equal(parameter, p2.Parameter);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByParameterWithDifferentNameShouldNotAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.ParameterName)]string p1,
+            SingleParameterType<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Parameter);
         }
 
         [Theory, AutoData]
@@ -196,11 +228,27 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByPropertyWithDifferentNameShouldNotAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.PropertyName)]string p1,
+            PropertyHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Property);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByFieldWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.FieldName)]string field,
             FieldHolder<object> p2)
         {
             Assert.Equal(field, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByFieldWithDifferentNameShouldNotAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.FieldName)]string p1,
+            FieldHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Field);
         }
 
         [Theory, AutoData]
@@ -212,6 +260,14 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToParameter(
+            [Frozen(Matching.MemberName)]string p1,
+            SingleParameterType<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Parameter);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingProperty(
             [Frozen(Matching.MemberName)]string property,
             PropertyHolder<object> p2)
@@ -220,11 +276,27 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToProperty(
+            [Frozen(Matching.MemberName)]string p1,
+            PropertyHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Property);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingField(
             [Frozen(Matching.MemberName)]string field,
             FieldHolder<object> p2)
         {
             Assert.Equal(field, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToField(
+            [Frozen(Matching.MemberName)]string p1,
+            FieldHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Field);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -180,27 +180,11 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
-        public void FreezeFirstParameterByParameterNameShouldAssignSameInstanceToSecondParameter(
-            [Frozen(Matching.ParameterName, "parameter")]string p1,
-            SingleParameterType<object> p2)
-        {
-            Assert.Equal(p1, p2.Parameter);
-        }
-
-        [Theory, AutoData]
         public void FreezeFirstParameterByParameterWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.ParameterName)]string parameter,
             SingleParameterType<object> p2)
         {
             Assert.Equal(parameter, p2.Parameter);
-        }
-
-        [Theory, AutoData]
-        public void FreezeFirstParameterByPropertyNameShouldAssignSameInstanceToSecondParameter(
-            [Frozen(Matching.PropertyName, "Property")]string p1,
-            PropertyHolder<object> p2)
-        {
-            Assert.Equal(p1, p2.Property);
         }
 
         [Theory, AutoData]
@@ -212,27 +196,11 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
-        public void FreezeFirstParameterByFieldNameShouldAssignSameInstanceToSecondParameter(
-            [Frozen(Matching.FieldName, "Field")]string p1,
-            FieldHolder<object> p2)
-        {
-            Assert.Equal(p1, p2.Field);
-        }
-
-        [Theory, AutoData]
         public void FreezeFirstParameterByFieldWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.FieldName)]string field,
             FieldHolder<object> p2)
         {
             Assert.Equal(field, p2.Field);
-        }
-
-        [Theory, AutoData]
-        public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingParameter(
-            [Frozen(Matching.MemberName, "parameter")]string p1,
-            SingleParameterType<object> p2)
-        {
-            Assert.Equal(p1, p2.Parameter);
         }
 
         [Theory, AutoData]
@@ -244,27 +212,11 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         [Theory, AutoData]
-        public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingProperty(
-            [Frozen(Matching.MemberName, "Property")]string p1,
-            PropertyHolder<object> p2)
-        {
-            Assert.Equal(p1, p2.Property);
-        }
-
-        [Theory, AutoData]
         public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingProperty(
             [Frozen(Matching.MemberName)]string property,
             PropertyHolder<object> p2)
         {
             Assert.Equal(property, p2.Property);
-        }
-
-        [Theory, AutoData]
-        public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingField(
-            [Frozen(Matching.MemberName, "Field")]string p1,
-            FieldHolder<object> p2)
-        {
-            Assert.Equal(p1, p2.Field);
         }
 
         [Theory, AutoData]

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -132,7 +132,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             [Frozen(As = typeof(AbstractType))]ConcreteType p1,
             AbstractType p2)
         {
-            Assert.Same(p1, p2);
+            Assert.Equal(p1, p2);
         }
 
         [Theory, AutoData]
@@ -140,7 +140,87 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             [Frozen(As = null)]ConcreteType p1,
             ConcreteType p2)
         {
-            Assert.Same(p1, p2);
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterShouldAssignSameInstanceToSecondParameter(
+            [Frozen]string p1,
+            string p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByExactTypeShouldAssignSameInstanceToSecondParameter(
+            [Frozen(By = Matching.ExactType)]ConcreteType p1,
+            ConcreteType p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByDirectBaseTypeShouldAssignSameInstanceToSecondParameter(
+            [Frozen(By = Matching.DirectBaseType)]ConcreteType p1,
+            AbstractType p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByInterfaceShouldAssignSameInstanceToSecondParameter(
+            [Frozen(By = Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
+            IInterface p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByParameterNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(By = Matching.ParameterName, TargetName = "parameter")]string p1,
+            SingleParameterType<object> p2)
+        {
+            Assert.Equal(p1, p2.Parameter);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByPropertyNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(By = Matching.PropertyName, TargetName = "Property")]string p1,
+            PropertyHolder<object> p2)
+        {
+            Assert.Equal(p1, p2.Property);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByFieldNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(By = Matching.FieldName, TargetName = "Field")]string p1,
+            FieldHolder<object> p2)
+        {
+            Assert.Equal(p1, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingParameter(
+            [Frozen(By = Matching.MemberName, TargetName = "parameter")]string p1,
+            SingleParameterType<object> p2)
+        {
+            Assert.Equal(p1, p2.Parameter);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingProperty(
+            [Frozen(By = Matching.MemberName, TargetName = "Property")]string p1,
+            PropertyHolder<object> p2)
+        {
+            Assert.Equal(p1, p2.Property);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingField(
+            [Frozen(By = Matching.MemberName, TargetName = "Field")]string p1,
+            FieldHolder<object> p2)
+        {
+            Assert.Equal(p1, p2.Field);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -157,7 +157,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByExactTypeShouldAssignSameInstanceToSecondParameter(
-            [Frozen(By = Matching.ExactType)]ConcreteType p1,
+            [Frozen(Matching.ExactType)]ConcreteType p1,
             ConcreteType p2)
         {
             Assert.Equal(p1, p2);
@@ -165,7 +165,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByDirectBaseTypeShouldAssignSameInstanceToSecondParameter(
-            [Frozen(By = Matching.DirectBaseType)]ConcreteType p1,
+            [Frozen(Matching.DirectBaseType)]ConcreteType p1,
             AbstractType p2)
         {
             Assert.Equal(p1, p2);
@@ -173,7 +173,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByInterfaceShouldAssignSameInstanceToSecondParameter(
-            [Frozen(By = Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
+            [Frozen(Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
             IInterface p2)
         {
             Assert.Equal(p1, p2);
@@ -181,7 +181,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByParameterNameShouldAssignSameInstanceToSecondParameter(
-            [Frozen(By = Matching.ParameterName, TargetName = "parameter")]string p1,
+            [Frozen(Matching.ParameterName, "parameter")]string p1,
             SingleParameterType<object> p2)
         {
             Assert.Equal(p1, p2.Parameter);
@@ -189,7 +189,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByPropertyNameShouldAssignSameInstanceToSecondParameter(
-            [Frozen(By = Matching.PropertyName, TargetName = "Property")]string p1,
+            [Frozen(Matching.PropertyName, "Property")]string p1,
             PropertyHolder<object> p2)
         {
             Assert.Equal(p1, p2.Property);
@@ -197,7 +197,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByFieldNameShouldAssignSameInstanceToSecondParameter(
-            [Frozen(By = Matching.FieldName, TargetName = "Field")]string p1,
+            [Frozen(Matching.FieldName, "Field")]string p1,
             FieldHolder<object> p2)
         {
             Assert.Equal(p1, p2.Field);
@@ -205,7 +205,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingParameter(
-            [Frozen(By = Matching.MemberName, TargetName = "parameter")]string p1,
+            [Frozen(Matching.MemberName, "parameter")]string p1,
             SingleParameterType<object> p2)
         {
             Assert.Equal(p1, p2.Parameter);
@@ -213,7 +213,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingProperty(
-            [Frozen(By = Matching.MemberName, TargetName = "Property")]string p1,
+            [Frozen(Matching.MemberName, "Property")]string p1,
             PropertyHolder<object> p2)
         {
             Assert.Equal(p1, p2.Property);
@@ -221,7 +221,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterByMemberNameShouldAssignSameInstanceToMatchingField(
-            [Frozen(By = Matching.MemberName, TargetName = "Field")]string p1,
+            [Frozen(Matching.MemberName, "Field")]string p1,
             FieldHolder<object> p2)
         {
             Assert.Equal(p1, p2.Field);

--- a/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
+++ b/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
@@ -95,6 +95,7 @@
     <Compile Include="FrozenAttribute.cs" />
     <Compile Include="GreedyAttribute.cs" />
     <Compile Include="InlineAutoDataAttribute.cs" />
+    <Compile Include="Matching.cs" />
     <Compile Include="ModestAttribute.cs" />
     <Compile Include="NoAutoPropertiesAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -45,7 +45,7 @@ namespace Ploeh.AutoFixture.Xunit
         /// Gets or sets the <see cref="Type"/> that the frozen parameter value
         /// should be mapped to in the <see cref="IFixture"/>.
         /// </summary>
-        [Obsolete("The ability to map a frozen object to a specific type is deprecated and will likely be removed in the future. If you wish to map a frozen type to its implemented interfaces, use [Frozen(Matching.ImplementedInterfaces)].")]
+        [Obsolete("The ability to map a frozen object to a specific type is deprecated and will likely be removed in the future. If you wish to map a frozen type to its implemented interfaces, use [Frozen(Matching.ImplementedInterfaces)]. If you instead wish to map it to its direct base type, use [Frozen(Matching.DirectBaseType)].")]
         public Type As { get; set; }
 
         /// <summary>

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -27,6 +27,7 @@ namespace Ploeh.AutoFixture.Xunit
         /// Gets or sets the <see cref="Type"/> that the frozen parameter value
         /// should be mapped to in the <see cref="IFixture"/>.
         /// </summary>
+        [Obsolete("The ability to map a frozen object to a specific type is deprecated and will likely be removed in the future. If you wish to map a frozen type to its implemented interfaces, use [Frozen(By = Matching.ImplementedInterfaces)].")]
         public Type As { get; set; }
 
         /// <summary>
@@ -71,14 +72,18 @@ namespace Ploeh.AutoFixture.Xunit
 
         private bool ShouldMatchBySpecificType()
         {
+#pragma warning disable 0618
             return this.As != null;
+#pragma warning restore 0618
         }
 
         private ICustomization FreezeAsType()
         {
             return new FreezingCustomization(
                 this.targetType,
+#pragma warning disable 0618
                 this.As ?? targetType);
+#pragma warning restore 0618
         }
 
         private ICustomization FreezeByCriteria()

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -45,7 +45,7 @@ namespace Ploeh.AutoFixture.Xunit
         /// Gets or sets the <see cref="Type"/> that the frozen parameter value
         /// should be mapped to in the <see cref="IFixture"/>.
         /// </summary>
-        [Obsolete("The ability to map a frozen object to a specific type is deprecated and will likely be removed in the future. If you wish to map a frozen type to its implemented interfaces, use [Frozen(By = Matching.ImplementedInterfaces)].")]
+        [Obsolete("The ability to map a frozen object to a specific type is deprecated and will likely be removed in the future. If you wish to map a frozen type to its implemented interfaces, use [Frozen(Matching.ImplementedInterfaces)].")]
         public Type As { get; set; }
 
         /// <summary>

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -19,12 +19,24 @@ namespace Ploeh.AutoFixture.Xunit
         /// <summary>
         /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
         /// </summary>
+        /// <remarks>
+        /// The <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the frozen parameter value
+        /// is <see cref="F:Matching.ExactType"/>.
+        /// </remarks>
+        public FrozenAttribute()
+            : this(Matching.ExactType)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
+        /// </summary>
         /// <param name="by">
         /// The <see cref="Matching"/> criteria used to determine
         /// which requests will be satisfied by the frozen parameter value.
-        /// The default value is <see cref="F:Matching.ExactType"/>.
         /// </param>
-        public FrozenAttribute(Matching by = Matching.ExactType)
+        public FrozenAttribute(Matching by)
         {
             this.by = by;
         }

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -14,7 +14,6 @@ namespace Ploeh.AutoFixture.Xunit
     public sealed class FrozenAttribute : CustomizeAttribute
     {
         private readonly Matching by;
-        private readonly string targetName;
         private IRequestSpecification matcher;
 
         /// <summary>
@@ -25,16 +24,9 @@ namespace Ploeh.AutoFixture.Xunit
         /// which requests will be satisfied by the frozen parameter value.
         /// The default value is <see cref="F:Matching.ExactType"/>.
         /// </param>
-        /// <param name="targetName">
-        /// The identifier used to determine which requests
-        /// for a class member will be satisfied by the frozen parameter value.
-        /// </param>
-        public FrozenAttribute(
-            Matching by = Matching.ExactType,
-            string targetName = null)
+        public FrozenAttribute(Matching by = Matching.ExactType)
         {
             this.by = by;
-            this.targetName = targetName;
         }
 
         /// <summary>
@@ -51,15 +43,6 @@ namespace Ploeh.AutoFixture.Xunit
         public Matching By
         {
             get { return by; }
-        }
-
-        /// <summary>
-        /// Gets the identifier used to determine which requests
-        /// for a class member will be satisfied by the frozen parameter value.
-        /// </summary>
-        public string TargetName
-        {
-            get { return targetName; }
         }
 
         /// <summary>
@@ -83,7 +66,7 @@ namespace Ploeh.AutoFixture.Xunit
             }
 
             var type = parameter.ParameterType;
-            var name = this.targetName ?? parameter.Name;
+            var name = parameter.Name;
 
             return ShouldMatchBySpecificType()
                 ? FreezeAsType(type)

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.Xunit
 {
@@ -11,6 +12,17 @@ namespace Ploeh.AutoFixture.Xunit
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class FrozenAttribute : CustomizeAttribute
     {
+        private IRequestSpecification matcher;
+        private Type targetType;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
+        /// </summary>
+        public FrozenAttribute()
+        {
+            this.By = Matching.ExactType;
+        }
+
         /// <summary>
         /// Gets or sets the <see cref="Type"/> that the frozen parameter value
         /// should be mapped to in the <see cref="IFixture"/>.
@@ -18,15 +30,31 @@ namespace Ploeh.AutoFixture.Xunit
         public Type As { get; set; }
 
         /// <summary>
-        /// Gets a customization that freezes the <see cref="Type"/> of the parameter.
+        /// Gets or sets the <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the frozen parameter value.
         /// </summary>
-        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <remarks>
+        /// If not specified, requests will be matched by exact type.
+        /// </remarks>
+        public Matching By { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier used to determine which requests
+        /// for a class member will be satisfied by the frozen parameter value.
+        /// </summary>
+        public string TargetName { get; set; }
+
+        /// <summary>
+        /// Gets a <see cref="FreezeOnMatchCustomization"/> configured
+        /// to match requests based on the <see cref="Type"/> of the parameter.
+        /// </summary>
+        /// <param name="parameter">
+        /// The parameter for which the customization is requested.
+        /// </param>
         /// <returns>
-        /// A customization that freezes the <see cref="Type"/> of the parameter.
+        /// A <see cref="FreezeOnMatchCustomization"/> configured
+        /// to match requests based on the <see cref="Type"/> of the parameter.
         /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="parameter"/> is null.
-        /// </exception>
         public override ICustomization GetCustomization(ParameterInfo parameter)
         {
             if (parameter == null)
@@ -34,8 +62,115 @@ namespace Ploeh.AutoFixture.Xunit
                 throw new ArgumentNullException("parameter");
             }
 
-            var targetType = parameter.ParameterType;
-            return new FreezingCustomization(targetType, As ?? targetType);
+            this.targetType = parameter.ParameterType;
+
+            return ShouldMatchBySpecificType()
+                ? FreezeAsType()
+                : FreezeByCriteria();
+        }
+
+        private bool ShouldMatchBySpecificType()
+        {
+            return this.As != null;
+        }
+
+        private ICustomization FreezeAsType()
+        {
+            return new FreezingCustomization(
+                this.targetType,
+                this.As ?? targetType);
+        }
+
+        private ICustomization FreezeByCriteria()
+        {
+            MatchByType();
+            MatchByName();
+            return new FreezeOnMatchCustomization(
+                this.targetType,
+                this.matcher);
+        }
+
+        private void MatchByType()
+        {
+            AlwaysMatchByExactType();
+            MatchByBaseType();
+            MatchByImplementedInterfaces();
+        }
+
+        private void MatchByName()
+        {
+            MatchByPropertyName();
+            MatchByParameterName();
+            MatchByFieldName();
+        }
+
+        private void AlwaysMatchByExactType()
+        {
+            MatchBy(
+                new OrRequestSpecification(
+                    new ExactTypeSpecification(targetType),
+                    new SeedRequestSpecification(targetType)));
+        }
+
+        private void MatchByBaseType()
+        {
+            if (ShouldMatchBy(Matching.DirectBaseType))
+            {
+                MatchBy(new DirectBaseTypeSpecification(this.targetType));
+            }
+        }
+
+        private void MatchByImplementedInterfaces()
+        {
+            if (ShouldMatchBy(Matching.ImplementedInterfaces))
+            {
+                MatchBy(new ImplementedInterfaceSpecification(this.targetType));
+            }
+        }
+
+        private void MatchByParameterName()
+        {
+            if (ShouldMatchBy(Matching.ParameterName))
+            {
+                MatchBy(
+                    new ParameterSpecification(
+                        this.targetType,
+                        this.TargetName));
+            }
+        }
+
+        private void MatchByPropertyName()
+        {
+            if (ShouldMatchBy(Matching.PropertyName))
+            {
+                MatchBy(
+                    new PropertySpecification(
+                        this.targetType,
+                        this.TargetName));
+            }
+        }
+
+        private void MatchByFieldName()
+        {
+            if (ShouldMatchBy(Matching.FieldName))
+            {
+                MatchBy(
+                    new FieldSpecification(
+                        this.targetType,
+                        this.TargetName));
+            }
+        }
+
+        private bool ShouldMatchBy(Matching criteria)
+        {
+            return this.By.HasFlag(criteria);
+        }
+
+        private void MatchBy(IRequestSpecification criteria)
+        {
+            this.matcher = this.matcher == null
+                ? criteria
+                : new OrRequestSpecification(this.matcher, criteria);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net/Matching.cs
+++ b/Src/AutoFixture.xUnit.net/Matching.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Xunit
+{
+    /// <summary>
+    /// The criteria used to determine which requests will be satisfied
+    /// by the frozen specimen created for a parameter
+    /// decorated with the <see cref="FrozenAttribute"/> attribute.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1714:FlagsEnumsShouldHavePluralNames", Justification = "This enumeration is designed to be used together with an attribute and is named to improve readability.")]
+    [Flags]
+    public enum Matching
+    {
+        /// <summary>
+        /// Matches requests for the exact same <see cref="Type"/>
+        /// as the type of the parameter.
+        /// </summary>
+        ExactType = 1,
+
+        /// <summary>
+        /// Matches requests for a <see cref="Type"/> that is
+        /// a direct base of the type of the parameter.
+        /// </summary>
+        DirectBaseType = 2,
+
+        /// <summary>
+        /// Matches requests for an interface <see cref="Type"/> that is
+        /// implemented by the type of the parameter.
+        /// </summary>
+        ImplementedInterfaces = 4,
+
+        /// <summary>
+        /// Matches requests for a <see cref="ParameterInfo"/> whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        ParameterName = 8,
+
+        /// <summary>
+        /// Matches requests for a <see cref="PropertyInfo"/> whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        PropertyName = 16,
+
+        /// <summary>
+        /// Matches requests for a <see cref="FieldInfo"/> whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        FieldName = 32,
+
+        /// <summary>
+        /// Matches requests for a parameter, property or field whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        MemberName = ParameterName | PropertyName | FieldName
+    }
+}

--- a/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
@@ -55,7 +55,7 @@ namespace Ploeh.AutoFixture.Kernel
             }
 
             return IsRequestForType(request) &&
-                   RequestedTypeMatchesCriteria(request);
+                   IsTargetTypeOrItsDirectBase(request);
         }
 
         private static bool IsRequestForType(object request)
@@ -63,7 +63,7 @@ namespace Ploeh.AutoFixture.Kernel
             return request is Type;
         }
 
-        private bool RequestedTypeMatchesCriteria(object request)
+        private bool IsTargetTypeOrItsDirectBase(object request)
         {
             return IsSameAsTargetType(request) ||
                    IsDirectBaseOfTargetType(request);

--- a/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
+++ b/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
@@ -56,7 +56,7 @@ namespace Ploeh.AutoFixture.Kernel
             }
 
             return IsRequestForType(request) &&
-                   RequestedTypeMatchesCriteria(request);
+                   IsTargetTypeOrImplementedInterface(request);
         }
 
         private static bool IsRequestForType(object request)
@@ -64,7 +64,7 @@ namespace Ploeh.AutoFixture.Kernel
             return request is Type;
         }
 
-        private bool RequestedTypeMatchesCriteria(object request)
+        private bool IsTargetTypeOrImplementedInterface(object request)
         {
             return IsSameAsTargetType(request) ||
                    IsInterfaceImplementedByTargetType(request);


### PR DESCRIPTION
This `CustomizeAttribute` leverages the `FreezeOnMatchCustomization` introduced in #317 by opening up its behavior to xUnit parameterized tests.

### Usage

The `FreezeAttribute` applies to the same scenarios as the current `FrozenAttribute`. Here's an example:

```csharp
[Theory, AutoData]
public void FreezeParameterForMatchingProperties(
    [Freeze(By = Matching.PropertyName, TargetName = "Property")]string p1,
    PropertyHolder<string> p2)
{
    Assert.Same(p1, p2.Property);
}
```

Following the same convention as the `FreezeOnMatchCustomization`, if no matching criteria are specified the attribute will mimic the behavior of the current `FrozenAttribute` matching only by _exact type_. In other words the following test:

```csharp
[Theory, AutoData]
public void FreezeParameterByExactType(
    [Freeze]string p1,
    string p2)
{
    Assert.Same(p1, p2);
}
```

is the same as:

```csharp
[Theory, AutoData]
public void FreezeParameterByExactType(
    [Freeze(By = Matching.ExactType)]string p1,
    string p2)
{
    Assert.Same(p1, p2);
}
```

The existing `As` functionality of the `FrozenAttribute` is also superseded by using the `Matching.ImplementedInterfaces` criteria.

For example, given `IFoo` and `Bar` where `Bar` implements `IFoo`, the following test:

```csharp
[Theory, AutoData]
public void FreezeParameterByExactType(
    [Frozen(As = typeof(IFoo))]Bar p1,
    IFoo p2)
{
    Assert.Same(p1, p2);
}
```

can now be expressed as:

```csharp
[Theory, AutoData]
public void FreezeParameterByExactType(
    [Freeze(By = Matching.ImplementedInterfaces)]Bar p1,
    IFoo p2)
{
    Assert.Same(p1, p2);
}
```

which will also match _any other interface_ implemented by `Bar`.

### Follow-ups

The are a few things I deliberately left out until after I gather your feedback:

- Since the `FreezeAttribute` effectively supersedes the existing `FrozenAttribute`, I propose we obsolete it and keep the "_Freeze_" prefix for consistency with the `FreezeCustomization`.
- I'll add the XML documentation once the feature is finalized.

I look forward to your comments.