### PR TITLE
attempt at addressing issue #413.  Upper bound is always last generat…

### DIFF
--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -56,13 +56,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentException("The limit must be a sequence of two or more integers.");
             }
 
-            for (var i = 0; i < limits.Count() - 1; i++)
-            {
-                if (limits[i + 1] < limits[i])
-                    throw new ArgumentException("The limit must be an increasing sequence.");
-            }
-
-                this.limits = limits;
+            this.limits = limits;
             this.syncRoot = new object();
             this.random = new Random();
             this.numbers = new HashSet<long>();
@@ -201,7 +195,7 @@ namespace Ploeh.AutoFixture
             else
             {
                 this.lower = limits[0];
-                this.upper = limits[1] > Int32.MaxValue
+                this.upper = limits[1] >= Int32.MaxValue
                     ? limits[1]
                     : limits[1] + 1;
             }

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -156,7 +156,7 @@ namespace Ploeh.AutoFixture
                 long result;
                 do
                 {
-                    if (this.lower >= int.MinValue && 
+                    if (this.lower >= int.MinValue &&
                         this.upper <= int.MaxValue)
                     {
                         result = this.random.Next((int)this.lower, (int)this.upper);
@@ -195,7 +195,9 @@ namespace Ploeh.AutoFixture
             else
             {
                 this.lower = limits[0];
-                this.upper = limits[1];
+                this.upper = limits[1] > Int32.MaxValue
+                    ? limits[1]
+                    : limits[1] + 1;
             }
 
             this.numbers.Clear();

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -56,7 +56,13 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentException("The limit must be a sequence of two or more integers.");
             }
 
-            this.limits = limits;
+            for (var i = 0; i < limits.Count() - 1; i++)
+            {
+                if (limits[i + 1] < limits[i])
+                    throw new ArgumentException("The limit must be an increasing sequence.");
+            }
+
+                this.limits = limits;
             this.syncRoot = new object();
             this.random = new Random();
             this.numbers = new HashSet<long>();

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -195,12 +195,24 @@ namespace Ploeh.AutoFixture
             else
             {
                 this.lower = limits[0];
-                this.upper = limits[1] >= Int32.MaxValue
-                    ? limits[1]
-                    : limits[1] + 1;
+                this.upper = this.GetUpperRangeFromLimits();
             }
 
             this.numbers.Clear();
+        }
+
+        /// <summary>
+        /// Returns upper limit + 1 when expecting to use upper as max value in Random.Next(Int32,Int32).
+        /// This ensures that the upper limit is included in the possible values returned by Random.Next(Int32,Int32)
+        /// 
+        /// When not expecting to use Random.Next(Int32,Int32).  It returns the original upper limit.
+        /// </summary>
+        /// <returns></returns>
+        private long GetUpperRangeFromLimits()
+        {
+            return limits[1] >= Int32.MaxValue
+                    ? limits[1]
+                    : limits[1] + 1;
         }
 
         private long GetNextInt64InRange()

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -948,8 +948,8 @@ namespace Ploeh.AutoFixtureUnitTest
             var result = sut.Create<DoublePropertyHolder<int, long>>();
             // Verify outcome
             Assert.True(
-                (result.Property1 >= lower && result.Property1 < upper) &&
-                (result.Property2 >= lower && result.Property2 < upper)
+                (result.Property1 >= lower && result.Property1 <= upper) &&
+                (result.Property2 >= lower && result.Property2 <= upper)
                 );
         }
 
@@ -5630,8 +5630,8 @@ namespace Ploeh.AutoFixtureUnitTest
         [InlineData(10)]
         public void CreateComplexArrayTypeReturnsArrayReflectingCorrectRepeatCount(int repeatCount)
         {
-            var sut = new Fixture{ RepeatCount = repeatCount };
-            
+            var sut = new Fixture { RepeatCount = repeatCount };
+
             var actual = sut.Create<int[,][]>();
 
             Assert.Equal(repeatCount, actual.GetLength(0));
@@ -5721,7 +5721,7 @@ namespace Ploeh.AutoFixtureUnitTest
             int count = 0;
             while (result.MoveNext())
             {
-                count ++;
+                count++;
                 Assert.True(count <= expectedCount);
             }
             Assert.Equal(expectedCount, count);

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -108,9 +108,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var unexpectedLimits = new long[]
             { 
-                (byte)10,
-                (Int16)50,
-                (Int32)20,
+                (byte)byte.MaxValue,
+                (Int16)Int16.MaxValue,
+                (Int32)Int32.MaxValue
             };
             var sut = new RandomNumericSequenceGenerator(
                 unexpectedLimits[0],

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -65,6 +65,19 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
+        [Theory]
+        [InlineData(new long[] { 2, 1 })]
+        [InlineData(new long[] { 1, 3, 2 })]
+        [InlineData(new long[] { 3, 4, 5, 1 })]
+        [InlineData(new long[] { 0, -1, 2 })]
+        [InlineData(new long[] { -8, -3, -4, 0 })]
+        [InlineData(new long[] { 1, 1, 2, 1 })]
+        public void InitializeWithNonIncreasingLimitThrows(long[] limits)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new RandomNumericSequenceGenerator(limits));
+        }
+
         [Fact]
         public void LimitsMatchListParameter()
         {

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -108,9 +108,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var unexpectedLimits = new long[]
             { 
-                (byte)10,
-                (Int16)50,
-                (Int32)20,
+                Byte.MaxValue, 
+                Int16.MaxValue, 
+                Int32.MaxValue
             };
             var sut = new RandomNumericSequenceGenerator(
                 unexpectedLimits[0],

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -108,9 +108,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var unexpectedLimits = new long[]
             { 
-                (byte)byte.MaxValue,
-                (Int16)Int16.MaxValue,
-                (Int32)Int32.MaxValue
+                (byte)10,
+                (Int16)50,
+                (Int32)20,
             };
             var sut = new RandomNumericSequenceGenerator(
                 unexpectedLimits[0],

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -121,9 +121,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var unexpectedLimits = new long[]
             { 
-                Byte.MaxValue, 
-                Int16.MaxValue, 
-                Int32.MaxValue
+                (byte)10,
+                (Int16)50,
+                (Int32)20,
             };
             var sut = new RandomNumericSequenceGenerator(
                 unexpectedLimits[0],

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -65,19 +65,6 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Theory]
-        [InlineData(new long[] { 2, 1 })]
-        [InlineData(new long[] { 1, 3, 2 })]
-        [InlineData(new long[] { 3, 4, 5, 1 })]
-        [InlineData(new long[] { 0, -1, 2 })]
-        [InlineData(new long[] { -8, -3, -4, 0 })]
-        [InlineData(new long[] { 1, 1, 2, 1 })]
-        public void InitializeWithNonIncreasingLimitThrows(long[] limits)
-        {
-            Assert.Throws<ArgumentException>(() =>
-                new RandomNumericSequenceGenerator(limits));
-        }
-
         [Fact]
         public void LimitsMatchListParameter()
         {


### PR DESCRIPTION
I took a stab at fixing this issue.  

I made the upper bound inclusive for the random generator only for Int32 values.

I also modified one test to include the upper bound in the range check (I hope that is OK).

All of the existing tests pass and there does not look to be any performance hit either.

Thanks.