### PR TITLE
Changed internal counter to Int64

### DIFF
--- a/Src/AutoFixture/NumericSequenceGenerator.cs
+++ b/Src/AutoFixture/NumericSequenceGenerator.cs
@@ -9,7 +9,7 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class NumericSequenceGenerator : ISpecimenBuilder
     {
-        private int value;
+        private long value = 0;
 
         /// <summary>
         /// Creates an anonymous number.
@@ -44,9 +44,9 @@ namespace Ploeh.AutoFixture
                 case TypeCode.Int16:
                     return (short)this.GetNextNumber();
                 case TypeCode.Int32:
-                    return this.GetNextNumber();
+                    return (int)this.GetNextNumber();
                 case TypeCode.Int64:
-                    return (long)this.GetNextNumber();
+                    return this.GetNextNumber();
                 case TypeCode.SByte:
                     return (sbyte)this.GetNextNumber();
                 case TypeCode.Single:
@@ -62,7 +62,7 @@ namespace Ploeh.AutoFixture
             }
         }
 
-        private int GetNextNumber()
+        private long GetNextNumber()
         {
             return Interlocked.Increment(ref this.value);
         }


### PR DESCRIPTION
Addressing #410

I simply changed the internal counter to long/Int64 and adapted the code accordingly. I tested it by setting the internal value to something like Int64.MaxValue - 5 and it worked fine.