### PR TITLE
Fix a number of typos

### DIFF
--- a/Src/AutoFixture/Kernel/FieldSpecification.cs
+++ b/Src/AutoFixture/Kernel/FieldSpecification.cs
@@ -76,7 +76,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// The <see cref="Type"/> with which the requested
         /// <see cref="FieldInfo"/> type should be compatible.
         /// </summary>
-        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This propery will be removed in a future version of AutoFixture.", false)]
+        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
         public Type TargetType
         {
             get { return this.targetType; }
@@ -86,7 +86,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// The name which the requested <see cref="FieldInfo"/> name
         /// should match exactly.
         /// </summary>
-        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This propery will be removed in a future version of AutoFixture.", false)]
+        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
         public string TargetName
         {
             get { return this.targetName; }

--- a/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <para>
         /// This method compares the candidate <paramref name="other" />
         /// against <see cref="TypeCriterion" /> and
-        /// <see cref="NameCriterion" />. If the field's type mathes the type
+        /// <see cref="NameCriterion" />. If the field's type matches the type
         /// criterion, and its name matches the name criterion, the return
         /// value is <see langword="true" />.
         /// </para>
@@ -90,7 +90,7 @@ namespace Ploeh.AutoFixture.Kernel
         }
 
         /// <summary>
-        /// The name criterion originall passed in via the class' constructor.
+        /// The name criterion originally passed in via the class' constructor.
         /// </summary>
         public IEquatable<string> NameCriterion
         {

--- a/Src/AutoFixture/Kernel/OmitSpecimen.cs
+++ b/Src/AutoFixture/Kernel/OmitSpecimen.cs
@@ -7,7 +7,7 @@ namespace Ploeh.AutoFixture.Kernel
 {
     /// <summary>
     /// A signal type used to indicate to the Auto-Property feature that a given request should be
-    /// ingored, and no further processing performed.
+    /// ignored, and no further processing performed.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/Src/AutoFixture/Kernel/ParameterSpecification.cs
+++ b/Src/AutoFixture/Kernel/ParameterSpecification.cs
@@ -77,7 +77,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// The <see cref="Type"/> with which the requested
         /// <see cref="ParameterInfo"/> type should be compatible.
         /// </summary>
-        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This propery will be removed in a future version of AutoFixture.", false)]
+        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
         public Type TargetType
         {
             get { return this.targetType; }
@@ -87,7 +87,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// The name which the requested <see cref="ParameterInfo"/> name
         /// should match exactly.
         /// </summary>
-        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This propery will be removed in a future version of AutoFixture.", false)]
+        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
         public string TargetName
         {
             get { return this.targetName; }

--- a/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <para>
         /// This method compares the candidate <paramref name="other" />
         /// against <see cref="TypeCriterion" /> and
-        /// <see cref="NameCriterion" />. If the parameter's type mathes the
+        /// <see cref="NameCriterion" />. If the parameter's type matches the
         /// type criterion, and its name matches the name criterion, the return
         /// value is <see langword="true" />.
         /// </para>
@@ -90,7 +90,7 @@ namespace Ploeh.AutoFixture.Kernel
         }
 
         /// <summary>
-        /// The name criterion originall passed in via the class' constructor.
+        /// The name criterion originally passed in via the class' constructor.
         /// </summary>
         public IEquatable<string> NameCriterion
         {

--- a/Src/AutoFixture/Kernel/PropertySpecification.cs
+++ b/Src/AutoFixture/Kernel/PropertySpecification.cs
@@ -78,7 +78,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// The <see cref="Type"/> with which the requested
         /// <see cref="PropertyInfo"/> type should be compatible.
         /// </summary>
-        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This propery will be removed in a future version of AutoFixture.", false)]
+        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
         public Type TargetType
         {
             get { return this.targetType; }
@@ -88,7 +88,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// The name which the requested <see cref="PropertyInfo"/> name
         /// should match exactly.
         /// </summary>
-        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This propery will be removed in a future version of AutoFixture.", false)]
+        [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
         public string TargetName
         {
             get { return this.targetName; }

--- a/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <para>
         /// This method compares the candidate <paramref name="other" />
         /// against <see cref="TypeCriterion" /> and
-        /// <see cref="NameCriterion" />. If the property's type mathes the
+        /// <see cref="NameCriterion" />. If the property's type matches the
         /// type criterion, and its name matches the name criterion, the return
         /// value is <see langword="true" />.
         /// </para>
@@ -108,7 +108,7 @@ namespace Ploeh.AutoFixture.Kernel
         }
 
         /// <summary>
-        /// The name criterion originall passed in via the class' constructor.
+        /// The name criterion originally passed in via the class' constructor.
         /// </summary>
         public IEquatable<string> NameCriterion
         {

--- a/Src/AutoFixtureUnitTest/OmitOnRecursionBehaviorTest.cs
+++ b/Src/AutoFixtureUnitTest/OmitOnRecursionBehaviorTest.cs
@@ -83,12 +83,12 @@ namespace Ploeh.AutoFixtureUnitTest
         [InlineData(0)]
         [InlineData(-7)]
         [InlineData(-42)]
-        public void ConstructorWithRecusionDepthLowerThanOneThrows(int recursionDeph)
+        public void ConstructorWithRecursionDepthLowerThanOneThrows(int recursionDepth)
         {
             // Fixture setup
             // Exercise system and verify outcome
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new OmitOnRecursionBehavior(recursionDeph));
+                new OmitOnRecursionBehavior(recursionDepth));
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/RecursionGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/RecursionGuardTest.cs
@@ -224,7 +224,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var builder = new DelegatingSpecimenBuilder();
             builder.OnCreate = (r, c) => c.Resolve(requestScenario.Dequeue());
 
-            // By setting the depth to two we expect the handle to be triggered at the third "1" occurence.
+            // By setting the depth to two we expect the handle to be triggered at the third "1" occurrence.
             var sut = new DelegatingRecursionGuard(builder, 2);
             object recursiveRequest = null;
 
@@ -662,7 +662,7 @@ namespace Ploeh.AutoFixtureUnitTest
         [InlineData(0)]
         [InlineData(-7)]
         [InlineData(-42)]
-        public void ConstructorWithRecusionDepthLowerThanOneThrows(int recursionDepth)
+        public void ConstructorWithRecursionDepthLowerThanOneThrows(int recursionDepth)
         {
             // Fixture setup
             var dummyBuilder = new DelegatingSpecimenBuilder();

--- a/Src/SemanticComparison/Likeness.cs
+++ b/Src/SemanticComparison/Likeness.cs
@@ -121,7 +121,7 @@ namespace Ploeh.SemanticComparison
         /// Turns off implicit default comparison of properties and fields.
         /// </summary>
         /// <returns>
-        /// A new <see cref="Likeness{TSource, TDestinaion}"/> that uses only explicitly defined
+        /// A new <see cref="Likeness{TSource, TDestination}"/> that uses only explicitly defined
         /// comparisons of properties and fields.
         /// </returns>
         public Likeness<TSource, TDestination> OmitAutoComparison()
@@ -174,7 +174,7 @@ namespace Ploeh.SemanticComparison
         /// </summary>
         /// <typeparam name="TProperty">The type of the property or field.</typeparam>
         /// <param name="propertyPicker">
-        /// An expresssion that identifies the property or field.
+        /// An expression that identifies the property or field.
         /// </param>
         /// <returns>
         /// A new instance of <see cref="LikenessMember{TSource, TDestination}"/> that represents
@@ -198,7 +198,7 @@ namespace Ploeh.SemanticComparison
         /// </summary>
         /// <typeparam name="TProperty">The type of the property or field.</typeparam>
         /// <param name="propertyPicker">
-        /// An expresssion that identifies the property or field.
+        /// An expression that identifies the property or field.
         /// </param>
         /// <returns>
         /// A new instance of <see cref="Likeness{TSource, TDestination}"/> that explicitly

--- a/Src/SemanticComparison/ProxyGenerator.cs
+++ b/Src/SemanticComparison/ProxyGenerator.cs
@@ -455,12 +455,12 @@ namespace Ploeh.SemanticComparison
                 .TrimCompilerGeneratedText(source.Name)
                 .ToUpperInvariant();
             
-            var targerName = ProxyGenerator
+            var targetName = ProxyGenerator
                 .TrimCompilerGeneratedText(target.Name)
                 .ToUpperInvariant();
 
-            return (sourceName.Contains(targerName)
-                 || targerName.Contains(sourceName))
+            return (sourceName.Contains(targetName)
+                 || targetName.Contains(sourceName))
                  && source.FieldType == target.FieldType;
         }
 

--- a/Src/SemanticComparisonUnitTest/LikenessTest.cs
+++ b/Src/SemanticComparisonUnitTest/LikenessTest.cs
@@ -759,7 +759,7 @@ namespace Ploeh.SemanticComparison.UnitTest
         }
 
         [Fact]
-        public void OmitAutoComparisonFollowedByCorrectComboOfDefaultEqualityAndExplicityWithReturnsTrue()
+        public void OmitAutoComparisonFollowedByCorrectComboOfDefaultEqualityAndExplicitlyWithReturnsTrue()
         {
             // Fixture setup
             var value = new QuadrupleParameterType<string, string, string, string>("Lorem", "ipsum", "dolor", "sit");


### PR DESCRIPTION
This PR fixes a number of typos in the comments, the attribute strings, along with method and variable naming.