### PR TITLE
Enabled FromFactory to return null values.

### DIFF
--- a/Src/AutoFixture/Kernel/Postprocessor.cs
+++ b/Src/AutoFixture/Kernel/Postprocessor.cs
@@ -273,6 +273,8 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             var specimen = this.builder.Create(request, context);
+            if (specimen == null)
+                return specimen;
 
             var ns = specimen as NoSpecimen;
             if (ns != null)

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5735,5 +5735,14 @@ namespace Ploeh.AutoFixtureUnitTest
             var actual = fixture.Create<System.Globalization.CultureInfo>();
             Assert.NotNull(actual);
         }
+
+        [Fact]
+        public void ReturningNullFromFactoryIsPossible()
+        {
+            var fixture = new Fixture();
+            fixture.Customize<string>(x => x.FromFactory(() => null));
+
+            Assert.DoesNotThrow(() => fixture.Create<string>());
+        }
     }
 }


### PR DESCRIPTION
The test is a simplified repro of this Stack Overflow question:
http://stackoverflow.com/q/33619619/126014

It goes:

"
In this sample code, I want to configure a `Fixture` object to return `null`
for strings half of the time.

    void Test()
    {
        var fixture = new Fixture();

        fixture.Customize<string>(x => x.FromFactory(CreateString));

        var str1 = fixture.Create<string>();

        //error occurs here when string should come back null
        var str2 = fixture.Create<string>();
    }

    bool _createString = false;

    string CreateString()
    {
        _createString = !_createString;

        return _createString ? "test" : null;
    }

The problem is, whenever my factory returns `null`, I get an
`InvalidOperationException`:

> The specimen returned by the decorated ISpecimenBuilder is not compatible
with System.String.

This happens for any type where I return `null` inside a factory. Is there any
way to configure `AutoFixture` to return `null` for a requested object?
"