### PR TITLE
Turns the member name comparison into a strategy.

### DIFF
--- a/Src/AutoFixture/Kernel/FieldSpecification.cs
+++ b/Src/AutoFixture/Kernel/FieldSpecification.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Ploeh.AutoFixture.Kernel
@@ -11,6 +12,7 @@ namespace Ploeh.AutoFixture.Kernel
     {
         private readonly Type targetType;
         private readonly string targetName;
+        private readonly IEqualityComparer<string> nameComparison;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldSpecification"/> class.
@@ -28,6 +30,36 @@ namespace Ploeh.AutoFixture.Kernel
         /// <paramref name="targetName"/> is <see langword="null"/>.
         /// </exception>
         public FieldSpecification(Type targetType, string targetName)
+            : this(targetType, targetName, StringComparer.Ordinal)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldSpecification"/> class.
+        /// </summary>
+        /// <param name="targetType">
+        /// The <see cref="Type"/> with which the requested
+        /// <see cref="FieldInfo"/> type should be compatible.
+        /// </param>
+        /// <param name="targetName">
+        /// The name which the requested <see cref="FieldInfo"/> name
+        /// should match according to the specified
+        /// <paramref name="nameComparison"/> criteria.
+        /// </param>
+        /// <param name="nameComparison">
+        /// The criteria used to match the requested
+        /// <see cref="FieldInfo"/> name with the specified
+        /// <paramref name="targetName"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="targetType"/> or
+        /// <paramref name="targetName"/> or
+        /// <paramref name="nameComparison"/> is <see langword="null"/>.
+        /// </exception>
+        public FieldSpecification(
+            Type targetType,
+            string targetName,
+            IEqualityComparer<string> nameComparison)
         {
             if (targetType == null)
             {
@@ -39,8 +71,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException("targetName");
             }
 
+            if (nameComparison == null)
+            {
+                throw new ArgumentNullException("nameComparison");
+            }
+
             this.targetType = targetType;
             this.targetName = targetName;
+            this.nameComparison = nameComparison;
         }
 
         /// <summary>
@@ -78,7 +116,7 @@ namespace Ploeh.AutoFixture.Kernel
 
             return IsRequestForField(request) &&
                    FieldIsCompatibleWithTargetType(request) &&
-                   FieldHasTargetName(request);
+                   FieldMatchesTargetName(request);
         }
 
         private static bool IsRequestForField(object request)
@@ -93,9 +131,11 @@ namespace Ploeh.AutoFixture.Kernel
                    .IsAssignableFrom(this.targetType);
         }
 
-        private bool FieldHasTargetName(object request)
+        private bool FieldMatchesTargetName(object request)
         {
-            return ((FieldInfo)request).Name == this.targetName;
+            return this.nameComparison.Equals(
+                ((FieldInfo)request).Name,
+                this.targetName);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/PropertySpecification.cs
+++ b/Src/AutoFixture/Kernel/PropertySpecification.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Ploeh.AutoFixture.Kernel
@@ -11,6 +12,7 @@ namespace Ploeh.AutoFixture.Kernel
     {
         private readonly Type targetType;
         private readonly string targetName;
+        private readonly IEqualityComparer<string> nameComparison;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertySpecification"/> class.
@@ -28,6 +30,36 @@ namespace Ploeh.AutoFixture.Kernel
         /// <paramref name="targetName"/> is <see langword="null"/>.
         /// </exception>
         public PropertySpecification(Type targetType, string targetName)
+            : this(targetType, targetName, StringComparer.Ordinal)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertySpecification"/> class.
+        /// </summary>
+        /// <param name="targetType">
+        /// The <see cref="Type"/> with which the requested
+        /// <see cref="PropertyInfo"/> type should be compatible.
+        /// </param>
+        /// <param name="targetName">
+        /// The name which the requested <see cref="PropertyInfo"/> name
+        /// should match according to the specified
+        /// <paramref name="nameComparison"/> criteria.
+        /// </param>
+        /// <param name="nameComparison">
+        /// The criteria used to match the requested
+        /// <see cref="PropertyInfo"/> name with the specified
+        /// <paramref name="targetName"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="targetType"/> or
+        /// <paramref name="targetName"/> or
+        /// <paramref name="nameComparison"/> is <see langword="null"/>.
+        /// </exception>
+        public PropertySpecification(
+            Type targetType,
+            string targetName,
+            IEqualityComparer<string> nameComparison)
         {
             if (targetType == null)
             {
@@ -39,8 +71,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException("targetName");
             }
 
+            if (nameComparison == null)
+            {
+                throw new ArgumentNullException("nameComparison");
+            }
+
             this.targetType = targetType;
             this.targetName = targetName;
+            this.nameComparison = nameComparison;
         }
 
         /// <summary>
@@ -78,7 +116,7 @@ namespace Ploeh.AutoFixture.Kernel
 
             return IsRequestForProperty(request) &&
                    PropertyIsCompatibleWithTargetType(request) &&
-                   PropertyHasTargetName(request);
+                   PropertyMatchesTargetName(request);
         }
 
         private static bool IsRequestForProperty(object request)
@@ -93,9 +131,11 @@ namespace Ploeh.AutoFixture.Kernel
                    .IsAssignableFrom(this.targetType);
         }
 
-        private bool PropertyHasTargetName(object request)
+        private bool PropertyMatchesTargetName(object request)
         {
-            return ((PropertyInfo)request).Name == this.targetName;
+            return this.nameComparison.Equals(
+                ((PropertyInfo)request).Name,
+                this.targetName);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/FieldSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FieldSpecificationTest.cs
@@ -54,6 +54,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        public void InitializeWithNullNameComparisonShouldThrowArgumentNullException()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new FieldSpecification(typeof(object), "someName", null));
+            // Teardown
+        }
+
+        [Fact]
         public void IsSatisfiedByWithNullRequestShouldThrowArgumentNullException()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/Kernel/ParameterSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ParameterSpecificationTest.cs
@@ -55,6 +55,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        public void InitializeWithNullNameComparisonShouldThrowArgumentNullException()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new ParameterSpecification(typeof(object), "someName", null));
+            // Teardown
+        }
+
+        [Fact]
         public void IsSatisfiedByWithNullRequestShouldThrowArgumentNullException()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/Kernel/PropertySpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/PropertySpecificationTest.cs
@@ -54,6 +54,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        public void InitializeWithNullNameComparisonShouldThrowArgumentNullException()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new PropertySpecification(typeof(object), "someName", null));
+            // Teardown
+        }
+
+        [Fact]
         public void IsSatisfiedByWithNullRequestShouldThrowArgumentNullException()
         {
             // Fixture setup


### PR DESCRIPTION
The identifiers used in `FieldSpecification`, `PropertySpecification` and `ParameterSpecification` can now be compared according to a strategy. The strategy is specified during initialization through an `IEqualityComparer<string>`.

For example, in order to make a _case-insensitive_ comparison of a property's name, one could say:

```csharp
new PropertySpecification(
    typeof(int),
    "Foo",
    StringComparer.OrdinalIgnoreCase);
```

If a strategy isn't specified at construction, the names will be compared in a _case-sensitive_ fashion, which is consistent with the current behavior.

This change enables to use the `FrozenAttribute` from #318 in scenarios where a field, property or parameter should be frozen by matching the name of the test parameter regardless of case.