### PR TITLE
The Matching DSL

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -119,6 +119,10 @@
     <Compile Include="Kernel\DirectBaseTypeSpecification.cs" />
     <Compile Include="Kernel\ParameterSpecification.cs" />
     <Compile Include="Kernel\FieldSpecification.cs" />
+    <Compile Include="Dsl\IMatchComposer.cs" />
+    <Compile Include="Dsl\MatchComposer.cs" />
+    <Compile Include="Dsl\NullMatchComposer.cs" />
+    <Compile Include="Dsl\PostprocessComposer.cs" />
     <Compile Include="MapCreateManyToEnumerable.cs" />
     <Compile Include="Kernel\MultipleToEnumerableRelay.cs" />
     <Compile Include="Kernel\NoConstructorsSpecification.cs" />

--- a/Src/AutoFixture/Dsl/IMatchComposer.cs
+++ b/Src/AutoFixture/Dsl/IMatchComposer.cs
@@ -1,0 +1,21 @@
+﻿using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Dsl
+{
+    public interface IMatchComposer<T> : ISpecimenBuilder
+    {
+        IMatchComposer<T> Or { get; }
+
+        IMatchComposer<T> ByDirectBaseType();
+
+        IMatchComposer<T> ByInterfaces();
+
+        IMatchComposer<T> ByExactType();
+
+        IMatchComposer<T> ByParameterName(string name);
+
+        IMatchComposer<T> ByPropertyName(string name);
+
+        IMatchComposer<T> ByFieldName(string name);
+    }
+}

--- a/Src/AutoFixture/Dsl/MatchComposer.cs
+++ b/Src/AutoFixture/Dsl/MatchComposer.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Dsl
+{
+    public class MatchComposer<T> : IMatchComposer<T>
+    {
+        private readonly ISpecimenBuilder builder;
+        private readonly Type targetType;
+        private IRequestSpecification matcher;
+        private bool orExpression;
+
+        public MatchComposer(ISpecimenBuilder builder)
+        {
+            this.builder = builder;
+            this.targetType = typeof(T);
+            this.matcher = new FalseRequestSpecification();
+        }
+
+        public ISpecimenBuilder Builder
+        {
+            get { return builder; }
+        }
+
+        public IMatchComposer<T> Or
+        {
+            get
+            {
+                this.orExpression = true;
+                return this;
+            }
+        }
+
+        public IMatchComposer<T> ByDirectBaseType()
+        {
+            AddCondition(new DirectBaseTypeSpecification(this.targetType));
+            return this;
+        }
+
+        public IMatchComposer<T> ByInterfaces()
+        {
+            AddCondition(new ImplementedInterfaceSpecification(this.targetType));
+            return this;
+        }
+
+        public IMatchComposer<T> ByExactType()
+        {
+            AddCondition(
+                new OrRequestSpecification(
+                    new ExactTypeSpecification(this.targetType),
+                    new SeedRequestSpecification(this.targetType)));
+            return this;
+        }
+
+        public IMatchComposer<T> ByParameterName(string name)
+        {
+            AddCondition(new ParameterSpecification(this.targetType, name));
+            return this;
+        }
+
+        public IMatchComposer<T> ByPropertyName(string name)
+        {
+            AddCondition(new PropertySpecification(this.targetType, name));
+            return this;
+        }
+
+        public IMatchComposer<T> ByFieldName(string name)
+        {
+            AddCondition(new FieldSpecification(this.targetType, name));
+            return this;
+        }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            var filter = new FilteringSpecimenBuilder(this.builder, this.matcher);
+            return filter.Create(request, context);
+        }
+
+        private void AddCondition(IRequestSpecification condition)
+        {
+            this.matcher = this.orExpression
+                ? new OrRequestSpecification(this.matcher, condition)
+                : condition;
+        }
+    }
+}

--- a/Src/AutoFixture/Dsl/NullMatchComposer.cs
+++ b/Src/AutoFixture/Dsl/NullMatchComposer.cs
@@ -1,0 +1,64 @@
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Dsl
+{
+    public class NullMatchComposer<T> : IMatchComposer<T>
+    {
+        private readonly ISpecimenBuilder builder;
+
+        public NullMatchComposer()
+            : this(new CompositeSpecimenBuilder())
+        {
+        }
+
+        public NullMatchComposer(ISpecimenBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        public ISpecimenBuilder Builder
+        {
+            get { return builder; }
+        }
+
+        public IMatchComposer<T> Or
+        {
+            get { return this; }
+        }
+
+        public IMatchComposer<T> ByDirectBaseType()
+        {
+            return this;
+        }
+
+        public IMatchComposer<T> ByInterfaces()
+        {
+            return this;
+        }
+
+        public IMatchComposer<T> ByExactType()
+        {
+            return this;
+        }
+
+        public IMatchComposer<T> ByParameterName(string name)
+        {
+            return this;
+        }
+
+        public IMatchComposer<T> ByPropertyName(string name)
+        {
+            return this;
+        }
+
+        public IMatchComposer<T> ByFieldName(string name)
+        {
+            return this;
+        }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            return this.builder.Create(request, context);
+        }
+    }
+}

--- a/Src/AutoFixture/Dsl/PostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/PostprocessComposer.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Dsl
+{
+    public static class PostprocessComposer
+    {
+        public static IMatchComposer<T> Match<T>(
+            this IPostprocessComposer<T> composer)
+        {
+            var graph = composer as ISpecimenBuilderNode;
+
+            if (graph == null)
+            {
+                return new NullMatchComposer<T>();
+            }
+
+            var container = graph
+                .SelectNodes(n => n is FilteringSpecimenBuilder)
+                .Cast<FilteringSpecimenBuilder>()
+                .First();
+            return new MatchComposer<T>(container.Builder);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -115,6 +115,8 @@
     <Compile Include="Kernel\DirectBaseTypeSpecificationTest.cs" />
     <Compile Include="Kernel\ParameterSpecificationTest.cs" />
     <Compile Include="Kernel\FieldSpecificationTest.cs" />
+    <Compile Include="Dsl\MatchComposerTest.cs" />
+    <Compile Include="Dsl\NullMatchComposerTest.cs" />
     <Compile Include="MapCreateManyToEnumerableTests.cs" />
     <Compile Include="Kernel\MultipleToEnumerableRelayTests.cs" />
     <Compile Include="Kernel\NoConstructorsSpecificationTest.cs" />

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -108,5 +108,6 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
         internal Func<IPostprocessComposer<T>> OnWithAutoProperties { get; set; }
         internal Func<object, IPostprocessComposer<T>> OnWithout { get; set; }
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
+        internal Func<IMatchComposer<T>> OnMatch { get; set; }
     }
 }

--- a/Src/AutoFixtureUnitTest/Dsl/MatchComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/MatchComposerTest.cs
@@ -1,0 +1,345 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Dsl;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest.Dsl
+{
+    public class MatchComposerTest
+    {
+        [Fact]
+        public void SutIsMatchComposer()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new MatchComposer<object>(null);
+            // Verify outcome
+            Assert.IsAssignableFrom<IMatchComposer<object>>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void BuilderIsCorrect()
+        {
+            // Fixture setup
+            var expected = new DelegatingSpecimenBuilder();
+            var sut = new MatchComposer<object>(expected);
+            // Exercise system
+            ISpecimenBuilder actual = sut.Builder;
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithoutMatchersNeverDelegatesToTheBuilder()
+        {
+            // Fixture setup
+            var expected = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (request, context) => expected
+            };
+            var sut = new MatchComposer<object>(builder);
+            // Exercise system
+            var actual = sut.Create(typeof(object), new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.NotSame(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByDirectBaseTypeReturnsSpecimenForRequestsOfSameOfBaseType()
+        {
+            // Fixture setup
+            var request = typeof(AbstractType);
+            var specimen = new ConcreteType();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => specimen
+            };
+            var sut = new MatchComposer<ConcreteType>(builder).ByDirectBaseType();
+            // Exercise system
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(specimen, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByDirectBaseTypeReturnsNoSpecimenForRequestsOfIncompatibleTypes()
+        {
+            // Fixture setup
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => new ConcreteType()
+            };
+            var sut = new MatchComposer<ConcreteType>(builder).ByDirectBaseType();
+            // Exercise system
+            var otherTypeRequest = typeof(string);
+            var actual = sut.Create(otherTypeRequest, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(otherTypeRequest), actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByImplementedInterfacesReturnsSpecimenForRequestsOfImplementedInterface()
+        {
+            // Fixture setup
+            var request = typeof(IInterface);
+            var specimen = new NoopInterfaceImplementer();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => specimen
+            };
+            var sut = new MatchComposer<NoopInterfaceImplementer>(builder).ByInterfaces();
+            // Exercise system
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(specimen, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByImplementedInterfacesReturnsNoSpecimenForRequestsOfNotImplementedInterface()
+        {
+            // Fixture setup
+            var request = typeof(IDisposable);
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => new NoopInterfaceImplementer()
+            };
+            var sut = new MatchComposer<NoopInterfaceImplementer>(builder).ByInterfaces();
+            // Exercise system
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(request), actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByImplementedInterfacesReturnsNoSpecimenForRequestsOfNonInterfaces()
+        {
+            // Fixture setup
+            var request = typeof(string);
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => new object()
+            };
+            var sut = new MatchComposer<NoopInterfaceImplementer>(builder).ByInterfaces();
+            // Exercise system
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(request), actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByExactTypeReturnsSpecimenForRequestsOfSameType()
+        {
+            // Fixture setup
+            var request = typeof(ConcreteType);
+            var specimen = new ConcreteType();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => specimen
+            };
+            var sut = new MatchComposer<ConcreteType>(builder).ByExactType();
+            // Exercise system
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(specimen, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByExactTypeReturnsSpecimenForSeededRequestsOfSameType()
+        {
+            // Fixture setup
+            var request = new SeededRequest(typeof(ConcreteType), new object());
+            var specimen = new ConcreteType();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => specimen
+            };
+            var sut = new MatchComposer<ConcreteType>(builder).ByExactType();
+            // Exercise system
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(specimen, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByExactTypeReturnsNoSpecimenForRequestsOfOtherTypes()
+        {
+            // Fixture setup
+            var request = typeof(string);
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => new ConcreteType()
+            };
+            var sut = new MatchComposer<ConcreteType>(builder).ByExactType();
+            // Exercise system
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(request), actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByParameterNameReturnsSpecimenForRequestsOfParameterTypeWithMatchingName()
+        {
+            // Fixture setup
+            var expected = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expected
+            };
+            var sut = new MatchComposer<object>(builder).ByParameterName("parameter");
+            // Exercise system
+            var request = Parameter<object>("parameter");
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByParameterNameReturnsNoSpecimenForRequestsOfParameterTypeWithOtherName()
+        {
+            // Fixture setup
+            var expected = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expected
+            };
+            var sut = new MatchComposer<object>(builder).ByParameterName("someOtherName");
+            // Exercise system
+            var request = Parameter<object>("parameter");
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(request), actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByPropertyNameReturnsSpecimenForRequestsOfPropertyTypeWithMatchingName()
+        {
+            // Fixture setup
+            var expected = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expected
+            };
+            var sut = new MatchComposer<object>(builder).ByPropertyName("Property");
+            // Exercise system
+            var request = Property<object>("Property");
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByPropertyNameReturnsNoSpecimenForRequestsOfPropertyTypeWithOtherName()
+        {
+            // Fixture setup
+            var expected = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expected
+            };
+            var sut = new MatchComposer<object>(builder).ByPropertyName("someOtherName");
+            // Exercise system
+            var request = Property<object>("Property");
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(request), actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByFieldNameReturnsSpecimenForRequestsOfFieldTypeWithMatchingName()
+        {
+            // Fixture setup
+            var expected = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expected
+            };
+            var sut = new MatchComposer<object>(builder).ByFieldName("Field");
+            // Exercise system
+            var request = Field<object>("Field");
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByFieldNameReturnsNoSpecimenForRequestsOfFieldTypeWithOtherName()
+        {
+            // Fixture setup
+            var expected = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expected
+            };
+            var sut = new MatchComposer<object>(builder).ByFieldName("someOtherName");
+            // Exercise system
+            var request = Field<object>("Field");
+            var actual = sut.Create(request, new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(request), actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMatchingByAnyOfMultipleMemberNamesReturnsSpecimenForMatchingRequests()
+        {
+            // Fixture setup
+            var expected = new object();
+            var context = new DelegatingSpecimenContext();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => expected
+            };
+            var sut = new MatchComposer<object>(builder)
+                .ByParameterName("parameter")
+                .Or.ByPropertyName("Property")
+                .Or.ByFieldName("Field");
+            // Exercise system
+            // Verify outcome
+            Assert.Same(expected, sut.Create(Parameter<object>("parameter"), context));
+            Assert.Same(expected, sut.Create(Property<object>("Property"), context));
+            Assert.Same(expected, sut.Create(Field<object>("Field"), context));
+            // Teardown
+        }
+
+        private static ParameterInfo Parameter<T>(string parameterName)
+        {
+            return typeof(SingleParameterType<T>)
+                   .GetConstructor(new[] { typeof(T) })
+                   .GetParameters()
+                   .Single(p => p.Name == parameterName);
+        }
+
+        private static PropertyInfo Property<T>(string propertyName)
+        {
+            return typeof(PropertyHolder<T>)
+                   .GetProperty(propertyName);
+        }
+
+        private static FieldInfo Field<T>(string fieldName)
+        {
+            return typeof(FieldHolder<T>)
+                   .GetField(fieldName);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -687,5 +687,28 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
             // Teardown
         }
+
+        [Fact]
+        public void MatchReturnsAMatchComposer()
+        {
+            // Fixture setup
+            var sut = SpecimenBuilderNodeFactory.CreateComposer<ConcreteType>();
+            // Exercise system and verify outcome
+            Assert.IsType<MatchComposer<ConcreteType>>(sut.Match());
+            // Teardown
+        }
+
+        [Fact]
+        public void MatchReturnsAMatchComposerThatWrapsTheBuilderInTheSutsRootNode()
+        {
+            // Fixture setup
+            var sut = SpecimenBuilderNodeFactory.CreateComposer<ConcreteType>();
+            var expected = ((FilteringSpecimenBuilder)sut.Builder).Builder;
+            // Exercise system
+            var builder = ((MatchComposer<ConcreteType>)sut.Match()).Builder;
+            // Verify outcome
+            Assert.Same(expected, builder);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
@@ -235,5 +235,17 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             Assert.Same(sut, result);
             // Teardown
         }
+
+        [Fact]
+        public void MatchReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new NullComposer<object>();
+            // Exercise system
+            var result = sut.Match();
+            // Verify outcome
+            Assert.IsAssignableFrom<NullMatchComposer<object>>(result);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/Dsl/NullMatchComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NullMatchComposerTest.cs
@@ -1,0 +1,134 @@
+﻿using Ploeh.AutoFixture.Dsl;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest.Dsl
+{
+    public class NullMatchComposerTest
+    {
+        [Fact]
+        public void SutIsMatchComposer()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new NullMatchComposer<object>();
+            // Verify outcome
+            Assert.IsAssignableFrom<IMatchComposer<object>>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithSpecimenBuilderCreatesUsingThatSpecimenBuilder()
+        {
+            // Fixture setup
+            var specimen = new object();
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (o, c) => specimen
+            };
+            var sut = new NullMatchComposer<object>(builder);
+            // Exercise system
+            var result = sut.Create(new object(), new DelegatingSpecimenContext());
+            // Verify outcome
+            Assert.Same(specimen, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithDefaultConstructorUsesEmptyCompositeSpecimenBuilder()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            var result = sut.Builder;
+            // Verify outcome
+            var composite = Assert.IsAssignableFrom<CompositeSpecimenBuilder>(result);
+            Assert.Empty(composite.Builders);
+            // Teardown
+        }
+
+        [Fact]
+        public void OrReturnsTheMatchComposerItself()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            // Verify outcome
+            Assert.Same(sut, sut.Or);
+            // Teardown
+        }
+
+        [Fact]
+        public void ByDirectBaseTypeReturnsTheMatchComposerItself()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            var result = sut.ByDirectBaseType();
+            // Verify outcome
+            Assert.Same(sut, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void ByInterfacesReturnsTheMatchComposerItself()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            var result = sut.ByInterfaces();
+            // Verify outcome
+            Assert.Same(sut, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void ByExactTypeReturnsTheMatchComposerItself()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            var result = sut.ByExactType();
+            // Verify outcome
+            Assert.Same(sut, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void ByParameterNameReturnsTheMatchComposerItself()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            var result = sut.ByParameterName("parameter");
+            // Verify outcome
+            Assert.Same(sut, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void ByPropertyNameReturnsTheMatchComposerItself()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            var result = sut.ByPropertyName("Property");
+            // Verify outcome
+            Assert.Same(sut, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void ByFieldNameReturnsTheMatchComposerItself()
+        {
+            // Fixture setup
+            var sut = new NullMatchComposer<object>();
+            // Exercise system
+            var result = sut.ByFieldName("Field");
+            // Verify outcome
+            Assert.Same(sut, result);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
@@ -666,6 +666,146 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
+        [Fact]
+        public void CustomizeFactoryWithMatchingByDirectBaseType()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = new ConcreteType();
+            fixture.Customize<ConcreteType>(c => c
+                   .FromFactory(() => expected)
+                   .Match().ByDirectBaseType());
+            // Exercise system
+            var actual = fixture.Create<AbstractType>();
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CustomizeFactoryWithMatchingByExactType()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = new ConcreteType();
+            fixture.Customize<ConcreteType>(c => c
+                   .FromFactory(() => expected)
+                   .Match().ByExactType());
+            // Exercise system
+            var actual = fixture.Create<ConcreteType>();
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CustomizeFactoryWithMatchingByDirectBaseTypeOrExactType()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = new ConcreteType();
+            fixture.Customize<ConcreteType>(c => c
+                .FromFactory(() => expected)
+                .Match().ByDirectBaseType().Or.ByExactType());
+            // Exercise system
+            // Verify outcome
+            Assert.Same(expected, fixture.Create<AbstractType>());
+            Assert.Same(expected, fixture.Create<ConcreteType>());
+            // Teardown
+        }
+
+        [Fact]
+        public void CustomizeFactoryWithMatchingByInterfaceOrExactType()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = new NoopInterfaceImplementer();
+            fixture.Customize<NoopInterfaceImplementer>(c => c
+                .FromFactory(() => expected)
+                .Match().ByInterfaces().Or.ByExactType());
+            // Exercise system
+            // Verify outcome
+            Assert.Same(expected, fixture.Create<IInterface>());
+            Assert.Same(expected, fixture.Create<NoopInterfaceImplementer>());
+            // Teardown
+        }
+
+        [Fact]
+        public void CustomizeFactoryWithMatchingByParameterName()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = new object();
+            fixture.Customize<ConcreteType>(c => c
+                   .FromFactory(new MethodInvoker(new GreedyConstructorQuery()))
+                   .OmitAutoProperties());
+            fixture.Customize<object>(c => c
+                   .FromFactory(() => expected)
+                   .Match().ByParameterName("obj1"));
+            // Exercise system
+            var actual = fixture.Create<ConcreteType>().Property1;
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CustomizeFactoryWithMatchingByPropertyName()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = new object();
+            fixture.Customize<object>(c => c
+                   .FromFactory(() => expected)
+                   .Match().ByPropertyName("Property"));
+            // Exercise system
+            var actual = fixture.Create<PropertyHolder<object>>().Property;
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CustomizeFactoryWithMatchingByFieldName()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = new object();
+            fixture.Customize<object>(c => c
+                   .FromFactory(() => expected)
+                   .Match().ByFieldName("Field"));
+            // Exercise system
+            var actual = fixture.Create<FieldHolder<object>>().Field;
+            // Verify outcome
+            Assert.Same(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CustomizeFactoryWithMatchingByMultipleMemberNames()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expected = "frozen";
+            fixture.Customize<ConcreteType>(c => c
+                   .FromFactory(new MethodInvoker(new GreedyConstructorQuery()))
+                   .Without(s => s.Property1)
+                   .Without(s => s.Property2));
+            fixture.Customize<object>(c => c
+                   .FromFactory(() => expected)
+                   .Match()
+                   .ByParameterName("obj1")
+                   .Or.ByParameterName("obj2")
+                   .Or.ByPropertyName("Property3"));
+            // Exercise system
+            var actual = fixture.Create<ConcreteType>();
+            // Verify outcome
+            Assert.Same(expected, actual.Property1);
+            Assert.Same(expected, actual.Property2);
+            Assert.Same(expected, actual.Property3);
+            // Teardown
+        }
+
         private static SpecimenContext CreateContainer()
         {
             var builder = Scenario.CreateAutoPropertyBuilder();


### PR DESCRIPTION
Built on top of the `IRequestSpecification` abstraction, this customization API makes it possible to associate specimen builders with different kinds of requests.

### Usage

Here's an example of how it can be used:

```csharp
fixture.Customize<Foo>(c => c
    .Without(s => s.AProperty)
    .Match()
        .ByBaseType()
        .Or.ByInterfaces()
        .Or.ByProperty("TheFoo"));
```

This effectually means:

> Create instances of `Foo` by omitting the `AProperty` property for every request for a type that is either a **direct base** of `Foo`, one of its **implemented interfaces** or for a **property named** `"TheFoo"` whose type is compatible (i.e. contravariant) to `Foo`.

A couple of things to point out:

- `Match<T>()` is implemented as an extension method to `IPostprocessComposer<T>`.
- The matching behavior is independent of the specimen builder used to satisfy the requests.

### Background

The idea behind the Matching DSL is to bring a simple and fairly common scenario like matching anonymous values based on different criteria up to a "user friendly" high level API, while in the past it used to require interaction with the lower level constructs.

Here's a concrete example taken from @ploeh's [post about building conventions in AutoFixture](http://blog.ploeh.dk/2010/10/19/Convention-basedCustomizationswithAutoFixture/).

In order to assign a valid currency code to all string parameters named "*currencyCode*", one would have to implement a custom `ISpecimenBuilder` and check for the right kind of requests:

```csharp
public class CurrencyCodeSpecimenBuilder : ISpecimenBuilder
{
    public object Create(object request, ISpecimenContext context)
    {
        var pi = request as ParameterInfo;

        if (pi == null)
        {
            return new NoSpecimen(request);
        }

        if (pi.ParameterType != typeof(string)
            || pi.Name != "currencyCode")
        {
            return new NoSpecimen(request);
        }
 
        return "DKK";
    }
}
```

Even if we're all very familiar with the concepts mentioned in that class (*specimen*, *request*, *specimen context*, *no specimen*) I'm pretty sure that they're completely foreign to most people who are approaching AutoFixture for the first time. And rightly so, since they belong to the realm of lower level abstractions.
In addition, this approach also requires you to deal with Reflection types directly.

Compare that with a customization that uses the Matching DSL:

```csharp
fixture.Customize<string>(c => c
       .FromFactory(() => "DKK")
       .Match().ByParameter("currencyCode"));
```

I can't count how many times I've wished I could simply write these kinds of customizations without having to first make custom builders, request specifications and so on.

### Follow-ups

The XML documentation is currently missing and I'll add it once the feature is finalized.

I look forward to your comments.