### PR TITLE
Add FrozenAttribute for xUnit.net v2

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -59,6 +59,7 @@
     <Compile Include="DelegatingFixture.cs" />
     <Compile Include="DelegatingSpecimenBuilder.cs" />
     <Compile Include="DependencyConstraints.cs" />
+    <Compile Include="FrozenAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Linq;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class FrozenAttributeTest
+    {
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new FrozenAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationFromNullParamterThrows()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                .GetParameters()
+                .Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezingCustomization>(result);
+            Assert.Equal(parameter.ParameterType, freezer.TargetType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsTheRegisteredTypeEqualToTheParameterType()
+        {
+            // Fixture setup
+            var sut = new FrozenAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                .GetParameters()
+                .Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezingCustomization>(result);
+            Assert.Equal(parameter.ParameterType, freezer.RegisteredType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithSpecificRegisteredTypeReturnsCorrectResult()
+        {
+            // Fixture setup
+            var registeredType = typeof(AbstractType);
+            var sut = new FrozenAttribute { As = registeredType };
+            var parameter = typeof(TypeWithConcreteParameterMethod)
+                .GetMethod("DoSomething", new[] { typeof(ConcreteType) })
+                .GetParameters()
+                .Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezingCustomization>(result);
+            Assert.Equal(registeredType, freezer.RegisteredType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithIncompatibleRegisteredTypeThrowsArgumentException()
+        {
+            // Fixture setup
+            var registeredType = typeof(string);
+            var sut = new FrozenAttribute { As = registeredType };
+            var parameter = typeof(TypeWithConcreteParameterMethod)
+                .GetMethod("DoSomething", new[] { typeof(ConcreteType) })
+                .GetParameters()
+                .Single();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentException>(() => sut.GetCustomization(parameter));
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="AutoDataAttribute.cs" />
     <Compile Include="CustomizeAttribute.cs" />
+    <Compile Include="FrozenAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// Theory to indicate that the parameter value should be frozen so that the same instance is
+    /// returned every time the <see cref="IFixture"/> creates an instance of that type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class FrozenAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Type"/> that the frozen parameter value
+        /// should be mapped to in the <see cref="IFixture"/>.
+        /// </summary>
+        public Type As { get; set; }
+
+        /// <summary>
+        /// Gets a customization that freezes the <see cref="Type"/> of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that freezes the <see cref="Type"/> of the parameter.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="parameter"/> is null.
+        /// </exception>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException("parameter");
+            }
+
+            var targetType = parameter.ParameterType;
+            return new FreezingCustomization(targetType, As ?? targetType);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the `FrozenAttribute` class and its tests. The code only differs in namespaces from the xUnit v1 version.