### PR TITLE
Addresses Issue 369

### DIFF
--- a/Src/AutoMoq/MockRelay.cs
+++ b/Src/AutoMoq/MockRelay.cs
@@ -81,7 +81,8 @@ namespace Ploeh.AutoFixture.AutoMoq
                 return new NoSpecimen(request);
 
             var result = MockRelay.ResolveMock(t, context);
-            if (result is NoSpecimen || result is OmitSpecimen)
+            // Note: null is a valid specimen (e.g., returned by NullRecursionHandler)
+            if (result is NoSpecimen || result is OmitSpecimen || result == null)
                 return result;
 
             var m = result as Mock;

--- a/Src/AutoMoq/MockRelay.cs
+++ b/Src/AutoMoq/MockRelay.cs
@@ -80,17 +80,21 @@ namespace Ploeh.AutoFixture.AutoMoq
             if (t == null)
                 return new NoSpecimen(request);
 
-            var m = MockRelay.ResolveMock(t, context);
+            var result = MockRelay.ResolveMock(t, context);
+            if (result is NoSpecimen || result is OmitSpecimen)
+                return result;
+
+            var m = result as Mock;
             if (m == null)
                 return new NoSpecimen(request);
 
             return m.Object;
         }
 
-        private static Mock ResolveMock(Type t, ISpecimenContext context)
+        private static object ResolveMock(Type t, ISpecimenContext context)
         {
-            var mockType = typeof(Mock<>).MakeGenericType(t);
-            return context.Resolve(mockType) as Mock;
+            var mockType = typeof (Mock<>).MakeGenericType(t);
+            return context.Resolve(mockType);
         }
 
         private class IsMockableSpecification : IRequestSpecification

--- a/Src/AutoMoqUnitTest/MockRelayTest.cs
+++ b/Src/AutoMoqUnitTest/MockRelayTest.cs
@@ -125,6 +125,42 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Teardown
         }
 
+        [Fact]
+        public void CreateReturnsNoSpecimenWhenContextReturnsNoSpecimen()
+        {
+            // Fixture setup
+            var request = typeof (IInterface);
+            var mockType = typeof (Mock<>).MakeGenericType(request);
+
+            var contextStub = new Mock<ISpecimenContext>();
+            contextStub.Setup(ctx => ctx.Resolve(mockType)).Returns(new NoSpecimen());
+
+            var sut = new MockRelay();
+            // Exercise system
+            var result = sut.Create(request, contextStub.Object);
+            // Verify outcome
+            Assert.IsType<NoSpecimen>(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsOmitSpecimenWhenContextReturnsOmitSpecimen()
+        {
+            // Fixture setup
+            var request = typeof (IInterface);
+            var mockType = typeof (Mock<>).MakeGenericType(request);
+
+            var contextStub = new Mock<ISpecimenContext>();
+            contextStub.Setup(ctx => ctx.Resolve(mockType)).Returns(new OmitSpecimen());
+
+            var sut = new MockRelay();
+            // Exercise system
+            var result = sut.Create(request, contextStub.Object);
+            // Verify outcome
+            Assert.IsType<OmitSpecimen>(result);
+            // Teardown
+        }
+
         [Theory]
         [InlineData(typeof(object))]
         [InlineData(typeof(AbstractType))]

--- a/Src/AutoMoqUnitTest/MockRelayTest.cs
+++ b/Src/AutoMoqUnitTest/MockRelayTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Moq;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
@@ -125,57 +127,37 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Teardown
         }
 
-        [Fact]
-        public void CreateReturnsNoSpecimenWhenContextReturnsNoSpecimen()
+        public class ValidNonMockSpecimens : IEnumerable<object[]>
         {
-            // Fixture setup
-            var request = typeof (IInterface);
-            var mockType = typeof (Mock<>).MakeGenericType(request);
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] {new NoSpecimen()};
+                yield return new object[] {new OmitSpecimen()};
+                yield return new object[] {null};
+            }
 
-            var contextStub = new Mock<ISpecimenContext>();
-            contextStub.Setup(ctx => ctx.Resolve(mockType)).Returns(new NoSpecimen());
-
-            var sut = new MockRelay();
-            // Exercise system
-            var result = sut.Create(request, contextStub.Object);
-            // Verify outcome
-            Assert.IsType<NoSpecimen>(result);
-            // Teardown
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
         }
 
-        [Fact]
-        public void CreateReturnsOmitSpecimenWhenContextReturnsOmitSpecimen()
+        [Theory]
+        [ClassData(typeof (ValidNonMockSpecimens))]
+        public void CreateReturnsCorrectResultWhenContextReturnsValidNonMockSpecimen(object validNonMockSpecimen)
         {
             // Fixture setup
             var request = typeof (IInterface);
             var mockType = typeof (Mock<>).MakeGenericType(request);
 
             var contextStub = new Mock<ISpecimenContext>();
-            contextStub.Setup(ctx => ctx.Resolve(mockType)).Returns(new OmitSpecimen());
+            contextStub.Setup(ctx => ctx.Resolve(mockType)).Returns(validNonMockSpecimen);
 
             var sut = new MockRelay();
             // Exercise system
             var result = sut.Create(request, contextStub.Object);
             // Verify outcome
-            Assert.IsType<OmitSpecimen>(result);
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateReturnsNullSpecimenWhenContextReturnsNull()
-        {
-            // Fixture setup
-            var request = typeof (IInterface);
-            var mockType = typeof (Mock<>).MakeGenericType(request);
-
-            var contextStub = new Mock<ISpecimenContext>();
-            contextStub.Setup(ctx => ctx.Resolve(mockType)).Returns(null);
-
-            var sut = new MockRelay();
-            // Exercise system
-            var result = sut.Create(request, contextStub.Object);
-            // Verify outcome
-            Assert.Null(result);
+            Assert.Equal(validNonMockSpecimen, result);
             // Teardown
         }
 

--- a/Src/AutoMoqUnitTest/MockRelayTest.cs
+++ b/Src/AutoMoqUnitTest/MockRelayTest.cs
@@ -161,6 +161,24 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Teardown
         }
 
+        [Fact]
+        public void CreateReturnsNullSpecimenWhenContextReturnsNull()
+        {
+            // Fixture setup
+            var request = typeof (IInterface);
+            var mockType = typeof (Mock<>).MakeGenericType(request);
+
+            var contextStub = new Mock<ISpecimenContext>();
+            contextStub.Setup(ctx => ctx.Resolve(mockType)).Returns(null);
+
+            var sut = new MockRelay();
+            // Exercise system
+            var result = sut.Create(request, contextStub.Object);
+            // Verify outcome
+            Assert.Null(result);
+            // Teardown
+        }
+
         [Theory]
         [InlineData(typeof(object))]
         [InlineData(typeof(AbstractType))]


### PR DESCRIPTION
This PR addresses issue #369.

I realized that the test cases in issue #369 also failed when the `OmitOnRecursionBehavior` is replaced by `NullRecursionBehavior`.

Therefore, not only does `MockRelay` need to "propagate" `OmitSpecimen`s returned by the underlying `ISpecimenContext`, it also needs to propagate `null` specimens. This PR covers both use cases.

---

Regarding regression tests: I was thinking I should copy the test cases presented in the issue ticket into the test suite.
These tests aren't unit tests, but more like integration/regression tests.

Is there a history of this being done in the past?
I found two cases, in the `Ploeh.AutoFixtureUnitTest.AbstractRecursionIssue` and `Ploeh.AutoFixtureUnitTest.NavigationPropertyRecursionIssue` namespaces, but I'm not sure this is a standard or whether this issue warrants regression tests.
