### PR TITLE
Changed AutoConfiguredNSubstituteCustomization to return finite sequences for abstract types implementing IEnumerable<T>

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
     <Compile Include="Kernel\CompositeSpecimenCommand.cs" />
+    <Compile Include="Kernel\EnumeratorRelay.cs" />
     <Compile Include="Kernel\GenericMethod.cs" />
     <Compile Include="Kernel\IMethodFactory.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingMethodFactory.cs" />

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Relays a request for <see cref="IEnumerator{T}" /> to 
+    /// <see cref="IEnumerable{T}"/> and converts the result to an enumerator
+    /// of a sequence of the requested type.
+    /// </summary>
+    public class EnumeratorRelay : ISpecimenBuilder
+    {
+        /// <summary>
+        /// Creates a new enumerator based on a request.
+        /// </summary>
+        /// <param name="request">
+        /// The request that describes what to create.
+        /// </param>
+        /// <param name="context">
+        /// A context that can be used to create other specimens.
+        /// </param>
+        /// <returns>
+        /// An enumerator of the requested type if possible; otherwise a 
+        /// <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// If <paramref name="request"/> is a request for an 
+        /// <see cref="IEnumerator{T}"/> and <paramref name="context"/> can
+        /// satisfy an <see cref="IEnumerable{T}"/> request for the
+        /// element type, the return value is an enumerator of the
+        /// requested type. If not, the return value is a
+        /// <see cref="NoSpecimen"/> instance.
+        /// </para>
+        /// </remarks>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context");
+
+            var t = request as Type;
+            if (t == null)
+                return new NoSpecimen(request);
+
+            var typeArguments = t.GetGenericArguments();
+            if (typeArguments.Length != 1 ||
+                typeof (IEnumerator<>) != t.GetGenericTypeDefinition())
+                return new NoSpecimen(request);
+
+            var specimenBuilder = (ISpecimenBuilder) Activator.CreateInstance(
+                typeof (EnumeratorRelay<>).MakeGenericType(typeArguments));
+            return specimenBuilder.Create(request, context);
+        }
+    }
+
+    internal class EnumeratorRelay<T> : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context");
+
+            var t = request as Type;
+            if (t == null)
+                return new NoSpecimen(request);
+
+            if (t != typeof(IEnumerator<T>))
+                return new NoSpecimen(request);
+
+            var enumerable =
+                context.Resolve(typeof (IEnumerable<T>)) as IEnumerable<T>;
+
+            if (enumerable == null)
+                return new NoSpecimen(request);
+
+            return enumerable.GetEnumerator();
+        }
+    }
+}
+

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -94,6 +94,7 @@
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />
+    <Compile Include="Kernel\EnumeratorRelayTest.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingMethodFactoryTests.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingStaticMethodFactoryTests.cs" />
     <Compile Include="Kernel\CompositeSpecimenCommandTest.cs" />

--- a/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest.Kernel
+{
+    public class EnumeratorRelayTest
+    {
+        [Fact]
+        public void SutIsISpecimenBuilder()
+        {
+            var sut = new EnumeratorRelay();
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            var sut = new EnumeratorRelay();
+            var dummyRequest = new object();
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(dummyRequest, null));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(Version))]
+        public void CreateWithNoEnumeratorRequestReturnsCorrectResult(
+            object request)
+        {
+            var sut = new EnumeratorRelay();
+            var dummyContext = new DelegatingSpecimenContext();
+
+            var result = sut.Create(request, dummyContext);
+
+            var expectedResult = new NoSpecimen(request);
+            Assert.Equal(expectedResult, result);
+        }
+
+
+        [Theory]
+        [InlineData(typeof (IEnumerator<object>), typeof (object))]
+        [InlineData(typeof (IEnumerator<string>), typeof (string))]
+        [InlineData(typeof (IEnumerator<int>), typeof (int))]
+        [InlineData(typeof (IEnumerator<Version>), typeof (Version))]
+        public void CreateWithEnumeratorRequestReturnsCorrectResult(
+            Type request,
+            Type itemType)
+        {
+            var expectedRequest =
+                typeof (IEnumerable<>).MakeGenericType(itemType);
+            var enumerable = (IList) Activator.CreateInstance(
+                typeof (List<>).MakeGenericType(itemType));
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r => expectedRequest.Equals(r)
+                    ? (object)enumerable
+                    : new NoSpecimen(r)
+            };
+            var sut = new EnumeratorRelay();
+
+            var result = sut.Create(request, context);
+
+            var expectedResult = enumerable.GetEnumerator();
+            Assert.Equal(expectedResult, result);
+        }
+        
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(object[]))]
+        public void CreateReturnsCorrectResultWhenContextReturnsNonEnumerableResult(
+            object response)
+        {
+            var request = typeof(IEnumerator<object>);
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r => response
+            };
+            var sut = new EnumeratorRelay();
+
+            var result = sut.Create(request, context);
+
+            var expectedResult = new NoSpecimen(request);
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
@@ -49,6 +49,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             if (fixture == null)
                 throw new ArgumentNullException("fixture");
 
+            fixture.ResidueCollectors.Add(new EnumeratorRelay());
             fixture.ResidueCollectors.Add(
                 new Postprocessor(
                     Builder,

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
@@ -415,5 +415,22 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Teardown
         }
 
+        [Fact]
+        public void InterfacesImplementingIEnumerableReturnFiniteSequence()
+        {
+            var fixture = new Fixture();
+            fixture.Customize(new AutoConfiguredNSubstituteCustomization());
+            var repeatCount = fixture.Create<int>();
+            fixture.RepeatCount = repeatCount;
+            var sut = fixture.Create<IMyList<string>>();
+
+            var result = sut.Take(repeatCount + 1).Count();
+
+            Assert.Equal(repeatCount, result);
+        }
+
+        public interface IMyList<out T> : IEnumerable<T>
+        {
+        }
     }
 }

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
@@ -51,8 +51,8 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Exercise system
             sut.Customize(fixture);
             // Verify outcome
-            var customization = Assert.Single(residueCollectors);
-            var postprocessor = Assert.IsAssignableFrom<Postprocessor>(customization);
+            var postprocessor =
+                Assert.Single(residueCollectors.OfType<Postprocessor>());
             var nsubstituteBuilder = Assert.IsAssignableFrom<NSubstituteBuilder>(postprocessor.Builder);
             var methodInvoker = Assert.IsAssignableFrom<MethodInvoker>(nsubstituteBuilder.Builder);
             Assert.IsAssignableFrom<AbstractTypeSpecification>(nsubstituteBuilder.SubstitutionSpecification);
@@ -74,9 +74,37 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
 
             sut.Customize(fixture);
 
-            var customization = Assert.Single(residueCollectors);
-            var postprocessor = Assert.IsAssignableFrom<Postprocessor>(customization);
+            var postprocessor =
+                Assert.Single(residueCollectors.OfType<Postprocessor>());
             Assert.Equal(builder, postprocessor.Builder);
+        }
+
+        [Fact]
+        public void CustomizeAddsEnumeratorRelayToResidueCollectors()
+        {
+            var builder = Substitute.For<ISpecimenBuilder>();
+            var residueCollectors = new List<ISpecimenBuilder>();
+            var fixture = Substitute.For<IFixture>();
+            fixture.ResidueCollectors.Returns(residueCollectors);
+            var sut = new AutoConfiguredNSubstituteCustomization(builder);
+
+            sut.Customize(fixture);
+
+            Assert.Single(residueCollectors.OfType<EnumeratorRelay>());
+        }
+
+        [Fact]
+        public void CustomizeAddsEnumeratorRelayInCorrectOrder()
+        {
+            var builder = Substitute.For<ISpecimenBuilder>();
+            var residueCollectors = new List<ISpecimenBuilder>();
+            var fixture = Substitute.For<IFixture>();
+            fixture.ResidueCollectors.Returns(residueCollectors);
+            var sut = new AutoConfiguredNSubstituteCustomization(builder);
+
+            sut.Customize(fixture);
+
+            Assert.IsAssignableFrom<EnumeratorRelay>(residueCollectors.First());
         }
     }
 }


### PR DESCRIPTION
This PR fixes #350.

It sets up auto-configured NSubstitute mocks that returns ``IEnumerator<T>`` and any abstract type implementing ``IEnumerable<T>`` to return a finite sequence.

Note that for interfaces like this:

```c#
public interface IMyList<T> : IEnumerable<T>
{
    int Count { get; }
}
```

``list.Count`` will not be equal to ``list.Count()``, since the former will be setup to return from AutoFixture while the latter will be processed by LINQ and will return the count of the ``GetEnumerator()`` items.