### PR TITLE
Add FavorArraysAttribute, FavorEnumerablesAttribute and FavorListsAttribute for xUnit.net v2

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -64,6 +64,7 @@
     <Compile Include="ModestAttributeTest.cs" />
     <Compile Include="NoAutoPropertiesAttributeTest.cs" />
     <Compile Include="FavorArraysAttributeTest.cs" />
+    <Compile Include="FavorEnumerablesAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -65,6 +65,7 @@
     <Compile Include="NoAutoPropertiesAttributeTest.cs" />
     <Compile Include="FavorArraysAttributeTest.cs" />
     <Compile Include="FavorEnumerablesAttributeTest.cs" />
+    <Compile Include="FavorListsAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -63,6 +63,7 @@
     <Compile Include="GreedyAttributeTest.cs" />
     <Compile Include="ModestAttributeTest.cs" />
     <Compile Include="NoAutoPropertiesAttributeTest.cs" />
+    <Compile Include="FavorArraysAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FavorArraysAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FavorArraysAttributeTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class FavorArraysAttributeTest
+    {
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new FavorArraysAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationFromNullParameterThrows()
+        {
+            // Fixture setup
+            var sut = new FavorArraysAttribute();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new FavorArraysAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var invoker = Assert.IsAssignableFrom<ConstructorCustomization>(result);
+            Assert.Equal(parameter.ParameterType, invoker.TargetType);
+            Assert.IsAssignableFrom<ArrayFavoringConstructorQuery>(invoker.Query);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FavorEnumerablesAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FavorEnumerablesAttributeTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class FavorEnumerablesAttributeTest
+    {
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new FavorEnumerablesAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationFromNullParameterThrows()
+        {
+            // Fixture setup
+            var sut = new FavorEnumerablesAttribute();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new FavorEnumerablesAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var invoker = Assert.IsAssignableFrom<ConstructorCustomization>(result);
+            Assert.Equal(parameter.ParameterType, invoker.TargetType);
+            Assert.IsAssignableFrom<EnumerableFavoringConstructorQuery>(invoker.Query);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FavorListsAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FavorListsAttributeTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class FavorListsAttributeTest
+    {
+        [Fact]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new FavorListsAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<CustomizeAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationFromNullParameterThrows()
+        {
+            // Fixture setup
+            var sut = new FavorListsAttribute();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new FavorListsAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify outcome
+            var invoker = Assert.IsAssignableFrom<ConstructorCustomization>(result);
+            Assert.Equal(parameter.ParameterType, invoker.TargetType);
+            Assert.IsAssignableFrom<ListFavoringConstructorQuery>(invoker.Query);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -72,6 +72,7 @@
     <Compile Include="NoAutoPropertiesAttribute.cs" />
     <Compile Include="FavorArraysAttribute.cs" />
     <Compile Include="FavorEnumerablesAttribute.cs" />
+    <Compile Include="FavorListsAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ModestAttribute.cs" />
     <Compile Include="NoAutoPropertiesAttribute.cs" />
     <Compile Include="FavorArraysAttribute.cs" />
+    <Compile Include="FavorEnumerablesAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -70,6 +70,7 @@
     <Compile Include="GreedyAttribute.cs" />
     <Compile Include="ModestAttribute.cs" />
     <Compile Include="NoAutoPropertiesAttribute.cs" />
+    <Compile Include="FavorArraysAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/FavorArraysAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FavorArraysAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// Theory to indicate that the parameter value should be created using a constructor with one
+    /// or more array arguments, if applicable.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class FavorArraysAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets a customization that associates a <see cref="ArrayFavoringConstructorQuery"/> with
+        /// the <see cref="Type"/> of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that associates a <see cref="ArrayFavoringConstructorQuery"/> with the
+        /// <see cref="Type"/> of the parameter.
+        /// </returns>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+                throw new ArgumentNullException("parameter");
+
+            return new ConstructorCustomization(parameter.ParameterType, new ArrayFavoringConstructorQuery());
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/FavorEnumerablesAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FavorEnumerablesAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// Theory to indicate that the parameter value should be created using a constructor with one
+    /// or more <see cref="IEnumerable{T}" /> arguments, if applicable.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class FavorEnumerablesAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets a customization that associates a <see cref="EnumerableFavoringConstructorQuery"/>
+        /// with the <see cref="Type"/> of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that associates a <see cref="EnumerableFavoringConstructorQuery"/> with
+        /// the <see cref="Type"/> of the parameter.
+        /// </returns>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+                throw new ArgumentNullException("parameter");
+
+            return new ConstructorCustomization(parameter.ParameterType, new EnumerableFavoringConstructorQuery());
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/FavorListsAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FavorListsAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// Theory to indicate that the parameter value should be created using a constructor with one
+    /// or more <see cref="IList{T}" /> arguments, if applicable.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class FavorListsAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets a customization that associates a <see cref="ListFavoringConstructorQuery"/> with
+        /// the <see cref="Type"/> of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that associates a <see cref="ListFavoringConstructorQuery"/> with the
+        /// <see cref="Type"/> of the parameter.
+        /// </returns>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+                throw new ArgumentNullException("parameter");
+
+            return new ConstructorCustomization(parameter.ParameterType, new ListFavoringConstructorQuery());
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds `FavorArraysAttribute`, `FavorEnumerablesAttribute` and `FavorListsAttribute` to the xUnit v2 glue library. Once more, the code differences from the v1 library are entirely in namespaces.