### PR TITLE
Add GreedyAttribute, ModestAttribute and NoAutoPropertiesAttribute for xUnit.net v2

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -61,6 +61,7 @@
     <Compile Include="DependencyConstraints.cs" />
     <Compile Include="FrozenAttributeTest.cs" />
     <Compile Include="GreedyAttributeTest.cs" />
+    <Compile Include="ModestAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -62,6 +62,7 @@
     <Compile Include="FrozenAttributeTest.cs" />
     <Compile Include="GreedyAttributeTest.cs" />
     <Compile Include="ModestAttributeTest.cs" />
+    <Compile Include="NoAutoPropertiesAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -60,6 +60,7 @@
     <Compile Include="DelegatingSpecimenBuilder.cs" />
     <Compile Include="DependencyConstraints.cs" />
     <Compile Include="FrozenAttributeTest.cs" />
+    <Compile Include="GreedyAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/GreedyAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/GreedyAttributeTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class GreedyAttributeTest
+    {
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new GreedyAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationFromNullParamterThrows()
+        {
+            // Fixture setup
+            var sut = new GreedyAttribute();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new GreedyAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var invoker = Assert.IsAssignableFrom<ConstructorCustomization>(result);
+            Assert.Equal(parameter.ParameterType, invoker.TargetType);
+            Assert.IsAssignableFrom<GreedyConstructorQuery>(invoker.Query);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/ModestAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/ModestAttributeTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class ModestAttributeTest
+    {
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new ModestAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationFromNullParamterThrows()
+        {
+            // Fixture setup
+            var sut = new ModestAttribute();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new ModestAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var invoker = Assert.IsAssignableFrom<ConstructorCustomization>(result);
+            Assert.Equal(parameter.ParameterType, invoker.TargetType);
+            Assert.IsAssignableFrom<ModestConstructorQuery>(invoker.Query);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/NoAutoPropertiesAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/NoAutoPropertiesAttributeTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class NoAutoPropertiesAttributeTest
+    {
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new NoAutoPropertiesAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+        }
+
+        [Fact]
+        public void GetCustomizationFromNullParameterThrows()
+        {
+            // Fixture setup
+            var sut = new NoAutoPropertiesAttribute();
+            // Exercise system and verify the outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsTheCorrectResult()
+        {
+            // Fixture setup
+            var sut = new NoAutoPropertiesAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                .GetParameters()
+                .Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify the outcome
+            Assert.IsAssignableFrom<NoAutoPropertiesCustomization>(result);
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -68,6 +68,7 @@
     <Compile Include="CustomizeAttribute.cs" />
     <Compile Include="FrozenAttribute.cs" />
     <Compile Include="GreedyAttribute.cs" />
+    <Compile Include="ModestAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -69,6 +69,7 @@
     <Compile Include="FrozenAttribute.cs" />
     <Compile Include="GreedyAttribute.cs" />
     <Compile Include="ModestAttribute.cs" />
+    <Compile Include="NoAutoPropertiesAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -67,6 +67,7 @@
     <Compile Include="AutoDataAttribute.cs" />
     <Compile Include="CustomizeAttribute.cs" />
     <Compile Include="FrozenAttribute.cs" />
+    <Compile Include="GreedyAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/GreedyAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/GreedyAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// Theory to indicate that the parameter value should be created using the most greedy
+    /// constructor that can be satisfied by an <see cref="IFixture"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class GreedyAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets a customization that associates a <see cref="GreedyConstructorQuery"/> with the
+        /// <see cref="Type"/> of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that associates a <see cref="GreedyConstructorQuery"/> with the
+        /// <see cref="Type"/> of the parameter.
+        /// </returns>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException("parameter");
+            }
+
+            return new ConstructorCustomization(parameter.ParameterType, new GreedyConstructorQuery());
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/ModestAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/ModestAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// Theory to indicate that the parameter value should be created using the most modest
+    /// constructor that can be satisfied by an <see cref="IFixture"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class ModestAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets a customization that associates a <see cref="ModestConstructorQuery"/> with the
+        /// <see cref="Type"/> of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that associates a <see cref="ModestConstructorQuery"/> with the
+        /// <see cref="Type"/> of the parameter.
+        /// </returns>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException("parameter");
+            }
+
+            return new ConstructorCustomization(parameter.ParameterType, new ModestConstructorQuery());
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/NoAutoPropertiesAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/NoAutoPropertiesAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// Theory to indicate that the parameter value should not have properties auto populated
+    /// when the <see cref="IFixture"/> creates an instance of that type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class NoAutoPropertiesAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets a customization that stops auto population of properties for the type of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that stops auto population of the <see cref="Type"/> of the parameter.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="parameter"/> is null.
+        /// </exception>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException("parameter");
+            }
+
+            var targetType = parameter.ParameterType;
+            return new NoAutoPropertiesCustomization(targetType);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the `GreedyAttribute`, `ModestAttribute` and `NoAutoPropertiesAttribute` classes and their tests for the xUnit v2 glue library. Again, the only code differences from the xUnit v1 project are namespaces.