### PR TITLE
Added CustomizeAttribute and tests

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -51,6 +51,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomizeAttributeTest.cs" />
+    <Compile Include="DelegatingCustomization.cs" />
+    <Compile Include="DelegatingCustomizeAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/CustomizeAttributeTest.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class CustomizeAttributeTest
+    {
+        [Fact]
+        public void TestableSutIsSut()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new DelegatingCustomizeAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new DelegatingCustomizeAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<Attribute>(sut);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingCustomization.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingCustomization.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    internal class DelegatingCustomization : ICustomization
+    {
+        internal DelegatingCustomization()
+        {
+            this.OnCustomize = f => { };
+        }
+
+        public void Customize(IFixture fixture)
+        {
+            this.OnCustomize(fixture);
+        }
+
+        internal Action<IFixture> OnCustomize { get; set; }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingCustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingCustomizeAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    internal class DelegatingCustomizeAttribute : CustomizeAttribute
+    {
+        internal DelegatingCustomizeAttribute()
+        {
+            this.OnGetCustomization = p => new DelegatingCustomization();
+        }
+
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            return this.OnGetCustomization(parameter);
+        }
+
+        internal Func<ParameterInfo, ICustomization> OnGetCustomization { get; set; }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -47,6 +47,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomizeAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/CustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/CustomizeAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// Base class for customizing parameters in methods
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
+    public abstract class CustomizeAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets a customization for a parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns></returns>
+        public abstract ICustomization GetCustomization(ParameterInfo parameter);
+    }
+}


### PR DESCRIPTION
This pull request adds the `CustomizeAttribute` class (and its tests), which is used by almost all other classes in the glue library. The code is identical with the xUnit v1 version, with namespace adjustments.