### PR TITLE
This commit is to address #427. Create InvariantCultureGenerator

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
+    <Compile Include="InvariantCultureGenerator.cs" />
     <Compile Include="Kernel\CompositeSpecimenCommand.cs" />
     <Compile Include="Kernel\EnumeratorRelay.cs" />
     <Compile Include="Kernel\GenericMethod.cs" />

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -38,6 +38,7 @@ namespace Ploeh.AutoFixture
             yield return new TaskGenerator();
             yield return new IntPtrGuard();
             yield return new MailAddressGenerator();
+            yield return new InvariantCultureGenerator();
         }
 
         /// <summary>

--- a/Src/AutoFixture/InvariantCultureGenerator.cs
+++ b/Src/AutoFixture/InvariantCultureGenerator.cs
@@ -1,0 +1,37 @@
+﻿using System.Globalization;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Handles creation requests for <see cref="CultureInfo"/> instances, 
+    /// returning always the same <see cref="CultureInfo.InvariantCulture"/>.
+    /// </summary>
+    public class InvariantCultureGenerator : ISpecimenBuilder
+    {
+        private readonly ExactTypeSpecification cultureTypeSpecification 
+			= new ExactTypeSpecification(typeof (CultureInfo));
+
+        /// <summary>
+        /// Generates a CultureInfo specimen based on a <see cref="CultureInfo"/> type request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        /// <remarks>>
+        /// The generated CultureInfo will always be the same as <see cref="CultureInfo.InvariantCulture"/>.
+        /// </remarks>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request == null)
+                return new NoSpecimen();
+
+            if (!cultureTypeSpecification.IsSatisfiedBy(request))
+                return new NoSpecimen(); ;
+
+            return CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -91,6 +91,7 @@
     <Compile Include="AbstractRecursionIssue\ItemBase.cs" />
     <Compile Include="AbstractRecursionIssue\ItemLocation.cs" />
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
+    <Compile Include="InvariantCultureGeneratorTest.cs" />
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />
     <Compile Include="DelegatingRecursionHandler.cs" />

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -43,8 +43,9 @@ namespace Ploeh.AutoFixtureUnitTest
                     typeof(DelegateGenerator),
                     typeof(TaskGenerator),
                     typeof(IntPtrGuard),
-                    typeof(MailAddressGenerator)
-                };
+                    typeof(MailAddressGenerator),
+                    typeof(InvariantCultureGenerator)
+                 };
             // Exercise system
             var sut = new DefaultPrimitiveBuilders();
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/InvariantCultureGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/InvariantCultureGeneratorTest.cs
@@ -1,0 +1,62 @@
+﻿using System.Globalization;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class InvariantCultureGeneratorTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            var sut = new InvariantCultureGenerator();
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void CreateWithNullRequestWillReturnNoSpecimen()
+        {
+            var sut = new InvariantCultureGenerator();
+
+            var actual = sut.Create(null, new DelegatingSpecimenContext());
+
+            Assert.Equal(new NoSpecimen(), actual);
+        }
+
+        [Fact]
+        public void CreateWithNullContextDoesNotThrow()
+        {
+            var sut = new InvariantCultureGenerator();
+            sut.Create(new object(), null);
+        }
+
+        [Fact]
+        public void CreateWithNonTypeRequestWillReturnNoSpecimen()
+        {
+            var sut = new InvariantCultureGenerator();
+            var actual = sut.Create(new object(), new DelegatingSpecimenContext());
+
+            Assert.Equal(new NoSpecimen(), actual);
+        }
+
+        [Fact]
+        public void CreateWithNonCultureInfoTypeWillReturnNoSpecimen()
+        {
+            var sut = new InvariantCultureGenerator();
+            var actual = sut.Create(typeof(object), new DelegatingSpecimenContext());
+
+            Assert.Equal(new NoSpecimen(), actual);
+        }
+
+        [Fact]
+        public void CreateWithCultureInfoRequestTypeReturnsInvariantCulture()
+        {
+            var sut = new InvariantCultureGenerator();
+            var actual = sut.Create(typeof(CultureInfo), new DelegatingSpecimenContext());
+
+            Assert.Equal(CultureInfo.InvariantCulture, actual);
+        }
+    }
+}


### PR DESCRIPTION
Second try at pull request - This time build is OK.

Create InvariantCultureGenerator and add it to DefaultPrimitiveBuilders.

This enhancement to AutoFixture will make possible to provide CultureInfo instances without any further customizations on user's end.
InvariantCultureGenerator will provide CultureInfo.InvariantCulture for any CultureInfo requests.
This generator has been added to DefaultPrimitiveBuilders class that agreggates generators for primitive BCL types.