### PR TITLE
Compatible version range for xUnit.net in AutoFixture.Xunit.nuspec

### DIFF
--- a/Nuget/Ploeh.AutoFixture.Xunit.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Xunit.nuspec
@@ -8,7 +8,7 @@
         <owners>Mark Seemann</owners>
         <dependencies>
             <dependency id="autofixture" version="2.2" />
-            <dependency id="xunit.extensions" version="1.8.0.1549" />
+            <dependency id="xunit.extensions" version="[1.8.0.1549,2.0.0)" />
         </dependencies>
         <summary>Extension to AutoFixture that integrates it with xUnit.net.</summary>
         <description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</description>


### PR DESCRIPTION
As it looks like, NuGet supports [specifying version ranges in *.nuspec* files](https://docs.nuget.org/create/versioning).  – This resolves #366. 

--

### Manual verification ###

The version now falls into a specified range:

![image](https://cloud.githubusercontent.com/assets/287532/6915217/de854ae4-d79a-11e4-8906-f3d248e37ab9.png)

NuGet will prevent updating project(s) using *AutoFixture.Xunit1* to v2 of xUnit.net:

![image](https://cloud.githubusercontent.com/assets/287532/6915245/1cedba6e-d79b-11e4-8675-46aa6f2aff97.png)
