### PR TITLE
Added EnumeratorRelay to the default collection of residue collectors

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -118,7 +118,8 @@ namespace Ploeh.AutoFixture
                                 new DictionaryRelay(),
                                 new CollectionRelay(),
                                 new ListRelay(),
-                                new EnumerableRelay())),
+                                new EnumerableRelay(),
+                                new EnumeratorRelay())),
                         new FilteringSpecimenBuilder(
                             new MutableValueTypeWarningThrower(),
                             new AndRequestSpecification(

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5145,6 +5145,7 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
+        [InlineData(typeof(EnumeratorRelay))]
         [InlineData(typeof(EnumerableRelay))]
         [InlineData(typeof(ListRelay))]
         [InlineData(typeof(CollectionRelay))]
@@ -5706,6 +5707,37 @@ namespace Ploeh.AutoFixtureUnitTest
             var actual = result.Value;
             // Verify outcome
             Assert.NotNull(actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreatesEnumerator()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            // Exercise system and verify outcome
+            IEnumerator<int> result = null;
+            Assert.DoesNotThrow(() => result = fixture.Create<IEnumerator<int>>());
+            Assert.NotNull(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreatesEnumeratorWithSpecifiedNumberOfItems()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var expectedCount = fixture.RepeatCount;
+            // Exercise system
+            var result = fixture.Create<IEnumerator<int>>();
+            // Verify outcome
+            int count = 0;
+            while (result.MoveNext())
+            {
+                count ++;
+                Assert.True(count <= expectedCount);
+            }
+            Assert.Equal(expectedCount, count);
             // Teardown
         }
     }

--- a/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
@@ -49,7 +49,6 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             if (fixture == null)
                 throw new ArgumentNullException("fixture");
 
-            fixture.ResidueCollectors.Add(new EnumeratorRelay());
             fixture.ResidueCollectors.Add(
                 new Postprocessor(
                     Builder,

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
@@ -78,33 +78,5 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
                 Assert.Single(residueCollectors.OfType<Postprocessor>());
             Assert.Equal(builder, postprocessor.Builder);
         }
-
-        [Fact]
-        public void CustomizeAddsEnumeratorRelayToResidueCollectors()
-        {
-            var builder = Substitute.For<ISpecimenBuilder>();
-            var residueCollectors = new List<ISpecimenBuilder>();
-            var fixture = Substitute.For<IFixture>();
-            fixture.ResidueCollectors.Returns(residueCollectors);
-            var sut = new AutoConfiguredNSubstituteCustomization(builder);
-
-            sut.Customize(fixture);
-
-            Assert.Single(residueCollectors.OfType<EnumeratorRelay>());
-        }
-
-        [Fact]
-        public void CustomizeAddsEnumeratorRelayInCorrectOrder()
-        {
-            var builder = Substitute.For<ISpecimenBuilder>();
-            var residueCollectors = new List<ISpecimenBuilder>();
-            var fixture = Substitute.For<IFixture>();
-            fixture.ResidueCollectors.Returns(residueCollectors);
-            var sut = new AutoConfiguredNSubstituteCustomization(builder);
-
-            sut.Customize(fixture);
-
-            Assert.IsAssignableFrom<EnumeratorRelay>(residueCollectors.First());
-        }
     }
 }


### PR DESCRIPTION
As discussed in #374, this PR adds the `EnumeratorRelay` created as part of #351 to the `ResidueCollectorNode`.

This way, all mocking glue libraries will return finite sequences for abstract types implementing `IEnumerable<T>`.