### PR TITLE
Extract common GetData logic from framework-specific AutoDataAttribute classes

### DIFF
--- a/Src/AutoFixture.NUnit2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoDataAttributeTest.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using Ploeh.AutoFixture.NUnit2.Addins;
 using NUnit.Framework;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixture.NUnit2.Addins;
 using Ploeh.TestTypeFoundation;
 
 namespace Ploeh.AutoFixture.NUnit2.UnitTest
@@ -147,6 +149,60 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             // Verify outcome
             Assert.True(new[] { expectedResult }.SequenceEqual(result.Single()));
             // Teardown
+        }
+
+        [Test]
+        public void GetDataReturnsValuesSuppliedByTestDataProvider()
+        {
+            // Fixture setup
+            var arguments = new[] { new object(), new object() };
+            var provider = new DelegatingTestDataProvider { OnGetData = m => arguments };
+            var sut = new TestableAutoDataAttribute(new DelegatingFixture()) { OnCreateDataProvider = () => provider };
+            // Excercise system
+            IEnumerable<object[]> result = sut.GetData(new Action<object>(ParameterizedMethod).Method);
+            // Verify outcome
+            Assert.AreEqual(arguments, result.Single());
+            // Teardown
+        }
+
+        [Test]
+        public void CreateDataProviderReturnsTestDataProviderConstructedWithGivenFixture()
+        {
+            // Fixture setup
+            bool fixtureInvoked = false;
+            var fixture = new DelegatingFixture { OnCreate = (request, context) => fixtureInvoked = true };
+            var sut = new TestableAutoDataAttribute(fixture);
+            // Excercise system
+            ITestDataProvider provider = sut.TestableCreateDataProvider();
+            // Verify outcome
+            provider.GetData(new Action<object>(ParameterizedMethod).Method);
+            Assert.IsTrue(fixtureInvoked);
+            // Teardown
+        }
+
+        private static void ParameterizedMethod(object parameter)
+        {
+        }
+
+        private class TestableAutoDataAttribute : AutoDataAttribute
+        {
+            public Func<ITestDataProvider> OnCreateDataProvider;
+
+            public TestableAutoDataAttribute(IFixture fixture)
+                : base(fixture)
+            {
+                this.OnCreateDataProvider = base.CreateDataProvider;
+            }
+
+            public ITestDataProvider TestableCreateDataProvider()
+            {
+                return base.CreateDataProvider();
+            }
+
+            protected override ITestDataProvider CreateDataProvider()
+            {
+                return this.OnCreateDataProvider();
+            }
         }
     }
 }

--- a/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <CodeAnalysisCulture>en-US</CodeAnalysisCulture> 
+    <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,6 +57,7 @@
     <Compile Include="DelegatingCustomizeAttribute.cs" />
     <Compile Include="DelegatingFixture.cs" />
     <Compile Include="DelegatingSpecimenBuilder.cs" />
+    <Compile Include="DelegatingTestDataProvider.cs" />
     <Compile Include="DependencyConstraints.cs" />
     <Compile Include="FakeDataAttribute.cs" />
     <Compile Include="FavorArraysAttributeTest.cs" />
@@ -91,6 +92,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/AutoFixture.NUnit2.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/CustomizeAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.NUnit2.UnitTest
 {
@@ -25,6 +26,16 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             var sut = new DelegatingCustomizeAttribute();
             // Verify outcome
             Assert.IsInstanceOf<Attribute>(sut);
+            // Teardown
+        }
+
+        [Test]
+        public void SutImplementsIParameterCustomizationProviderToBeRecognizedByTestDataProvider()
+        {
+            // Fixture setup
+            // Exercise system 
+            // Verify outcome
+            Assert.True(typeof(IParameterCustomizationProvider).IsAssignableFrom(typeof(CustomizeAttribute)));
             // Teardown
         }
     }

--- a/Src/AutoFixture.NUnit2.UnitTest/DelegatingTestDataProvider.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/DelegatingTestDataProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.NUnit2.UnitTest
+{
+    internal class DelegatingTestDataProvider : ITestDataProvider
+    {
+        public Func<MethodInfo, IEnumerable<object>> OnGetData = method => Enumerable.Empty<object>();
+
+        public IEnumerable<object> GetData(MethodInfo testMethod)
+        {
+            return this.OnGetData(testMethod);
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using Ploeh.AutoFixture.NUnit2.Addins;
 using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixture.NUnit2.Addins;
 
 namespace Ploeh.AutoFixture.NUnit2
 {
@@ -90,33 +90,17 @@ namespace Ploeh.AutoFixture.NUnit2
                 throw new ArgumentNullException("method");
             }
 
-            var specimens = new List<object>();
-            foreach (var p in method.GetParameters())
-            {
-                CustomizeFixture(p);
-
-                var specimen = Resolve(p);
-                specimens.Add(specimen);
-            }
-
+            ITestDataProvider dataProvider = this.CreateDataProvider();
+            IEnumerable<object> specimens = dataProvider.GetData(method);
             return new[] { specimens.ToArray() };
         }
 
-        private void CustomizeFixture(ParameterInfo p)
+        /// <summary>
+        /// Returns a <see cref="TestDataProvider"/> constructed with the current <see cref="Fixture"/>.
+        /// </summary>
+        protected virtual ITestDataProvider CreateDataProvider()
         {
-            var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy).OfType<CustomizeAttribute>();
-            foreach (var ca in customizeAttributes)
-            {
-                var c = ca.GetCustomization(p);
-                Fixture.Customize(c);
-            }
-        }
-
-        private object Resolve(ParameterInfo p)
-        {
-            var context = new SpecimenContext(Fixture);
-            return context.Resolve(p);
+            return new TestDataProvider(_fixture);
         }
 
         private static IFixture CreateFixture(Type type)

--- a/Src/AutoFixture.NUnit2/CustomizeAttribute.cs
+++ b/Src/AutoFixture.NUnit2/CustomizeAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.NUnit2
 {
@@ -8,7 +9,7 @@ namespace Ploeh.AutoFixture.NUnit2
     /// <see cref="AutoDataAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class CustomizeAttribute : Attribute
+    public abstract class CustomizeAttribute : Attribute, IParameterCustomizationProvider
     {
         /// <summary>
         /// Gets a customization for a parameter.

--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoDataAttributeTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Extensions;
@@ -149,6 +151,59 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             // Verify outcome
             Assert.True(new[] { expectedResult }.SequenceEqual(result.Single()));
             // Teardown
+        }
+
+        [Fact]
+        public void GetDataReturnsValuesSuppliedByTestDataProvider()
+        {
+            // Fixture setup
+            var arguments = new[] { new object(), new object() };
+            var provider = new DelegatingTestDataProvider { OnGetData = m => arguments };
+            var sut = new TestableAutoDataAttribute(new DelegatingFixture()) { OnCreateDataProvider = () => provider };
+            // Excercise system
+            IEnumerable<object[]> result = sut.GetData(new Action<object>(ParameterizedMethod).Method, new Type[0]);
+            // Verify outcome
+            Assert.Equal(arguments, result.Single());
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateDataProviderReturnsTestDataProviderConstructedWithGivenFixture()
+        {
+            // Fixture setup
+            bool fixtureInvoked = false;
+            var fixture = new DelegatingFixture { OnCreate = (request, context) => fixtureInvoked = true };
+            var sut = new TestableAutoDataAttribute(fixture);
+            // Excercise system
+            ITestDataProvider provider = sut.TestableCreateDataProvider();
+            // Verify outcome
+            provider.GetData(new Action<object>(ParameterizedMethod).Method);
+            Assert.True(fixtureInvoked);
+            // Teardown
+        }
+
+        private static void ParameterizedMethod(object parameter)
+        {
+        }
+
+        private class TestableAutoDataAttribute : AutoDataAttribute
+        {
+            public Func<ITestDataProvider> OnCreateDataProvider;
+
+            public TestableAutoDataAttribute(IFixture fixture) : base(fixture)
+            {
+                this.OnCreateDataProvider = base.CreateDataProvider;
+            }
+
+            public ITestDataProvider TestableCreateDataProvider()
+            {
+                return base.CreateDataProvider();
+            }
+
+            protected override ITestDataProvider CreateDataProvider()
+            {
+                return this.OnCreateDataProvider();
+            }
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
@@ -70,6 +70,7 @@
     <Compile Include="AutoDataAttributeTest.cs" />
     <Compile Include="CompositeDataAttributeSufficientDataTest.cs" />
     <Compile Include="CompositeDataAttributeTest.cs" />
+    <Compile Include="DelegatingTestDataProvider.cs" />
     <Compile Include="DependencyConstraints.cs" />
     <Compile Include="ComposerWithoutADefaultConstructor.cs" />
     <Compile Include="CustomizeAttributeTest.cs" />

--- a/Src/AutoFixture.xUnit.net.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/CustomizeAttributeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Ploeh.AutoFixture.Kernel;
 using Xunit;
 
 namespace Ploeh.AutoFixture.Xunit.UnitTest
@@ -24,6 +25,16 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             var sut = new DelegatingCustomizeAttribute();
             // Verify outcome
             Assert.IsAssignableFrom<Attribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutImplementsIParameterCustomizationProviderToBeRecognizedByTestDataProvider()
+        {
+            // Fixture setup
+            // Exercise system 
+            // Verify outcome
+            Assert.True(typeof(IParameterCustomizationProvider).IsAssignableFrom(typeof(CustomizeAttribute)));
             // Teardown
         }
     }

--- a/Src/AutoFixture.xUnit.net.UnitTest/DelegatingTestDataProvider.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/DelegatingTestDataProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Xunit.UnitTest
+{
+    internal class DelegatingTestDataProvider : ITestDataProvider
+    {
+        public Func<MethodInfo, IEnumerable<object>> OnGetData = method => Enumerable.Empty<object>();
+
+        public IEnumerable<object> GetData(MethodInfo testMethod)
+        {
+            return this.OnGetData(testMethod);
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
@@ -91,33 +91,17 @@ namespace Ploeh.AutoFixture.Xunit
                 throw new ArgumentNullException("methodUnderTest");
             }
 
-            var specimens = new List<object>();
-            foreach (var p in methodUnderTest.GetParameters())
-            {
-                this.CustomizeFixture(p);
-
-                var specimen = this.Resolve(p);
-                specimens.Add(specimen);
-            }
-
+            ITestDataProvider dataProvider = this.CreateDataProvider();
+            IEnumerable<object> specimens = dataProvider.GetData(methodUnderTest);
             return new[] { specimens.ToArray() };
         }
 
-        private void CustomizeFixture(ParameterInfo p)
+        /// <summary>
+        /// Returns a <see cref="TestDataProvider"/> constructed with the current <see cref="fixture"/>.
+        /// </summary>
+        protected virtual ITestDataProvider CreateDataProvider()
         {
-            var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy).OfType<CustomizeAttribute>();
-            foreach (var ca in customizeAttributes)
-            {
-                var c = ca.GetCustomization(p);
-                this.Fixture.Customize(c);
-            }
-        }
-
-        private object Resolve(ParameterInfo p)
-        {
-            var context = new SpecimenContext(this.Fixture);
-            return context.Resolve(p);
+            return new TestDataProvider(this.fixture);
         }
 
         private static IFixture CreateFixture(Type type)

--- a/Src/AutoFixture.xUnit.net/CustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/CustomizeAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.Xunit
 {
@@ -8,7 +9,7 @@ namespace Ploeh.AutoFixture.Xunit
     /// <see cref="AutoDataAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class CustomizeAttribute : Attribute
+    public abstract class CustomizeAttribute : Attribute, IParameterCustomizationProvider
     {
         /// <summary>
         /// Gets a customization for a parameter.

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Sdk;
@@ -147,6 +149,60 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             // Verify outcome
             Assert.True(new[] { expectedResult }.SequenceEqual(result.Single()));
             // Teardown
+        }
+
+
+        [Fact]
+        public void GetDataReturnsValuesSuppliedByTestDataProvider()
+        {
+            // Fixture setup
+            var arguments = new[] { new object(), new object() };
+            var provider = new DelegatingTestDataProvider { OnGetData = m => arguments };
+            var sut = new TestableAutoDataAttribute(new DelegatingFixture()) { OnCreateDataProvider = () => provider };
+            // Excercise system
+            IEnumerable<object[]> result = sut.GetData(new Action<object>(ParameterizedMethod).Method);
+            // Verify outcome
+            Assert.Equal(arguments, result.Single());
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateDataProviderReturnsTestDataProviderConstructedWithGivenFixture()
+        {
+            // Fixture setup
+            bool fixtureInvoked = false;
+            var fixture = new DelegatingFixture { OnCreate = (request, context) => fixtureInvoked = true };
+            var sut = new TestableAutoDataAttribute(fixture);
+            // Excercise system
+            ITestDataProvider provider = sut.TestableCreateDataProvider();
+            // Verify outcome
+            provider.GetData(new Action<object>(ParameterizedMethod).Method);
+            Assert.True(fixtureInvoked);
+            // Teardown
+        }
+
+        private static void ParameterizedMethod(object parameter)
+        {
+        }
+
+        private class TestableAutoDataAttribute : AutoDataAttribute
+        {
+            public Func<ITestDataProvider> OnCreateDataProvider;
+
+            public TestableAutoDataAttribute(IFixture fixture) : base(fixture)
+            {
+                this.OnCreateDataProvider = base.CreateDataProvider;
+            }
+
+            public ITestDataProvider TestableCreateDataProvider()
+            {
+                return base.CreateDataProvider();
+            }
+
+            protected override ITestDataProvider CreateDataProvider()
+            {
+                return this.OnCreateDataProvider();
+            }
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -62,6 +62,7 @@
     <Compile Include="DelegatingCustomizeAttribute.cs" />
     <Compile Include="DelegatingFixture.cs" />
     <Compile Include="DelegatingSpecimenBuilder.cs" />
+    <Compile Include="DelegatingTestDataProvider.cs" />
     <Compile Include="DependencyConstraints.cs" />
     <Compile Include="FrozenAttributeTest.cs" />
     <Compile Include="GreedyAttributeTest.cs" />

--- a/Src/AutoFixture.xUnit.net2.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/CustomizeAttributeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Ploeh.AutoFixture.Kernel;
 using Xunit;
 
 namespace Ploeh.AutoFixture.Xunit2.UnitTest
@@ -24,6 +25,16 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             var sut = new DelegatingCustomizeAttribute();
             // Verify outcome
             Assert.IsAssignableFrom<Attribute>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutImplementsIParameterCustomizationProviderToBeRecognizedByTestDataProvider()
+        {
+            // Fixture setup
+            // Exercise system 
+            // Verify outcome
+            Assert.True(typeof(IParameterCustomizationProvider).IsAssignableFrom(typeof(CustomizeAttribute)));
             // Teardown
         }
     }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingTestDataProvider.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingTestDataProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    internal class DelegatingTestDataProvider : ITestDataProvider
+    {
+        public Func<MethodInfo, IEnumerable<object>> OnGetData = method => Enumerable.Empty<object>();
+
+        public IEnumerable<object> GetData(MethodInfo testMethod)
+        {
+            return this.OnGetData(testMethod);
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
@@ -93,33 +93,17 @@ namespace Ploeh.AutoFixture.Xunit2
                 throw new ArgumentNullException("methodUnderTest");
             }
 
-            var specimens = new List<object>();
-            foreach (var p in methodUnderTest.GetParameters())
-            {
-                this.CustomizeFixture(p);
-
-                var specimen = this.Resolve(p);
-                specimens.Add(specimen);
-            }
-
+            ITestDataProvider dataProvider = this.CreateDataProvider();
+            IEnumerable<object> specimens = dataProvider.GetData(methodUnderTest);
             return new[] { specimens.ToArray() };
         }
 
-        private void CustomizeFixture(ParameterInfo p)
+        /// <summary>
+        /// Returns a <see cref="TestDataProvider"/> constructed with the current <see cref="fixture"/>.
+        /// </summary>
+        protected virtual ITestDataProvider CreateDataProvider()
         {
-            var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy).OfType<CustomizeAttribute>();
-            foreach (var ca in customizeAttributes)
-            {
-                var c = ca.GetCustomization(p);
-                this.Fixture.Customize(c);
-            }
-        }
-
-        private object Resolve(ParameterInfo p)
-        {
-            var context = new SpecimenContext(this.Fixture);
-            return context.Resolve(p);
+            return new TestDataProvider(this.fixture);
         }
 
         private static IFixture CreateFixture(Type type)

--- a/Src/AutoFixture.xUnit.net2/CustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/CustomizeAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.Xunit2
 {
@@ -8,7 +9,7 @@ namespace Ploeh.AutoFixture.Xunit2
     /// <see cref="AutoDataAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class CustomizeAttribute : Attribute
+    public abstract class CustomizeAttribute : Attribute, IParameterCustomizationProvider
     {
         /// <summary>
         /// Gets a customization for a parameter.

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -101,7 +101,10 @@
     <Compile Include="Kernel\EnumeratorRelay.cs" />
     <Compile Include="Kernel\GenericMethod.cs" />
     <Compile Include="Kernel\IMethodFactory.cs" />
+    <Compile Include="Kernel\ITestDataProvider.cs" />
+    <Compile Include="Kernel\IParameterCustomizationProvider.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingMethodFactory.cs" />
+    <Compile Include="Kernel\TestDataProvider.cs" />
     <Compile Include="Kernel\TemplateMethodQuery.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingMethod.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingStaticMethodFactory.cs" />

--- a/Src/AutoFixture/Kernel/IParameterCustomizationProvider.cs
+++ b/Src/AutoFixture/Kernel/IParameterCustomizationProvider.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Provides an <see cref="ICustomization"/> for a given <see cref="ParameterInfo"/>.
+    /// </summary>
+    public interface IParameterCustomizationProvider
+    {
+        /// <summary>
+        /// Gets a customization for a parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        ICustomization GetCustomization(ParameterInfo parameter);
+    }
+}

--- a/Src/AutoFixture/Kernel/ITestDataProvider.cs
+++ b/Src/AutoFixture/Kernel/ITestDataProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Provides automatically generated arguments for a test method.
+    /// </summary>
+    public interface ITestDataProvider
+    {
+        /// <summary>
+        /// Returns arguments for invoking the given <paramref name="testMethod"/>.
+        /// </summary>
+        /// <param name="testMethod">A <see cref="MethodInfo"/> instance representing a test method.</param>
+        IEnumerable<object> GetData(MethodInfo testMethod);
+    }
+}

--- a/Src/AutoFixture/Kernel/TestDataProvider.cs
+++ b/Src/AutoFixture/Kernel/TestDataProvider.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Provides arguments generated for a test method based on parameter types as well 
+    /// as attributes applied to the test method's parameters.
+    /// </summary>
+    public class TestDataProvider : ITestDataProvider
+    {
+        private readonly IFixture fixture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestDataProvider"/> class.
+        /// </summary>
+        /// <param name="fixture">
+        /// An <see cref="IFixture"/> that will be used create argument values. The <paramref name="fixture"/> can be  
+        /// customized by parameters marked with attributes implementing the 
+        /// <see cref="IParameterCustomizationProvider"/> interface.
+        /// </param>
+        public TestDataProvider(IFixture fixture)
+        {
+            if (fixture == null)
+            {
+                throw new ArgumentNullException("fixture");
+            }
+
+            this.fixture = fixture;
+        }
+
+        /// <summary>
+        /// Returns arguments for invoking the given <paramref name="testMethod"/>.
+        /// </summary>
+        /// <param name="testMethod">A <see cref="MethodInfo"/> representing a test method.</param>
+        public IEnumerable<object> GetData(MethodInfo testMethod)
+        {
+            if (testMethod == null)
+            {
+                throw new ArgumentNullException("testMethod");
+            }
+
+            var arguments = new List<object>();
+            foreach (ParameterInfo parameter in testMethod.GetParameters())
+            {
+                this.CustomizeFixture(parameter);
+                object argument = this.GenerateArgument(parameter);
+                arguments.Add(argument);
+            }
+
+            return arguments;
+        }
+
+        private void CustomizeFixture(ParameterInfo parameter)
+        {
+            var providers = parameter.GetCustomAttributes(false).OfType<IParameterCustomizationProvider>();
+            foreach (IParameterCustomizationProvider provider in providers)
+            {
+                ICustomization customization = provider.GetCustomization(parameter);
+                this.fixture.Customize(customization);
+            }
+        }
+
+        private object GenerateArgument(ParameterInfo parameter)
+        {
+            var context = new SpecimenContext(this.fixture);
+            return context.Resolve(parameter);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -93,6 +93,7 @@
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
+    <Compile Include="DelegatingFixture.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />
     <Compile Include="Kernel\EnumeratorRelayTest.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingMethodFactoryTests.cs" />
@@ -101,6 +102,7 @@
     <Compile Include="Kernel\DelegatingMethod.cs" />
     <Compile Include="Kernel\DelegatingMethodFactory.cs" />
     <Compile Include="Kernel\GenericMethodTests.cs" />
+    <Compile Include="Kernel\TestDataProviderTest.cs" />
     <Compile Include="Kernel\TemplateMethodQueryTests.cs" />
     <Compile Include="Kernel\MissingParametersSupplyingMethodTests.cs" />
     <Compile Include="FreezeOnMatchCustomizationTest.cs" />

--- a/Src/AutoFixtureUnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingFixture.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Dsl;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class DelegatingFixture : IFixture
+    {
+        public Func<ICustomization, IFixture> OnCustomize { get; set; }
+        public Func<object, ISpecimenContext, object> OnCreate { get; set; }
+
+        public DelegatingFixture()
+        {
+            this.OnCustomize = customization => this;
+            this.OnCreate = (request, context) => new object();
+        }
+
+        public IList<ISpecimenBuilderTransformation> Behaviors
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IList<ISpecimenBuilder> Customizations
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public bool OmitAutoProperties
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public int RepeatCount
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public IList<ISpecimenBuilder> ResidueCollectors
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ICustomizationComposer<T> Build<T>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFixture Customize(ICustomization customization)
+        {
+            return this.OnCustomize(customization);
+        }
+
+        public void Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            return this.OnCreate(request, context);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/Kernel/TestDataProviderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TestDataProviderTest.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest.Kernel
+{
+    public class TestDataProviderTest
+    {
+        private readonly MethodInfo methodWithOneParameter = new Action<object>(MethodWithOneParameter).Method;
+        private readonly MethodInfo methodWithTwoParameters = new Action<object, object>(MethodWithTwoParameters).Method;
+
+        [Fact]
+        public void SutIsITestDataProvider()
+        {
+            // Fixture setup
+            var sut = new TestDataProvider(new Fixture());
+            // Exercise system and verify outcome
+            Assert.IsAssignableFrom<ITestDataProvider>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void ConsturctorThrowsArgumentNullExceptionsWhenFixtureIsNull()
+        {
+            // Fixture setup, exercise system and verify outcome
+            var e = Assert.Throws<ArgumentNullException>(() => new TestDataProvider(null));
+            Assert.Equal("fixture", e.ParamName);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataThrowsArgumentNullExceptionWhenTestMethodIsNull()
+        {
+            // Fixture setup
+            var sut = new TestDataProvider(new Fixture());
+            // Exercise system and verify outcome
+            var e = Assert.Throws<ArgumentNullException>(() => sut.GetData(null));
+            Assert.Equal("testMethod", e.ParamName);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataAppliesCustomizationsFromAllParameterAttributes()
+        {
+            // Fixture setup
+            var customizationTypes = new List<Type>();
+            IFixture fixture = CreateTestFixture(customizationTypes);
+            var sut = new TestDataProvider(fixture);
+            // Exercise system
+            sut.GetData(this.methodWithOneParameter);
+            // Verify outcome
+            Assert.Equal(new[] { typeof(ParameterCustomization), typeof(ParameterCustomization) }, customizationTypes);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataAppliesCustomizationsFromAllParameters()
+        {
+            // Fixture setup
+            var customizationTypes = new List<Type>();
+            IFixture fixture = CreateTestFixture(customizationTypes);
+            var sut = new TestDataProvider(fixture);
+            // Exercise system
+            sut.GetData(this.methodWithTwoParameters);
+            // Verify outcome
+            Assert.Equal(new[] { typeof(ParameterCustomization), typeof(ParameterCustomization) }, customizationTypes);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataResolvesParameterWithCorrectSpecimenContext()
+        {
+            // Fixture setup
+            ISpecimenContext createContext = null;
+            var fixture = new DelegatingFixture();
+            fixture.OnCreate = (request, context) =>
+            {
+                createContext = context;
+                return new object();
+            };
+            var sut = new TestDataProvider(fixture);
+            // Excercise system
+            sut.GetData(this.methodWithOneParameter);
+            // Verify outcome
+            var specimenContext = Assert.IsType<SpecimenContext>(createContext);
+            Assert.Same(fixture, specimenContext.Builder);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataResolvesAllParametersUsingFixture()
+        {
+            // Fixture setup
+            var createRequests = new List<object>();
+            var fixture = new DelegatingFixture();
+            fixture.OnCreate = (request, context) =>
+            {
+                createRequests.Add(request);
+                return new object();
+            };
+            var sut = new TestDataProvider(fixture);
+            // Excercise system
+            sut.GetData(this.methodWithTwoParameters);
+            // Verify outcome
+            Assert.Equal(this.methodWithTwoParameters.GetParameters(), createRequests);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetDataReturnsSpecimensGeneratedByFixtureForAllParameters()
+        {
+            // Fixture setup
+            var specimens = new List<object>();
+            var fixture = new DelegatingFixture();
+            fixture.OnCreate = (request, context) =>
+            {
+                var specimen = new object();
+                specimens.Add(specimen);
+                return specimen;
+            };
+            var sut = new TestDataProvider(fixture);
+            // Excercise system
+            IEnumerable<object> arguments = sut.GetData(this.methodWithTwoParameters);
+            // Verify outcome
+            Assert.Equal(specimens, arguments);
+            // Teardown
+        }
+
+        private static IFixture CreateTestFixture(ICollection<Type> customizationTypes)
+        {
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = customization =>
+            {
+                customizationTypes.Add(customization.GetType());
+                return fixture;
+            };
+            return fixture;
+        }
+
+        private static void MethodWithOneParameter([ParameterCustomization, ParameterCustomization] object parameter)
+        {
+        }
+
+        private static void MethodWithTwoParameters([ParameterCustomization] object parameter1, [ParameterCustomization] object parameter2)
+        {
+        }
+
+        [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
+        private class ParameterCustomizationAttribute : Attribute, IParameterCustomizationProvider
+        {
+            public ICustomization GetCustomization(ParameterInfo parameter)
+            {
+                return new ParameterCustomization();
+            }
+        }
+
+        private class ParameterCustomization : ICustomization
+        {
+            public void Customize(IFixture fixture)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Defining test data customization attributes that are specific to a _mocking_ framework without taking a dependency on a specific _test_ framework is not possible today because the `CustomizeAttribute` classes are defined in the _test framework assemblies_, like `Ploeh.AutoFixture.Nunit2`, `Ploeh.AutoFixture.Xunit` and `Ploeh.AutoFixture.Xunit2`, while the mocking attributes, such as the `SubstituteAttribute` added in #430, have to be defined in the _mocking framework assemblies_, like the `Ploeh.AutoFixture.NSubstitute`. Because of this limitation, the usage of the `SubstituteAttribute` can produce obscure test failures, described in #430, due to missing fixture customizations.

Here is the desired usage scenario:

```C#
using Ploeh.AutoFixture.NSubstitute;
using Ploeh.AutoFixture.xUnit;
using Xunit;

public class MyTest
{
    [Fact, AutoData]
    public void Test1([Substitute]MyType sample)
    {
        // Fixture setup
        // Exercise system
        sample.HelloWorld();
        // Verify results
        sample.Received().HelloWorld();
        // Teardown
    }
}
```

Today, this test fails with an obscure error saying that the object instance for which the `Received` method is called is not a substitute. Developer writing this test has to know that an `AutoNSubstituteCustomization` or an `AutoConfiguredNSubstituteCustomization` has to be used for this test to work correctly.

To solve this problem, this pull request 
- introduces a new Kernel interface, `IParameterCustomizationProvider` that can be implemented by attributes defined by any of the _mocking_ assemblies, like `AutoFixture.NSubstitute` and `AutoFixture.AutoMoq`, without additional dependencies. 
- implements a new `TestDataProvider` utility class that uses `IParameterCustomizationProvider` and consolidates the fixture customization logic from the three separate `AutoDataAttribute` implementations in `AutoFixture.Nunit2`, `AutoFixture.xUnit` and `AutoFixture.xUnit2`. 
- modifies the existing `AutoDataAttribute` implementationsto use the common logic in the `TestDataProvider`.

Once this pull request is merged, the existing `SubstituteAttribute` can be changed to implement the new `IParameterCustomizationProvider` interface, which will make the test in the scenario above work as expected.