### PR TITLE
Adding EqualityAssertion.

### DIFF
--- a/Src/Idioms/EqualityAssertion.cs
+++ b/Src/Idioms/EqualityAssertion.cs
@@ -1,0 +1,364 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Idioms
+{
+	/// <summary>
+	/// Represent an assertion which verifies that an equality method returns the correct value.
+	/// </summary>
+	public class EqualityAssertion : IdiomaticAssertion
+	{
+		private readonly Func<object, object, bool> comparer;
+		private IFixture fixture;
+
+		/// <summary>
+		/// Creates a new instance of EqualityAssertion which verified the Object.Equals method
+		/// </summary>
+		/// <param name="fixture">A composer which can create instances required to implement the idiomatic unit test.</param>
+		public EqualityAssertion(IFixture fixture)
+			: this(fixture, (x, y) => x.Equals(y))
+		{
+		}
+
+		/// <summary>
+		/// Creates a new instance of EqualityAssertion which verified the given equality comparer
+		/// </summary>
+		/// <param name="fixture">A composer which can create instances required to implement the idiomatic unit test.</param>
+		/// <param name="comparer">The equality comparer</param>
+		public EqualityAssertion(IFixture fixture, Func<object, object, bool> comparer)
+		{
+			if (fixture == null) throw new ArgumentNullException("fixture");
+			if (comparer == null) throw new ArgumentNullException("comparer");
+			this.fixture = fixture;
+			this.comparer = comparer;
+		}
+
+		/// <summary>
+		/// Gets the fixture supplied by the constructor
+		/// </summary>
+		public IFixture Fixture
+		{
+			get { return this.fixture; }
+		}
+
+		/// <summary>
+		/// Gets the comparer supplied by the constructor
+		/// </summary>
+		public Func<object, object, bool> Comparer
+		{
+			get { return this.comparer; }
+		}
+
+		/// <summary>
+		/// Verifies that the equality comparer returns the correct value when comparing
+		/// 2 objects created from the given <see cref="ConstructorInfo"/>.
+		/// The comparer should return
+		/// - True when the constructor is invoked with the same arguments
+		/// - False when the constructor is invoked with different arguments
+		/// </summary>
+		/// <param name="constructorInfo">The constructor to verify</param>
+		public override void Verify(ConstructorInfo constructorInfo)
+		{
+			if (constructorInfo == null)
+			{
+				throw new ArgumentNullException("constructorInfo");
+			}
+			var parameters = constructorInfo.GetParameters();
+			var customizations = GetFreezingCustomizations(parameters);
+			var constructorInfoSpecimenBuilder =
+				new Postprocessor(
+					new ConstructorInfoSpecimenBuilder(),
+					new AutoPropertiesCommand()
+					);
+			using (new FixtureCustomizationsDisposable(this.fixture))
+			{
+				this.fixture.Customizations.Add(constructorInfoSpecimenBuilder);
+				this.fixture.Customize(
+					new CompositeCustomization(
+						GetFreezingCustomizations(constructorInfo.ReflectedType)));
+				VerifyEqualReturnsTrue(constructorInfo, customizations);
+				for (var i = 0; i < parameters.Length; ++i)
+				{
+					VerifyEqualReturnsFalse(constructorInfo, parameters, customizations, i);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Verifies that the equality comparer returns the correct value when comparing
+		/// 2 objects where the given property has a different value
+		/// </summary>
+		/// <param name="propertyInfo">The PropertyInfo to verify</param>
+		public override void Verify(PropertyInfo propertyInfo)
+		{
+			if (propertyInfo == null)
+			{
+				throw new ArgumentNullException("propertyInfo");
+			}
+			if (!propertyInfo.CanWrite)
+			{
+				return;
+			}
+			var propertyInfos = GetWriteablePropertyInfo(propertyInfo.ReflectedType)
+											.Where(pi => pi != propertyInfo);
+			var fieldInfos = GetWriteableFieldsInfo(propertyInfo.ReflectedType);
+
+			VerifyMember(propertyInfo, propertyInfos, fieldInfos, propertyInfo.ReflectedType, "property");
+		}
+
+		/// <summary>
+		/// Verifies that the equality comparer returns the correct value when comparing
+		/// 2 objects where the given field has a different value
+		/// </summary>
+		/// <param name="fieldInfo">The FieldInfo to verify</param>
+		public override void Verify(FieldInfo fieldInfo)
+		{
+			if (fieldInfo == null)
+			{
+				throw new ArgumentNullException("fieldInfo");
+			}
+			if (fieldInfo.IsInitOnly)
+			{
+				return;
+			}
+			var propertyInfos = GetWriteablePropertyInfo(fieldInfo.ReflectedType);
+			var fieldInfos = GetWriteableFieldsInfo(fieldInfo.ReflectedType)
+									.Where(fi => fi != fieldInfo);
+
+			VerifyMember(fieldInfo, propertyInfos, fieldInfos, fieldInfo.ReflectedType, "field");
+		}
+
+		private static PropertyInfo[] GetWriteablePropertyInfo(Type type)
+		{
+			return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+						.Where(pi => pi.CanWrite)
+						.ToArray();
+		}
+
+		private static FieldInfo[] GetWriteableFieldsInfo(Type type)
+		{
+			return type.GetFields(BindingFlags.Public | BindingFlags.Instance)
+				.Where(fi => !fi.IsInitOnly)
+				.ToArray();
+		}
+
+		private void VerifyEqualReturnsFalse(ConstructorInfo constructorInfo, ParameterInfo[] parameters, IEnumerable<ICustomization> customizations, int i)
+		{
+			using (new FixtureCustomizationsDisposable(this.fixture))
+			{
+				this.fixture.Customize(new CompositeCustomization(new IndexedReplacement<ICustomization>(i, customizations).Expand(new EmptyCustomization())));
+				var actual = CompareSpecimens(constructorInfo);
+				if (actual)
+				{
+					throw new EqualsOverrideException(
+						string.Format(CultureInfo.CurrentCulture,
+						"Equality is not properly implemented. Creating 2 instances of '{0}' with "+ 
+						"the constructor '{1}', with the same values except '{2}' returned true " +
+						"when applying the equality comparer, but false was expected.",
+						constructorInfo.ReflectedType.Name,
+						string.Join(",", parameters.Select(p => p.ParameterType.Name + " " + p.Name)),
+						parameters[i].Name));
+				}
+			}
+		}
+
+		private void VerifyEqualReturnsTrue(ConstructorInfo constructorInfo, IEnumerable<ICustomization> customizations)
+		{
+			using (new FixtureCustomizationsDisposable(this.fixture))
+			{
+				this.fixture.Customize(new CompositeCustomization(customizations));
+				var actual = CompareSpecimens(constructorInfo);
+				if (!actual)
+				{
+					throw new EqualsOverrideException(
+						string.Format(CultureInfo.CurrentCulture,
+						"Equality is not properly implemented. Two same instances of {0} were "+ 
+						"compared but the equality method returned false.",
+						constructorInfo.ReflectedType));
+				}
+			}
+		}
+
+		private void VerifyMember(
+			MemberInfo memberInfo, 
+			IEnumerable<PropertyInfo> propertyInfos,
+			IEnumerable<FieldInfo> fieldInfos, 
+			Type type, 
+			string memberType)
+		{
+			var constructor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance).First();
+			var parameters = constructor.GetParameters();
+			var customizations = GetFreezingCustomizations(parameters)
+				.Concat(GetPropertyInfoFreezingCustomizations(propertyInfos))
+				.Concat(GetFieldInfoFreezingCustomizations(fieldInfos));
+			var constructorInfoSpecimenBuilder =
+				new Postprocessor(
+					new ConstructorInfoSpecimenBuilder(),
+					new AutoPropertiesCommand()
+					);
+			using (new FixtureCustomizationsDisposable(this.fixture))
+			{
+				fixture.Customizations.Add(constructorInfoSpecimenBuilder);
+				fixture.Customize(new CompositeCustomization(customizations));
+				var actual = CompareSpecimens(constructor);
+				if (actual)
+				{
+					throw new EqualsOverrideException(
+						string.Format(CultureInfo.CurrentCulture,
+						"Equality is not properly implemented. Creating 2 instances of '{0}' " +
+						"with 2 different values in the {1} '{2}' returned true when " +
+						"applying the equality comparer, but false was expected.",
+						type.Name,
+						memberType,
+						memberInfo.Name));
+				}
+			}
+		}
+
+		private bool CompareSpecimens(object request)
+		{
+			var specimen = new Tuple<object, object>(
+				this.fixture.Create(request, new SpecimenContext(this.fixture)),
+				this.fixture.Create(request, new SpecimenContext(this.fixture))
+				);
+			return comparer(specimen.Item1, specimen.Item2);
+		}
+
+		private static ICustomization[] GetFreezingCustomizations(IEnumerable<ParameterInfo> parameters)
+		{
+			return parameters.Select(p =>
+				new FreezeOnMatchCustomization(
+					p.ParameterType,
+					new EqualsRequestSpecification(p)
+					))
+					.ToArray();
+		}
+
+		private static ICustomization[] GetFreezingCustomizations(Type type)
+		{
+			var bindingFlag = BindingFlags.Public | BindingFlags.Instance;
+			return GetPropertyInfoFreezingCustomizations(type.GetProperties(bindingFlag))
+					   .Concat(GetFieldInfoFreezingCustomizations(type.GetFields(bindingFlag)))
+					   .ToArray();
+		}
+
+		private static ICustomization[] GetPropertyInfoFreezingCustomizations(IEnumerable<PropertyInfo> propertyInfos)
+		{
+			return propertyInfos.Select(pi => new FreezeOnMatchCustomization(
+												pi.PropertyType,
+												new EqualsRequestSpecification(pi))
+										)
+										.ToArray();
+		}
+
+		private static ICustomization[] GetFieldInfoFreezingCustomizations(IEnumerable<FieldInfo> fieldInfos)
+		{
+			return fieldInfos.Select(fi => new FreezeOnMatchCustomization(
+												fi.FieldType,
+												new EqualsRequestSpecification(fi))
+												)
+										.ToArray();
+		}
+
+		/// <summary>
+		/// Specification which is statisfied when the request equal the request given in the constructor
+		/// </summary>
+		private class EqualsRequestSpecification : IRequestSpecification
+		{
+			private object frozenRequest;
+
+			/// <summary>
+			/// Creates a new instance of EqualsRequestSpecification
+			/// </summary>
+			/// <param name="frozenRequest">The request to match</param>
+			public EqualsRequestSpecification(object frozenRequest)
+			{
+				if (frozenRequest == null)
+				{
+					throw new ArgumentNullException("frozenRequest");
+				}
+				this.frozenRequest = frozenRequest;
+			}
+
+			public bool IsSatisfiedBy(object request)
+			{
+				if (request == null)
+				{
+					throw new ArgumentNullException("request");
+				}
+				return request.Equals(this.frozenRequest);
+			}
+		}
+
+		/// <summary>
+		/// When disposed, remove all customizations that were added to the fixture 
+		/// after this class is instanciated
+		/// </summary>
+		private class FixtureCustomizationsDisposable : IDisposable
+		{
+			private readonly IFixture fixture;
+			private List<ISpecimenBuilder> customizations;
+
+			public FixtureCustomizationsDisposable(IFixture fixture)
+			{
+				if (fixture == null) throw new ArgumentNullException("fixture");
+				this.fixture = fixture;
+				this.customizations = fixture.Customizations.ToList();
+			}
+
+			public void Dispose()
+			{
+				if (this.customizations == null)
+				{
+					return;
+				}
+				var customizationsToRemove = Interlocked.Exchange(ref this.customizations, null);
+				foreach (var customization in fixture.Customizations.Except(customizationsToRemove))
+				{
+					fixture.Customizations.Remove(customization);
+				}
+			}
+		}
+
+		/// <summary>
+		/// An empty customization which does nothing
+		/// </summary>
+		private class EmptyCustomization : ICustomization
+		{
+			public void Customize(IFixture fixture)
+			{
+			}
+		}
+
+		/// <summary>
+		/// Creates a value based on a ConstructorInfo
+		/// </summary>
+		private class ConstructorInfoSpecimenBuilder : ISpecimenBuilder
+		{
+			/// <summary>
+			/// Creates a value when the given request is an instance of <see cref="ConstructorInfo" />
+			/// </summary>
+			/// <param name="request">The request object.</param>
+			/// <param name="context">The context used to resolve requests.</param>
+			/// <returns>An instance of the type which the ConstructorInfo belongs to.</returns>
+			public object Create(object request, ISpecimenContext context)
+			{
+				var constructorInfo = request as ConstructorInfo;
+				if (constructorInfo == null)
+				{
+					return new NoSpecimen(request);
+				}
+				var args = constructorInfo.GetParameters()
+										  .Select(p => context.Resolve(p))
+										  .ToArray();
+				return constructorInfo.Invoke(args);
+			}
+		}
+	}
+}

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -88,6 +88,7 @@
     <Compile Include="CompositeIdiomaticAssertion.cs" />
     <Compile Include="CopyAndUpdateAssertion.cs" />
     <Compile Include="CopyAndUpdateException.cs" />
+    <Compile Include="EqualityAssertion.cs" />
     <Compile Include="EqualsOverrideException.cs" />
     <Compile Include="CompositeBehaviorExpectation.cs" />
     <Compile Include="EmptyGuidBehaviorExpectation.cs" />

--- a/Src/IdiomsUnitTest/EqualityAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityAssertionTest.cs
@@ -1,0 +1,503 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Ploeh.AutoFixture.Idioms;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixture.IdiomsUnitTest
+{
+	public class EqualityAssertionTest
+	{
+		[Fact]
+		public void SutIsIdiomaticAssertion()
+		{
+			// Fixture setup
+			var dummyComposer = new Fixture();
+			// Exercise system
+			var sut = new EqualityAssertion(dummyComposer);
+			// Verify outcome
+			Assert.IsAssignableFrom<IdiomaticAssertion>(sut);
+			// Teardown
+		}
+
+		[Fact]
+		public void ComposerIsCorrect()
+		{
+			// Fixture setup
+			var expectedComposer = new Fixture();
+			var sut = new EqualityAssertion(expectedComposer);
+			// Exercise system
+			var result = sut.Fixture;
+			// Verify outcome
+			Assert.Equal(expectedComposer, result);
+			// Teardown
+		}
+
+		[Fact]
+		public void ComparerIsCorrect()
+		{
+			// Fixture setup
+			Func<object, object, bool> expectedComparer = (x, y) => true;
+			var sut = new EqualityAssertion(new Fixture(), expectedComparer);
+			// Exercise system
+			var result = sut.Comparer;
+			// Verify outcome
+			Assert.Equal(expectedComparer, result);
+			// Teardown
+		}
+
+		[Fact]
+		public void ConstructWithNullComposerThrows()
+		{
+			// Fixture setup
+			Func<object, object, bool> dummyComparer = (x, y) => true;
+			// Exercise system and verify outcome
+			Assert.Throws<ArgumentNullException>(() => new EqualityAssertion(null));
+			// Teardown
+		}
+
+		[Fact]
+		public void ConstructWithNullComparerThrows()
+		{
+			// Fixture setup
+			var dummyComposer = new Fixture();
+			// Exercise system and verify outcome
+			Assert.Throws<ArgumentNullException>(() => new EqualityAssertion(dummyComposer, null));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyNullConstructorInfoThrows()
+		{
+			// Fixture setup
+			var dummyComposer = new Fixture();
+			var sut = new EqualityAssertion(dummyComposer);
+			// Exercise system and verify outcome
+			Assert.Throws<ArgumentNullException>(() => sut.Verify((ConstructorInfo)null));
+			// Teardown
+		}
+
+		[Theory,
+		InlineData(true),
+		InlineData(false)]
+		public void DefaultComparerShouldCallEquals(bool expected)
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			var comparer = sut.Comparer;
+			// Exercise system
+			var result = comparer(new EqualityResponder(expected), new object());
+			// Verify outcome
+			Assert.Equal(expected, result);
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyConstructorInfoWhenEqualsIsProperlyImplementedDoesNotThrow()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			var constructor = typeof(EqualProperlyImplementedTestClass).GetConstructors().First();
+			// Exercise system and verify outcome
+			Assert.DoesNotThrow(() => sut.Verify(constructor));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyConstructorInfoWhenEqualsIsNotProperlyImplementedThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			var constructor = typeof(EqualNotProperlyImplementedTestClass).GetConstructors().First();
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(constructor));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyConstructorInfoWhenEqualsReturnsFalseThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			var constructor = typeof(EqualReturnsFalse).GetConstructors().First();
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(constructor));
+			// Teardown
+		}
+
+
+		[Fact]
+		public void VerifyConstructorInfoWhenEqualsReturnsTrueThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			var constructor = typeof(EqualReturnsTrue).GetConstructors().First();
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(constructor));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyConstructorInfoWhenHavingEnumerableDoesNotThrow()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			var constructor = typeof(EqualProperlyImplementedWithArray).GetConstructors().First();
+			// Exercise system and verify outcome
+			Assert.DoesNotThrow(() => sut.Verify(constructor));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyConstructorInfoWhenHavingEnumerableThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			var constructor = typeof(EqualNotProperlyImplementedWithArray).GetConstructors().First();
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(constructor));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyNullPropertyInfoThrows()
+		{
+			// Fixture setup
+			var dummyComposer = new Fixture();
+			var sut = new EqualityAssertion(dummyComposer);
+			// Exercise system and verify outcome
+			Assert.Throws<ArgumentNullException>(() => sut.Verify((PropertyInfo)null));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyPropertyInfoWhenEqualsIsProperlyImplementedDoesNotThrow()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.DoesNotThrow(() => sut.Verify(typeof(EqualProperlyImplementedTestClass).GetProperties()));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyPropertyInfoWhenEqualsIsNotProperlyImplementedThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(typeof(EqualNotProperlyImplementedTestClass).GetProperties()));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyPropertyInfoWhenEqualsReturnsFalseDoesNotThrow()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.DoesNotThrow(() => sut.Verify(typeof(EqualReturnsFalse).GetProperties()));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyPropertyInfoWhenEqualsReturnsTrueThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(typeof(EqualReturnsTrue).GetProperties()));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyNullFieldInfoThrows()
+		{
+			// Fixture setup
+			var dummyComposer = new Fixture();
+			var sut = new EqualityAssertion(dummyComposer);
+			// Exercise system and verify outcome
+			Assert.Throws<ArgumentNullException>(() => sut.Verify((FieldInfo)null));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyFieldInfoWhenEqualsIsProperlyImplementedDoesNotThrow()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.DoesNotThrow(() => sut.Verify(typeof(EqualProperlyImplementedTestClass).GetFields()));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyFieldInfoWhenEqualsIsNotProperlyImplementedThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(typeof(EqualNotProperlyImplementedTestClass).GetFields()));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyFieldInfoWhenEqualsReturnsFalseDoesNotThrow()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.DoesNotThrow(() => sut.Verify(typeof(EqualReturnsFalse).GetFields()));
+			// Teardown
+		}
+
+		[Fact]
+		public void VerifyFieldInfoWhenEqualsReturnsTrueThrows()
+		{
+			// Fixture setup
+			var sut = new EqualityAssertion(new Fixture());
+			// Exercise system and verify outcome
+			Assert.Throws<EqualsOverrideException>(() => sut.Verify(typeof(EqualReturnsTrue).GetFields()));
+			// Teardown
+		}
+
+		
+		/// <summary>
+		/// An class implementing Equals properly
+		/// </summary>
+		public class EqualProperlyImplementedTestClass : IEquatable<EqualProperlyImplementedTestClass>
+		{
+			private static readonly object _defaultTestB = new object();
+			private readonly string _testA;
+			private readonly object _testB;
+			private readonly int _testC;
+
+			public EqualProperlyImplementedTestClass(string a, object b, int c)
+			{
+				_testA = a;
+				_testB = b ?? _defaultTestB;
+				_testC = c;
+			}
+
+			public string TestA { get { return _testA; } }
+			public object TestB { get { return _testB; } }
+			public int TestC { get { return _testC; } }
+			public string TestD { get; set; }
+			public int TestE { get; set; }
+			public object TestF;
+			public string TestI;
+
+			public readonly string TestJ;
+
+			public bool Equals(EqualProperlyImplementedTestClass other)
+			{
+				if (other == null)
+				{
+					return false;
+				}
+				return TestA.Equals(other.TestA) &&
+					TestB.Equals(other.TestB) &&
+					TestC.Equals(other.TestC) &&
+					TestD.Equals(other.TestD) &&
+					TestE.Equals(other.TestE) &&
+					TestF.Equals(other.TestF) &&
+					TestI.Equals(other.TestI);
+			}
+
+			public override bool Equals(object obj)
+			{
+				var other = obj as EqualProperlyImplementedTestClass;
+				if (other == null)
+				{
+					return false;
+				}
+				return this.Equals(other);
+			}
+
+			public override int GetHashCode()
+			{
+				return base.GetHashCode();
+			}
+		}
+				
+		/// <summary>
+		/// An class not implementing Equals properly
+		/// </summary>
+		public class EqualNotProperlyImplementedTestClass : IEquatable<EqualNotProperlyImplementedTestClass>
+		{
+			private static readonly object _defaultTestB = new object();
+			private readonly string _testA;
+			private readonly object _testB;
+			private readonly int _testC;
+
+			public EqualNotProperlyImplementedTestClass(string a, object b, int c)
+			{
+				_testA = a;
+				_testB = b ?? _defaultTestB;
+				_testC = c;
+			}
+
+			public string TestA { get { return _testA; } }
+			public object TestB { get { return _testB; } }
+			public int TestC { get { return _testC; } }
+			public string TestD { get; set; }
+			public int TestE { get; set; }
+			public object TestF;
+			public string TestI;
+
+			public bool Equals(EqualNotProperlyImplementedTestClass other)
+			{
+				if (other == null)
+				{
+					return false;
+				}
+				return TestA.Equals(other.TestA) &&
+					   //omit TestB comparison
+					   TestC.Equals(other.TestC) &&
+					   //omit TestD
+					   TestE.Equals(other.TestE) &&
+					   //omit TestF comparison
+					   TestI.Equals(other.TestI);
+			}
+
+			public override bool Equals(object obj)
+			{
+				var other = obj as EqualNotProperlyImplementedTestClass;
+				if (other == null)
+				{
+					return false;
+				}
+				return this.Equals(other);
+			}
+
+			public override int GetHashCode()
+			{
+				return base.GetHashCode();
+			}
+		}
+
+		public class EqualReturnsFalse
+		{
+			private readonly string _testA;
+			private readonly object _testB;
+			private readonly int _testC;
+
+			public string TestA { get; set; }
+
+			public string TestB;
+
+			public EqualReturnsFalse(string a, object b, int c)
+			{
+				_testA = a;
+				_testB = b;
+				_testC = c;
+			}
+
+			public override bool Equals(object obj)
+			{
+				return false;
+			}
+
+			public override int GetHashCode()
+			{
+				return base.GetHashCode();
+			}
+		}
+
+		public class EqualReturnsTrue
+		{
+			private readonly string _testA;
+			private readonly object _testB;
+			private readonly int _testC;
+
+			public string TestA { get; set; }
+
+			public string TestB;
+
+			public EqualReturnsTrue(string a, object b, int c)
+			{
+				_testA = a;
+				_testB = b;
+				_testC = c;
+			}
+
+			public override bool Equals(object obj)
+			{
+				return true;
+			}
+
+			public override int GetHashCode()
+			{
+				return base.GetHashCode();
+			}
+		}
+
+		public class EqualProperlyImplementedWithArray : IEquatable<EqualProperlyImplementedWithArray>
+		{
+			private readonly object[] _values;
+
+			public EqualProperlyImplementedWithArray(IEnumerable<object> values) : this(values.ToArray())
+			{
+			}
+
+			private EqualProperlyImplementedWithArray(object[] values)
+			{
+				_values = values;
+			}
+
+			public object[] Values { get { return _values; } }
+
+			public bool Equals(EqualProperlyImplementedWithArray other)
+			{
+				return this.Values.SequenceEqual(other.Values);
+			}
+
+			public override bool Equals(object obj)
+			{
+				return Equals((EqualProperlyImplementedWithArray)obj);
+			}
+
+			public override int GetHashCode()
+			{
+				return base.GetHashCode();
+			}
+		}
+
+		public class EqualNotProperlyImplementedWithArray : IEquatable<EqualNotProperlyImplementedWithArray>
+		{
+			private readonly object[] _values;
+
+			public EqualNotProperlyImplementedWithArray(IEnumerable<object> values) : this(values.ToArray())
+			{
+			}
+
+			private EqualNotProperlyImplementedWithArray(object[] values)
+			{
+				_values = values;
+			}
+
+			public object[] Values { get { return _values; } }
+
+			public bool Equals(EqualNotProperlyImplementedWithArray other)
+			{
+				//Equals should use SequenceEquals when having enumerables
+				return this.Values.Equals(other.Values);
+			}
+
+			public override bool Equals(object obj)
+			{
+				return Equals((EqualNotProperlyImplementedWithArray)obj);
+			}
+
+			public override int GetHashCode()
+			{
+				return base.GetHashCode();
+			}
+		}
+	}
+}

--- a/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -77,6 +77,7 @@
     <Compile Include="DelegatingExpansion.cs" />
     <Compile Include="EmptyGuidBehaviorExpectationTest.cs" />
     <Compile Include="EnumerableComparison.cs" />
+    <Compile Include="EqualityAssertionTest.cs" />
     <Compile Include="GetHashCodeSuccessiveAssertionTest.cs" />
     <Compile Include="IndexedReplacementTest.cs" />
     <Compile Include="MethodInvokeCommandTest.cs" />


### PR DESCRIPTION
This PR fixes issue #98 

It assert that the given equality comparer behaves correctly.

The assertion is performed for each `ConstructorInfo`, `PropertyInfo` and `FieldInfo`.
It uses the new MatchOnCustomization in order freeze values.

Here is how to use it : 

    var assertion = new EqualityAssertion(new Fixture());
    assertion.Verify(typeof(MyValueClass));

By default it uses Object.Equals, but you can also use a custom comparer :

    var assertion = new EqualityAssertion(new Fixture(), (x,y) => x == y);

When verifying the `ConstructorInfo` it does the following :
It creates 2 same instances with the given constructor, by freezing all the `ParameterInfo`, and verifies that the 2 instances are equal.
It iterates over all the `ParameterInfo` and freeze all except one. Then create 2 instances and verifies that they are not equal.

When verifiying the `PropertyInfo` and `FieldInfo`, it freezes all members of the `ReflectedType` except the given `PropertyInfo` or `FieldInfo`, creates 2 instances and verifies they are not equal.