### PR TITLE
Added more detailed exception messages

### DIFF
--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -89,8 +89,7 @@ namespace Ploeh.AutoFixture.Kernel
                 {
                     throw new ObjectCreationException(string.Format(
                         CultureInfo.CurrentCulture,
-                        "AutoFixture was unable to create an instance from {0}, most likely because it has no " +
-                        "public constructor, is an abstract or non-public type.{1}{1}Request path:{1}{2}",
+                        BuildCoreMessageTemplate(request),
                         request,
                         Environment.NewLine,
                         BuildRequestPathText(this.SpecimenRequests)));
@@ -102,6 +101,63 @@ namespace Ploeh.AutoFixture.Kernel
             }
             return result;
         }
+
+        private static string BuildCoreMessageTemplate(object request)
+        {
+            var t = request as Type;
+
+            if (t != null && t.IsInterface)
+                return
+                    "AutoFixture was unable to create an instance from {0} " +
+                    "because it's an interface. There's no single, most " +
+                    "appropriate way to create an object implementing the " +
+                    "interface, but you can help AutoFixture figure it out." +
+                    "{1}" +
+                    "{1}" +
+                    "If you have a concrete class implementing the " +
+                    "interface, you can map the interface to that class:" +
+                    typeMappingOptionsHelp;
+
+            if (t != null && t.IsAbstract)
+                return
+                    "AutoFixture was unable to create an instance from {0} " +
+                    "because it's an abstract class. There's no single, " +
+                    "most appropriate way to create an object deriving from " +
+                    "that class, but you can help AutoFixture figure it out." +
+                    "{1}" +
+                    "{1}" +
+                    "If you have a concrete class deriving from the abstract" +
+                    "class, you can map the abstract class to that derived " + 
+                    "class:" +
+                    typeMappingOptionsHelp;
+
+            return
+                "AutoFixture was unable to create an instance from {0}, " +
+                "most likely because it has no public constructor, is an " +
+                "abstract or non-public type.{1}{1}Request path:{1}{2}";
+        }
+
+        private const string typeMappingOptionsHelp =
+            "{1}" +
+            "{1}" +
+            "fixture.Customizations.Add({1}" +
+            "    new TypeRelay({1}" +
+            "        typeof({0}),{1}" +
+            "        typeof(YourConcreteImplementation)));" +
+            "{1}" +
+            "{1}" +
+            "Alternatively, you can turn AutoFixture into an Auto-Mocking " +
+            "Container using your favourite dynamic mocking library, such " +
+            "as Moq, FakeItEasy, NSubstitute, and others. As an examle, to " +
+            "use Moq, you can customize AutoFixture like this:" +
+            "{1}" +
+            "{1}" +
+            "fixture.Customizations.Add(new AutoMoqCustomization());" +
+            "{1}" +
+            "{1}" +
+            "See http://blog.ploeh.dk/2010/08/19/AutoFixtureasanauto-mockingcontainer " +
+            "for more details." +
+            "{1}";
 
         private static string BuildRequestPathText(IEnumerable<object> recordedRequests)
         {

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -116,7 +116,10 @@ namespace Ploeh.AutoFixture.Kernel
                     "{1}" +
                     "If you have a concrete class implementing the " +
                     "interface, you can map the interface to that class:" +
-                    typeMappingOptionsHelp;
+                    typeMappingOptionsHelp +
+                    "{1}" +
+                    "{1}" +
+                    "Request path:{1}{2}{1}";
 
             if (t != null && t.IsAbstract)
                 return
@@ -129,7 +132,10 @@ namespace Ploeh.AutoFixture.Kernel
                     "If you have a concrete class deriving from the abstract" +
                     "class, you can map the abstract class to that derived " + 
                     "class:" +
-                    typeMappingOptionsHelp;
+                    typeMappingOptionsHelp +
+                    "{1}" +
+                    "{1}" +
+                    "Request path:{1}{2}{1}";
 
             return
                 "AutoFixture was unable to create an instance from {0}, " +
@@ -156,8 +162,7 @@ namespace Ploeh.AutoFixture.Kernel
             "{1}" +
             "{1}" +
             "See http://blog.ploeh.dk/2010/08/19/AutoFixtureasanauto-mockingcontainer " +
-            "for more details." +
-            "{1}";
+            "for more details.";
 
         private static string BuildRequestPathText(IEnumerable<object> recordedRequests)
         {

--- a/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
@@ -263,6 +263,10 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                 "auto-mocking",
                 e.Message,
                 StringComparison.CurrentCultureIgnoreCase);
+            Assert.Contains(
+                "request path",
+                e.Message,
+                StringComparison.CurrentCultureIgnoreCase);
         }
 
         [Fact]


### PR DESCRIPTION
when an interface or abstract class is requested.

It seems to be a FAQ that people don't understand what to do when running
into the previous error, so hopefully this will help such users.

Since this modification touches on some of @adamchester's work that I don't feel that I fully understand, I'd appreciate a review :smile: 