### PR TITLE
Integrate xUnit.net v2 glue library into build process

### DIFF
--- a/BuildRelease.msbuild
+++ b/BuildRelease.msbuild
@@ -44,6 +44,9 @@
       <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.dll" />
       <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.pdb" />
       <BuildOutput Include="Src\AutoFixture.xUnit.net\bin\Release\Ploeh.AutoFixture.Xunit.XML" />
+      <BuildOutput Include="Src\AutoFixture.xUnit.net2\bin\Release\Ploeh.AutoFixture.Xunit2.dll" />
+      <BuildOutput Include="Src\AutoFixture.xUnit.net2\bin\Release\Ploeh.AutoFixture.Xunit2.pdb" />
+      <BuildOutput Include="Src\AutoFixture.xUnit.net2\bin\Release\Ploeh.AutoFixture.Xunit2.XML" />
       <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.dll" />
       <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.pdb" />
       <BuildOutput Include="Src\AutoFixture.NUnit2\bin\Release\Ploeh.AutoFixture.NUnit2.XML" />

--- a/Nuget/Ploeh.AutoFixture.Xunit2.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Xunit2.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+    <metadata>
+        <id>AutoFixture.Xunit2</id>
+        <version>2.2</version>
+        <title>AutoFixture with xUnit.net v2 data theories</title>
+        <authors>Mark Seemann</authors>
+        <owners>Mark Seemann</owners>
+        <dependencies>
+            <dependency id="autofixture" version="2.2" />
+            <dependency id="xunit.core" version="[2,3)" />
+        </dependencies>
+        <summary>Extension to AutoFixture that integrates it with xUnit.net v2.</summary>
+        <description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</description>
+        <iconUrl>http://i3.codeplex.com/Download?ProjectName=autofixture&amp;DownloadId=278049</iconUrl>
+        <language>en-US</language>
+        <licenseUrl>https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt</licenseUrl>
+        <projectUrl>https://github.com/AutoFixture/AutoFixture</projectUrl>
+    </metadata>
+    <files>
+        <file src="Ploeh.AutoFixture.Xunit2.dll" target="lib\net45" />
+        <file src="Ploeh.AutoFixture.Xunit2.pdb" target="lib\net45" />
+        <file src="Ploeh.AutoFixture.Xunit2.XML" target="lib\net45" />
+        <file src="..\Src\AutoFixture.xUnit.net2\**\*.cs" target="src" />
+        <file src="Install.ps1" target="tools" />
+    </files>
+</package>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -58,6 +58,7 @@
     <Compile Include="DelegatingCustomizeAttribute.cs" />
     <Compile Include="DelegatingFixture.cs" />
     <Compile Include="DelegatingSpecimenBuilder.cs" />
+    <Compile Include="DependencyConstraints.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DependencyConstraints.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class DependencyConstraints
+    {
+        [Theory]
+        [InlineData("FakeItEasy")]
+        [InlineData("Foq")]
+        [InlineData("FsCheck")]
+        [InlineData("Moq")]
+        [InlineData("NSubstitute")]
+        [InlineData("nunit.framework")]
+        [InlineData("Rhino.Mocks")]
+        [InlineData("Unquote")]
+        [InlineData("xunit")]
+        [InlineData("xunit.extensions")]
+        public void AutoFixtureXunit2DoesNotReference(string assemblyName)
+        {
+            // Fixture setup
+            // Exercise system
+            var references = typeof(AutoDataAttribute).Assembly.GetReferencedAssemblies();
+            // Verify outcome
+            Assert.False(references.Any(an => an.Name == assemblyName));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("FakeItEasy")]
+        [InlineData("Foq")]
+        [InlineData("FsCheck")]
+        [InlineData("Moq")]
+        [InlineData("NSubstitute")]
+        [InlineData("nunit.framework")]
+        [InlineData("Rhino.Mocks")]
+        [InlineData("Unquote")]
+        [InlineData("xunit")]
+        [InlineData("xunit.extensions")]
+        public void AutoFixtureXunit2UnitTestsDoNotReference(string assemblyName)
+        {
+            // Fixture setup
+            // Exercise system
+            var references = this.GetType().Assembly.GetReferencedAssemblies();
+            // Verify outcome
+            Assert.False(references.Any(an => an.Name == assemblyName));
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -29,7 +29,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DocumentationFile>bin\Release\Ploeh.AutoFixture.Xunit2.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Verify|AnyCPU' ">
+    <OutputPath>bin\Verify\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
+    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
+    <ErrorReport>prompt</ErrorReport>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRules>
+    </CodeAnalysisRules>
+    <DocumentationFile>bin\Verify\Ploeh.AutoFixture.Xunit2.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
This pull request does three things:

- Add the dependency constraints tests to make sure the glue library and test project don't reference third party assemblies used only in other AutoFixture projects; as per @moodmosaic's comment in the original pull request #294, I have updated these to check for all the different libraries for which glue projects exist
- Enable building a NuGet package for the glue library
- Add a `Verify` configuration to the glue library project and set the "Treat warnings as errors" flag