### PR TITLE
Added EmailAddressLocalPart and EmailAddressLocalPartGenerator.

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -97,6 +97,8 @@
   <ItemGroup>
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
+    <Compile Include="EmailAddressLocalPart.cs" />
+    <Compile Include="EmailAddressLocalPartGenerator.cs" />
     <Compile Include="Kernel\CompositeSpecimenCommand.cs" />
     <Compile Include="Kernel\EnumeratorRelay.cs" />
     <Compile Include="Kernel\GenericMethod.cs" />

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -38,6 +38,7 @@ namespace Ploeh.AutoFixture
             yield return new TaskGenerator();
             yield return new IntPtrGuard();
             yield return new MailAddressGenerator();
+            yield return new EmailAddressLocalPartGenerator();
         }
 
         /// <summary>

--- a/Src/AutoFixture/EmailAddressLocalPart.cs
+++ b/Src/AutoFixture/EmailAddressLocalPart.cs
@@ -7,33 +7,29 @@ using System.Text.RegularExpressions;
 namespace Ploeh.AutoFixture
 {
     /// <summary>
-    /// Represents the local part of the email address, defined as everything up to, but not including the @ sign.  
-    /// The requirements enforced on the local part are defined in RFC 3696.  The regular expression for validating 
-    /// the local part borrowed from Phil Haack at 
-    /// http://haacked.com/archive/2007/08/21/i-knew-how-to-validate-an-email-address-until-i.aspx/
+    /// Represents the local part of the email address, defined as everything up to, but not including, the @ sign.  
+    /// Since EmailAddressLocalPart is used in constructing MailAddress, enforcement of rules on a valid email address
+    /// is performed by <see cref="System.Net.Mail.MailAddress"/> and not EmailAddressLocalPart other than as noted. 
     /// </summary>
-    public class EmailAddressLocalPart : IEquatable<EmailAddressLocalPart>
+    public class EmailAddressLocalPart
     {
-        private static string pattern = @"^(?!\.)(""([^""\r\\]|\\[""\r\\])*""|"
-                                               + @"([-A-Za-z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)$";
         private readonly string localPart;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EmailAddressLocalPart"/> class. Throws ArgumentNullException
-        /// if localPart is null or empty.  Throws ArgumentException if localPart is longer than 64 characters or
-        /// does not conform to the local pat requirements per RFC 3696. 
+        /// if localPart is null.  Throws ArgumentException if localPart is empty.
         /// </summary>
-        /// <param name="localPart">The local part.</param>        
+        /// <param name="localPart">The local part.</param>                
         public EmailAddressLocalPart(string localPart)
         {
-            if (string.IsNullOrEmpty(localPart))
+            if (localPart == null)
             {
-                throw new ArgumentNullException(localPart);
+                throw new ArgumentNullException("localPart");
             }
 
-            if (!EmailAddressLocalPart.IsValid(localPart))
+            if (localPart.Length == 0)
             {
-                throw new ArgumentException("Email address local part can only contain letters, digits, and special characters !#$%&'*+/=?^_`{|}~");
+                throw new ArgumentException("localPart cannot be empty");
             }
 
             this.localPart = localPart;
@@ -45,21 +41,6 @@ namespace Ploeh.AutoFixture
         public string LocalPart
         {
             get { return this.localPart; }
-        }
-
-        /// <summary>
-        /// Indicates whether the current object is equal to another object of the same type.
-        /// </summary>
-        /// <param name="other">An object to compare with this object.</param>
-        /// <returns>
-        /// true if the current object is equal to the other parameter; otherwise, false.
-        /// </returns>
-        public bool Equals(EmailAddressLocalPart other)
-        {
-            if (other == null)
-                return false; 
-
-            return this.localPart.Equals(other.localPart);
         }
 
         /// <summary>
@@ -79,7 +60,7 @@ namespace Ploeh.AutoFixture
             var other = obj as EmailAddressLocalPart;
             if (other != null)
             {
-                return this.Equals(other);
+                return this.localPart.Equals(other.localPart);
             }
 
             return base.Equals(obj);
@@ -106,37 +87,6 @@ namespace Ploeh.AutoFixture
         public override string ToString()
         {
             return this.localPart;
-        }       
-
-        /// <summary>
-        /// Returns true if the localPart is valid in terms of both length and conformity with allowable
-        /// characters and character ordering, false otherwise. 
-        /// </summary>
-        /// <param name="localPart"></param>
-        /// <returns></returns>
-        public static bool IsValid(string localPart)
-        {
-            if (string.IsNullOrEmpty(localPart))
-                return false;
-
-            return localPart.Length <= MaximumAllowableLength && Regex.IsMatch(localPart, ValidEmailAddressPattern);
-        }
-
-        /// <summary>
-        /// Gets the maximum length, inclusive, supported as the local part. 
-        /// </summary>
-        public static int MaximumAllowableLength
-        {
-            get { return 64; }
-        }
-
-        /// <summary>
-        /// Gets the pattern used by EmailAddressLocalPart to validate local parts.  This pattern is used
-        /// to validate for character content, but not for length.
-        /// </summary>
-        public static string ValidEmailAddressPattern
-        {
-            get { return pattern; }
         }
     }
 }

--- a/Src/AutoFixture/EmailAddressLocalPart.cs
+++ b/Src/AutoFixture/EmailAddressLocalPart.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Represents the local part of the email address, defined as everything up to, but not including the @ sign.  
+    /// The requirements enforced on the local part are defined in RFC 3696.  The regular expression for validating 
+    /// the local part borrowed from Phil Haack at 
+    /// http://haacked.com/archive/2007/08/21/i-knew-how-to-validate-an-email-address-until-i.aspx/
+    /// </summary>
+    public class EmailAddressLocalPart : IEquatable<EmailAddressLocalPart>
+    {
+        private static string pattern = @"^(?!\.)(""([^""\r\\]|\\[""\r\\])*""|"
+                                               + @"([-A-Za-z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)$";
+        private readonly string localPart;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmailAddressLocalPart"/> class. Throws ArgumentNullException
+        /// if localPart is null or empty.  Throws ArgumentException if localPart is longer than 64 characters or
+        /// does not conform to the local pat requirements per RFC 3696. 
+        /// </summary>
+        /// <param name="localPart">The local part.</param>        
+        public EmailAddressLocalPart(string localPart)
+        {
+            if (string.IsNullOrEmpty(localPart))
+            {
+                throw new ArgumentNullException(localPart);
+            }
+
+            if (!EmailAddressLocalPart.IsValid(localPart))
+            {
+                throw new ArgumentException("Email address local part can only contain letters, digits, and special characters !#$%&'*+/=?^_`{|}~");
+            }
+
+            this.localPart = localPart;
+        }
+
+        /// <summary>
+        /// Get the local part.
+        /// </summary>
+        public string LocalPart
+        {
+            get { return this.localPart; }
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the other parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(EmailAddressLocalPart other)
+        {
+            if (other == null)
+                return false; 
+
+            return this.localPart.Equals(other.localPart);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object"/> to compare with this instance.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; 
+        /// otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="T:System.NullReferenceException">
+        /// The <paramref name="obj"/> parameter is null.
+        ///   </exception>
+        public override bool Equals(object obj)
+        {
+            var other = obj as EmailAddressLocalPart;
+            if (other != null)
+            {
+                return this.Equals(other);
+            }
+
+            return base.Equals(obj);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data 
+        /// structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return this.localPart.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents the local part for this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents the local part for this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return this.localPart;
+        }       
+
+        /// <summary>
+        /// Returns true if the localPart is valid in terms of both length and conformity with allowable
+        /// characters and character ordering, false otherwise. 
+        /// </summary>
+        /// <param name="localPart"></param>
+        /// <returns></returns>
+        public static bool IsValid(string localPart)
+        {
+            if (string.IsNullOrEmpty(localPart))
+                return false;
+
+            return localPart.Length <= MaximumAllowableLength && Regex.IsMatch(localPart, ValidEmailAddressPattern);
+        }
+
+        /// <summary>
+        /// Gets the maximum length, inclusive, supported as the local part. 
+        /// </summary>
+        public static int MaximumAllowableLength
+        {
+            get { return 64; }
+        }
+
+        /// <summary>
+        /// Gets the pattern used by EmailAddressLocalPart to validate local parts.  This pattern is used
+        /// to validate for character content, but not for length.
+        /// </summary>
+        public static string ValidEmailAddressPattern
+        {
+            get { return pattern; }
+        }
+    }
+}

--- a/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
+++ b/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
@@ -1,0 +1,66 @@
+﻿using Ploeh.AutoFixture.Kernel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Creates new <see cref="EmailAddressLocalPart"/> instances.
+    /// </summary>
+    public class EmailAddressLocalPartGenerator : ISpecimenBuilder
+    {
+        /// <summary>
+        /// Creates a new specimen based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }                        
+
+            if (request == null || !typeof(EmailAddressLocalPart).Equals(request))
+            {
+                return new NoSpecimen(request);
+            }
+
+            var localPart = CreateLocalPart(context);
+
+            if (!EmailAddressLocalPart.IsValid(localPart))
+                return new NoSpecimen(request);
+
+            return new EmailAddressLocalPart(localPart);
+        }
+       
+        /// <summary>
+        /// Creates a local part using the provided Specimen Context.  If the local part is greater
+        /// than  EmailAddressLocalPart.MaximumAllowableLength, truncates it to that length.  It is 
+        /// still possible the localPart is invalid based on EmailAddressLocalPart's rules.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        private static string CreateLocalPart(ISpecimenContext context)
+        {
+            var localPart = context.Resolve(typeof(string)) as string;
+
+            if (localPart == null)
+                return null;
+
+            if (localPart.Length > EmailAddressLocalPart.MaximumAllowableLength)
+            {
+                return localPart.Substring(0, EmailAddressLocalPart.MaximumAllowableLength);
+            }
+            else
+            {
+                return localPart;
+            }            
+        }
+    }
+}

--- a/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
+++ b/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
@@ -24,43 +24,21 @@ namespace Ploeh.AutoFixture
             if (context == null)
             {
                 throw new ArgumentNullException("context");
-            }                        
+            }
 
             if (request == null || !typeof(EmailAddressLocalPart).Equals(request))
             {
                 return new NoSpecimen(request);
             }
 
-            var localPart = CreateLocalPart(context);
-
-            if (!EmailAddressLocalPart.IsValid(localPart))
-                return new NoSpecimen(request);
-
-            return new EmailAddressLocalPart(localPart);
-        }
-       
-        /// <summary>
-        /// Creates a local part using the provided Specimen Context.  If the local part is greater
-        /// than  EmailAddressLocalPart.MaximumAllowableLength, truncates it to that length.  It is 
-        /// still possible the localPart is invalid based on EmailAddressLocalPart's rules.
-        /// </summary>
-        /// <param name="context"></param>
-        /// <returns></returns>
-        private static string CreateLocalPart(ISpecimenContext context)
-        {
             var localPart = context.Resolve(typeof(string)) as string;
 
-            if (localPart == null)
-                return null;
-
-            if (localPart.Length > EmailAddressLocalPart.MaximumAllowableLength)
+            if (string.IsNullOrEmpty(localPart))
             {
-                return localPart.Substring(0, EmailAddressLocalPart.MaximumAllowableLength);
+                return new NoSpecimen(request);
             }
-            else
-            {
-                return localPart;
-            }            
-        }
+
+            return new EmailAddressLocalPart(localPart);
+        }       
     }
 }

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -44,11 +44,7 @@ namespace Ploeh.AutoFixture
             try
             {
                 return TryCreateMailAddress(request, context);
-            }
-            catch (ArgumentNullException)
-            {
-                return new NoSpecimen(request);
-            }
+            }           
             catch (ArgumentException)
             {
                 return new NoSpecimen(request);

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -36,10 +36,21 @@ namespace Ploeh.AutoFixture
                 return new NoSpecimen(request);
             }
 
-            var name = Guid.NewGuid().ToString();
-            var host = fictitiousDomains[(uint)name.GetHashCode() % 3];
+            if (context == null)
+            {
+                return new NoSpecimen(request);
+            }
+                    
+            var localPart = context.Resolve(typeof(EmailAddressLocalPart)) as EmailAddressLocalPart;
 
-            var email = string.Format(CultureInfo.InvariantCulture, "{0} <{0}@{1}>", name, host);
+            if (localPart == null)
+            {
+                return new NoSpecimen(request);
+            }
+
+            var host = fictitiousDomains[(uint)localPart.GetHashCode() % 3];
+
+            var email = string.Format(CultureInfo.InvariantCulture, "{0} <{0}@{1}>", localPart, host);
             return new MailAddress(email);
         }
     }

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -44,11 +44,7 @@ namespace Ploeh.AutoFixture
             try
             {
                 return TryCreateMailAddress(request, context);
-            }           
-            catch (ArgumentException)
-            {
-                return new NoSpecimen(request);
-            }
+            }                    
             catch (FormatException)
             {
                 return new NoSpecimen(request);

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -31,16 +31,36 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
             if (!typeof(MailAddress).Equals(request))
             {
                 return new NoSpecimen(request);
             }
 
-            if (context == null)
+            try
+            {
+                return TryCreateMailAddress(request, context);
+            }
+            catch (ArgumentNullException)
             {
                 return new NoSpecimen(request);
             }
-                    
+            catch (ArgumentException)
+            {
+                return new NoSpecimen(request);
+            }
+            catch (FormatException)
+            {
+                return new NoSpecimen(request);
+            }
+        }
+
+        private object TryCreateMailAddress(object request, ISpecimenContext context)
+        {
             var localPart = context.Resolve(typeof(EmailAddressLocalPart)) as EmailAddressLocalPart;
 
             if (localPart == null)
@@ -53,5 +73,5 @@ namespace Ploeh.AutoFixture
             var email = string.Format(CultureInfo.InvariantCulture, "{0} <{0}@{1}>", localPart, host);
             return new MailAddress(email);
         }
-    }
+    }       
 }

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -94,6 +94,8 @@
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />
+    <Compile Include="EmailAddressLocalPartGeneratorTest.cs" />
+    <Compile Include="EmailAddressLocalPartTest.cs" />
     <Compile Include="Kernel\EnumeratorRelayTest.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingMethodFactoryTests.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingStaticMethodFactoryTests.cs" />

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -43,7 +43,8 @@ namespace Ploeh.AutoFixtureUnitTest
                     typeof(DelegateGenerator),
                     typeof(TaskGenerator),
                     typeof(IntPtrGuard),
-                    typeof(MailAddressGenerator)
+                    typeof(MailAddressGenerator),
+                    typeof(EmailAddressLocalPartGenerator)
                 };
             // Exercise system
             var sut = new DefaultPrimitiveBuilders();

--- a/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
@@ -1,0 +1,165 @@
+﻿using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class EmailAddressLocalPartGeneratorTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new EmailAddressLocalPartGenerator();
+            // Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullRequestReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPartGenerator();
+            // Exercise system
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(null, dummyContext);
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(), result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPartGenerator();
+            var dummyRequest = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() => sut.Create(dummyRequest, null));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNonEmailAddressLocalPartRequestReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPartGenerator();
+            var dummyRequest = new object();
+            // Exercise system
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(dummyRequest, dummyContext);
+            // Verify outcome
+            var expectedResult = new NoSpecimen(dummyRequest);
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWhenLocalPartReceivedFromContextIsNullReturnsCorrectResult()
+        {
+            // Fixture setup
+            var request = typeof(EmailAddressLocalPart);
+            object expectedValue = null;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r => typeof(string).Equals(r) ? expectedValue : new NoSpecimen(r)
+            };
+            var sut = new EmailAddressLocalPartGenerator();
+            // Exercise system and verify outcome
+            var result = sut.Create(request, context);
+            var expectedResult = new NoSpecimen(request);
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsEmailAddressLocalPartUsingLocalPartReceivedFromContext()
+        {
+            // Fixture setup
+            var request = typeof(EmailAddressLocalPart);
+            string expectedLocalPart = Guid.NewGuid().ToString();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (typeof(string).Equals(r))
+                    {
+                        return expectedLocalPart;
+                    }
+
+                    return new NoSpecimen(r);
+                }
+            };
+            var sut = new EmailAddressLocalPartGenerator();
+            // Exercise system
+            var result = sut.Create(typeof(EmailAddressLocalPart), context) as EmailAddressLocalPart;
+            // Verify outcome
+            Assert.Equal(expectedLocalPart, result.LocalPart);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsEmailAddressLocalPartWithCorrectlyTruncatedLocalPartFromContext()
+        {
+            // Fixture setup
+            var request = typeof(EmailAddressLocalPart);
+            string contextLocalPart = Guid.NewGuid().ToString() + Guid.NewGuid().ToString();
+            string expectedLocalPart = contextLocalPart.Substring(0, 64);
+
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (typeof(string).Equals(r))
+                    {
+                        return contextLocalPart;
+                    }
+
+                    return new NoSpecimen(r);
+                }
+            };
+            var sut = new EmailAddressLocalPartGenerator();
+            // Exercise system
+            var result = sut.Create(typeof(EmailAddressLocalPart), context) as EmailAddressLocalPart;
+            // Verify outcome
+            Assert.Equal(expectedLocalPart, result.LocalPart);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsNoSpecimenWhenContextCreatesInvalidLocalPartString()
+        {
+            // Fixture setup
+            var request = typeof(EmailAddressLocalPart);
+            var invalidLocalPart = "@@Invalid";
+
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (typeof(string).Equals(r))
+                    {
+                        return invalidLocalPart;
+                    }
+
+                    return new NoSpecimen(r);
+                }
+            };
+            var sut = new EmailAddressLocalPartGenerator();
+            // Exercise system
+            var result = sut.Create(typeof(EmailAddressLocalPart), context);
+            // Verify outcome
+            var expectedResult = new NoSpecimen(request);
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+    }
+}

--- a/Src/AutoFixtureUnitTest/EmailAddressLocalPartTest.cs
+++ b/Src/AutoFixtureUnitTest/EmailAddressLocalPartTest.cs
@@ -1,0 +1,169 @@
+﻿using Ploeh.AutoFixture;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class EmailAddressLocalPartTest
+    {
+        [Fact]
+        public void InitializeWithNullLocalPartThrows()
+        {
+            var sut = new EmailAddressLocalPart("good.localPart");
+
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(
+                () => new EmailAddressLocalPart(null));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(@"@CantStartWithAtSign")]
+        [InlineData(@".StartsWithPeriod")]
+        [InlineData(@"Has..TwoPeriods")]
+        [InlineData(@"EndsWithPeriod.")]
+        [InlineData(@".")]
+        [InlineData(@"Ima Notquoted")]
+        public void InitializeWithInvalidLocalPartThrows(string localPart)
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentException>(
+                () => new EmailAddressLocalPart(localPart));
+            // Teardown
+        }
+
+        [Theory]        
+        [InlineData(@"""Quoted\\WithSlash""")]
+        [InlineData("\"Quoted\\\rWithLineBreak\"")]
+        [InlineData(@"""Both\""Quoted""")]
+        [InlineData(@"service/department")]
+        [InlineData(@"$StartWithDollar")]
+        [InlineData(@"!def!xyz%abc")]
+        [InlineData(@"_Good.Email")]
+        [InlineData(@"~")]
+        [InlineData(@"""Quoted@AtSign""")]
+        [InlineData(@"Ima.InternalPeriod")]
+        [InlineData(@"""Ima.Quoted""")]
+        [InlineData(@"""Ima Quoted""")]
+        public void InitializeWithValidLocalPartSetsLocalPart(string localPart)
+        {
+            // Fixture setup            
+            var sut = new EmailAddressLocalPart(localPart);
+            // Exercise system
+            string result = sut.LocalPart;
+            // Verify outcome
+            Assert.Equal(localPart, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void ToStringReturnsCorrectResult()
+        {
+            // Fixture setup
+            string expected = "good.localPart";
+            var sut = new EmailAddressLocalPart("good.localPart");
+            // Exercise system
+            var result = sut.ToString();
+            // Verify outcome
+            Assert.Equal(expected, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsEquatable()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new EmailAddressLocalPart("good.localPart");
+            // Verify outcome
+            Assert.IsAssignableFrom<IEquatable<EmailAddressLocalPart>>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualNullObject()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPart("good.localPart");
+            object other = null;
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualNullSut()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPart("good.localPart");
+            UriScheme other = null;
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualAnonymousObject()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPart("good.localPart");
+            var anonymousObject = new object();
+            // Exercise system
+            bool result = sut.Equals(anonymousObject);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualOtherObjectWhenSchemesDiffer()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPart("good.localPart");
+            object other = new EmailAddressLocalPart("good2.localPart");
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualOtherSutWhenSchemesDiffer()
+        {
+            // Fixture setup
+            var sut = new EmailAddressLocalPart("good.localPart");
+            var other = new EmailAddressLocalPart("good2.localPart");
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }      
+
+
+        [Fact]
+        public void GetHashCodeWhenSchemeIsNotDefaultReturnsCorrectResult()
+        {
+            // Fixture setup
+            var localPart = "good.localPart";
+            var sut = new UriScheme(localPart);
+            // Exercise system
+            int result = sut.GetHashCode();
+            // Verify outcome
+            int expectedHashCode = localPart.GetHashCode();
+            Assert.Equal(expectedHashCode, result);
+            // Teardown
+        }
+    }    
+}

--- a/Src/AutoFixtureUnitTest/EmailAddressLocalPartTest.cs
+++ b/Src/AutoFixtureUnitTest/EmailAddressLocalPartTest.cs
@@ -12,9 +12,7 @@ namespace Ploeh.AutoFixtureUnitTest
     {
         [Fact]
         public void InitializeWithNullLocalPartThrows()
-        {
-            var sut = new EmailAddressLocalPart("good.localPart");
-
+        {          
             // Fixture setup
             // Exercise system and verify outcome
             Assert.Throws<ArgumentNullException>(
@@ -22,43 +20,13 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Theory]
-        [InlineData(@"@CantStartWithAtSign")]
-        [InlineData(@".StartsWithPeriod")]
-        [InlineData(@"Has..TwoPeriods")]
-        [InlineData(@"EndsWithPeriod.")]
-        [InlineData(@".")]
-        [InlineData(@"Ima Notquoted")]
-        public void InitializeWithInvalidLocalPartThrows(string localPart)
+        [Fact]
+        public void InitializeWithEmptyLocalPartThrows()
         {
             // Fixture setup
             // Exercise system and verify outcome
             Assert.Throws<ArgumentException>(
-                () => new EmailAddressLocalPart(localPart));
-            // Teardown
-        }
-
-        [Theory]        
-        [InlineData(@"""Quoted\\WithSlash""")]
-        [InlineData("\"Quoted\\\rWithLineBreak\"")]
-        [InlineData(@"""Both\""Quoted""")]
-        [InlineData(@"service/department")]
-        [InlineData(@"$StartWithDollar")]
-        [InlineData(@"!def!xyz%abc")]
-        [InlineData(@"_Good.Email")]
-        [InlineData(@"~")]
-        [InlineData(@"""Quoted@AtSign""")]
-        [InlineData(@"Ima.InternalPeriod")]
-        [InlineData(@"""Ima.Quoted""")]
-        [InlineData(@"""Ima Quoted""")]
-        public void InitializeWithValidLocalPartSetsLocalPart(string localPart)
-        {
-            // Fixture setup            
-            var sut = new EmailAddressLocalPart(localPart);
-            // Exercise system
-            string result = sut.LocalPart;
-            // Verify outcome
-            Assert.Equal(localPart, result);
+                () => new EmailAddressLocalPart(string.Empty));
             // Teardown
         }
 
@@ -66,31 +34,20 @@ namespace Ploeh.AutoFixtureUnitTest
         public void ToStringReturnsCorrectResult()
         {
             // Fixture setup
-            string expected = "good.localPart";
-            var sut = new EmailAddressLocalPart("good.localPart");
+            string expected = Guid.NewGuid().ToString();
+            var sut = new EmailAddressLocalPart(expected);
             // Exercise system
             var result = sut.ToString();
             // Verify outcome
             Assert.Equal(expected, result);
             // Teardown
-        }
-
-        [Fact]
-        public void SutIsEquatable()
-        {
-            // Fixture setup
-            // Exercise system
-            var sut = new EmailAddressLocalPart("good.localPart");
-            // Verify outcome
-            Assert.IsAssignableFrom<IEquatable<EmailAddressLocalPart>>(sut);
-            // Teardown
-        }
+        }      
 
         [Fact]
         public void SutDoesNotEqualNullObject()
         {
             // Fixture setup
-            var sut = new EmailAddressLocalPart("good.localPart");
+            var sut = new EmailAddressLocalPart(Guid.NewGuid().ToString());
             object other = null;
             // Exercise system
             bool result = sut.Equals(other);
@@ -99,12 +56,12 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact]
+        [Fact]        
         public void SutDoesNotEqualNullSut()
         {
             // Fixture setup
-            var sut = new EmailAddressLocalPart("good.localPart");
-            UriScheme other = null;
+            var sut = new EmailAddressLocalPart(Guid.NewGuid().ToString());
+            EmailAddressLocalPart other = null;
             // Exercise system
             bool result = sut.Equals(other);
             // Verify outcome
@@ -116,7 +73,7 @@ namespace Ploeh.AutoFixtureUnitTest
         public void SutDoesNotEqualAnonymousObject()
         {
             // Fixture setup
-            var sut = new EmailAddressLocalPart("good.localPart");
+            var sut = new EmailAddressLocalPart(Guid.NewGuid().ToString());
             var anonymousObject = new object();
             // Exercise system
             bool result = sut.Equals(anonymousObject);
@@ -126,11 +83,11 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void SutDoesNotEqualOtherObjectWhenSchemesDiffer()
+        public void SutDoesNotEqualOtherObjectWhenLocalPartsDiffer()
         {
             // Fixture setup
-            var sut = new EmailAddressLocalPart("good.localPart");
-            object other = new EmailAddressLocalPart("good2.localPart");
+            var sut = new EmailAddressLocalPart(Guid.NewGuid().ToString());
+            object other = new EmailAddressLocalPart(Guid.NewGuid().ToString());
             // Exercise system
             bool result = sut.Equals(other);
             // Verify outcome
@@ -139,11 +96,11 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void SutDoesNotEqualOtherSutWhenSchemesDiffer()
+        public void SutDoesNotEqualOtherSutWhenLocalPartsDiffer()
         {
             // Fixture setup
-            var sut = new EmailAddressLocalPart("good.localPart");
-            var other = new EmailAddressLocalPart("good2.localPart");
+            var sut = new EmailAddressLocalPart(Guid.NewGuid().ToString());
+            var other = new EmailAddressLocalPart(Guid.NewGuid().ToString());
             // Exercise system
             bool result = sut.Equals(other);
             // Verify outcome
@@ -151,13 +108,27 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }      
 
-
         [Fact]
-        public void GetHashCodeWhenSchemeIsNotDefaultReturnsCorrectResult()
+        public void SutEqualsOtherSutWhenLocalPartsAreEqual()
         {
             // Fixture setup
-            var localPart = "good.localPart";
-            var sut = new UriScheme(localPart);
+            var localPart = Guid.NewGuid().ToString();
+
+            var sut = new EmailAddressLocalPart(localPart);
+            var other = new EmailAddressLocalPart(localPart);
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.True(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetHashCodeReturnsCorrectResult()
+        {
+            // Fixture setup
+            var localPart = Guid.NewGuid().ToString();
+            var sut = new EmailAddressLocalPart(localPart);
             // Exercise system
             int result = sut.GetHashCode();
             // Verify outcome


### PR DESCRIPTION
Here's my first pass at #348.  Quick synopsis:

- Added `EmailAddressLocalPart` and `EmailAddressLocalPartGenerator` using `UriScheme` as a model
- `EmailAddressLocalGenerator` fetches a string from the `ISpecimenContext` to use in creating the local part; that's how `UriGenerator` seems to do it, wasn't sure if that was preferable to using standalone local part creation logic to avoid a case when the context's string behavior has been altered
- Added unit tests for each component
- Updated `MailAddressGenerator` to request `EmailAddressLocalPart` from the context and modified/added tests
- Updated `DefaultPrimitiveBuilders` to include `EmailAddressLocalPartGenerator` and its related test

I did add a bit of validation to `EmailAddressLocalPart` based on the RFC specification, basically length and a regular expression I cited in the comments that evaluates it for character positioning.  I wasn't sure if all of that is desired or not.  

I ran build-release.sh and it completed without errors.  My only other question is whether I should add a test to `FixtureTest` or not.  There is one there for `MailAddressGenerator`, not sure if that's sufficient or we want a separate one.  