### PR TITLE
FrozenAttribute with matching strategy for xUnit2

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
@@ -36,7 +36,9 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             // Fixture setup
             var registeredType = typeof(AbstractType);
+#pragma warning disable 0618
             var sut = new FrozenAttribute { As = registeredType };
+#pragma warning restore 0618
             var parameter = typeof(TypeWithConcreteParameterMethod)
                 .GetMethod("DoSomething", new[] { typeof(ConcreteType) })
                 .GetParameters()
@@ -54,7 +56,9 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             // Fixture setup
             var registeredType = typeof(string);
+#pragma warning disable 0618
             var sut = new FrozenAttribute { As = registeredType };
+#pragma warning restore 0618
             var parameter = typeof(TypeWithConcreteParameterMethod)
                 .GetMethod("DoSomething", new[] { typeof(ConcreteType) })
                 .GetParameters()

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
@@ -32,40 +32,6 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationReturnsCorrectResult()
-        {
-            // Fixture setup
-            var sut = new FrozenAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers)
-                .GetMethod("DoSomething", new[] { typeof(object) })
-                .GetParameters()
-                .Single();
-            // Exercise system
-            var result = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezingCustomization>(result);
-            Assert.Equal(parameter.ParameterType, freezer.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationReturnsTheRegisteredTypeEqualToTheParameterType()
-        {
-            // Fixture setup
-            var sut = new FrozenAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers)
-                .GetMethod("DoSomething", new[] { typeof(object) })
-                .GetParameters()
-                .Single();
-            // Exercise system
-            var result = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezingCustomization>(result);
-            Assert.Equal(parameter.ParameterType, freezer.RegisteredType);
-            // Teardown
-        }
-
-        [Fact]
         public void GetCustomizationWithSpecificRegisteredTypeReturnsCorrectResult()
         {
             // Fixture setup

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
@@ -21,7 +21,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Fact]
-        public void GetCustomizationFromNullParamterThrows()
+        public void GetCustomizationFromNullParameterThrows()
         {
             // Fixture setup
             var sut = new FrozenAttribute();

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Reflection;
-using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 
@@ -66,82 +64,6 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             // Exercise system and verify outcome
             Assert.Throws<ArgumentException>(() => sut.GetCustomization(parameter));
             // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationShouldMatchByExactParameterType()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute();
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var exactTypeMatcher = matcher.Specifications.OfType<ExactTypeSpecification>().SingleOrDefault();
-            Assert.NotNull(exactTypeMatcher);
-            Assert.Equal(parameter.ParameterType, exactTypeMatcher.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationShouldMatchBySeedRequestForParameterType()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute();
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var seedRequestMatcher = matcher.Specifications.OfType<SeedRequestSpecification>().SingleOrDefault();
-            Assert.NotNull(seedRequestMatcher);
-            Assert.Equal(parameter.ParameterType, seedRequestMatcher.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationWithMatchingByDirectBaseTypeShouldMatchByBaseType()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute(Matching.DirectBaseType);
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var directBaseTypeMatcher = matcher.Specifications.OfType<DirectBaseTypeSpecification>().SingleOrDefault();
-            Assert.NotNull(directBaseTypeMatcher);
-            Assert.Equal(parameter.ParameterType, directBaseTypeMatcher.TargetType);
-            // Teardown
-        }
-
-        [Fact]
-        public void GetCustomizationWithMatchingByImplementedInterfacesShouldMatchByImplementedInterfaces()
-        {
-            // Fixture setup
-            var parameter = AParameter<object>();
-            var sut = new FrozenAttribute(Matching.ImplementedInterfaces);
-            // Exercise system
-            var customization = sut.GetCustomization(parameter);
-            // Verify outcome
-            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
-            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
-            var interfaceTypeMatcher = matcher.Specifications.OfType<ImplementedInterfaceSpecification>().SingleOrDefault();
-            Assert.NotNull(interfaceTypeMatcher);
-            Assert.Equal(parameter.ParameterType, interfaceTypeMatcher.TargetType);
-            // Teardown
-        }
-
-        private static ParameterInfo AParameter<T>()
-        {
-            return typeof(SingleParameterType<T>)
-                .GetConstructor(new[] { typeof(T) })
-                .GetParameters()
-                .Single(p => p.Name == "parameter");
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 
@@ -94,6 +96,82 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             // Exercise system and verify outcome
             Assert.Throws<ArgumentException>(() => sut.GetCustomization(parameter));
             // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationShouldMatchByExactParameterType()
+        {
+            // Fixture setup
+            var parameter = AParameter<object>();
+            var sut = new FrozenAttribute();
+            // Exercise system
+            var customization = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            var exactTypeMatcher = matcher.Specifications.OfType<ExactTypeSpecification>().SingleOrDefault();
+            Assert.NotNull(exactTypeMatcher);
+            Assert.Equal(parameter.ParameterType, exactTypeMatcher.TargetType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationShouldMatchBySeedRequestForParameterType()
+        {
+            // Fixture setup
+            var parameter = AParameter<object>();
+            var sut = new FrozenAttribute();
+            // Exercise system
+            var customization = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            var seedRequestMatcher = matcher.Specifications.OfType<SeedRequestSpecification>().SingleOrDefault();
+            Assert.NotNull(seedRequestMatcher);
+            Assert.Equal(parameter.ParameterType, seedRequestMatcher.TargetType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithMatchingByDirectBaseTypeShouldMatchByBaseType()
+        {
+            // Fixture setup
+            var parameter = AParameter<object>();
+            var sut = new FrozenAttribute(Matching.DirectBaseType);
+            // Exercise system
+            var customization = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            var directBaseTypeMatcher = matcher.Specifications.OfType<DirectBaseTypeSpecification>().SingleOrDefault();
+            Assert.NotNull(directBaseTypeMatcher);
+            Assert.Equal(parameter.ParameterType, directBaseTypeMatcher.TargetType);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetCustomizationWithMatchingByImplementedInterfacesShouldMatchByImplementedInterfaces()
+        {
+            // Fixture setup
+            var parameter = AParameter<object>();
+            var sut = new FrozenAttribute(Matching.ImplementedInterfaces);
+            // Exercise system
+            var customization = sut.GetCustomization(parameter);
+            // Verify outcome
+            var freezer = Assert.IsAssignableFrom<FreezeOnMatchCustomization>(customization);
+            var matcher = Assert.IsType<OrRequestSpecification>(freezer.Matcher);
+            var interfaceTypeMatcher = matcher.Specifications.OfType<ImplementedInterfaceSpecification>().SingleOrDefault();
+            Assert.NotNull(interfaceTypeMatcher);
+            Assert.Equal(parameter.ParameterType, interfaceTypeMatcher.TargetType);
+            // Teardown
+        }
+
+        private static ParameterInfo AParameter<T>()
+        {
+            return typeof(SingleParameterType<T>)
+                .GetConstructor(new[] { typeof(T) })
+                .GetParameters()
+                .Single(p => p.Name == "parameter");
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -163,11 +163,27 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByExactTypeShouldNotAssignSameInstanceToSecondParameterOfDifferentType(
+            [Frozen(Matching.ExactType)]ConcreteType p1,
+            object p2)
+        {
+            Assert.NotEqual(p1, p2);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByDirectBaseTypeShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.DirectBaseType)]ConcreteType p1,
             AbstractType p2)
         {
             Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByDirectBaseTypeShouldNotAssignSameInstanceToSecondParameterOfIndirectBaseType(
+            [Frozen(Matching.DirectBaseType)]ConcreteType p1,
+            object p2)
+        {
+            Assert.NotEqual(p1, p2);
         }
 
         [Theory, AutoData]
@@ -179,11 +195,27 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByInterfaceShouldNotAssignSameInstanceToSecondParameterOfNonInterfaceType(
+            [Frozen(Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
+            object p2)
+        {
+            Assert.NotEqual(p1, p2);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByParameterWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.ParameterName)]string parameter,
             SingleParameterType<object> p2)
         {
             Assert.Equal(parameter, p2.Parameter);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByParameterWithDifferentNameShouldNotAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.ParameterName)]string p1,
+            SingleParameterType<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Parameter);
         }
 
         [Theory, AutoData]
@@ -195,11 +227,27 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByPropertyWithDifferentNameShouldNotAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.PropertyName)]string p1,
+            PropertyHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Property);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByFieldWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.FieldName)]string field,
             FieldHolder<object> p2)
         {
             Assert.Equal(field, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByFieldWithDifferentNameShouldNotAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.FieldName)]string p1,
+            FieldHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Field);
         }
 
         [Theory, AutoData]
@@ -211,6 +259,14 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToParameter(
+            [Frozen(Matching.MemberName)]string p1,
+            SingleParameterType<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Parameter);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingProperty(
             [Frozen(Matching.MemberName)]string property,
             PropertyHolder<object> p2)
@@ -219,11 +275,27 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToProperty(
+            [Frozen(Matching.MemberName)]string p1,
+            PropertyHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Property);
+        }
+
+        [Theory, AutoData]
         public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingField(
             [Frozen(Matching.MemberName)]string field,
             FieldHolder<object> p2)
         {
             Assert.Equal(field, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToField(
+            [Frozen(Matching.MemberName)]string p1,
+            FieldHolder<object> p2)
+        {
+            Assert.NotEqual(p1, p2.Field);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -128,7 +128,9 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterAsBaseTypeAssignsSameInstanceToSecondParameterOfThatBaseType(
+#pragma warning disable 0618
             [Frozen(As = typeof(AbstractType))]ConcreteType p1,
+#pragma warning restore 0618
             AbstractType p2)
         {
             Assert.Same(p1, p2);
@@ -136,7 +138,9 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
 
         [Theory, AutoData]
         public void FreezeFirstParameterAsNullTypeAssignsSameInstanceToSecondParameterOfSameType(
+#pragma warning disable 0618
             [Frozen(As = null)]ConcreteType p1,
+#pragma warning restore 0618
             ConcreteType p2)
         {
             Assert.Same(p1, p2);

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -141,5 +141,85 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             Assert.Same(p1, p2);
         }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterShouldAssignSameInstanceToSecondParameter(
+            [Frozen]string p1,
+            string p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByExactTypeShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.ExactType)]ConcreteType p1,
+            ConcreteType p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByDirectBaseTypeShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.DirectBaseType)]ConcreteType p1,
+            AbstractType p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByInterfaceShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
+            IInterface p2)
+        {
+            Assert.Equal(p1, p2);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByParameterWithSameNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.ParameterName)]string parameter,
+            SingleParameterType<object> p2)
+        {
+            Assert.Equal(parameter, p2.Parameter);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByPropertyWithSameNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.PropertyName)]string property,
+            PropertyHolder<object> p2)
+        {
+            Assert.Equal(property, p2.Property);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByFieldWithSameNameShouldAssignSameInstanceToSecondParameter(
+            [Frozen(Matching.FieldName)]string field,
+            FieldHolder<object> p2)
+        {
+            Assert.Equal(field, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingParameter(
+            [Frozen(Matching.MemberName)]string parameter,
+            SingleParameterType<object> p2)
+        {
+            Assert.Equal(parameter, p2.Parameter);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingProperty(
+            [Frozen(Matching.MemberName)]string property,
+            PropertyHolder<object> p2)
+        {
+            Assert.Equal(property, p2.Property);
+        }
+
+        [Theory, AutoData]
+        public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingField(
+            [Frozen(Matching.MemberName)]string field,
+            FieldHolder<object> p2)
+        {
+            Assert.Equal(field, p2.Field);
+        }
     }
 }

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -70,6 +70,7 @@
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="FrozenAttribute.cs" />
     <Compile Include="GreedyAttribute.cs" />
+    <Compile Include="Matching.cs" />
     <Compile Include="NoPreDiscoveryDataDiscoverer.cs" />
     <Compile Include="ModestAttribute.cs" />
     <Compile Include="NoAutoPropertiesAttribute.cs" />

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -45,6 +45,7 @@ namespace Ploeh.AutoFixture.Xunit2
         /// Gets or sets the <see cref="Type"/> that the frozen parameter value
         /// should be mapped to in the <see cref="IFixture"/>.
         /// </summary>
+        [Obsolete("The ability to map a frozen object to a specific type is deprecated and will likely be removed in the future. If you wish to map a frozen type to its implemented interfaces, use [Frozen(Matching.ImplementedInterfaces)]. If you instead wish to map it to its direct base type, use [Frozen(Matching.DirectBaseType)].")]
         public Type As { get; set; }
 
         /// <summary>
@@ -86,14 +87,18 @@ namespace Ploeh.AutoFixture.Xunit2
 
         private bool ShouldMatchBySpecificType()
         {
+#pragma warning disable 0618
             return this.As != null;
+#pragma warning restore 0618
         }
 
         private ICustomization FreezeAsType(Type type)
         {
             return new FreezingCustomization(
                 type,
+#pragma warning disable 0618
                 this.As ?? type);
+#pragma warning restore 0618
         }
 
         private ICustomization FreezeByCriteria(Type type, string name)

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.Xunit2
 {
@@ -11,6 +13,34 @@ namespace Ploeh.AutoFixture.Xunit2
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class FrozenAttribute : CustomizeAttribute
     {
+        private readonly Matching by;
+        private IRequestSpecification matcher;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the frozen parameter value
+        /// is <see cref="F:Matching.ExactType"/>.
+        /// </remarks>
+        public FrozenAttribute()
+            : this(Matching.ExactType)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
+        /// </summary>
+        /// <param name="by">
+        /// The <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the frozen parameter value.
+        /// </param>
+        public FrozenAttribute(Matching by)
+        {
+            this.by = by;
+        }
+
         /// <summary>
         /// Gets or sets the <see cref="Type"/> that the frozen parameter value
         /// should be mapped to in the <see cref="IFixture"/>.
@@ -18,15 +48,27 @@ namespace Ploeh.AutoFixture.Xunit2
         public Type As { get; set; }
 
         /// <summary>
-        /// Gets a customization that freezes the <see cref="Type"/> of the parameter.
+        /// Gets the <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the frozen parameter value.
         /// </summary>
-        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        public Matching By
+        {
+            get { return by; }
+        }
+
+        /// <summary>
+        /// Gets a <see cref="FreezeOnMatchCustomization"/> configured
+        /// to match requests based on the <see cref="Type"/> and optionally
+        /// the name of the parameter.
+        /// </summary>
+        /// <param name="parameter">
+        /// The parameter for which the customization is requested.
+        /// </param>
         /// <returns>
-        /// A customization that freezes the <see cref="Type"/> of the parameter.
+        /// A <see cref="FreezeOnMatchCustomization"/> configured
+        /// to match requests based on the <see cref="Type"/> and optionally
+        /// the name of the parameter.
         /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="parameter"/> is null.
-        /// </exception>
         public override ICustomization GetCustomization(ParameterInfo parameter)
         {
             if (parameter == null)
@@ -34,8 +76,148 @@ namespace Ploeh.AutoFixture.Xunit2
                 throw new ArgumentNullException("parameter");
             }
 
-            var targetType = parameter.ParameterType;
-            return new FreezingCustomization(targetType, As ?? targetType);
+            var type = parameter.ParameterType;
+            var name = parameter.Name;
+
+            return ShouldMatchBySpecificType()
+                ? FreezeAsType(type)
+                : FreezeByCriteria(type, name);
+        }
+
+        private bool ShouldMatchBySpecificType()
+        {
+            return this.As != null;
+        }
+
+        private ICustomization FreezeAsType(Type type)
+        {
+            return new FreezingCustomization(
+                type,
+                this.As ?? type);
+        }
+
+        private ICustomization FreezeByCriteria(Type type, string name)
+        {
+            MatchByType(type);
+            MatchByName(type, name);
+            return new FreezeOnMatchCustomization(type, this.matcher);
+        }
+
+        private void MatchByType(Type type)
+        {
+            AlwaysMatchByExactType(type);
+            MatchByBaseType(type);
+            MatchByImplementedInterfaces(type);
+        }
+
+        private void MatchByName(Type type, string name)
+        {
+            MatchByPropertyName(type, name);
+            MatchByParameterName(type, name);
+            MatchByFieldName(type, name);
+        }
+
+        private void AlwaysMatchByExactType(Type type)
+        {
+            MatchBy(
+                new OrRequestSpecification(
+                    new ExactTypeSpecification(type),
+                    new SeedRequestSpecification(type)));
+        }
+
+        private void MatchByBaseType(Type type)
+        {
+            if (ShouldMatchBy(Matching.DirectBaseType))
+            {
+                MatchBy(new DirectBaseTypeSpecification(type));
+            }
+        }
+
+        private void MatchByImplementedInterfaces(Type type)
+        {
+            if (ShouldMatchBy(Matching.ImplementedInterfaces))
+            {
+                MatchBy(new ImplementedInterfaceSpecification(type));
+            }
+        }
+
+        private void MatchByParameterName(Type type, string name)
+        {
+            if (ShouldMatchBy(Matching.ParameterName))
+            {
+                MatchBy(
+                    new ParameterSpecification(
+                        new ParameterTypeAndNameCriterion(
+                            DerivesFrom(type),
+                            IsNamed(name))));
+            }
+        }
+
+        private void MatchByPropertyName(Type type, string name)
+        {
+            if (ShouldMatchBy(Matching.PropertyName))
+            {
+                MatchBy(
+                    new PropertySpecification(
+                        new PropertyTypeAndNameCriterion(
+                            DerivesFrom(type),
+                            IsNamed(name))));
+            }
+        }
+
+        private void MatchByFieldName(Type type, string name)
+        {
+            if (ShouldMatchBy(Matching.FieldName))
+            {
+                MatchBy(
+                    new FieldSpecification(
+                        new FieldTypeAndNameCriterion(
+                            DerivesFrom(type),
+                            IsNamed(name))));
+            }
+        }
+
+        private bool ShouldMatchBy(Matching criteria)
+        {
+            return this.By.HasFlag(criteria);
+        }
+
+        private void MatchBy(IRequestSpecification criteria)
+        {
+            this.matcher = this.matcher == null
+                ? criteria
+                : new OrRequestSpecification(this.matcher, criteria);
+        }
+
+        private static Criterion<Type> DerivesFrom(Type type)
+        {
+            return new Criterion<Type>(
+                type,
+                new DerivesFromTypeComparer());
+        }
+
+        private static Criterion<string> IsNamed(string name)
+        {
+            return new Criterion<string>(
+                name,
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        private class DerivesFromTypeComparer : IEqualityComparer<Type>
+        {
+            public bool Equals(Type x, Type y)
+            {
+                if (y == null && x == null)
+                    return true;
+                if (y == null)
+                    return false;
+                return y.IsAssignableFrom(x);
+            }
+
+            public int GetHashCode(Type obj)
+            {
+                return 0;
+            }
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -14,7 +14,6 @@ namespace Ploeh.AutoFixture.Xunit2
     public sealed class FrozenAttribute : CustomizeAttribute
     {
         private readonly Matching by;
-        private IRequestSpecification matcher;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
@@ -103,83 +102,64 @@ namespace Ploeh.AutoFixture.Xunit2
 
         private ICustomization FreezeByCriteria(Type type, string name)
         {
-            MatchByType(type);
-            MatchByName(type, name);
-            return new FreezeOnMatchCustomization(type, this.matcher);
+            var filter = new Filter(ByExactType(type))
+                .Or(ByBaseType(type))
+                .Or(ByImplementedInterfaces(type))
+                .Or(ByPropertyName(type, name))
+                .Or(ByParameterName(type, name))
+                .Or(ByFieldName(type, name));
+            return new FreezeOnMatchCustomization(type, filter);
         }
 
-        private void MatchByType(Type type)
+        private static IRequestSpecification ByExactType(Type type)
         {
-            AlwaysMatchByExactType(type);
-            MatchByBaseType(type);
-            MatchByImplementedInterfaces(type);
+            return new OrRequestSpecification(
+                new ExactTypeSpecification(type),
+                new SeedRequestSpecification(type));
         }
 
-        private void MatchByName(Type type, string name)
+        private IRequestSpecification ByBaseType(Type type)
         {
-            MatchByPropertyName(type, name);
-            MatchByParameterName(type, name);
-            MatchByFieldName(type, name);
+            return ShouldMatchBy(Matching.DirectBaseType)
+                ? new DirectBaseTypeSpecification(type)
+                : NoMatch();
         }
 
-        private void AlwaysMatchByExactType(Type type)
+        private IRequestSpecification ByImplementedInterfaces(Type type)
         {
-            MatchBy(
-                new OrRequestSpecification(
-                    new ExactTypeSpecification(type),
-                    new SeedRequestSpecification(type)));
+            return ShouldMatchBy(Matching.ImplementedInterfaces)
+                ? new ImplementedInterfaceSpecification(type)
+                : NoMatch();
         }
 
-        private void MatchByBaseType(Type type)
+        private IRequestSpecification ByParameterName(Type type, string name)
         {
-            if (ShouldMatchBy(Matching.DirectBaseType))
-            {
-                MatchBy(new DirectBaseTypeSpecification(type));
-            }
+            return ShouldMatchBy(Matching.ParameterName)
+                ? new ParameterSpecification(
+                    new ParameterTypeAndNameCriterion(
+                        DerivesFrom(type),
+                        IsNamed(name)))
+                : NoMatch();
         }
 
-        private void MatchByImplementedInterfaces(Type type)
+        private IRequestSpecification ByPropertyName(Type type, string name)
         {
-            if (ShouldMatchBy(Matching.ImplementedInterfaces))
-            {
-                MatchBy(new ImplementedInterfaceSpecification(type));
-            }
+            return ShouldMatchBy(Matching.PropertyName)
+                ? new PropertySpecification(
+                    new PropertyTypeAndNameCriterion(
+                        DerivesFrom(type),
+                        IsNamed(name)))
+                : NoMatch();
         }
 
-        private void MatchByParameterName(Type type, string name)
+        private IRequestSpecification ByFieldName(Type type, string name)
         {
-            if (ShouldMatchBy(Matching.ParameterName))
-            {
-                MatchBy(
-                    new ParameterSpecification(
-                        new ParameterTypeAndNameCriterion(
-                            DerivesFrom(type),
-                            IsNamed(name))));
-            }
-        }
-
-        private void MatchByPropertyName(Type type, string name)
-        {
-            if (ShouldMatchBy(Matching.PropertyName))
-            {
-                MatchBy(
-                    new PropertySpecification(
-                        new PropertyTypeAndNameCriterion(
-                            DerivesFrom(type),
-                            IsNamed(name))));
-            }
-        }
-
-        private void MatchByFieldName(Type type, string name)
-        {
-            if (ShouldMatchBy(Matching.FieldName))
-            {
-                MatchBy(
-                    new FieldSpecification(
-                        new FieldTypeAndNameCriterion(
-                            DerivesFrom(type),
-                            IsNamed(name))));
-            }
+            return ShouldMatchBy(Matching.FieldName)
+                ? new FieldSpecification(
+                    new FieldTypeAndNameCriterion(
+                        DerivesFrom(type),
+                        IsNamed(name)))
+                : NoMatch();
         }
 
         private bool ShouldMatchBy(Matching criteria)
@@ -187,11 +167,9 @@ namespace Ploeh.AutoFixture.Xunit2
             return this.By.HasFlag(criteria);
         }
 
-        private void MatchBy(IRequestSpecification criteria)
+        private static IRequestSpecification NoMatch()
         {
-            this.matcher = this.matcher == null
-                ? criteria
-                : new OrRequestSpecification(this.matcher, criteria);
+            return new FalseRequestSpecification();
         }
 
         private static Criterion<Type> DerivesFrom(Type type)
@@ -206,6 +184,29 @@ namespace Ploeh.AutoFixture.Xunit2
             return new Criterion<string>(
                 name,
                 StringComparer.OrdinalIgnoreCase);
+        }
+
+        private class Filter : IRequestSpecification
+        {
+            private readonly IRequestSpecification criteria;
+
+            public Filter(IRequestSpecification criteria)
+            {
+                this.criteria = criteria;
+            }
+
+            public Filter Or(IRequestSpecification condition)
+            {
+                return new Filter(
+                    new OrRequestSpecification(
+                        this.criteria,
+                        condition));
+            }
+
+            public bool IsSatisfiedBy(object request)
+            {
+                return this.criteria.IsSatisfiedBy(request);
+            }
         }
 
         private class DerivesFromTypeComparer : IEqualityComparer<Type>

--- a/Src/AutoFixture.xUnit.net2/Matching.cs
+++ b/Src/AutoFixture.xUnit.net2/Matching.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    /// <summary>
+    /// The criteria used to determine which requests will be satisfied
+    /// by the frozen specimen created for a parameter
+    /// decorated with the <see cref="FrozenAttribute"/> attribute.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1714:FlagsEnumsShouldHavePluralNames", Justification = "This enumeration is designed to be used together with an attribute and is named to improve readability.")]
+    [Flags]
+    public enum Matching
+    {
+        /// <summary>
+        /// Matches requests for the exact same <see cref="Type"/>
+        /// as the type of the parameter.
+        /// </summary>
+        ExactType = 1,
+
+        /// <summary>
+        /// Matches requests for a <see cref="Type"/> that is
+        /// a direct base of the type of the parameter.
+        /// </summary>
+        DirectBaseType = 2,
+
+        /// <summary>
+        /// Matches requests for an interface <see cref="Type"/> that is
+        /// implemented by the type of the parameter.
+        /// </summary>
+        ImplementedInterfaces = 4,
+
+        /// <summary>
+        /// Matches requests for a <see cref="ParameterInfo"/> whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        ParameterName = 8,
+
+        /// <summary>
+        /// Matches requests for a <see cref="PropertyInfo"/> whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        PropertyName = 16,
+
+        /// <summary>
+        /// Matches requests for a <see cref="FieldInfo"/> whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        FieldName = 32,
+
+        /// <summary>
+        /// Matches requests for a parameter, property or field whose
+        /// <see cref="Type"/> is compatible with the type of the parameter
+        /// and has a specific name.
+        /// </summary>
+        MemberName = ParameterName | PropertyName | FieldName
+    }
+}


### PR DESCRIPTION
Ports the `FrozenAttribute` with matching strategy to the **xUnit2** Glue Library.

For example you can freeze a parameter for any interfaces implemented by its type:

```csharp
[Theory, AutoData]
public void FreezeByImplementedInterface(
    [Frozen(Matching.ImplementedInterfaces)]Foo p1,
    IFoo p2)
{
    Assert.Equal(p1, p2);
}
```

or freeze a parameter for any properties with the same name (case-insensitive) and a compatible type: 

```csharp
[Theory, AutoData]
public void FreezeByMatchingPropertyTypeAndName(
    [Frozen(Matching.PropertyName)]string bar,
    Foo p)
{
    Assert.Equal(bar, p.Bar);
}
```