### PR TITLE
Introduce AttributeRelay<T> class

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
+    <Compile Include="DataAnnotations\AttributeRelay.cs" />
     <Compile Include="Kernel\CompositeSpecimenCommand.cs" />
     <Compile Include="Kernel\EnumeratorRelay.cs" />
     <Compile Include="Kernel\GenericMethod.cs" />

--- a/Src/AutoFixture/DataAnnotations/AttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/AttributeRelay.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.DataAnnotations
+{
+    /// <summary>
+    /// Relays requests made for properties, fields or parameters to different requests, based on custom attributes 
+    /// applied to the code elements. 
+    /// </summary>
+    /// <remarks>
+    /// A typical example is relaying a request for a parameter that has <see cref="RangeAttribute"/> applied to it 
+    /// to a <see cref="RangedNumberRequest"/>. Another way to describe it, a request for a <see cref="ParameterInfo"/>
+    /// instance that contains a <see cref="RangeAttribute"/>, is transformed to a <see cref="RangedNumberRequest"/>
+    /// with parameters extracted from the attribute.
+    /// </remarks>
+    /// <typeparam name="TAttribute">
+    /// An <see cref="Attribute"/> type that can be applied to a property, a field or a method. The attribute is 
+    /// expected to allow applying only once. When the same attribute is applied multiple times to the same code 
+    /// element, an <see cref="InvalidOperationException"/> will be thrown.
+    /// </typeparam>
+    public class AttributeRelay<TAttribute> : ISpecimenBuilder
+        where TAttribute : Attribute
+    {
+        private readonly Func<ICustomAttributeProvider, TAttribute, object> createRelayedRequest;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AttributeRelay{TAttribute}"/> class.
+        /// </summary>
+        /// <param name="createRelayedRequest">
+        /// A delegate responsible for creating a relayed request based on an <see cref="Attribute"/> applied to to the 
+        /// code element represented by an <see cref="ICustomAttributeProvider"/>.
+        /// </param>
+        public AttributeRelay(Func<ICustomAttributeProvider, TAttribute, object> createRelayedRequest)
+        {
+            if (createRelayedRequest == null)
+            {
+                throw new ArgumentNullException("createRelayedRequest");
+            }
+
+            this.createRelayedRequest = createRelayedRequest;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="MethodInfo"/> representing the delegate specified in the constructor.
+        /// </summary>
+        /// <remarks>
+        /// This property is meant to be used in structural inspection tests for classes that use the
+        /// <see cref="AttributeRelay{T}"/>. It returns a <see cref="MethodInfo"/> instead of the actual
+        /// delegate to clearly state that the delegate is not meant to be invoked directly by this class'
+        /// consumers.
+        /// </remarks>
+        public MethodInfo CreateRelayedRequestMethod 
+        {
+            get { return this.createRelayedRequest.Method; }
+        }
+
+        /// <summary>
+        /// Creates a relayed request based on a custom attribute applied to a code element and resolves it from the 
+        /// given <paramref name="context"/>.
+        /// </summary>
+        /// <returns>
+        /// A specimen resolved from the <paramref name="context"/> based on a relayed request.
+        /// If the <paramref name="request"/> code element does not have attribute of expected type applied to it, 
+        /// returns <see cref="NoSpecimen"/>.
+        /// </returns>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            var customAttributeProvider = request as ICustomAttributeProvider;
+            if (customAttributeProvider == null)
+            {
+                return new NoSpecimen(request);
+            }
+
+            TAttribute attribute;
+
+            try
+            {
+                attribute = customAttributeProvider.GetCustomAttributes(typeof(TAttribute), true)
+                    .OfType<TAttribute>().SingleOrDefault();
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException(
+                    string.Format(
+                        CultureInfo.CurrentCulture, 
+                        "Multiple instances of {0} were found for {1}.", 
+                        typeof(TAttribute), request), 
+                    e);
+            }
+
+            if (attribute == null)
+            {
+                return new NoSpecimen(request);
+            }
+
+            object relayedRequest = this.createRelayedRequest(customAttributeProvider, attribute);
+            return context.Resolve(relayedRequest);
+        }
+    }
+}

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 
@@ -12,6 +11,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// </summary>
     public class RangeAttributeRelay : ISpecimenBuilder
     {
+        private readonly ISpecimenBuilder relayBuilder = new AttributeRelay<RangeAttribute>(CreateRelayedRequest);
+
         /// <summary>
         /// Creates a new specimen based on a requested range.
         /// </summary>
@@ -24,32 +25,10 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (request == null)
-            {
-                return new NoSpecimen();
-            }
-
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-
-            var customAttributeProvider = request as ICustomAttributeProvider;
-            if (customAttributeProvider == null)
-            {
-                return new NoSpecimen(request);
-            }
-
-            var rangeAttribute = customAttributeProvider.GetCustomAttributes(typeof(RangeAttribute), inherit: true).Cast<RangeAttribute>().SingleOrDefault();
-            if (rangeAttribute == null)
-            {
-                return new NoSpecimen(request);
-            }
-
-            return context.Resolve(RangeAttributeRelay.Create(rangeAttribute, request));
+            return this.relayBuilder.Create(request, context);
         }
 
-        private static RangedNumberRequest Create(RangeAttribute rangeAttribute, object request)
+        private static object CreateRelayedRequest(ICustomAttributeProvider request, RangeAttribute rangeAttribute)
         {
             Type conversionType = null;
 

--- a/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 
@@ -11,6 +9,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// </summary>
     public class RegularExpressionAttributeRelay : ISpecimenBuilder
     {
+        private readonly ISpecimenBuilder relayBuilder = new AttributeRelay<RegularExpressionAttribute>(CreateRelayedRequest);
+
         /// <summary>
         /// Creates a new specimen based on a request.
         /// </summary>
@@ -21,29 +21,12 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (request == null)
-            {
-                return new NoSpecimen();
-            }
+            return this.relayBuilder.Create(request, context);
+        }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-
-            var customAttributeProvider = request as ICustomAttributeProvider;
-            if (customAttributeProvider == null)
-            {
-                return new NoSpecimen(request);
-            }
-
-            var regularExpressionAttribute = customAttributeProvider.GetCustomAttributes(typeof(RegularExpressionAttribute), inherit: true).Cast<RegularExpressionAttribute>().SingleOrDefault();
-            if (regularExpressionAttribute == null)
-            {
-                return new NoSpecimen(request);
-            }
-
-            return context.Resolve(new RegularExpressionRequest(regularExpressionAttribute.Pattern));
+        private static object CreateRelayedRequest(ICustomAttributeProvider request, RegularExpressionAttribute attribute)
+        {
+            return new RegularExpressionRequest(attribute.Pattern);
         }
     }
 }

--- a/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 
@@ -11,6 +9,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// </summary>
     public class StringLengthAttributeRelay : ISpecimenBuilder
     {
+        private readonly ISpecimenBuilder relayBuilder = new AttributeRelay<StringLengthAttribute>(CreateRelayedRequest);
+
         /// <summary>
         /// Creates a new specimen based on a specified length of characters that are allowed.
         /// </summary>
@@ -23,29 +23,12 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (request == null)
-            {
-                return new NoSpecimen();
-            }
+            return this.relayBuilder.Create(request, context);
+        }
 
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
-
-            var customAttributeProvider = request as ICustomAttributeProvider;
-            if (customAttributeProvider == null)
-            {
-                return new NoSpecimen(request);
-            }
-
-            var stringLengthAttribute = customAttributeProvider.GetCustomAttributes(typeof(StringLengthAttribute), inherit: true).Cast<StringLengthAttribute>().SingleOrDefault();
-            if (stringLengthAttribute == null)
-            {
-                return new NoSpecimen(request);
-            }
-
-            return context.Resolve(new ConstrainedStringRequest(stringLengthAttribute.MaximumLength));
+        private static object CreateRelayedRequest(ICustomAttributeProvider request, StringLengthAttribute attribute)
+        {
+            return new ConstrainedStringRequest(attribute.MaximumLength);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AbstractRecursionIssue\ItemLocation.cs" />
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
+    <Compile Include="DataAnnotations\AttributeRelayTest.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />
     <Compile Include="Kernel\EnumeratorRelayTest.cs" />

--- a/Src/AutoFixtureUnitTest/DataAnnotations/AttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/AttributeRelayTest.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Ploeh.AutoFixture.DataAnnotations;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
+{
+    public class AttributeRelayTest
+    {
+        [Fact]
+        public void ClassIsISpecimenBuilderToParticipateInFixtureCustomization()
+        {
+            // Fixture setup
+            // Exercise system
+            // Verify outcome
+            Assert.True(typeof(ISpecimenBuilder).IsAssignableFrom(typeof(AttributeRelay<>)));
+            // Teardown
+        }
+
+        [Fact]
+        public void ConstructorThrowsArgumentNullExceptionWhenCreateRelayedRequestIsNullToFailFast()
+        {
+            // Fixture setup
+            Func<ICustomAttributeProvider, Attribute, object> createRelayedRequest = null;
+            // Exercise system
+            // Verify outcome
+            var e = Assert.Throws<ArgumentNullException>(() => new AttributeRelay<Attribute>(createRelayedRequest));
+            Assert.Equal("createRelayedRequest", e.ParamName);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateRelayedRequestMethodReturnsMethodInfoOfDelegateSpecifiedInConstructorToAllowInspectionTests()
+        {
+            // Fixture setup
+            Func<ICustomAttributeProvider, Attribute, object> createRelayedRequest = (r, a) => new object();
+            var sut = new AttributeRelay<Attribute>(createRelayedRequest);
+            // Exercise system
+            MethodInfo method = sut.CreateRelayedRequestMethod;
+            // Verify outcome
+            Assert.Same(createRelayedRequest.Method, method);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsNoSpecimenWhenRequestIsNull()
+        {
+            // Fixture setup
+            var sut = new AttributeRelay<Attribute>((r, a) => new object());
+            var context = new DelegatingSpecimenContext();
+            // Exercise system
+            object result = sut.Create(null, context);
+            // Verify outcome
+            Assert.IsType<NoSpecimen>(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsNoSpecimenWhenRequestIsNotICustomAttributeProvider()
+        {
+            // Fixture setup
+            var sut = new AttributeRelay<Attribute>((r, a) => new object());
+            var request = new object();
+            var context = new DelegatingSpecimenContext();
+            // Exercise system
+            object result = sut.Create(request, context);
+            // Verify outcome
+            var noSpecimen = Assert.IsType<NoSpecimen>(result);
+            Assert.Same(request, noSpecimen.Request);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsNoSpecimenWhenICustomAttributeProviderDoesNotReturnExpectedAttributeType()
+        {
+            // Fixture setup
+            var sut = new AttributeRelay<RangeAttribute>((r, a) => new object());
+            var providedAttribute = new ProvidedAttribute(new RequiredAttribute(), default(bool));
+            var request = new FakeCustomAttributeProvider(providedAttribute);
+            var context = new DelegatingSpecimenContext();
+            // Exercise system
+            object result = sut.Create(request, context);
+            // Verify outcome
+            var noSpecimen = Assert.IsType<NoSpecimen>(result);
+            Assert.Same(request, noSpecimen.Request);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateGetsInheritedAttributesFromProviderBecauseAttributesAreInheritedByDefault()
+        {
+            // Fixture setup
+            bool inheritedAttributeRequested = false;
+            var sut = new AttributeRelay<RequiredAttribute>((r, a) => inheritedAttributeRequested = true);
+            var providedAttribute = new ProvidedAttribute(new RequiredAttribute(), inherited: true);
+            var request = new FakeCustomAttributeProvider(providedAttribute);
+            var context = new DelegatingSpecimenContext();
+            // Exercise system
+            sut.Create(request, context);
+            // Verify outcome
+            Assert.True(inheritedAttributeRequested);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateGetsDerivedAttributesFromProviderToAllowDescendantsHandleAttributeClassHierarchies()
+        {
+            // Fixture setup
+            bool derivedAttributeObtained = false;
+            var sut = new AttributeRelay<ValidationAttribute>((r, a) => derivedAttributeObtained = true);
+            var providedAttribute = new ProvidedAttribute(new RequiredAttribute(), inherited: true);
+            var request = new FakeCustomAttributeProvider(providedAttribute);
+            var context = new DelegatingSpecimenContext();
+            // Exercise system
+            sut.Create(request, context);
+            // Verify outcome
+            Assert.True(derivedAttributeObtained);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreatePassesICustomAttributeProviderAndAttributeItReturnsToCreateRelayedRequest()
+        {
+            // Fixture setup
+            ICustomAttributeProvider requestReceivedByCreateRelayedRequest = null;
+            RangeAttribute attributeReceivedByCreateRelayedRequest = null;
+            Func<ICustomAttributeProvider, RangeAttribute, object> createRelayedRequest = (r, a) => 
+            {
+                requestReceivedByCreateRelayedRequest = r;
+                attributeReceivedByCreateRelayedRequest = a;
+                return default(object);
+            };
+            var sut = new AttributeRelay<RangeAttribute>(createRelayedRequest);
+            var attribute = new RangeAttribute(0, 1);
+            var request = new FakeCustomAttributeProvider(new ProvidedAttribute(attribute, default(bool)));
+            var context = new DelegatingSpecimenContext();
+            // Exercise system
+            sut.Create(request, context);
+            // Verify outcome
+            Assert.Same(request, requestReceivedByCreateRelayedRequest);
+            Assert.Same(attribute, attributeReceivedByCreateRelayedRequest);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateResolvesRelayedRequestFromContext()
+        {
+            // Fixture setup
+            var relayedRequest = new object();
+            var sut = new AttributeRelay<RequiredAttribute>((r, a) => relayedRequest);
+            var request = new FakeCustomAttributeProvider(new ProvidedAttribute(new RequiredAttribute(), default(bool)));
+            object requestResolvedFromContext = null;
+            var context = new DelegatingSpecimenContext { OnResolve = r => requestResolvedFromContext = r };
+            // Exercise system
+            sut.Create(request, context);
+            // Verify outcome
+            Assert.Same(relayedRequest, requestResolvedFromContext);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsInstanceResolvedFromContext()
+        {
+            // Fixture setup
+            var sut = new AttributeRelay<RequiredAttribute>((r, a) => new object());
+            var request = new FakeCustomAttributeProvider(new ProvidedAttribute(new RequiredAttribute(), default(bool)));
+            var returnedByContext = new object();
+            var context = new DelegatingSpecimenContext { OnResolve = r => returnedByContext };
+            // Exercise system
+            object result = sut.Create(request, context);
+            // Verify outcome
+            Assert.Same(returnedByContext, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateThrowsArgumentNullExceptionWhenContextIsNullToFailFast()
+        {
+            // Fixture setup
+            var sut = new AttributeRelay<Attribute>((r, a) => new object());
+            var request = new object();
+            // Exercise system
+            var e = Assert.Throws<ArgumentNullException>(() => sut.Create(request, null));
+            // Verify outcome
+            Assert.Equal("context", e.ParamName);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateThrowsInvalidOperationExceptionWhenProviderReturnsMultipleAttributesOfExpectedType()
+        {
+            // Fixture setup
+            var sut = new AttributeRelay<RequiredAttribute>((element, attribute) => new object());
+            var providedAttribute = new ProvidedAttribute(new RequiredAttribute(), default(bool));
+            var request = new FakeCustomAttributeProvider(providedAttribute, providedAttribute);
+            var context = new DelegatingSpecimenContext();
+            // Exercise system
+            var e = Assert.Throws<InvalidOperationException>(() => sut.Create(request, context));
+            // Verify outcome
+            Assert.Contains("multiple", e.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(typeof(RequiredAttribute).FullName, e.Message);
+            Assert.Contains(request.ToString(), e.Message);
+            Assert.NotNull(e.InnerException);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Ploeh.AutoFixture.DataAnnotations;
 using Ploeh.AutoFixture.Kernel;
@@ -23,64 +22,43 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         }
 
         [Fact]
-        public void CreateWithNullRequestReturnsCorrectResult()
+        public void SutReusesLogicOfAttributeRelayWhichIsTestedSeparately()
         {
-            // Fixture setup
-            var sut = new StringLengthAttributeRelay();
+            //Fixture setup
+            var sut = new TestableStringLengthAttributeRelay();
             // Exercise system
-            var dummyContext = new DelegatingSpecimenContext();
-            var result = sut.Create(null, dummyContext);
             // Verify outcome
-            Assert.Equal(new NoSpecimen(), result);
+            var relayBuilder = Assert.IsAssignableFrom<AttributeRelay<StringLengthAttribute>>(sut.RelayBuilder);
+            Assert.Same(
+                typeof(StringLengthAttributeRelay).GetMethod("CreateRelayedRequest", BindingFlags.Static | BindingFlags.NonPublic),
+                relayBuilder.CreateRelayedRequestMethod);
             // Teardown
         }
 
         [Fact]
-        public void CreateWithNullContextThrows()
+        public void CreateReturnsObjectCreatedByRelayBuilderBasedOnGivenRequestAndContext()
         {
             // Fixture setup
-            var sut = new StringLengthAttributeRelay();
-            var dummyRequest = new object();
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                sut.Create(dummyRequest, null));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateWithAnonymousRequestReturnsCorrectResult()
-        {
-            // Fixture setup
-            var sut = new StringLengthAttributeRelay();
-            var dummyRequest = new object();
+            object relayRequest = null;
+            ISpecimenContext relayContext = null;
+            var relayResult = new object();
+            var relayBuilder = new DelegatingSpecimenBuilder();
+            relayBuilder.OnCreate = (r, c) =>
+            {
+                relayRequest = r;
+                relayContext = c;
+                return relayResult;
+            };
+            var sut = new TestableStringLengthAttributeRelay { RelayBuilder = relayBuilder };
             // Exercise system
-            var dummyContainer = new DelegatingSpecimenContext();
-            var result = sut.Create(dummyRequest, dummyContainer);
+            var actualRequest = new object();
+            var actualContext = new DelegatingSpecimenContext();
+            object actualResult = sut.Create(actualRequest, actualContext);
             // Verify outcome
-            var expectedResult = new NoSpecimen(dummyRequest);
-            Assert.Equal(expectedResult, result);
-            // Teardown
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData(1)]
-        [InlineData(typeof(object))]
-        [InlineData(typeof(string))]
-        [InlineData(typeof(int))]
-        [InlineData(typeof(Version))]
-        public void CreateWithNonConstrainedStringRequestReturnsCorrectResult(object request)
-        {
-            // Fixture setup
-            var sut = new StringLengthAttributeRelay();
-            // Exercise system
-            var dummyContext = new DelegatingSpecimenContext();
-            var result = sut.Create(request, dummyContext);
-            // Verify outcome
-            var expectedResult = new NoSpecimen(request);
-            Assert.Equal(expectedResult, result);
-            // Teardown
+            Assert.Same(actualRequest, relayRequest);
+            Assert.Same(actualContext, relayContext);
+            Assert.Same(actualResult, relayResult);
+            // Teardown            
         }
 
         [Theory]
@@ -105,6 +83,18 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             // Verify outcome
             Assert.Equal(expectedResult, result);
             // Teardown
+        }
+
+        private class TestableStringLengthAttributeRelay : StringLengthAttributeRelay
+        {
+            private static readonly FieldInfo relayBuilder = typeof(StringLengthAttributeRelay)
+                .GetField("relayBuilder", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            public ISpecimenBuilder RelayBuilder
+            {
+                get { return (ISpecimenBuilder)relayBuilder.GetValue(this); }
+                set { relayBuilder.SetValue(this, value); }
+            }
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/FakeCustomAttributeProvider.cs
+++ b/Src/AutoFixtureUnitTest/FakeCustomAttributeProvider.cs
@@ -17,22 +17,32 @@ namespace Ploeh.AutoFixtureUnitTest
         public object[] GetCustomAttributes(bool inherit)
         {
             return (from p in this.providedAttributes
-                    where p.Inherited == inherit
+                    where IsMatching(p, inherit)
                     select p.Attribute).ToArray();
         }
 
         public object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
             return (from p in this.providedAttributes
-                    where p.Attribute.GetType() == attributeType && p.Inherited == inherit
+                    where IsMatching(p, attributeType, inherit)
                     select p.Attribute).ToArray();
         }
 
         public bool IsDefined(Type attributeType, bool inherit)
         {
             return (from p in this.providedAttributes
-                    where p.Attribute.GetType() == attributeType && p.Inherited == inherit
+                    where IsMatching(p, attributeType, inherit)
                     select p.Attribute).Any();
+        }
+
+        private bool IsMatching(ProvidedAttribute p, Type attributeType, bool inherit)
+        {
+            return attributeType.IsAssignableFrom(p.Attribute.GetType()) && IsMatching(p, inherit);
+        }
+
+        private bool IsMatching(ProvidedAttribute p, bool inherit)
+        {
+            return !p.Inherited || p.Inherited == inherit;
         }
     }
 }


### PR DESCRIPTION
This pull request extracts common logic from the existing `RangeAttributeRelay`,  `RegularExpressionAttributeRelay` and `StringLengthAttributeRelay` classes to a new concrete class, called  `AttributeRelay<T>`. The existing classes are modified to reuse the new class in their implementations of the `ISpecimenBuilder.Create` method.

### Motivation
Implementations of the `ISpecimenBuilder.Create` method in the three existing classes contain complex logic for finding custom attributes applied to a code element (a parameter, a property, etc), creating a relayed request based on a well-known attribute and resolving it from the `ISpecimenContext`. Most of this logic does not depend on the specific attribute type or the code element to which it is applied and thus could be reused by the existing classes. 

The new `AttributeRelay<T>` class can also be reused by the `SubstituteAttribute`, which was previously submitted in pull request #421 and will be re-submitted in a separate, smaller pull request. The `SubstituteAttribute` is a major motivation for this refactoring, because without the `AttributeRelay<T>`, one would need to create yet another copy of the attribute relay boilerplate code, brining the total number of nearly identical copies to 4. The effort required to extract existing duplicate logic into a reusable component is comparable to re-implementing another copy, but unlike the latter, it reduces the overall amount of code in AutoFixture and improves test coverage.

### Usage
In addition to using `AttributeRelay<T>` when implementing the `ISpecimenBuilder.Create` method, the new class could also be used directly, without the need to introduce a separate `ISpecimenBuilder` class. Here is an example of how it could be used to support the upcoming `SubstituteAttribute`.

```C#
public class AutoSubstituteCustomization : ICustomization
{
  public void Customize(IFixture fixture)
  {
    // ...
    fixture.Customizations.Insert(0, new AttributeRelay<SubstituteAttribute>(SubstituteRequest.Create));
  }
}

public class SubstituteRequest
{
  public static object Create(ICustomAttributeProvider codeElement, SubstituteAttribute attribute)
  {
    return new SubstituteRequest(/* ... */);
  }
}
```

### Out of scope
The following changes may be worth considering in the future. They were not included in this pull request to keep it small and speed up the code review. 
* Moving the private `CreateRelayedRequest` method from the existing `AttributeRelay` classes to their respective `Request` classes and making them public would allow to significantly simplify tests. Because these methods are private today, testing them requires stubbing and mocking the `ISpecimenBuilder` and `ISpecimenContext` interfaces. Simply making them public in the `Relay` classes would feel like exposing internal implementation details. However, if they were defined on the respective `Request` classes, they would be fairly typical factory methods and making them public would be natural.
* Eliminating the existing `AttributeRelay` classes and using the new `AttributeRelay<T>` directly would help to reduce the amount of product and test code. With `ISpecimenBuilder.Create` implemented by the `AttributeRelay<T>` and the `CreateRelayedRequest` methods moved to their respective `Request` classes, the existing `AttributeRelay` classes would become empty shells with 2 lines of code(excluding declarations) per class, but still require a significant amount of test infrastructure. This would constitute a breaking change and have to wait until v4.