### PR TITLE
Issue #349: use context to resolve domain name

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
+    <Compile Include="DomainName.cs" />
     <Compile Include="InvariantCultureGenerator.cs" />
     <Compile Include="EmailAddressLocalPart.cs" />
     <Compile Include="EmailAddressLocalPartGenerator.cs" />

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
     <Compile Include="DomainName.cs" />
+    <Compile Include="DomainNameGenerator.cs" />
     <Compile Include="InvariantCultureGenerator.cs" />
     <Compile Include="EmailAddressLocalPart.cs" />
     <Compile Include="EmailAddressLocalPartGenerator.cs" />

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -39,6 +39,7 @@ namespace Ploeh.AutoFixture
             yield return new IntPtrGuard();
             yield return new MailAddressGenerator();
             yield return new EmailAddressLocalPartGenerator();
+            yield return new DomainNameGenerator();
         }
 
         /// <summary>

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -1,0 +1,87 @@
+﻿using System;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Represents a domain name.
+    /// </summary>
+    public class DomainName
+    {
+        private string domainName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainName"/> class. Throws ArgumentNullException
+        /// if domainName is null. Throws ArgumentException if domainName is empty.
+        /// </summary>
+        public DomainName(string domainName)
+        {
+            if (domainName == null)
+            {
+                throw new ArgumentNullException("domainName");
+            }
+
+            if (domainName == string.Empty)
+            {
+                throw new ArgumentException("domainName");
+            }
+
+            this.domainName = domainName;
+        }
+
+        /// <summary>
+        /// Get the name of the domain.
+        /// </summary>
+        public string Domain
+        {
+            get
+            {
+                return this.domainName;
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents the domain name for this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String"/> that represents the domain name for this instance.
+        public override string ToString()
+        {
+            return this.domainName;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object"/> to compare with this instance.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; 
+        /// otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="T:System.NullReferenceException">
+        /// The <paramref name="obj"/> parameter is null.
+        ///   </exception>
+        public override bool Equals(object obj)
+        {
+            var other = obj as DomainName;
+
+            if (other != null)
+            {
+                return this.domainName.Equals(other.domainName);
+            }
+            return base.Equals(obj);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data 
+        /// structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return this.domainName.GetHashCode();
+        }
+    }
+}

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -20,9 +20,9 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException("domainName");
             }
 
-            if (domainName == string.Empty)
+            if (domainName.Length == 0)
             {
-                throw new ArgumentException("domainName");
+                throw new ArgumentException("domainName cannot be empty");
             }
 
             this.domainName = domainName;

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -44,6 +44,7 @@ namespace Ploeh.AutoFixture
         /// </summary>
         /// <returns>
         /// A <see cref="System.String"/> that represents the domain name for this instance.
+        /// </returns>
         public override string ToString()
         {
             return this.domainName;

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -19,12 +19,6 @@ namespace Ploeh.AutoFixture
             {
                 throw new ArgumentNullException("domainName");
             }
-
-            if (domainName.Length == 0)
-            {
-                throw new ArgumentException("domainName cannot be empty");
-            }
-
             this.domainName = domainName;
         }
 

--- a/Src/AutoFixture/DomainNameGenerator.cs
+++ b/Src/AutoFixture/DomainNameGenerator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Creates new <see cref="DomainName"/> instances.
+    /// </summary>
+    public class DomainNameGenerator : ISpecimenBuilder
+    {
+        private readonly string[] fictitiousDomains =
+        {
+            "example.com",
+            "example.net",
+            "example.org"
+        };
+
+        private readonly Random random = new Random();
+
+        /// <summary>
+        /// Creates a new specimen based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request == null || !typeof(DomainName).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            var index = random.Next(0, fictitiousDomains.Length);
+            return new DomainName(fictitiousDomains[index]);
+        }
+    }
+}

--- a/Src/AutoFixture/DomainNameGenerator.cs
+++ b/Src/AutoFixture/DomainNameGenerator.cs
@@ -29,7 +29,7 @@ namespace Ploeh.AutoFixture
         {
             if (request == null || !typeof(DomainName).Equals(request))
             {
-                return new NoSpecimen();
+                return new NoSpecimen(request);
             }
 
             var index = random.Next(0, fictitiousDomains.Length);

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -54,15 +54,14 @@ namespace Ploeh.AutoFixture
         private object TryCreateMailAddress(object request, ISpecimenContext context)
         {
             var localPart = context.Resolve(typeof(EmailAddressLocalPart)) as EmailAddressLocalPart;
+            var domainName = context.Resolve(typeof(DomainName)) as DomainName;
 
-            if (localPart == null)
+            if (localPart == null || domainName == null)
             {
                 return new NoSpecimen(request);
             }
 
-            var host = fictitiousDomains[(uint)localPart.GetHashCode() % 3];
-
-            var email = string.Format(CultureInfo.InvariantCulture, "{0} <{0}@{1}>", localPart, host);
+            var email = string.Format(CultureInfo.InvariantCulture, "{0} <{0}@{1}>", localPart, domainName);
             return new MailAddress(email);
         }
     }       

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -10,13 +10,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class MailAddressGenerator : ISpecimenBuilder
     {
-        private readonly string[] fictitiousDomains = 
-        { 
-            "example.com", 
-            "example.net", 
-            "example.org" 
-        };
-
         /// <summary>
         /// Creates a new MailAddress.
         /// </summary>
@@ -51,7 +44,7 @@ namespace Ploeh.AutoFixture
             }
         }
 
-        private object TryCreateMailAddress(object request, ISpecimenContext context)
+        private static object TryCreateMailAddress(object request, ISpecimenContext context)
         {
             var localPart = context.Resolve(typeof(EmailAddressLocalPart)) as EmailAddressLocalPart;
             var domainName = context.Resolve(typeof(DomainName)) as DomainName;

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -91,6 +91,7 @@
     <Compile Include="AbstractRecursionIssue\ItemBase.cs" />
     <Compile Include="AbstractRecursionIssue\ItemLocation.cs" />
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
+    <Compile Include="DomainNameTest.cs" />
     <Compile Include="InvariantCultureGeneratorTest.cs" />
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />
     <Compile Include="DataAnnotations\StringLengthArgumentSupportTests.cs" />

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -91,6 +91,7 @@
     <Compile Include="AbstractRecursionIssue\ItemBase.cs" />
     <Compile Include="AbstractRecursionIssue\ItemLocation.cs" />
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
+    <Compile Include="DomainNameGeneratorTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="InvariantCultureGeneratorTest.cs" />
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -44,7 +44,8 @@ namespace Ploeh.AutoFixtureUnitTest
                     typeof(TaskGenerator),
                     typeof(IntPtrGuard),
                     typeof(MailAddressGenerator),
-                    typeof(EmailAddressLocalPartGenerator)
+                    typeof(EmailAddressLocalPartGenerator),
+                    typeof(DomainNameGenerator)
                  };
             // Exercise system
             var sut = new DefaultPrimitiveBuilders();

--- a/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
@@ -52,8 +52,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(typeof(DomainName), null);
             // Verify outcome
-            Assert.IsAssignableFrom<DomainName>(result);
-            var actualDomainName = (DomainName)result;
+            var actualDomainName = Assert.IsAssignableFrom<DomainName>(result);
             Assert.True(Regex.IsMatch(actualDomainName.Domain, @"example\.(com|org|net)"));
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
@@ -1,0 +1,77 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class DomainNameGeneratorTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            // Fixture setup
+
+            // Exercise system
+            var sut = new DomainNameGenerator();
+            // Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullRequestReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new DomainNameGenerator();
+            // Exercise system
+            var result = sut.Create(null, null);
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(), result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNonDomainNameRequestReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new DomainNameGenerator();
+            // Exercise system
+            var result = sut.Create(typeof(object), null);
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(), result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateReturnsOneOfTheFictiousDomains()
+        {
+            // Fixture setup
+            var sut = new DomainNameGenerator();
+            // Exercise system
+            var result = sut.Create(typeof(DomainName), null);
+            // Verify outcome
+            Assert.IsAssignableFrom<DomainName>(result);
+            var actualDomainName = (DomainName)result;
+            Assert.True(Regex.IsMatch(actualDomainName.Domain, @"example\.(com|org|net)"));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateManyTimesReturnsAllConfiguredFictiousDomains()
+        {
+            // Fixture setup
+            var sut = new DomainNameGenerator();
+            var expectedDomains = new[] {"example.com", "example.net", "example.org"}.Select(x => new DomainName(x)).ToList();
+            // Exercise system
+            var result = Enumerable.Range(0, 100).Select(x => sut.Create(typeof(DomainName), null)).ToList();
+            // Verify outcome
+            foreach (var expectedDomain in expectedDomains)
+            {
+                Assert.Contains(expectedDomain, result);
+            }
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
@@ -36,11 +36,12 @@ namespace Ploeh.AutoFixtureUnitTest
         public void CreateWithNonDomainNameRequestReturnsCorrectResult()
         {
             // Fixture setup
+            var nonDomainNameRequest = typeof(object);
             var sut = new DomainNameGenerator();
             // Exercise system
-            var result = sut.Create(typeof(object), null);
+            var result = sut.Create(nonDomainNameRequest, null);
             // Verify outcome
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(new NoSpecimen(nonDomainNameRequest), result);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/DomainNameTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameTest.cs
@@ -53,19 +53,6 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void SutDoesNotEqualNullSut()
-        {
-            // Fixture setup
-            var sut = new DomainName(Guid.NewGuid().ToString());
-            DomainName other = null;
-            // Exercise system
-            bool result = sut.Equals(other);
-            // Verify outcome
-            Assert.False(result);
-            // Teardown
-        }
-
-        [Fact]
         public void SutDoesNotEqualAnonymousObject()
         {
             // Fixture setup
@@ -84,19 +71,6 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var sut = new DomainName(Guid.NewGuid().ToString());
             object other = new DomainName(Guid.NewGuid().ToString());
-            // Exercise system
-            bool result = sut.Equals(other);
-            // Verify outcome
-            Assert.False(result);
-            // Teardown
-        }
-
-        [Fact]
-        public void SutDoesNotEqualOtherSutWhenDomainNamesDiffer()
-        {
-            // Fixture setup
-            var sut = new DomainName(Guid.NewGuid().ToString());
-            var other = new DomainName(Guid.NewGuid().ToString());
             // Exercise system
             bool result = sut.Equals(other);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/DomainNameTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameTest.cs
@@ -17,16 +17,6 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void InitializeWithEmptyDomainNameThrows()
-        {
-            // Fixture setup
-            Assert.Throws<ArgumentException>(
-                () => new DomainName(string.Empty));
-            // Exercise system and verify outcome
-            // Teardown
-        }
-
-        [Fact]
         public void ToStringReturnsCorrectResult()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/DomainNameTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameTest.cs
@@ -1,0 +1,136 @@
+﻿using Ploeh.AutoFixture;
+using System;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class DomainNameTest
+    {
+        [Fact]
+        public void InitializeWithNullDomainNameThrows()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(
+                () => new DomainName(null));
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithEmptyDomainNameThrows()
+        {
+            // Fixture setup
+            Assert.Throws<ArgumentException>(
+                () => new DomainName(string.Empty));
+            // Exercise system and verify outcome
+            // Teardown
+        }
+
+        [Fact]
+        public void ToStringReturnsCorrectResult()
+        {
+            // Fixture setup
+            var expected = Guid.NewGuid().ToString();
+            var sut = new DomainName(expected);
+            // Exercise system
+            var result = sut.ToString();
+            // Verify outcome
+            Assert.Equal(expected, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualNullObject()
+        {
+            // Fixture setup
+            var sut = new DomainName(Guid.NewGuid().ToString());
+            object other = null;
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualNullSut()
+        {
+            // Fixture setup
+            var sut = new DomainName(Guid.NewGuid().ToString());
+            DomainName other = null;
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualAnonymousObject()
+        {
+            // Fixture setup
+            var sut = new DomainName(Guid.NewGuid().ToString());
+            var anonymousObject = new object();
+            // Exercise system
+            bool result = sut.Equals(anonymousObject);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualOtherObjectWhenDomainNamesDiffer()
+        {
+            // Fixture setup
+            var sut = new DomainName(Guid.NewGuid().ToString());
+            object other = new DomainName(Guid.NewGuid().ToString());
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutDoesNotEqualOtherSutWhenDomainNamesDiffer()
+        {
+            // Fixture setup
+            var sut = new DomainName(Guid.NewGuid().ToString());
+            var other = new DomainName(Guid.NewGuid().ToString());
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutEqualsOtherSutWhenDomainNamesAreEqual()
+        {
+            // Fixture setup
+            var domainName = Guid.NewGuid().ToString();
+
+            var sut = new DomainName(domainName);
+            var other = new DomainName(domainName);
+            // Exercise system
+            bool result = sut.Equals(other);
+            // Verify outcome
+            Assert.True(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void GetHashCodeReturnsCorrectResult()
+        {
+            // Fixture setup
+            var domainName = Guid.NewGuid().ToString();
+            var sut = new DomainName(domainName);
+            // Exercise system
+            int result = sut.GetHashCode();
+            // Verify outcome
+            int expectedHashCode = domainName.GetHashCode();
+            Assert.Equal(expectedHashCode, result);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/MailAddressGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/MailAddressGeneratorTests.cs
@@ -107,9 +107,9 @@ namespace Ploeh.AutoFixtureUnitTest
             };
             var sut = new MailAddressGenerator();
             // Exercise system
-            var expectedResult = new NoSpecimen(request);
             var result = sut.Create(request, context);
             // Verify outcome
+            var expectedResult = new NoSpecimen(request);
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -131,9 +131,9 @@ namespace Ploeh.AutoFixtureUnitTest
             };
             var sut = new MailAddressGenerator();
             // Exercise system
-            var expectedResult = new NoSpecimen(request);
             var result = sut.Create(request, context);
             // Verify outcome
+            var expectedResult = new NoSpecimen(request);
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -162,9 +162,9 @@ namespace Ploeh.AutoFixtureUnitTest
             };
             var sut = new MailAddressGenerator();
             // Exercise system
-            var expectedResult = new NoSpecimen(request);
             var result = sut.Create(request, context);
             // Verify outcome
+            var expectedResult = new NoSpecimen(request);
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/MailAddressGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/MailAddressGeneratorTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net.Mail;
-using System.Text.RegularExpressions;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.AutoFixtureUnitTest.Kernel;
@@ -61,17 +60,25 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void CreateWithMailAddressRequestReturnsCorrectResultUsingLocalPartFromContext()
+        public void CreateWithMailAddressRequestReturnsCorrectResultUsingLocalPartAndDomainNameFromContext()
         {
             // Fixture setup
             var request = typeof(MailAddress);
             var expectedLocalPart = new EmailAddressLocalPart(Guid.NewGuid().ToString());
+            var expectedDomainName = new DomainName(Guid.NewGuid().ToString());
             var context = new DelegatingSpecimenContext()
             {
                 OnResolve = r =>
                {
-                   Assert.Equal(typeof(EmailAddressLocalPart), r);
-                   return expectedLocalPart;
+                   Assert.True(typeof(EmailAddressLocalPart).Equals(r) || typeof(DomainName).Equals(r));
+                   if (typeof(EmailAddressLocalPart).Equals(r))
+                   {
+                       return expectedLocalPart;
+                   }
+                   else
+                   {
+                       return expectedDomainName;
+                   }
                }
             };
             var sut = new MailAddressGenerator();
@@ -79,7 +86,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var result = (MailAddress)sut.Create(request, context);
             // Verify outcome
             Assert.Equal(expectedLocalPart.LocalPart, result.User);
-            Assert.True(Regex.IsMatch(result.Host, @"example\.(com|org|net)"));
+            Assert.Equal(expectedDomainName.Domain, result.Host);
             // Teardown
         }
 
@@ -87,13 +94,39 @@ namespace Ploeh.AutoFixtureUnitTest
         public void CreateWithMailAddressRequestReturnsNoSpecimenWhenContextReturnsNullLocalPart()
         {
             // Fixture setup
-            var request = typeof(MailAddress);         
+            var request = typeof(MailAddress);
+            var anonymousDomainName = new DomainName(Guid.NewGuid().ToString());
+
             var context = new DelegatingSpecimenContext()
             {
                 OnResolve = r =>
                 {
-                    Assert.Equal(typeof(EmailAddressLocalPart), r);
-                    return null;                    
+                    Assert.True(typeof(EmailAddressLocalPart).Equals(r) || typeof(DomainName).Equals(r));
+                    return typeof(DomainName).Equals(r) ? anonymousDomainName : null;
+                }
+            };
+            var sut = new MailAddressGenerator();
+            // Exercise system
+            var expectedResult = new NoSpecimen(request);
+            var result = sut.Create(request, context);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMailAddressRequestReturnsNoSpecimenWhenContextReturnsNullDomainName()
+        {
+            // Fixture setup
+            var request = typeof(MailAddress);
+            var anonymousLocalPart = new EmailAddressLocalPart(Guid.NewGuid().ToString());
+
+            var context = new DelegatingSpecimenContext()
+            {
+                OnResolve = r =>
+                {
+                    Assert.True(typeof(EmailAddressLocalPart).Equals(r) || typeof(DomainName).Equals(r));
+                    return typeof(EmailAddressLocalPart).Equals(r) ? anonymousLocalPart : null;
                 }
             };
             var sut = new MailAddressGenerator();
@@ -110,13 +143,21 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var localPart = new EmailAddressLocalPart("@Invalid@");
+            var anonymousDomainName = new DomainName(Guid.NewGuid().ToString());
             var request = typeof(MailAddress);
             var context = new DelegatingSpecimenContext()
             {
                 OnResolve = r =>
                 {
-                    Assert.Equal(typeof(EmailAddressLocalPart), r);
-                    return localPart;
+                    Assert.True(typeof(EmailAddressLocalPart).Equals(r) || typeof(DomainName).Equals(r));
+                    if (typeof(EmailAddressLocalPart).Equals(r))
+                    {
+                        return localPart;
+                    }
+                    else
+                    {
+                        return anonymousDomainName;
+                    }
                 }
             };
             var sut = new MailAddressGenerator();


### PR DESCRIPTION
@ploeh As discussed, a PR for #349. My first PR for AutoFixture ;)

A few heads-up: I cheated a bit, I looked heavily at the PR of #348, since it was very similar to this, and to look at naming of test scenario's, and general code style of AutoFixture. So it might look a bit familiar.

Next, I could reuse the `.GetHashCode() % 3`, so I used `Random` for this. I don't know if that the right approach is, but getting a random `int` from the context seemed wrong to me, since that can get frozen, and that will fix the `DomainName` as well, isn't it?

Finally, for testing the random domain names, I have a `foreach` loop in my test, which is usually bad, but I didn't know how to test it otherwise. Let me know what you thing of it.