### PR TITLE
AutoMoq - Handle other valid specimens

### DIFF
--- a/Src/AutoMoq/AutoMockPropertiesCommand.cs
+++ b/Src/AutoMoq/AutoMockPropertiesCommand.cs
@@ -23,7 +23,6 @@ namespace Ploeh.AutoFixture.AutoMoq
         /// <param name="context">The context that is used to create anonymous values.</param>
         public void Execute(object specimen, ISpecimenContext context)
         {
-            if (specimen == null) throw new ArgumentNullException("specimen");
             if (context == null) throw new ArgumentNullException("context");
 
             var mock = specimen as Mock;

--- a/Src/AutoMoq/MockPostprocessor.cs
+++ b/Src/AutoMoq/MockPostprocessor.cs
@@ -54,7 +54,11 @@ namespace Ploeh.AutoFixture.AutoMoq
                 return new NoSpecimen(request);
             }            
 
-            var m = this.builder.Create(request, context) as Mock;
+            var specimen = this.builder.Create(request, context);
+            if (specimen is NoSpecimen || specimen is OmitSpecimen || specimen == null)
+                return specimen;
+
+            var m = specimen as Mock;
             if (m == null)
             {
                 return new NoSpecimen(request);

--- a/Src/AutoMoq/MockType.cs
+++ b/Src/AutoMoq/MockType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -64,13 +65,31 @@ namespace Ploeh.AutoFixture.AutoMoq
         }
 
         internal static IReturnsResult<TMock> ReturnsUsingContext<TMock, TResult>(this IReturns<TMock, TResult> setup,
-                                                                                  ISpecimenContext context)
+            ISpecimenContext context)
             where TMock : class
         {
             return setup.Returns(() =>
             {
                 var specimen = context.Resolve(typeof (TResult));
-                TResult result = specimen is TResult ? (TResult) specimen : default(TResult);
+
+                // check if specimen is null but member is non-nullable value type
+                if (specimen == null && (default(TResult) != null))
+                    throw new InvalidOperationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "Tried to setup a member with a return type of {0}, but null was found instead.",
+                            typeof (TResult)));
+
+                // check if specimen can be safely converted to TResult
+                if (specimen != null && !(specimen is TResult))
+                    throw new InvalidOperationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "Tried to setup a member with a return type of {0}, but an instance of {1} was found instead.",
+                            typeof (TResult),
+                            specimen.GetType()));
+
+                TResult result = (TResult) specimen;
 
                 //"cache" value for future invocations
                 setup.Returns(result);

--- a/Src/AutoMoq/MockType.cs
+++ b/Src/AutoMoq/MockType.cs
@@ -68,11 +68,14 @@ namespace Ploeh.AutoFixture.AutoMoq
             where TMock : class
         {
             return setup.Returns(() =>
-                {
-                    var result = (TResult) context.Resolve(typeof (TResult));
-                    setup.Returns(result);
-                    return result;
-                });
+            {
+                var specimen = context.Resolve(typeof (TResult));
+                TResult result = specimen is TResult ? (TResult) specimen : default(TResult);
+
+                //"cache" value for future invocations
+                setup.Returns(result);
+                return result;
+            });
         }
     }
 }

--- a/Src/AutoMoq/MockVirtualMethodsCommand.cs
+++ b/Src/AutoMoq/MockVirtualMethodsCommand.cs
@@ -51,19 +51,22 @@ namespace Ploeh.AutoFixture.AutoMoq
                 var returnType = method.ReturnType;
                 var methodInvocationLambda = MakeMethodInvocationLambda(mockedType, method, context);
 
-                if (method.IsVoid())
+                if (methodInvocationLambda != null)
                 {
-                    this.GetType()
-                        .GetMethod("SetupVoidMethod", BindingFlags.NonPublic | BindingFlags.Static)
-                        .MakeGenericMethod(mockedType)
-                        .Invoke(this, new object[] {mock, methodInvocationLambda});
-                }
-                else
-                {
-                    this.GetType()
-                        .GetMethod("SetupMethod", BindingFlags.NonPublic | BindingFlags.Static)
-                        .MakeGenericMethod(mockedType, returnType)
-                        .Invoke(this, new object[] {mock, methodInvocationLambda, context});
+                    if (method.IsVoid())
+                    {
+                        this.GetType()
+                            .GetMethod("SetupVoidMethod", BindingFlags.NonPublic | BindingFlags.Static)
+                            .MakeGenericMethod(mockedType)
+                            .Invoke(this, new object[] {mock, methodInvocationLambda});
+                    }
+                    else
+                    {
+                        this.GetType()
+                            .GetMethod("SetupMethod", BindingFlags.NonPublic | BindingFlags.Static)
+                            .MakeGenericMethod(mockedType, returnType)
+                            .Invoke(this, new object[] {mock, methodInvocationLambda, context});
+                    }
                 }
             }
         }
@@ -141,6 +144,9 @@ namespace Ploeh.AutoFixture.AutoMoq
                                          .Select(param => MakeParameterExpression(param, context))
                                          .ToList();
 
+            if (methodCallParams.Any(exp => exp == null))
+                return null;
+
             //e.g. "x.Method(It.IsAny<string>(), out parameter)"
             var methodCall = Expression.Call(lambdaParam, method, methodCallParams);
 
@@ -159,6 +165,9 @@ namespace Ploeh.AutoFixture.AutoMoq
 
                 //resolve the "out" param from the context
                 object variable = context.Resolve(underlyingType);
+
+                if (variable is OmitSpecimen)
+                    return null;
 
                 return Expression.Constant(variable, underlyingType);
             }

--- a/Src/AutoMoq/MockVirtualMethodsCommand.cs
+++ b/Src/AutoMoq/MockVirtualMethodsCommand.cs
@@ -36,7 +36,6 @@ namespace Ploeh.AutoFixture.AutoMoq
         /// <param name="context">The context of the mock.</param>
         public void Execute(object specimen, ISpecimenContext context)
         {
-            if (specimen == null) throw new ArgumentNullException("specimen");
             if (context == null) throw new ArgumentNullException("context");
 
             var mock = specimen as Mock;

--- a/Src/AutoMoq/StubPropertiesCommand.cs
+++ b/Src/AutoMoq/StubPropertiesCommand.cs
@@ -21,8 +21,6 @@ namespace Ploeh.AutoFixture.AutoMoq
         /// <param name="context">The context of the mock.</param>
         public void Execute(object specimen, ISpecimenContext context)
         {
-            if (specimen == null) throw new ArgumentNullException("specimen");
-
             var mock = specimen as Mock;
             if (mock == null)
                 return;

--- a/Src/AutoMoqUnitTest/AutoMockPropertiesCommandTest.cs
+++ b/Src/AutoMoqUnitTest/AutoMockPropertiesCommandTest.cs
@@ -13,14 +13,15 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
     public class AutoMockPropertiesCommandTest
     {
-        [Fact]
-        public void ExecuteThrowsWhenSpecimenIsNull()
+        [Theory]
+        [ClassData(typeof (ValidNonMockSpecimens))]
+        public void ExecuteDoesNotThrowsWhenSpecimenIsValidNonMockSpecimen(object validNonMockSpecimen)
         {
             // Fixture setup
             var context = new Mock<ISpecimenContext>().Object;
             var sut = new AutoMockPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() => sut.Execute(null, context));
+            Assert.DoesNotThrow(() => sut.Execute(validNonMockSpecimen, context));
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -92,6 +92,8 @@
     <Compile Include="TestTypes\IInterfaceWithMethod.cs" />
     <Compile Include="TestTypes\IInterfaceWithMethodWithOutParameterOfReferenceType.cs" />
     <Compile Include="TestTypes\IInterfaceWithNewMethod.cs" />
+    <Compile Include="TestTypes\IInterfaceWithNonNullableValueTypeProperty.cs" />
+    <Compile Include="TestTypes\IInterfaceWithNullableValueTypeProperty.cs" />
     <Compile Include="TestTypes\IInterfaceWithoutMembers.cs" />
     <Compile Include="TestTypes\IInterfaceWithOutMethod.cs" />
     <Compile Include="TestTypes\IInterfaceWithParameterlessMethod.cs" />

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -90,6 +90,7 @@
     <Compile Include="TestTypes\IInterfaceWithGenericMethod.cs" />
     <Compile Include="TestTypes\IInterfaceWithIndexer.cs" />
     <Compile Include="TestTypes\IInterfaceWithMethod.cs" />
+    <Compile Include="TestTypes\IInterfaceWithMethodWithOutParameterOfReferenceType.cs" />
     <Compile Include="TestTypes\IInterfaceWithNewMethod.cs" />
     <Compile Include="TestTypes\IInterfaceWithoutMembers.cs" />
     <Compile Include="TestTypes\IInterfaceWithOutMethod.cs" />

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -111,6 +111,7 @@
     <Compile Include="TestTypes\TypeWithStaticMethod.cs" />
     <Compile Include="TestTypes\TypeWithStaticProperty.cs" />
     <Compile Include="TestTypes\TypeWithVirtualMembers.cs" />
+    <Compile Include="ValidNonMockSpecimens.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj">

--- a/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
+++ b/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
@@ -86,22 +86,22 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         }
 
         [Theory]
-        [InlineData(typeof(Mock<object>), "")]
-        [InlineData(typeof(Mock<object>), null)]
-        public void CreateFromMockRequestWhenDecoratedBuilderReturnsNoMockReturnsCorrectResult(object request, object innerResult)
+        [ClassData(typeof (ValidNonMockSpecimens))]
+        public void CreateFromMockRequestWhenDecoratedBuilderReturnsValidNonMockSpecimenReturnsCorrectResult(
+            object validNonMockSpecimen)
         {
             // Fixture setup
+            var request = typeof (Mock<object>);
             var context = new Mock<ISpecimenContext>().Object;
 
             var builderStub = new Mock<ISpecimenBuilder>();
-            builderStub.Setup(b => b.Create(request, context)).Returns(innerResult);
+            builderStub.Setup(b => b.Create(request, context)).Returns(validNonMockSpecimen);
 
             var sut = new MockPostprocessor(builderStub.Object);
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
-            var expectedResult = new NoSpecimen(request);
-            Assert.Equal(expectedResult, result);
+            Assert.Equal(validNonMockSpecimen, result);
             // Teardown
         }
 

--- a/Src/AutoMoqUnitTest/MockRelayTest.cs
+++ b/Src/AutoMoqUnitTest/MockRelayTest.cs
@@ -127,21 +127,6 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Teardown
         }
 
-        public class ValidNonMockSpecimens : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] {new NoSpecimen()};
-                yield return new object[] {new OmitSpecimen()};
-                yield return new object[] {null};
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
-
         [Theory]
         [ClassData(typeof (ValidNonMockSpecimens))]
         public void CreateReturnsCorrectResultWhenContextReturnsValidNonMockSpecimen(object validNonMockSpecimen)

--- a/Src/AutoMoqUnitTest/MockTypeTest.cs
+++ b/Src/AutoMoqUnitTest/MockTypeTest.cs
@@ -63,5 +63,33 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var result = mock.Object.Property;
             fixture.Verify(f => f.Create(typeof (string), It.IsAny<SpecimenContext>()), Times.Once());
         }
+
+        [Fact]
+        public void ReturnsUsingFixtureSetsMockUpWithNullWhenContextReturnsNull()
+        {
+            // Fixture setup
+            var mock = new Mock<IInterfaceWithProperty>();
+            var fixture = new Mock<ISpecimenBuilder>();
+            fixture.Setup(f => f.Create(typeof (string), It.IsAny<ISpecimenContext>()))
+                .Returns(null as Type);
+            // Exercise system
+            mock.Setup(x => x.Property).ReturnsUsingFixture(fixture.Object);
+            // Verify outcome
+            Assert.Null(mock.Object.Property);
+        }
+
+        [Fact]
+        public void ReturnsUsingFixtureSetsMockUpWithNullWhenContextReturnsOmitSpecimen()
+        {
+            // Fixture setup
+            var mock = new Mock<IInterfaceWithProperty>();
+            var fixture = new Mock<ISpecimenBuilder>();
+            fixture.Setup(f => f.Create(typeof (string), It.IsAny<ISpecimenContext>()))
+                .Returns(new OmitSpecimen());
+            // Exercise system
+            mock.Setup(x => x.Property).ReturnsUsingFixture(fixture.Object);
+            // Verify outcome
+            Assert.Null(mock.Object.Property);
+        }
     }
 }

--- a/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
@@ -6,20 +6,22 @@ using Moq;
 using Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
     public class MockVirtualMethodsCommandTest
     {
-        [Fact]
-        public void SetupThrowsWhenMockIsNull()
+        [Theory]
+        [ClassData(typeof (ValidNonMockSpecimens))]
+        public void ExecuteShouldNotThrowWhenSpecimenIsValidNonMockSpecimen(object validNonMockSpecimen)
         {
             // Fixture setup
             var context = new Mock<ISpecimenContext>();
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(
-                () => sut.Execute(null, context.Object));
+            Assert.DoesNotThrow(
+                () => sut.Execute(validNonMockSpecimen, context.Object));
             // Teardown
         }
 

--- a/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Moq;
@@ -284,6 +285,44 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
             Assert.DoesNotThrow(() => sut.Execute(specimen, context.Object));
+        }
+
+        [Fact]
+        public void SetsUpOutParametersWithNullWhenContextReturnsNull()
+        {
+            // Fixture setup
+            var contextMock = new Mock<ISpecimenContext>();
+            contextMock.Setup(ctx => ctx.Resolve(typeof (string)))
+                .Returns(null);
+            var mock = new Mock<IInterfaceWithMethodWithOutParameterOfReferenceType>();
+
+            var sut = new MockVirtualMethodsCommand();
+            // Exercise system
+            sut.Execute(mock, contextMock.Object);
+            // Verify outcome
+            string outResult;
+            mock.Object.Method(out outResult);
+            Assert.Null(outResult);
+            // Teardown
+        }
+
+        [Fact]
+        public void DoesNotSetupMethodsWithOutParametersWhenContextReturnsOmitSpecimen()
+        {
+            // Fixture setup
+            var contextMock = new Mock<ISpecimenContext>();
+            contextMock.Setup(ctx => ctx.Resolve(typeof (int)))
+                .Returns(new OmitSpecimen());
+            var mock = new Mock<IInterfaceWithOutMethod>(MockBehavior.Strict);
+
+            var sut = new MockVirtualMethodsCommand();
+            // Exercise system
+            sut.Execute(mock, contextMock.Object);
+            // Verify outcome
+            // The mock has strict behaviour - calling methods that were not setup cause an exception to be thrown
+            int outResult;
+            Assert.Throws<MockException>(() => mock.Object.Method(out outResult));
+            // Teardown
         }
     }
 }

--- a/Src/AutoMoqUnitTest/StubPropertiesCommandTest.cs
+++ b/Src/AutoMoqUnitTest/StubPropertiesCommandTest.cs
@@ -13,14 +13,15 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
     public class StubPropertiesCommandTest
     {
-        [Fact]
-        public void ExecuteThrowsWhenSpecimenIsNull()
+        [Theory]
+        [ClassData(typeof (ValidNonMockSpecimens))]
+        public void ExecuteDoesNotThrowsWhenSpecimenIsValidNonMockSpecimen(object validNonMockSpecimen)
         {
             // Fixture setup
             var context = new Mock<ISpecimenContext>().Object;
             var sut = new StubPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() => sut.Execute(null, context));
+            Assert.DoesNotThrow(() => sut.Execute(validNonMockSpecimen, context));
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithMethodWithOutParameterOfReferenceType.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithMethodWithOutParameterOfReferenceType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes
+{
+    public interface IInterfaceWithMethodWithOutParameterOfReferenceType
+    {
+        string Method(out string s);
+    }
+}

--- a/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithNonNullableValueTypeProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithNonNullableValueTypeProperty.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes
+{
+    public interface IInterfaceWithNonNullableValueTypeProperty
+    {
+        int Property { get; set; }
+    }
+}

--- a/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithNullableValueTypeProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithNullableValueTypeProperty.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes
+{
+    public interface IInterfaceWithNullableValueTypeProperty
+    {
+        int? Property { get; set; }
+    }
+}

--- a/Src/AutoMoqUnitTest/ValidNonMockSpecimens.cs
+++ b/Src/AutoMoqUnitTest/ValidNonMockSpecimens.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.AutoMoq.UnitTest
+{
+    internal class ValidNonMockSpecimens : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] {new NoSpecimen()};
+            yield return new object[] {new OmitSpecimen()};
+            yield return new object[] {null};
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
As discussed in #369, this PR aims to refactor AutoMoq so that `null`, `NoSpecimen` and `OmitSpecimen` are properly validated.

Most cases are pretty straightforward to fix, but two stand out:

## Out parameters

This is more or less what AutoMoq currently does when setting up a method with an `out` parameter (reflection and abstractions aside):

```csharp
// AutoMoq
var outResult = fixture.Create<string>();
mock.Setup(m => m.Method(out outResult).Returns( ... );
```
```csharp
var frozenString = fixture.Freeze<string>();
var sut = fixture.Create<ISomething>();

string outResult = null;
sut.Method(out outResult);
Assert.Equal(frozenString, outResult);
```

In the context of resolving the value for an `out` parameter, what might the meaning of `OmitSpecimen` be? I can think of two possible definitions:

* Don't "assign" anything to the `out` parameter
    * (*Weeell*, `out` parameters must be assigned something, so "Assign `default(T)` to the `out` parameter" is a better description.)
* Don't setup the method

I ended up implementing the second definition - although, in hindsight, the first sounds more appropriate.
Opinions? Maybe there's a third definition?

## ReturnsUsingFixture / ReturnsUsingContext

This is a tricky one. How should `OmitSpecimen` be treated here?

In #397, I suggested the [following spec](https://github.com/AutoFixture/AutoFixture/pull/397#issuecomment-95675027):

> Don't set it up, at all. Instead, let the mocking framework decide what to do. The framework might then decide to either return null, 0, a mock (e.g., in Moq if `DefaultValue` is set to `DefaultValue.Mock`), or maybe even throw an exception.

However, I don't think this spec can be implemented in Moq.

This is the closest I got, by using a callback that would later decide whether or not to call `Returns`.

```csharp
internal static IReturnsThrows<TMock, TResult> ReturnsUsingContext<TMock, TResult>(
        this ISetup<TMock, TResult> setup, ISpecimenContext context)
    where TMock : class
{
    bool hasBeenSetup = false;
    return setup
        .Callback(() =>
        {
            if (hasBeenSetup)
                return;
            hasBeenSetup = true;

            var specimen = context.Resolve(typeof (TResult));

            // "specimen is TResult" returns false if specimen is null.
            // For that reason, we have to additionally check if null is a valid specimen for TResult,
            // i.e., if TResult is a reference type or Nullable<T>.
            if (specimen is TResult || (specimen == null && default(TResult) == null))
            {
                var result = (TResult)specimen;
                setup.Returns(result);
            }
        });
}
```

Before why I explain the drawbacks of this solution, let us break the spec in parts:

1. "let the mocking framework decide what to do. The framework might then decide to either return null, 0, ..." 
1. "... a mock (e.g., in Moq if `DefaultValue` is set to `DefaultValue.Mock`), ..."
1. "... or maybe even throw an exception."

##### (1) "let the mocking framework decide what to do. The framework might then decide to either return null, 0, ..." 

This point is possible, and can be achieved using the implementation above.

```csharp
public interface ITest
{
    string Property { get; set; }
}

// Fixture setup
var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());

var mock = fixture.Create<Mock<ITest>>();
// Exercise system
mock.Setup(m => m.Property).ReturnsUsingFixture(new Omitter());
// Verify outcome
Assert.Null(mock.Object.Property);
```

##### (2) "... a mock (e.g., in Moq if `DefaultValue` is set to `DefaultValue.Mock`), ..."

Not possible, this test fails:

```csharp
public interface ITest2
{
    ITest Property { get; set; }
}

// Fixture setup
var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());

var mock = fixture.Create<Mock<ITest2>>();
mock.DefaultValue = DefaultValue.Mock;
// Exercise system
mock.Setup(m => m.Property).ReturnsUsingFixture(new Omitter());
// Verify outcome
var propertyValue = mock.Object.Property;
Assert.NotNull(propertyValue);
```

##### (3) "... or maybe even throw an exception."

Technically possible - you could chain two calls, like `mock.Setup(...).ReturnsUsingContext(...).Throws<Exception>`.

The problem is, if we do that, our callback with the conditional setup won't ever be called. The call to `Throws` completely overrides it, and every member invocation will result in an exception being thrown. For example, this test fails:

```csharp
var mock = new Mock<ITest>();

mock.Setup(m => m.Property)
    .ReturnsUsingFixture(new Fixture())
    .Throws<Exception>();

Assert.DoesNotThrow(() => { var _ = mock.Object.Property; });
```

So, 2 out of the 3 requirements cannot be implemented.  A couple more cons:

* In order to internally be able to call `Callback`, we'd have to change the return type and the type of the first parameter of `ReturnsUsingFixture` (low impact breaking change).
* This change in the signature would allow for a non-intuitive API (e.g., `ReturnsUsingFixture().Returns()`, or `ReturnsUsingFixture().Throws()`)

To sum things up, I believe we're better off simply returning `default(T)` if we get an `OmitSpecimen`.


(This turned out to be longer than I thought :sweat: ).