### PR TITLE
Supports returning abstract types setup calls to be overriden.

### DIFF
--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -190,9 +190,10 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
                     var value = new Lazy<T>(() => (T)Context.Resolve(typeof(T)));
                     object[] arguments = callInfo.Args();
                     ReturnsFixedValue(methodInfo, callInfo, value);
+                    var returnValue = value.Value;
                     InvokeMethod(methodInfo, arguments);
 
-                    return value.Value;
+                    return returnValue;
                 });
             }
 

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
@@ -294,6 +294,19 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
         }
 
         [Fact]
+        public void SetupCallsReturningAbstractTypesAreOverridable()
+        {
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var substitute = fixture.Create<IInterfaceWithCircularDependency>();
+            var expected = fixture.Create<IInterfaceWithCircularDependency>();
+            substitute.Component.Returns(expected);
+
+            var result = substitute.Component;
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         public void VoidMethodsAreIgnored()
         {
             var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());


### PR DESCRIPTION
This PR fixes #346.