### PR TITLE
Resolves #467 by relaying non-seeded requests.

### DIFF
--- a/Src/AutoFixture/Kernel/SeededFactory.cs
+++ b/Src/AutoFixture/Kernel/SeededFactory.cs
@@ -44,6 +44,11 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
+            if (request != null && request.Equals(typeof(T)))
+            {
+                return this.create(default(T));
+            }
+
             var seededRequest = request as SeededRequest;
             if (seededRequest == null)
             {

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -3523,6 +3523,29 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
+        public void CustomizeFromSeedWithUnmodifiedSeedValueWillPopulatePropertyOfSameType()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            // Exercise system
+            fixture.Customize<Version>(c => c.FromSeed(s => s));
+            // Verify outcome
+            Assert.Null(fixture.Create<PropertyHolder<Version>>().Property);
+        }
+
+        [Fact]
+        public void CustomizeFromSeedWithFixedSeedValueWillPopulatePropertyOfSameType()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var seed = new Version();
+            // Exercise system
+            fixture.Customize<Version>(c => c.FromSeed(s => seed));
+            // Verify outcome
+            Assert.Equal(seed, fixture.Create<PropertyHolder<Version>>().Property);
+        }
+
+        [Fact]
         [Obsolete]
         public void BuildAndCreateAnonymousWillSetInt32Property()
         {


### PR DESCRIPTION
This PR modifies the `SeededFactory<T>` class to relay also [_non-seeded_ requests](https://github.com/AutoFixture/AutoFixture/blob/master/Src/AutoFixture/Kernel/SeededFactory.cs#L47-L51) for `T` to the custom factory function passing the _default value_ of `T` as a seed. This is to solve #467.