### PR TITLE
Missing Fact attributes

### DIFF
--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -43,6 +43,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             Assert.Equal("Ploeh", ph.Property);
         }
 
+        [Theory]
         [InlineAutoData("foo")]
         [InlineAutoData("foo", "bar")]
         public void InlineAutoDataUsesSuppliedDataValues(string s1, string s2)

--- a/Src/SemanticComparisonUnitTest/MemberComparerTest.cs
+++ b/Src/SemanticComparisonUnitTest/MemberComparerTest.cs
@@ -34,7 +34,7 @@ namespace Ploeh.SemanticComparison.UnitTest
         {
             // Fixture setup
             var dummyComparer = new DelegatingEqualityComparer();
-            var dummySpecification = new DelegatingSpecification<FieldInfo>(); 
+            var dummySpecification = new DelegatingSpecification<FieldInfo>();
             // Exercise system and verify outcome
             Assert.Throws<ArgumentNullException>(() =>
                 new MemberComparer(
@@ -138,6 +138,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Teardown
         }
 
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public void IsSatisfiedByForPropertyReturnsCorrectResult(bool expected)
@@ -147,14 +148,14 @@ namespace Ploeh.SemanticComparison.UnitTest
             var dummyComparer = new DelegatingEqualityComparer();
             var dummySpecification = new DelegatingSpecification<FieldInfo>();
 
-            var propertySpecificationStub = 
+            var propertySpecificationStub =
                 new DelegatingSpecification<PropertyInfo>
                 {
                     OnIsSatisfiedBy = x => expected
                 };
-           
+
             var sut = new MemberComparer(
-                dummyComparer, 
+                dummyComparer,
                 propertySpecificationStub,
                 dummySpecification);
             // Exercise system
@@ -164,6 +165,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Teardown
         }
 
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public void IsSatisfiedByForFieldReturnsCorrectResult(bool expected)
@@ -194,7 +196,7 @@ namespace Ploeh.SemanticComparison.UnitTest
         [InlineData(123, 123, true)]
         [InlineData(123, 321, false)]
         public void EqualsForwardsCorrectCallToComparer(
-            object a, 
+            object a,
             object b,
             bool expected)
         {


### PR DESCRIPTION
I came across a few tests that were missing their [Fact] attributes. I have added those, and the tests pass.

The first commit also cleans up some stray whitespace in the affected file; this is incidental but I guess doesn't do any harm.