### PR TITLE
xUnit 2 corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ AutoFixture is available via NuGet:
 * [AutoFixture.AutoNSubstitute](http://nuget.org/packages/AutoFixture.AutoNSubstitute)
 * [AutoFixture.AutoFoq](http://www.nuget.org/packages/AutoFixture.AutoFoq)
 * [AutoFixture.Xunit](http://nuget.org/packages/AutoFixture.Xunit)
+* [AutoFixture.Xunit2](http://nuget.org/packages/AutoFixture.Xunit2)
 * [AutoFixture.NUnit2](http://nuget.org/packages/AutoFixture.NUnit2)
 * [AutoFixture.Idioms](http://nuget.org/packages/AutoFixture.Idioms)
 * [SemanticComparison](http://nuget.org/packages/SemanticComparison)

--- a/Src/AutoFixture.xUnit.net2.UnitTest/packages.config
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/packages.config
@@ -5,4 +5,5 @@
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
   <package id="xunit.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request adds two small things related to the xUnit 2 glue library that were overlooked:

- The Visual Studio test runner reference in the xUnit 2 glue library test project
- The link to the `AutoFixture.Xunit2` NuGet package in the readme file