### PR TITLE
CreateMany should accept zero - updated to include FiniteSequenceRequest

### DIFF
--- a/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
@@ -24,9 +24,9 @@ namespace Ploeh.AutoFixture.Kernel
             {
                 throw new ArgumentNullException("request");
             }
-            if (count <= 0)
+            if (count < 0)
             {
-                throw new ArgumentOutOfRangeException("count", string.Format(CultureInfo.CurrentCulture, "The requested count must be a positive number, but was {0}.", count));
+                throw new ArgumentOutOfRangeException("count", string.Format(CultureInfo.CurrentCulture, "The requested count must be a positive number (or zero), but was {0}.", count));
             }        
 
             this.request = request;

--- a/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRequestTest.cs
@@ -19,14 +19,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        [Fact]
-        public void InitializeWithInvalidCountThrows()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-3)]
+        public void InitializeWithInvalidCountThrows(int count)
         {
             // Fixture setup
             var dummyRequest = new object();
             // Exercise system and verify outcome
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new FiniteSequenceRequest(dummyRequest, -1));
+                new FiniteSequenceRequest(dummyRequest, count));
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRequestTest.cs
@@ -19,20 +19,19 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(-1)]
-        public void InitializeWithInvalidCountThrows(int count)
+        [Fact]
+        public void InitializeWithInvalidCountThrows()
         {
             // Fixture setup
             var dummyRequest = new object();
             // Exercise system and verify outcome
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new FiniteSequenceRequest(dummyRequest, count));
+                new FiniteSequenceRequest(dummyRequest, -1));
             // Teardown
         }
 
         [Theory]
+        [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]
         [InlineData(10)]


### PR DESCRIPTION
An additional pull request to allow CreateMany to accept the value 0. An original fix was made, but that didn't allow zero as was intended.
This is for issue https://github.com/AutoFixture/AutoFixture/issues/365