### PR TITLE
Add CompositeDataAttribute to xUnit.net v2 glue library

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -53,6 +53,9 @@
   <ItemGroup>
     <Compile Include="AutoDataAttributeTest.cs" />
     <Compile Include="ComposerWithoutADefaultConstructor.cs" />
+    <Compile Include="ClassDataAttribute.cs" />
+    <Compile Include="CompositeDataAttributeSufficientDataTest.cs" />
+    <Compile Include="CompositeDataAttributeTest.cs" />
     <Compile Include="CustomizeAttributeTest.cs" />
     <Compile Include="DelegatingCustomization.cs" />
     <Compile Include="DelegatingCustomizeAttribute.cs" />
@@ -66,6 +69,7 @@
     <Compile Include="FavorArraysAttributeTest.cs" />
     <Compile Include="FavorEnumerablesAttributeTest.cs" />
     <Compile Include="FavorListsAttributeTest.cs" />
+    <Compile Include="FakeDataAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/ClassDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/ClassDataAttribute.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    /// <summary>
+    /// Provides a data source for a data theory, with the data coming from a class
+    /// which must implement IEnumerable&lt;object[]&gt;.
+    /// </summary>
+    /// <remarks>
+    /// This is essentially the ClassDataAttribute class from xUnit 1, adjusted for changes in the DataAttribute API.
+    /// It has been put here to make the existing tests run with xUnit 2 with the least possible effort.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public class ClassDataAttribute : DataAttribute
+    {
+        private readonly Type @class;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassDataAttribute"/> class.
+        /// </summary>
+        /// <param name="class">The class that provides the data.</param>
+        public ClassDataAttribute(Type @class)
+        {
+            this.@class = @class;
+        }
+
+        /// <summary>
+        /// Gets the type of the class that provides the data.
+        /// </summary>
+        public Type Class
+        {
+            get { return @class; }
+        }
+
+        /// <inheritdoc/>
+        public override IEnumerable<object[]> GetData(MethodInfo methodUnderTest)
+        {
+            return (IEnumerable<object[]>)Activator.CreateInstance(@class);
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/CompositeDataAttributeSufficientDataTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/CompositeDataAttributeSufficientDataTest.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
+    {
+        private readonly MethodInfo method;
+
+        public CompositeDataAttributeSufficientDataTest()
+        {
+            this.method = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object), typeof(object), typeof(object) });
+            var parameters = method.GetParameters();
+        }
+
+        [Theory]
+        [ClassData(typeof(CompositeDataAttributeSufficientDataTest))]
+        public void GetDataReturnsCorrectResult(IEnumerable<DataAttribute> attributes, IEnumerable<object[]> expectedResult)
+        {
+            // Fixture setup
+            // Exercise system
+            var result = new CompositeDataAttribute(attributes.ToArray()).GetData(this.method).ToList();
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(result, new TheoryComparer()));
+            // Teardown
+        }
+
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 3 }
+                    }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } }),
+                        new FakeDataAttribute(this.method, new[] { new object[] { 4, 5, 6 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 3 }
+                    }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1       } }),
+                        new FakeDataAttribute(this.method, new[] { new object[] { 2, 3, 4 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 3, 4 }
+                    }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2    } }),
+                        new FakeDataAttribute(this.method, new[] { new object[] { 3, 4, 5 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 5 }
+                    }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 }
+                    }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4,  5, 6 }                          }),
+                        new FakeDataAttribute(this.method, new[] { new object[] { 7, 8    }, new object[] { 9, 10    }, new object[] { 11, 12 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 }
+                    }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2    }, new object[] {  3,  4     }, new object[] {  5,  6     } }),
+                        new FakeDataAttribute(this.method, new[] { new object[] { 7, 8, 9 }, new object[] { 10, 11, 12 }, new object[] { 13, 14, 15 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 9 }, new object[] { 3, 4, 12 }, new object[] { 5, 6, 15 }
+                    }
+            );
+
+            // Second attribute restricts
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
+                        new FakeDataAttribute(this.method, new[] { new object[] { 7, 8, 9 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 3 }
+                    }
+            );
+
+            // Shortest data provider is limiting factor
+            yield return CreateTestCase(
+                data: new[]
+                    {
+                        new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } }),
+                        new FakeDataAttribute(this.method, new[] { new object[] { 4, 5, 6 }, new object[] { 7, 8, 9 } })
+                    },
+                expected: new[]
+                    {
+                        new object[] { 1, 2, 3 }
+                    }
+            );
+
+            // Test incorrect number of parameters - should just return what it's given
+            // and let xUnit deal with counting parameters
+            yield return CreateTestCase(
+                data: new[]
+                {
+                    new FakeDataAttribute(this.method, new[] { new object[] { 1, 2 } }),
+                    new FakeDataAttribute(this.method, new[] { new object[] { 3, 4 } })
+                },
+                expected: new[]
+                {
+                    new object[] { 1, 2 }
+                }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                {
+                    new FakeDataAttribute(this.method, new[] { new object[] { 1    } }),
+                    new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                },
+                expected: new[]
+                {
+                    new object[] { 1, 3 },
+                }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                {
+                    new FakeDataAttribute(this.method, new[] { new object[] { 1    } }),
+                    new FakeDataAttribute(this.method, new[] { new object[] {      } }),
+                    new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                },
+                expected: new[]
+                {
+                    new object[] { 1, 3 },
+                }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                {
+                    new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
+                    new FakeDataAttribute(this.method, new[] { new object[] { 2 } }),
+                    new FakeDataAttribute(this.method, new[] { new object[] { 3 } })
+                },
+                expected: new[]
+                {
+                    new object[] { 1 }
+                }
+            );
+
+            yield return CreateTestCase(
+                data: new[]
+                {
+                    new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3, 4 } }),
+                },
+                expected: new[]
+                {
+                    new object[] { 1, 2, 3, 4 }
+                }
+            );
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private static object[] CreateTestCase(object[] data, object[] expected)
+        {
+            return new object[] { data, expected };
+        }
+
+        private sealed class TheoryComparer : IEqualityComparer<object[]>
+        {
+            public bool Equals(object[] x, object[] y)
+            {
+                return x.SequenceEqual(y);
+            }
+
+            public int GetHashCode(object[] array)
+            {
+                return (from obj in array select obj.GetHashCode()).Aggregate((x, y) => x ^ y);
+            }
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/CompositeDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/CompositeDataAttributeTest.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class CompositeDataAttributeTest
+    {
+        [Fact]
+        public void SutIsDataAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new CompositeDataAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<DataAttribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithNullArrayThrows()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new CompositeDataAttribute(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void AttributesIsCorrectWhenInitializedWithArray()
+        {
+            // Fixture setup
+            Action a = delegate { };
+            var method = a.Method;
+
+            var attributes = new[]
+            {
+                new FakeDataAttribute(method, Enumerable.Empty<object[]>()),
+                new FakeDataAttribute(method, Enumerable.Empty<object[]>()),
+                new FakeDataAttribute(method, Enumerable.Empty<object[]>())
+            };
+
+            var sut = new CompositeDataAttribute(attributes);
+            // Exercise system
+            IEnumerable<DataAttribute> result = sut.Attributes;
+            // Verify outcome
+            Assert.True(attributes.SequenceEqual(result));
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithNullEnumerableThrows()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new CompositeDataAttribute((IReadOnlyCollection<DataAttribute>)null));
+            // Teardown
+        }
+
+        [Fact]
+        public void AttributesIsCorrectWhenInitializedWithEnumerable()
+        {
+            // Fixture setup
+            Action a = delegate { };
+            var method = a.Method;
+
+            var attributes = new[]
+            {
+                new FakeDataAttribute(method, Enumerable.Empty<object[]>()),
+                new FakeDataAttribute(method, Enumerable.Empty<object[]>()),
+                new FakeDataAttribute(method, Enumerable.Empty<object[]>())
+            };
+
+            var sut = new CompositeDataAttribute(attributes);
+            // Exercise system
+            var result = sut.Attributes;
+            // Verify outcome
+            Assert.True(attributes.SequenceEqual(result));
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataWithNullMethodThrows()
+        {
+            // Fixture setup
+            var sut = new CompositeDataAttribute();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetData(null).ToList());
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataOnMethodWithNoParametersReturnsNoTheory()
+        {
+            // Fixture setup
+            Action a = delegate { };
+            var method = a.Method;
+            var parameters = method.GetParameters();
+            var parameterTypes = (from pi in parameters
+                                  select pi.ParameterType).ToArray();
+
+            var sut = new CompositeDataAttribute(
+               new FakeDataAttribute(method, Enumerable.Empty<object[]>()),
+               new FakeDataAttribute(method, Enumerable.Empty<object[]>()),
+               new FakeDataAttribute(method, Enumerable.Empty<object[]>())
+               );
+
+            // Exercise system and verify outcome
+            var result = sut.GetData(a.Method);
+            Array.ForEach(result.ToArray(), Assert.Empty);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FakeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FakeDataAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    public class FakeDataAttribute : DataAttribute
+    {
+        private readonly MethodInfo expectedMethod;
+        private readonly IEnumerable<object[]> output;
+
+        public FakeDataAttribute(MethodInfo expectedMethod, IEnumerable<object[]> output)
+        {
+            this.expectedMethod = expectedMethod;
+            this.output = output;
+        }
+
+        public override IEnumerable<object[]> GetData(MethodInfo methodUnderTest)
+        {
+            Assert.Equal(this.expectedMethod, methodUnderTest);
+
+            return this.output;
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -65,7 +65,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoDataAttribute.cs" />
+    <Compile Include="CompositeDataAttribute.cs" />
     <Compile Include="CustomizeAttribute.cs" />
+    <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="FrozenAttribute.cs" />
     <Compile Include="GreedyAttribute.cs" />
     <Compile Include="ModestAttribute.cs" />

--- a/Src/AutoFixture.xUnit.net2/CompositeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/CompositeDataAttribute.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// An implementation of DataAttribute that composes other DataAttribute instances.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    [CLSCompliant(false)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
+    public class CompositeDataAttribute : DataAttribute
+    {
+        private readonly IReadOnlyCollection<DataAttribute> attributes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeDataAttribute"/> class.
+        /// </summary>
+        /// <param name="attributes">The attributes representing a data source for a data theory.
+        /// </param>
+        public CompositeDataAttribute(IReadOnlyCollection<DataAttribute> attributes)
+            : this(attributes.ToArray())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeDataAttribute"/> class.
+        /// </summary>
+        /// <param name="attributes">The attributes representing a data source for a data theory.
+        /// </param>
+        public CompositeDataAttribute(params DataAttribute[] attributes)
+        {
+            if (attributes == null)
+            {
+                throw new ArgumentNullException("attributes");
+            }
+
+            this.attributes = attributes;
+        }
+
+        /// <summary>
+        /// Gets the attributes supplied through one of the constructors.
+        /// </summary>
+        public IEnumerable<DataAttribute> Attributes
+        {
+            get { return this.attributes; }
+        }
+
+        /// <summary>
+        /// Returns the composition of data to be used to test the theory. Favors the data returned
+        /// by DataAttributes in ascending order. Data already returned is ignored on next
+        /// DataAttribute returned data.
+        /// </summary>
+        /// <param name="methodUnderTest">The method that is being tested.</param>
+        /// <returns>
+        /// Returns the composition of the theory data.
+        /// </returns>
+        /// <remarks>
+        /// The number of test cases is set from the first DataAttribute theory length.
+        /// </remarks>
+        public override IEnumerable<object[]> GetData(MethodInfo methodUnderTest)
+        {
+            if (methodUnderTest == null)
+            {
+                throw new ArgumentNullException("methodUnderTest");
+            }
+
+            return this.attributes
+                .Select(attr => attr.GetData(methodUnderTest))
+                .Zip(dataSets => dataSets.Collapse().ToArray());
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/EnumerableExtensions.cs
+++ b/Src/AutoFixture.xUnit.net2/EnumerableExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    internal static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Applies a specified function to the corresponding elements of any number of sequences.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the input sequences.</typeparam>
+        /// <typeparam name="TResult">The type of the elements of the result sequence.</typeparam>
+        /// <param name="sequences">The input sequences.</param>
+        /// <param name="resultSelector">A function that specifies how to combine the corresponding elements of the sequences.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> that contains elements of the input sequences, combined by resultSelector.</returns>
+        internal static IEnumerable<TResult> Zip<T, TResult>(this IEnumerable<IEnumerable<T>> sequences,
+            Func<IEnumerable<T>, TResult> resultSelector)
+        {
+            var enumerators = sequences.Select(s => s.GetEnumerator()).ToList();
+            while (enumerators.All(e => e.MoveNext()))
+                yield return resultSelector(enumerators.Select(e => e.Current));
+        }
+
+        /// <summary>
+        /// Collapses a series of sequences down by using items from the first sequence until it finishes,
+        /// then continuing from the same index through the second sequence, and so on until all sequences
+        /// have been exhausted.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the input sequences.</typeparam>
+        /// <param name="sequences">The input sequences.</param>
+        /// <returns>Items from each sequence in turn, yielding those from the first sequence first.</returns>
+        internal static IEnumerable<T> Collapse<T>(this IEnumerable<IEnumerable<T>> sequences)
+        {
+            var position = 0;
+            foreach (var sequence in sequences)
+            {
+                var skipped = sequence.Skip(position);
+                foreach (var item in skipped)
+                {
+                    position++;
+                    yield return item;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the `CompositeDataAttribute` class to the xUnit v2 glue library.

The differences from the xUnit v1 project are as follows:
- Namespace adjustments
- xUnit's `DataAttribute.GetData()` does not take a second parameter of `Type[]` anymore
- xUnit 2 removed `ClassDataAttribute`, which the tests for `CompositeDataAttribute` use. According to @bradwilson (https://twitter.com/bradwilson/status/585529188515479552), there is no straight-up replacement/alternative for that, so I opted for lifting the class from xUnit v1 and including it in the test project for the time being.