### PR TITLE
Constructor of RandomNumericSequenceGenerator now checks that given limits are ascending

### DIFF
--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -54,10 +54,9 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentException("Limits must be at least two ascending numbers.", "limits");
             }
 
-            this.limits = limits;
+            ValidateThatLimitsAreStrictlyAscending(limits);
 
-            this.ValidateThatLimitsAreStrictlyAscending();
-            
+            this.limits = limits;
             this.syncRoot = new object();
             this.random = new Random();
             this.numbers = new HashSet<long>();
@@ -95,9 +94,9 @@ namespace Ploeh.AutoFixture
             return this.CreateRandom(type);
         }
 
-        private void ValidateThatLimitsAreStrictlyAscending()
+        private static void ValidateThatLimitsAreStrictlyAscending(long[] limits)
         {
-            if (this.limits.Zip(this.limits.Skip(1), (a, b) => a >= b).Any(b => b))
+            if (limits.Zip(limits.Skip(1), (a, b) => a >= b).Any(b => b))
             {
                 throw new ArgumentOutOfRangeException("limits", "Limits must be ascending numbers.");
             }

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -51,17 +51,13 @@ namespace Ploeh.AutoFixture
 
             if (limits.Length < 2)
             {
-                throw new ArgumentException("limits must be two or more Int64.", "limits");
+                throw new ArgumentException("Limits must be at least two ascending numbers.", "limits");
             }
 
             //Check that limits are ascending
-            var previous = limits[0];
-            foreach (var item in limits.Skip(1))
+            if (limits.Zip(limits.Skip(1), (a, b) => a >= b).Any(b => b))
             {
-                if (previous >= item)
-                    throw new ArgumentOutOfRangeException("limits", "limits must be ascending Int64.");
-
-                previous = item;
+                throw new ArgumentOutOfRangeException("limits", "Limits must be ascending numbers.");
             }
 
             this.limits = limits;

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -30,8 +30,7 @@ namespace Ploeh.AutoFixture
         /// <summary>
         /// Initializes a new instance of the <see cref="RandomNumericSequenceGenerator" /> class.
         /// </summary>
-        /// <param name="limits">A sequence of integers beginning with two positive or negative 
-        /// number optionally followed by a series of greater numbers.</param>
+        /// <param name="limits">A sequence of at least two ascending numbers.</param>
         public RandomNumericSequenceGenerator(IEnumerable<long> limits)
             : this(limits.ToArray())
         {
@@ -40,8 +39,7 @@ namespace Ploeh.AutoFixture
         /// <summary>
         /// Initializes a new instance of the <see cref="RandomNumericSequenceGenerator" /> class.
         /// </summary>
-        /// <param name="limits">An array of integers beginning with two positive or negative 
-        /// number optionally followed by a series of greater numbers.</param>
+        /// <param name="limits">A array of at least two ascending numbers.</param>
         /// <exception cref="System.ArgumentNullException"></exception>
         /// <exception cref="System.ArgumentException"></exception>
         public RandomNumericSequenceGenerator(params long[] limits)
@@ -54,6 +52,16 @@ namespace Ploeh.AutoFixture
             if (limits.Length < 2)
             {
                 throw new ArgumentException("The limit must be a sequence of two or more integers.");
+            }
+
+            //Check that limits are ascending
+            var previous = limits[0];
+            foreach (var item in limits.Skip(1))
+            {
+                if (previous >= item)
+                    throw new ArgumentOutOfRangeException("limits", "limits must be ascending numbers");
+
+                previous = item;
             }
 
             this.limits = limits;

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture
         /// <summary>
         /// Initializes a new instance of the <see cref="RandomNumericSequenceGenerator" /> class.
         /// </summary>
-        /// <param name="limits">A array of at least two ascending numbers.</param>
+        /// <param name="limits">An array of at least two ascending numbers.</param>
         /// <exception cref="System.ArgumentNullException"></exception>
         /// <exception cref="System.ArgumentException"></exception>
         public RandomNumericSequenceGenerator(params long[] limits)
@@ -54,13 +54,10 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentException("Limits must be at least two ascending numbers.", "limits");
             }
 
-            //Check that limits are ascending
-            if (limits.Zip(limits.Skip(1), (a, b) => a >= b).Any(b => b))
-            {
-                throw new ArgumentOutOfRangeException("limits", "Limits must be ascending numbers.");
-            }
-
             this.limits = limits;
+
+            this.ValidateThatLimitsAreStrictlyAscending();
+            
             this.syncRoot = new object();
             this.random = new Random();
             this.numbers = new HashSet<long>();
@@ -96,6 +93,14 @@ namespace Ploeh.AutoFixture
             }
 
             return this.CreateRandom(type);
+        }
+
+        private void ValidateThatLimitsAreStrictlyAscending()
+        {
+            if (this.limits.Zip(this.limits.Skip(1), (a, b) => a >= b).Any(b => b))
+            {
+                throw new ArgumentOutOfRangeException("limits", "Limits must be ascending numbers.");
+            }
         }
 
         private object CreateRandom(Type request)

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -51,7 +51,7 @@ namespace Ploeh.AutoFixture
 
             if (limits.Length < 2)
             {
-                throw new ArgumentException("The limit must be a sequence of two or more integers.");
+                throw new ArgumentException("limits must be two or more Int64.", "limits");
             }
 
             //Check that limits are ascending
@@ -59,7 +59,7 @@ namespace Ploeh.AutoFixture
             foreach (var item in limits.Skip(1))
             {
                 if (previous >= item)
-                    throw new ArgumentOutOfRangeException("limits", "limits must be ascending numbers");
+                    throw new ArgumentOutOfRangeException("limits", "limits must be ascending Int64.");
 
                 previous = item;
             }

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -65,6 +65,22 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
+        [Theory]
+        [InlineData(new long[] { 10, 5 })]
+        [InlineData(new long[] { 32, 8, Int32.MaxValue })]
+        [InlineData(new long[] { 0, -2, 5 })]
+        [InlineData(new long[] { -4, -8 })]
+        [InlineData(new long[] { 1, 1, 5 })]
+        [InlineData(new long[] { 1, 5, 5 })]
+        public void InitializeWithLimitsNotAscendingThrows(long[] limits)
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new RandomNumericSequenceGenerator(limits));
+            // Teardown
+        }
+
         [Fact]
         public void LimitsMatchListParameter()
         {
@@ -99,28 +115,6 @@ namespace Ploeh.AutoFixtureUnitTest
             IEnumerable<long> result = sut.Limits;
             // Verify outcome
             Assert.True(expectedResult.SequenceEqual(result));
-            // Teardown
-        }
-
-        [Fact]
-        public void LimitsDoesNotMatchParamsArray()
-        {
-            // Fixture setup
-            var unexpectedLimits = new long[]
-            { 
-                Byte.MaxValue, 
-                Int16.MaxValue, 
-                Int32.MaxValue
-            };
-            var sut = new RandomNumericSequenceGenerator(
-                unexpectedLimits[0],
-                unexpectedLimits[2],
-                unexpectedLimits[1]
-                );
-            // Exercise system
-            IEnumerable<long> result = sut.Limits;
-            // Verify outcome
-            Assert.False(unexpectedLimits.SequenceEqual(result));
             // Teardown
         }
 


### PR DESCRIPTION
Addressing #408 

I changed documentation on constructors. I also found out that if the two first numbers in limits are equal, there was an infinite loop, that's why I enforced that the sequence in strictly ascending (this wasn't an issue for numbers after the two first, but oh well...)

I also had to remove a test that wasn't relevant any more.