### PR TITLE
Fixes the shotgun freeze issue in NUnit2

### DIFF
--- a/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
@@ -190,6 +190,14 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         }
 
         [Test, AutoData]
+        public void FreezeFirstParameterByParameterWithDifferentNameShouldNotAssignSameInstanceToSecondParameterOfSameType(
+            [Frozen(Matching.ParameterName)]string p1,
+            SingleParameterType<string> p2)
+        {
+            Assert.AreNotEqual(p1, p2.Parameter);
+        }
+
+        [Test, AutoData]
         public void FreezeFirstParameterByPropertyWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.PropertyName)]string property,
             PropertyHolder<object> p2)
@@ -201,6 +209,14 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         public void FreezeFirstParameterByPropertyWithDifferentNameShouldNotAssignSameInstanceToSecondParameter(
             [Frozen(Matching.PropertyName)]string p1,
             PropertyHolder<object> p2)
+        {
+            Assert.AreNotEqual(p1, p2.Property);
+        }
+
+        [Test, AutoData]
+        public void FreezeFirstParameterByPropertyWithDifferentNameShouldNotAssignSameInstanceToSecondParameterOfSameType(
+            [Frozen(Matching.PropertyName)]string p1,
+            PropertyHolder<string> p2)
         {
             Assert.AreNotEqual(p1, p2.Property);
         }
@@ -222,6 +238,14 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         }
 
         [Test, AutoData]
+        public void FreezeFirstParameterByFieldWithDifferentNameShouldNotAssignSameInstanceToSecondParameterOfSameType(
+            [Frozen(Matching.FieldName)]string p1,
+            FieldHolder<string> p2)
+        {
+            Assert.AreNotEqual(p1, p2.Field);
+        }
+
+        [Test, AutoData]
         public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingParameter(
             [Frozen(Matching.MemberName)]string parameter,
             SingleParameterType<object> p2)
@@ -233,6 +257,14 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToParameter(
             [Frozen(Matching.MemberName)]string p1,
             SingleParameterType<object> p2)
+        {
+            Assert.AreNotEqual(p1, p2.Parameter);
+        }
+
+        [Test, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToParameterOfSameType(
+            [Frozen(Matching.MemberName)]string p1,
+            SingleParameterType<string> p2)
         {
             Assert.AreNotEqual(p1, p2.Parameter);
         }
@@ -254,6 +286,14 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         }
 
         [Test, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToPropertyOfSameType(
+            [Frozen(Matching.MemberName)]string p1,
+            PropertyHolder<string> p2)
+        {
+            Assert.AreNotEqual(p1, p2.Property);
+        }
+
+        [Test, AutoData]
         public void FreezeFirstParameterByMemberWithSameNameShouldAssignSameInstanceToMatchingField(
             [Frozen(Matching.MemberName)]string field,
             FieldHolder<object> p2)
@@ -265,6 +305,14 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToField(
             [Frozen(Matching.MemberName)]string p1,
             FieldHolder<object> p2)
+        {
+            Assert.AreNotEqual(p1, p2.Field);
+        }
+
+        [Test, AutoData]
+        public void FreezeFirstParameterByMemberWithDifferentNameShouldNotAssignSameInstanceToFieldOfSameType(
+            [Frozen(Matching.MemberName)]string p1,
+            FieldHolder<string> p2)
         {
             Assert.AreNotEqual(p1, p2.Field);
         }

--- a/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
@@ -158,6 +158,22 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         }
 
         [Test, AutoData]
+        public void FreezeFirstParameterByDirectBaseTypeShouldNotAssignSameInstanceToSecondParameterOfSameType(
+            [Frozen(Matching.DirectBaseType)]ConcreteType p1,
+            ConcreteType p2)
+        {
+            Assert.AreNotEqual(p1, p2);
+        }
+
+        [Test, AutoData]
+        public void FreezeFirstParameterByExactOrDirectBaseTypeShouldAssignSameInstanceToSecondParameterOfSameType(
+            [Frozen(Matching.ExactType | Matching.DirectBaseType)]ConcreteType p1,
+            ConcreteType p2)
+        {
+            Assert.AreEqual(p1, p2);
+        }
+
+        [Test, AutoData]
         public void FreezeFirstParameterByInterfaceShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
             IInterface p2)

--- a/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
@@ -190,6 +190,22 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         }
 
         [Test, AutoData]
+        public void FreezeFirstParameterByInterfaceShouldNotAssignSameInstanceToSecondParameterOfSameType(
+            [Frozen(Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
+            NoopInterfaceImplementer p2)
+        {
+            Assert.AreNotEqual(p1, p2);
+        }
+
+        [Test, AutoData]
+        public void FreezeFirstParameterByDirectOrInterfaceShouldAssignSameInstanceToSecondParameterOfSameType(
+            [Frozen(Matching.ExactType | Matching.ImplementedInterfaces)]NoopInterfaceImplementer p1,
+            NoopInterfaceImplementer p2)
+        {
+            Assert.AreEqual(p1, p2);
+        }
+
+        [Test, AutoData]
         public void FreezeFirstParameterByParameterWithSameNameShouldAssignSameInstanceToSecondParameter(
             [Frozen(Matching.ParameterName)]string parameter,
             SingleParameterType<object> p2)

--- a/Src/AutoFixture.NUnit2/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit2/FrozenAttribute.cs
@@ -140,7 +140,10 @@ namespace Ploeh.AutoFixture.NUnit2
         private IRequestSpecification ByImplementedInterfaces(Type type)
         {
             return ShouldMatchBy(Matching.ImplementedInterfaces)
-                ? new ImplementedInterfaceSpecification(type)
+                ? new AndRequestSpecification(
+                    new InverseRequestSpecification(
+                        new ExactTypeSpecification(type)),
+                    new ImplementedInterfaceSpecification(type))
                 : NoMatch();
         }
 

--- a/Src/AutoFixture.NUnit2/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit2/FrozenAttribute.cs
@@ -76,12 +76,9 @@ namespace Ploeh.AutoFixture.NUnit2
                 throw new ArgumentNullException("parameter");
             }
 
-            var type = parameter.ParameterType;
-            var name = parameter.Name;
-
             return ShouldMatchBySpecificType()
-                ? FreezeAsType(type)
-                : FreezeByCriteria(type, name);
+                ? FreezeAsType(parameter.ParameterType)
+                : FreezeByCriteria(parameter);
         }
 
         private bool ShouldMatchBySpecificType()
@@ -100,22 +97,34 @@ namespace Ploeh.AutoFixture.NUnit2
 #pragma warning restore 0618
         }
 
-        private ICustomization FreezeByCriteria(Type type, string name)
+        private ICustomization FreezeByCriteria(ParameterInfo parameter)
         {
-            var filter = new Filter(ByExactType(type))
+            var type = parameter.ParameterType;
+            var name = parameter.Name;
+
+            var filter = new Filter(ByEqual(parameter))
+                .Or(ByExactType(type))
                 .Or(ByBaseType(type))
                 .Or(ByImplementedInterfaces(type))
                 .Or(ByPropertyName(type, name))
                 .Or(ByParameterName(type, name))
                 .Or(ByFieldName(type, name));
+
             return new FreezeOnMatchCustomization(type, filter);
         }
 
-        private static IRequestSpecification ByExactType(Type type)
+        private static IRequestSpecification ByEqual(object target)
         {
-            return new OrRequestSpecification(
-                new ExactTypeSpecification(type),
-                new SeedRequestSpecification(type));
+            return new EqualRequestSpecification(target);
+        }
+
+        private IRequestSpecification ByExactType(Type type)
+        {
+            return ShouldMatchBy(Matching.ExactType)
+                ? new OrRequestSpecification(
+                    new ExactTypeSpecification(type),
+                    new SeedRequestSpecification(type))
+                : NoMatch();
         }
 
         private IRequestSpecification ByBaseType(Type type)

--- a/Src/AutoFixture.NUnit2/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit2/FrozenAttribute.cs
@@ -130,7 +130,10 @@ namespace Ploeh.AutoFixture.NUnit2
         private IRequestSpecification ByBaseType(Type type)
         {
             return ShouldMatchBy(Matching.DirectBaseType)
-                ? new DirectBaseTypeSpecification(type)
+                ? new AndRequestSpecification(
+                    new InverseRequestSpecification(
+                        new ExactTypeSpecification(type)),
+                    new DirectBaseTypeSpecification(type))
                 : NoMatch();
         }
 


### PR DESCRIPTION
I just discovered an issue in the new policy-based `[Frozen]` attribute for **NUnit2**: freezing by using a matching strategy erroneously freezes the _exact type of the test parameter_ as well.

For example, this test passes:

```csharp
[Test, AutoData]
public void FreezeByPropertyOfDifferentNameAndTypeShouldNotAssignSameInstanceToParameter(
    [Frozen(Matching.PropertyName)]string p1,
    PropertyHolder<object> p2)
    {
        Assert.AreNotEqual(p1, p2.Property);
    }
```

but this one doesn't:

```csharp
[Test, AutoData]
public void FreezeByPropertyOfDifferentNameButSameTypeShouldNotAssignSameInstanceToParameter(
    [Frozen(Matching.PropertyName)]string p1,
    PropertyHolder<string> p2)
    {
        Assert.AreNotEqual(p1, p2.Property);
    }
```

This PR eliminates this unintended side effect by making sure that the specified matching strategy is treated as an exclusive condition, like it was originally intended.