### PR TITLE
Fixed exception when adding duplicated entries to a dictionary

### DIFF
--- a/Src/AutoFixture/DictionaryFiller.cs
+++ b/Src/AutoFixture/DictionaryFiller.cs
@@ -58,8 +58,17 @@ namespace Ploeh.AutoFixture
             var enumerable = context.Resolve(new MultipleRequest(kvpType)) as IEnumerable;
             foreach (var item in enumerable)
             {
-                var addMethod = typeof(ICollection<>).MakeGenericType(kvpType).GetMethod("Add", new[] { kvpType });
-                addMethod.Invoke(specimen, new[] { item });
+                var key = kvpType.GetProperty("Key").GetValue(item, new object[] { });
+
+                var dictionaryType = typeof(IDictionary<,>).MakeGenericType(typeArguments[0], typeArguments[1]);
+                var containsKeyMethod = dictionaryType.GetMethod("ContainsKey");
+                var keyIsAlreadyPresent = (bool)containsKeyMethod.Invoke(specimen, new[] { key });
+
+                if (!keyIsAlreadyPresent)
+                {
+                    var addMethod = typeof(ICollection<>).MakeGenericType(kvpType).GetMethod("Add", new[] { kvpType });
+                    addMethod.Invoke(specimen, new[] { item });
+                }
             }
         }
     }

--- a/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
+++ b/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
@@ -130,5 +130,21 @@ namespace Ploeh.AutoFixtureUnitTest
             Assert.True(expectedResult.SequenceEqual(dictionary));
             // Teardown
         }
+
+        [Fact]
+        public void DoesNotThrowWithDuplicateEntries()
+        {
+            // Fixture setup
+            var dictionary = new Dictionary<int, string>();
+
+            var request = new MultipleRequest(typeof(KeyValuePair<int, string>));
+            var sequence = Enumerable.Repeat(0, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
+            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? (object)sequence : new NoSpecimen(r) };
+
+            var sut = new DictionaryFiller();
+            // Exercise system & Verify outcome
+            Assert.DoesNotThrow(() => sut.Execute(dictionary, context));
+            // Teardown
+        }
     }
 }


### PR DESCRIPTION
Adressing #407.

Guard clause added by calling the `ContainsKey` prior to calling `Add`.