### PR TITLE
Resolves issue #447

### DIFF
--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -99,7 +99,8 @@ namespace Ploeh.AutoFixture
 
         private void FreezeTypeForMatchingRequests(IFixture fixture)
         {
-            fixture.Customizations.Add(
+            fixture.Customizations.Insert(
+                0,
                 new FilteringSpecimenBuilder(
                     FreezeTargetType(fixture),
                     this.matcher));


### PR DESCRIPTION
Fixes #447, where the `FreezeOnMatchCustomization` conflicted with the `AutoMoqCustomization` – and all other auto-mocking customizations for that matter – causing the frozen mock not to be returned for requests of the implemented interface type.