### PR TITLE
Deprecated NoSpecimen.Request,

### DIFF
--- a/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
@@ -68,19 +68,25 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
             var type = request as Type;
             if (!type.IsFake())
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var fake = this.builder.Create(request, context) as FakeItEasy.Configuration.IHideObjectMembers;
             if (fake == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var fakeType = type.GetFakedType();
             if (fake.GetType().GetFakedType() != fakeType)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return fake;

--- a/Src/AutoFakeItEasy/FakeItEasyRelay.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyRelay.cs
@@ -70,17 +70,23 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
                 throw new ArgumentNullException("context");
 
             if (!this.fakeableSpecification.IsSatisfiedBy(request))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var type = request as Type;
             if (type == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var fakeType = typeof(Fake<>).MakeGenericType(type);
 
             var fake = context.Resolve(fakeType) as FakeItEasy.Configuration.IHideObjectMembers;
             if (fake == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return fake.GetType().GetProperty("FakedObject").GetValue(fake, null);
         }

--- a/Src/AutoFakeItEasyUnitTest/FakeItEasyBuilderTest.cs
+++ b/Src/AutoFakeItEasyUnitTest/FakeItEasyBuilderTest.cs
@@ -58,7 +58,9 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             var dummyContext = A.Fake<ISpecimenContext>();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -95,7 +97,9 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -115,7 +119,9 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -134,7 +140,9 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFakeItEasyUnitTest/FakeItEasyRelayTest.cs
+++ b/Src/AutoFakeItEasyUnitTest/FakeItEasyRelayTest.cs
@@ -81,7 +81,9 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -121,7 +123,9 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             // Exercise system
             var result = sut.Create(request, contextStub.FakedObject);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -171,7 +175,9 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             var dummyContext = A.Fake<ISpecimenContext>();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoFixture/BooleanSwitch.cs
+++ b/Src/AutoFixture/BooleanSwitch.cs
@@ -66,7 +66,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(bool).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/ByteSequenceGenerator.cs
+++ b/Src/AutoFixture/ByteSequenceGenerator.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(byte).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/CharSequenceGenerator.cs
+++ b/Src/AutoFixture/CharSequenceGenerator.cs
@@ -30,7 +30,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(char).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/ConstrainedStringGenerator.cs
+++ b/Src/AutoFixture/ConstrainedStringGenerator.cs
@@ -32,7 +32,9 @@ namespace Ploeh.AutoFixture
             var constrain = request as ConstrainedStringRequest;
             if (constrain == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return ConstrainedStringGenerator.Create(constrain.MinimumLength, constrain.MaximumLength, context);

--- a/Src/AutoFixture/CurrentDateTimeGenerator.cs
+++ b/Src/AutoFixture/CurrentDateTimeGenerator.cs
@@ -21,7 +21,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(DateTime).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return DateTime.Now;

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -37,13 +37,17 @@ namespace Ploeh.AutoFixture.DataAnnotations
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var rangeAttribute = customAttributeProvider.GetCustomAttributes(typeof(RangeAttribute), inherit: true).Cast<RangeAttribute>().SingleOrDefault();
             if (rangeAttribute == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(RangeAttributeRelay.Create(rangeAttribute, request));

--- a/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
@@ -34,13 +34,17 @@ namespace Ploeh.AutoFixture.DataAnnotations
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var regularExpressionAttribute = customAttributeProvider.GetCustomAttributes(typeof(RegularExpressionAttribute), inherit: true).Cast<RegularExpressionAttribute>().SingleOrDefault();
             if (regularExpressionAttribute == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(new RegularExpressionRequest(regularExpressionAttribute.Pattern));

--- a/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
@@ -36,13 +36,17 @@ namespace Ploeh.AutoFixture.DataAnnotations
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var stringLengthAttribute = customAttributeProvider.GetCustomAttributes(typeof(StringLengthAttribute), inherit: true).Cast<StringLengthAttribute>().SingleOrDefault();
             if (stringLengthAttribute == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(new ConstrainedStringRequest(stringLengthAttribute.MaximumLength));

--- a/Src/AutoFixture/DecimalSequenceGenerator.cs
+++ b/Src/AutoFixture/DecimalSequenceGenerator.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(decimal).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/DomainNameGenerator.cs
+++ b/Src/AutoFixture/DomainNameGenerator.cs
@@ -29,7 +29,9 @@ namespace Ploeh.AutoFixture
         {
             if (request == null || !typeof(DomainName).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var index = random.Next(0, fictitiousDomains.Length);

--- a/Src/AutoFixture/DoubleSequenceGenerator.cs
+++ b/Src/AutoFixture/DoubleSequenceGenerator.cs
@@ -56,7 +56,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(double).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
+++ b/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
@@ -28,14 +28,18 @@ namespace Ploeh.AutoFixture
 
             if (request == null || !typeof(EmailAddressLocalPart).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var localPart = context.Resolve(typeof(string)) as string;
 
             if (string.IsNullOrEmpty(localPart))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return new EmailAddressLocalPart(localPart);

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -46,7 +46,9 @@ namespace Ploeh.AutoFixture
             var t = request as Type;
             if (!EnumGenerator.IsEnumType(t))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             lock (this.syncRoot)

--- a/Src/AutoFixture/GuidGenerator.cs
+++ b/Src/AutoFixture/GuidGenerator.cs
@@ -41,7 +41,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(Guid).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return GuidGenerator.Create();

--- a/Src/AutoFixture/Int16SequenceGenerator.cs
+++ b/Src/AutoFixture/Int16SequenceGenerator.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(short).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/Int32SequenceGenerator.cs
+++ b/Src/AutoFixture/Int32SequenceGenerator.cs
@@ -51,7 +51,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(int).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/Int64SequenceGenerator.cs
+++ b/Src/AutoFixture/Int64SequenceGenerator.cs
@@ -51,7 +51,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(long).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/Kernel/ArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/ArrayRelay.cs
@@ -38,16 +38,22 @@ namespace Ploeh.AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             if (!type.IsArray)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             var elementType = type.GetElementType();
             var specimen = context.Resolve(new MultipleRequest(elementType));
             if (specimen is OmitSpecimen)
                 return specimen;
             var elements = specimen as IEnumerable;
             if (elements == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             return ArrayRelay.ToArray(elements, elementType);
         }
 

--- a/Src/AutoFixture/Kernel/CollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/CollectionRelay.cs
@@ -37,11 +37,17 @@ namespace Ploeh.AutoFixture.Kernel
             // This is performance-sensitive code when used repeatedly over many requests.
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
+#pragma warning disable 618
             if (type == null) return new NoSpecimen(request);
+#pragma warning restore 618
             var typeArguments = type.GetGenericArguments();
+#pragma warning disable 618
             if (typeArguments.Length != 1) return new NoSpecimen(request);
+#pragma warning restore 618
             var gtd = type.GetGenericTypeDefinition();
+#pragma warning disable 618
             if (gtd != typeof (ICollection<>)) return new NoSpecimen(request);
+#pragma warning restore 618
             return context.Resolve(typeof (List<>).MakeGenericType(typeArguments));
         }
     }

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -61,7 +61,9 @@ namespace Ploeh.AutoFixture.Kernel
                 if (!(result is NoSpecimen)) return result;
             }
 
+#pragma warning disable 618
             return new NoSpecimen(request);
+#pragma warning restore 618
         }
 
         /// <summary>Composes the supplied builders.</summary>

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -32,12 +32,16 @@ namespace Ploeh.AutoFixture.Kernel
 
             if (delegateType == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             if (!typeof(Delegate).IsAssignableFrom(delegateType))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var delegateMethod = delegateType.GetMethod("Invoke");

--- a/Src/AutoFixture/Kernel/DictionaryRelay.cs
+++ b/Src/AutoFixture/Kernel/DictionaryRelay.cs
@@ -37,11 +37,17 @@ namespace Ploeh.AutoFixture.Kernel
             // This is performance-sensitive code when used repeatedly over many requests.
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
+#pragma warning disable 618
             if (type == null) return new NoSpecimen(request);
+#pragma warning restore 618
             var typeArguments = type.GetGenericArguments();
+#pragma warning disable 618
             if (typeArguments.Length != 2) return new NoSpecimen(request);
+#pragma warning restore 618
             var gtd = type.GetGenericTypeDefinition();
+#pragma warning disable 618
             if (gtd != typeof(IDictionary<,>)) return new NoSpecimen(request);
+#pragma warning restore 618
             return context.Resolve(typeof(Dictionary<,>).MakeGenericType(typeArguments));
         }
     }

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -39,18 +39,26 @@ namespace Ploeh.AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             var typeArgs = type.GetGenericArguments();
             if (typeArgs.Length != 1)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             if (type.GetGenericTypeDefinition() != typeof(IEnumerable<>))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             var specimen = context.Resolve(new MultipleRequest(typeArgs[0]));
             if (specimen is OmitSpecimen)
                 return specimen;
             var enumerable = specimen as IEnumerable<object>;
             if (enumerable == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return typeof (ConvertedEnumerable<>)
                 .MakeGenericType(typeArgs)

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -40,12 +40,16 @@ namespace Ploeh.AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var typeArguments = t.GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof (IEnumerator<>) != t.GetGenericTypeDefinition())
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var specimenBuilder = (ISpecimenBuilder) Activator.CreateInstance(
                 typeof (EnumeratorRelay<>).MakeGenericType(typeArguments));
@@ -62,16 +66,22 @@ namespace Ploeh.AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             if (t != typeof(IEnumerator<T>))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var enumerable =
                 context.Resolve(typeof (IEnumerable<T>)) as IEnumerable<T>;
 
             if (enumerable == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return enumerable.GetEnumerator();
         }

--- a/Src/AutoFixture/Kernel/FieldRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/FieldRequestRelay.cs
@@ -29,7 +29,9 @@ namespace Ploeh.AutoFixture.Kernel
             var fieldInfo = request as FieldInfo;
             if (fieldInfo == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(new SeededRequest(fieldInfo.FieldType, fieldInfo.Name));

--- a/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
@@ -65,7 +65,9 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (!this.specification.IsSatisfiedBy(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.builder.Create(request, context);

--- a/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
@@ -35,7 +35,9 @@ namespace Ploeh.AutoFixture.Kernel
             var manyRequest = request as FiniteSequenceRequest;
             if (manyRequest == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return from req in manyRequest.CreateRequests()

--- a/Src/AutoFixture/Kernel/IntPtrGuard.cs
+++ b/Src/AutoFixture/Kernel/IntPtrGuard.cs
@@ -39,7 +39,9 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (!typeof(IntPtr).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             throw new IllegalRequestException("A request for an IntPtr was detected. This is an unsafe resource that will crash the process if used, so the request is denied. A common source of IntPtr requests are requests for delegates such as Func<T> or Action<T>. If this is the case, the expected workaround is to Customize (Register or Inject) the offending type by specifying a proper creational strategy.");

--- a/Src/AutoFixture/Kernel/ListRelay.cs
+++ b/Src/AutoFixture/Kernel/ListRelay.cs
@@ -34,12 +34,16 @@ namespace Ploeh.AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var typeArguments = t.GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof(IList<>) != t.GetGenericTypeDefinition())
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return context.Resolve(
                 typeof(List<>).MakeGenericType(typeArguments));

--- a/Src/AutoFixture/Kernel/MethodInvoker.cs
+++ b/Src/AutoFixture/Kernel/MethodInvoker.cs
@@ -72,7 +72,9 @@ namespace Ploeh.AutoFixture.Kernel
                 }
             }
 
+#pragma warning disable 618
             return new NoSpecimen(request);
+#pragma warning restore 618
         }
 
         private IEnumerable<IMethod> GetConstructors(object request)

--- a/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
@@ -29,7 +29,9 @@ namespace Ploeh.AutoFixture.Kernel
 
             var arrayType = request as Type;
             if (arrayType == null || !IsMultidimensionalArray(arrayType))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return CreateMultidimensionalArray(arrayType, context);
         }

--- a/Src/AutoFixture/Kernel/MultipleRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleRelay.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixture.Kernel
             var manyRequest = request as MultipleRequest;
             if (manyRequest == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(new FiniteSequenceRequest(manyRequest.Request, this.Count));

--- a/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
@@ -50,13 +50,17 @@ namespace Ploeh.AutoFixture.Kernel
             
             var multipleRequest = request as MultipleRequest;
             if (multipleRequest == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var innerRequest = GetInnerRequest(multipleRequest);
 
             var itemType = innerRequest as Type;
             if (itemType == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return context.Resolve(
                 typeof(IEnumerable<>).MakeGenericType(itemType));

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -30,6 +30,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <param name="request">
         /// The original request that prompts the creation of this instance.
         /// </param>
+        [Obsolete("The Request property, and the constructor that populates it, is being retired in future versions of AutoFixture, as it has turned out that no one uses it. If you're seeing this warning in AutoFixture 3.x, and, despite expectations, have a real need to use the Request property, please provide feedback on https://github.com/AutoFixture/AutoFixture/issues/475 .")]
         public NoSpecimen(object request)
         {
             this.request = request;
@@ -43,6 +44,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// This property value may be <see langword="null"/>.
         /// </para>
         /// </remarks>
+        [Obsolete("The Request property is being retired in future versions of AutoFixture, as it has turned out that no one uses it. If you're seeing this warning in AutoFixture 3.x, and, despite expectations, have a real need to use the Request property, please provide feedback on https://github.com/AutoFixture/AutoFixture/issues/475 .")]
         public object Request
         {
             get { return this.request; }
@@ -73,7 +75,9 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>A hash code for the current <see cref="NoSpecimen"/> instance.</returns>
         public override int GetHashCode()
         {
+#pragma warning disable 618
             return this.Request == null ? 0 : this.Request.GetHashCode();
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -93,8 +97,10 @@ namespace Ploeh.AutoFixture.Kernel
             {
                 return false;
             }
-        
+
+#pragma warning disable 618
             return object.Equals(this.Request, other.Request);
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
@@ -59,10 +59,14 @@ namespace Ploeh.AutoFixture.Kernel
 
             var pi = request as ParameterInfo;
             if (pi == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             if (!pi.ParameterType.IsArray)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var returnValue = context.Resolve(
                 new SeededRequest(

--- a/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
@@ -60,13 +60,19 @@ namespace Ploeh.AutoFixture.Kernel
 
             var pi = request as ParameterInfo;
             if (pi == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             if (!pi.ParameterType.IsGenericType)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             if (IsNotEnumerable(pi))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var returnValue = context.Resolve(
                 new SeededRequest(

--- a/Src/AutoFixture/Kernel/Omitter.cs
+++ b/Src/AutoFixture/Kernel/Omitter.cs
@@ -66,7 +66,9 @@ namespace Ploeh.AutoFixture.Kernel
             if (this.specification.IsSatisfiedBy(request))
                 return new OmitSpecimen();
 
+#pragma warning disable 618
             return new NoSpecimen(request);
+#pragma warning restore 618
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
@@ -29,7 +29,9 @@ namespace Ploeh.AutoFixture.Kernel
             var paramInfo = request as ParameterInfo;
             if (paramInfo == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(new SeededRequest(paramInfo.ParameterType, paramInfo.Name));

--- a/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
@@ -29,7 +29,9 @@ namespace Ploeh.AutoFixture.Kernel
             var propertyInfo = request as PropertyInfo;
             if (propertyInfo == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(new SeededRequest(propertyInfo.PropertyType, propertyInfo.Name));

--- a/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
+++ b/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
@@ -39,7 +39,9 @@ namespace Ploeh.AutoFixture.Kernel
             var seededRequest = request as SeededRequest;
             if (seededRequest == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return context.Resolve(seededRequest.Request);

--- a/Src/AutoFixture/Kernel/SeededFactory.cs
+++ b/Src/AutoFixture/Kernel/SeededFactory.cs
@@ -52,18 +52,24 @@ namespace Ploeh.AutoFixture.Kernel
             var seededRequest = request as SeededRequest;
             if (seededRequest == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             if (!seededRequest.Request.Equals(typeof(T)))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             if ((seededRequest.Seed != null)
                 && !(seededRequest.Seed is T))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
             var seed = (T)seededRequest.Seed;
 

--- a/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
@@ -46,7 +46,9 @@ namespace Ploeh.AutoFixture.Kernel
             var manyRequest = request as FiniteSequenceRequest;
             if (manyRequest == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return (from req in manyRequest.CreateRequests()

--- a/Src/AutoFixture/Kernel/TypeRelay.cs
+++ b/Src/AutoFixture/Kernel/TypeRelay.cs
@@ -84,7 +84,9 @@ namespace Ploeh.AutoFixture.Kernel
             
             var t = request as Type;
             if (t == null || t != this.from)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return context.Resolve(this.to);
         }

--- a/Src/AutoFixture/LazyRelay.cs
+++ b/Src/AutoFixture/LazyRelay.cs
@@ -40,10 +40,14 @@ namespace Ploeh.AutoFixture
 
             var t = request as Type;
             if (t == null || !t.IsGenericType)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             if (t.GetGenericTypeDefinition() != typeof(Lazy<>))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var builder = (ILazyBuilder)Activator
                 .CreateInstance(typeof(LazyBuilder<>)

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -31,7 +31,9 @@ namespace Ploeh.AutoFixture
 
             if (!typeof(MailAddress).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             try
@@ -40,7 +42,9 @@ namespace Ploeh.AutoFixture
             }                    
             catch (FormatException)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
         }
 
@@ -51,7 +55,9 @@ namespace Ploeh.AutoFixture
 
             if (localPart == null || domainName == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var email = string.Format(CultureInfo.InvariantCulture, "{0} <{0}@{1}>", localPart, domainName);

--- a/Src/AutoFixture/MutableValueTypeGenerator.cs
+++ b/Src/AutoFixture/MutableValueTypeGenerator.cs
@@ -33,9 +33,11 @@ namespace Ploeh.AutoFixture
             Type type = request as Type;
             if (type == null || !valueTypeWithoutConstructorsSpecification.IsSatisfiedBy(type))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
-            
+
             return Activator.CreateInstance(type);
         }
     }

--- a/Src/AutoFixture/NumericSequenceGenerator.cs
+++ b/Src/AutoFixture/NumericSequenceGenerator.cs
@@ -24,7 +24,9 @@ namespace Ploeh.AutoFixture
         {
             var type = request as Type;
             if (type == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return this.CreateNumericSpecimen(type);
         }
@@ -58,7 +60,9 @@ namespace Ploeh.AutoFixture
                 case TypeCode.UInt64:
                     return (ulong)this.GetNextNumber();
                 default:
+#pragma warning disable 618
                     return new NoSpecimen(request);
+#pragma warning restore 618
             }
         }
 

--- a/Src/AutoFixture/RandomBooleanSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomBooleanSequenceGenerator.cs
@@ -33,7 +33,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(bool).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.GenerateBoolean(context);

--- a/Src/AutoFixture/RandomCharSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomCharSequenceGenerator.cs
@@ -35,7 +35,9 @@ namespace Ploeh.AutoFixture
         public object Create(object request, ISpecimenContext context)
         {
             if (!typeof(char).Equals(request))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return Convert.ToChar(
                 this.randomPrintableCharNumbers.Create(typeof(int), context),

--- a/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
@@ -59,7 +59,9 @@ namespace Ploeh.AutoFixture
             }
 
             return IsNotDateTimeRequest(request)
+#pragma warning disable 618
                        ? new NoSpecimen(request)
+#pragma warning restore 618
                        : this.CreateRandomDate(context);
         }
 

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -88,7 +88,9 @@ namespace Ploeh.AutoFixture
             var type = request as Type;
             if (type == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.CreateRandom(type);
@@ -151,7 +153,9 @@ namespace Ploeh.AutoFixture
                         this.GetNextRandom();
 
                 default:
+#pragma warning disable 618
                     return new NoSpecimen(request);
+#pragma warning restore 618
             }
         }
 

--- a/Src/AutoFixture/RandomRangedNumberGenerator.cs
+++ b/Src/AutoFixture/RandomRangedNumberGenerator.cs
@@ -48,7 +48,9 @@ namespace Ploeh.AutoFixture
             var rangedNumberRequest = request as RangedNumberRequest;
             
             if (rangedNumberRequest == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             try
             {
@@ -56,8 +58,10 @@ namespace Ploeh.AutoFixture
             }
             catch (ArgumentException)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
-            }           
+#pragma warning restore 618
+            }
         }
 
         /// <summary>

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -45,13 +45,17 @@ namespace Ploeh.AutoFixture
             var range = request as RangedNumberRequest;
             if (range == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var value = context.Resolve(range.OperandType) as IComparable;
             if (value == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             try
@@ -60,7 +64,9 @@ namespace Ploeh.AutoFixture
             }
             catch (InvalidOperationException)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.rangedValue;

--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -28,7 +28,9 @@ namespace Ploeh.AutoFixture
             var regularExpressionRequest = request as RegularExpressionRequest;
             if (regularExpressionRequest == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return RegularExpressionGenerator.CreateAnonymous(regularExpressionRequest);
@@ -48,14 +50,20 @@ namespace Ploeh.AutoFixture
             }
             catch (InvalidOperationException)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
             catch (ArgumentException)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
+#pragma warning disable 618
             return new NoSpecimen(request);
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/SByteSequenceGenerator.cs
+++ b/Src/AutoFixture/SByteSequenceGenerator.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(sbyte).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/SingleSequenceGenerator.cs
+++ b/Src/AutoFixture/SingleSequenceGenerator.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(float).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.Create();

--- a/Src/AutoFixture/StrictlyMonotonicallyIncreasingDateTimeGenerator.cs
+++ b/Src/AutoFixture/StrictlyMonotonicallyIncreasingDateTimeGenerator.cs
@@ -34,7 +34,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(DateTime).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.seed.AddDays(this.GetNextNumberInSequence());

--- a/Src/AutoFixture/StringGenerator.cs
+++ b/Src/AutoFixture/StringGenerator.cs
@@ -51,13 +51,17 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(string).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var specimen = this.createSpecimen();
             if (specimen == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
             if (specimen is NoSpecimen)
             {

--- a/Src/AutoFixture/StringSeedRelay.cs
+++ b/Src/AutoFixture/StringSeedRelay.cs
@@ -36,13 +36,17 @@ namespace Ploeh.AutoFixture
             if (seededRequest == null ||
                 (!seededRequest.Request.Equals(typeof(string))))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var seed = seededRequest.Seed as string;
             if (seed == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var containerResult = context.Resolve(typeof(string));

--- a/Src/AutoFixture/TaskGenerator.cs
+++ b/Src/AutoFixture/TaskGenerator.cs
@@ -31,7 +31,9 @@ namespace Ploeh.AutoFixture
 
             var type = request as Type;
             if (type == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             //check if type is a constructed generic type whose definition matches Task<>
             if (type.IsGenericType && !type.IsGenericTypeDefinition &&
@@ -42,7 +44,9 @@ namespace Ploeh.AutoFixture
             if (type == typeof (Task))
                 return CreateNonGenericTask();
 
+#pragma warning disable 618
             return new NoSpecimen(request);
+#pragma warning restore 618
         }
 
         private static object CreateGenericTask(Type taskType, ISpecimenContext context)

--- a/Src/AutoFixture/TypeGenerator.cs
+++ b/Src/AutoFixture/TypeGenerator.cs
@@ -24,7 +24,9 @@ namespace Ploeh.AutoFixture
                 return typeof(object);
             }
 
+#pragma warning disable 618
             return new NoSpecimen(request);
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/UInt16SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt16SequenceGenerator.cs
@@ -45,7 +45,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(ushort).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.CreateAnonymous();

--- a/Src/AutoFixture/UInt32SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt32SequenceGenerator.cs
@@ -45,7 +45,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(uint).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.CreateAnonymous();

--- a/Src/AutoFixture/UInt64SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt64SequenceGenerator.cs
@@ -45,7 +45,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(ulong).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.CreateAnonymous();

--- a/Src/AutoFixture/UriGenerator.cs
+++ b/Src/AutoFixture/UriGenerator.cs
@@ -25,19 +25,25 @@ namespace Ploeh.AutoFixture
 
             if (!typeof(Uri).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var scheme = context.Resolve(typeof(UriScheme)) as UriScheme;
             if (scheme == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var authority = context.Resolve(typeof(string)) as string;
             if (authority == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return UriGenerator.CreateAnonymous(scheme, authority);

--- a/Src/AutoFixture/UriSchemeGenerator.cs
+++ b/Src/AutoFixture/UriSchemeGenerator.cs
@@ -19,7 +19,9 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(UriScheme).Equals(request))
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return new UriScheme();

--- a/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
+++ b/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
@@ -160,7 +160,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonBooleanRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonBooleanRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonByteRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonByteRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/CharSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/CharSequenceGeneratorTest.cs
@@ -54,7 +54,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), result);
+#pragma warning restore 618
             // Teardown
         }
 
@@ -70,7 +72,9 @@ namespace Ploeh.AutoFixtureUnitTest
             object contextValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => expectedType.Equals(r) ? contextValue : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new ConstrainedStringGenerator();
             // Exercise system
@@ -88,7 +92,9 @@ namespace Ploeh.AutoFixtureUnitTest
             object expectedValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => typeof(string).Equals(r) ? expectedValue : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new ConstrainedStringGenerator();
             // Exercise system and verify outcome
@@ -105,7 +111,9 @@ namespace Ploeh.AutoFixtureUnitTest
             object contextValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => typeof(string).Equals(r) ? contextValue : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new ConstrainedStringGenerator();
             // Exercise system
@@ -123,7 +131,9 @@ namespace Ploeh.AutoFixtureUnitTest
             object contextValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => typeof(string).Equals(r) ? contextValue : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new ConstrainedStringGenerator();
             // Exercise system

--- a/Src/AutoFixtureUnitTest/CurrentDateTimeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/CurrentDateTimeGeneratorTest.cs
@@ -53,7 +53,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDateTimeRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonDateTimeRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
@@ -58,7 +58,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -79,7 +81,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -108,7 +112,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new RangeAttributeRelay();
             // Exercise system
@@ -154,7 +160,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new RangeAttributeRelay();
             // Exercise system
@@ -200,7 +208,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new RangeAttributeRelay();
             // Exercise system

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionAttributeRelayTest.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -78,7 +80,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -97,7 +101,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new RegularExpressionAttributeRelay();
             // Exercise system

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -78,7 +80,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -97,7 +101,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new StringLengthAttributeRelay();
             // Exercise system

--- a/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDecimalRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonDecimalRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
+++ b/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
@@ -121,7 +121,9 @@ namespace Ploeh.AutoFixtureUnitTest
 
             var expectedRequest = new MultipleRequest(typeof(KeyValuePair<int, string>));
             var expectedResult = Enumerable.Range(1, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)expectedResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new DictionaryFiller();
             // Exercise system
@@ -139,7 +141,9 @@ namespace Ploeh.AutoFixtureUnitTest
 
             var request = new MultipleRequest(typeof(KeyValuePair<int, string>));
             var sequence = Enumerable.Repeat(0, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? (object)sequence : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new DictionaryFiller();
             // Exercise system & Verify outcome

--- a/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
@@ -41,7 +41,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(nonDomainNameRequest, null);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(nonDomainNameRequest), result);
+#pragma warning restore 618
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDoubleRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonDoubleRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
@@ -87,7 +87,9 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             {
                 OnCreate = (r, c) => r == request && c == context ?
                     expected :
+#pragma warning disable 618
                     new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new CompositeNodeComposer<ushort>(
                 new CompositeSpecimenBuilder(

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -73,7 +73,9 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             {
                 OnCreate = (r, c) => r == request && c == context ?
                     expected :
+#pragma warning disable 618
                     new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new NodeComposer<object>(builder);
             // Exercise system

--- a/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -79,7 +81,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var sut = new EmailAddressLocalPartGenerator();
             // Exercise system and verify outcome
             var result = sut.Create(request, context);
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -126,7 +130,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(typeof(EmailAddressLocalPart), context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
@@ -36,7 +36,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
@@ -100,7 +100,9 @@ namespace Ploeh.AutoFixtureUnitTest
                 OnCreate = (request, ctx) =>
                     request.Equals(frozenType)
                         ? new object()
+#pragma warning disable 618
                         : new NoSpecimen(request)
+#pragma warning restore 618
             };
             var sut = new FreezeOnMatchCustomization(
                 frozenType,

--- a/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
@@ -102,7 +102,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(nonGuidRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonGuidRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt16Request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonInt16Request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt32Request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonInt32Request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt64Request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonInt64Request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ArrayRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ArrayRelayTest.cs
@@ -47,7 +47,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -62,7 +64,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             var expectedRequest = new MultipleRequest(itemType);
             object expectedResult = Array.CreateInstance(itemType, 0);
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new ArrayRelay();
             // Exercise system
@@ -79,7 +83,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var request = typeof(int[]);
             var expectedRequest = new MultipleRequest(typeof(int));
             var enumerable = Enumerable.Range(1, 3);
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new ArrayRelay();
             // Exercise system
@@ -104,7 +110,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -70,7 +72,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             var expectedRequest = typeof(List<>).MakeGenericType(itemType);
             object contextResult = typeof(List<>).MakeGenericType(itemType).GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new CollectionRelay();
             // Exercise system

--- a/Src/AutoFixtureUnitTest/Kernel/CompositeSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CompositeSpecimenBuilderTest.cs
@@ -186,7 +186,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(anonymousRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(anonymousRequest);
+#pragma warning restore 618
             Assert.Equal(expected, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
@@ -51,7 +51,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDelegateRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonDelegateRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
@@ -59,7 +59,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -74,7 +76,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             var expectedRequest = typeof(Dictionary<,>).MakeGenericType(keyType, itemType);
             object contextResult = typeof(Dictionary<,>).MakeGenericType(keyType, itemType).GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new DictionaryRelay();
             // Exercise system

--- a/Src/AutoFixtureUnitTest/Kernel/DisposableTrackerTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DisposableTrackerTest.cs
@@ -78,7 +78,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             var builder = new DelegatingSpecimenBuilder
             {
+#pragma warning disable 618
                 OnCreate = (r, c) => (r == request) && (c == ctx) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
             };
 
             var sut = new DisposableTracker(builder);

--- a/Src/AutoFixtureUnitTest/Kernel/EnumerableRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumerableRelayTest.cs
@@ -56,7 +56,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext { OnResolve = r => Enumerable.Empty<object>() };
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -71,7 +73,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             var expectedRequest = new MultipleRequest(itemType);
             object contextResult = Enumerable.Empty<object>();
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new EnumerableRelay();
             // Exercise system
@@ -88,7 +92,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var request = typeof(IEnumerable<int>);
             var expectedRequest = new MultipleRequest(typeof(int));
             var enumerable = Enumerable.Range(1, 3).Cast<object>();
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new EnumerableRelay();
             // Exercise system
@@ -113,7 +119,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -133,7 +141,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             };
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : new NoSpecimen(r)
+#pragma warning restore 618
             };
 
             var sut = new EnumerableRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
@@ -41,7 +41,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             var result = sut.Create(request, dummyContext);
 
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
         }
 
@@ -63,7 +65,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             {
                 OnResolve = r => expectedRequest.Equals(r)
                     ? (object)enumerable
+#pragma warning disable 618
                     : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new EnumeratorRelay();
 
@@ -90,7 +94,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             var result = sut.Create(request, context);
 
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/FieldRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FieldRequestRelayTest.cs
@@ -54,7 +54,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonFieldRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonFieldRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -64,12 +66,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var fieldInfo = typeof(FieldHolder<object>).GetField("Field");
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen(fieldInfo) };
+#pragma warning restore 618
             var sut = new FieldRequestRelay();
             // Exercise system
             var result = sut.Create(fieldInfo, container);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(fieldInfo);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/FilteringSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FilteringSpecimenBuilderTest.cs
@@ -80,7 +80,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRelayTest.cs
@@ -42,7 +42,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -59,7 +61,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -101,7 +105,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var q = new Queue<object>(results);
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => request.Equals(r) ? q.Dequeue() : new NoSpecimen(r)
+#pragma warning restore 618
             };
 
             var sut = new FiniteSequenceRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/IntPtrGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/IntPtrGuardTest.cs
@@ -37,7 +37,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -70,7 +72,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             var expectedRequest = typeof(List<>).MakeGenericType(itemType);
             object contextResult = typeof(List<>).MakeGenericType(itemType).GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new ListRelay();
             // Exercise system

--- a/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
@@ -80,7 +80,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(nonTypeRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonTypeRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -96,7 +98,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -106,12 +110,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var type = typeof(string);
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen(type) };
+#pragma warning restore 618
             var sut = new MethodInvoker(new ModestConstructorQuery());
             // Exercise system
             var result = sut.Create(type, container);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(type);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -125,7 +133,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(typeof(AbstractType), container);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(typeof(AbstractType));
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -136,7 +146,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             var requestedType = typeof(DoubleParameterType<string, int>);
             var parameters = requestedType.GetConstructors().Single().GetParameters();
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => parameters[0] == r ? new object() : new NoSpecimen(r) };
+#pragma warning restore 618
             var sut = new MethodInvoker(new ModestConstructorQuery());
             // Exercise system
             var result = sut.Create(requestedType, container);
@@ -240,7 +252,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                         return expectedNumber;
                     }
                 }
+#pragma warning disable 618
                 return new NoSpecimen(r);
+#pragma warning restore 618
             };
             // Exercise system
             var result = sut.Create(requestedType, context);

--- a/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
@@ -41,7 +41,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             {
                 var sut = new MultidimensionalArrayRelay();
                 var dummyContext = new DelegatingSpecimenContext();
+#pragma warning disable 618
                 var expected = new NoSpecimen(r);
+#pragma warning restore 618
 
                 var actual = sut.Create(r, dummyContext);
 

--- a/Src/AutoFixtureUnitTest/Kernel/MultipleRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultipleRelayTest.cs
@@ -79,7 +79,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -96,7 +98,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -109,7 +113,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var count = 7;
             var expectedTranslation = new FiniteSequenceRequest(request.Request, 7);
             var expectedResult = new object();
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => expectedTranslation.Equals(r) ? expectedResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new MultipleRelay { Count = count };
             // Exercise system

--- a/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
@@ -33,7 +33,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }
@@ -85,7 +87,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }
@@ -141,7 +145,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/NoSpecimenOutputGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NoSpecimenOutputGuardTest.cs
@@ -113,7 +113,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var request = new object();
             var context = new DelegatingSpecimenContext();
             var expectedResult = new object();
+#pragma warning disable 618
             var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == request && c == context ? expectedResult : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new NoSpecimenOutputGuard(builder);
             // Exercise system
@@ -127,7 +129,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void CreateThrowsWhenDecoratedBuilderReturnsNoSpecimen()
         {
             // Fixture setup
+#pragma warning disable 618
             var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen(r) };
+#pragma warning restore 618
             var sut = new NoSpecimenOutputGuard(builder);
             // Exercise system and verify outcome
             var dummyRequest = new object();
@@ -143,14 +147,18 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup            
             var request = new object();
 
+#pragma warning disable 618
             var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen(r) };
+#pragma warning restore 618
             var spec = new DelegatingRequestSpecification { OnIsSatisfiedBy = r => request == r ? false : true };
             var sut = new NoSpecimenOutputGuard(builder, spec);
             // Exercise system
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/NoSpecimenTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NoSpecimenTest.cs
@@ -12,7 +12,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             var sut = new NoSpecimen();
             // Exercise system
+#pragma warning disable 618
             var result = sut.Request;
+#pragma warning restore 618
             // Verify outcome
             Assert.Null(result);
             // Teardown
@@ -23,9 +25,11 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
+#pragma warning disable 618
             var sut = new NoSpecimen(null);
             // Verify outcome
             Assert.Null(sut.Request);
+#pragma warning restore 618
             // Teardown
         }
 
@@ -34,9 +38,11 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var expectedRequest = new object();
+#pragma warning disable 618
             var sut = new NoSpecimen(expectedRequest);
             // Exercise system
             var result = sut.Request;
+#pragma warning restore 618
             // Verify outcome
             Assert.Equal(expectedRequest, result);
             // Teardown
@@ -97,7 +103,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var sut = new NoSpecimen();
+#pragma warning disable 618
             object other = new NoSpecimen(new object());
+#pragma warning restore 618
             // Exercise system
             var result = sut.Equals(other);
             // Verify outcome
@@ -110,7 +118,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var sut = new NoSpecimen();
+#pragma warning disable 618
             var other = new NoSpecimen(new object());
+#pragma warning restore 618
             // Exercise system
             var result = sut.Equals(other);
             // Verify outcome
@@ -122,7 +132,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void SutDoesNotEqualOtherObjectWhenOtherRequestIsNull()
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new NoSpecimen(new object());
+#pragma warning restore 618
             object other = new NoSpecimen();
             // Exercise system
             var result = sut.Equals(other);
@@ -135,7 +147,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void SutDoesNotEqualOtherSutWhenOtherRequestIsNull()
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new NoSpecimen(new object());
+#pragma warning restore 618
             var other = new NoSpecimen();
             // Exercise system
             var result = sut.Equals(other);
@@ -148,8 +162,10 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void SutDoesNotEqualOtherObjectWhenRequestsDiffer()
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new NoSpecimen(new object());
             object other = new NoSpecimen(new object());
+#pragma warning restore 618
             // Exercise system
             var result = sut.Equals(other);
             // Verify outcome
@@ -161,8 +177,10 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void SutDoesNotEqualOtherSutWhenRequestsDiffer()
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new NoSpecimen(new object());
             var other = new NoSpecimen(new object());
+#pragma warning restore 618
             // Exercise system
             var result = sut.Equals(other);
             // Verify outcome
@@ -201,8 +219,10 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var request = new object();
+#pragma warning disable 618
             var sut = new NoSpecimen(request);
             object other = new NoSpecimen(request);
+#pragma warning restore 618
             // Exercise system
             var result = sut.Equals(other);
             // Verify outcome
@@ -215,8 +235,10 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var request = new object();
+#pragma warning disable 618
             var sut = new NoSpecimen(request);
             var other = new NoSpecimen(request);
+#pragma warning restore 618
             // Exercise system
             var result = sut.Equals(other);
             // Verify outcome
@@ -241,7 +263,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var request = new object();
+#pragma warning disable 618
             var sut = new NoSpecimen(request);
+#pragma warning restore 618
             // Exercise system
             var result = sut.GetHashCode();
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/Kernel/OmitArrayParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitArrayParameterRequestRelayTests.cs
@@ -69,7 +69,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             var sut = new OmitArrayParameterRequestRelay();
             var actual = sut.Create(request, new DelegatingSpecimenContext());
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), actual);
+#pragma warning restore 618
         }
 
         [Theory]
@@ -93,7 +95,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(parameterInfo, dummyContext);
 
+#pragma warning disable 618
             var expected = new NoSpecimen(parameterInfo);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
@@ -69,7 +69,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             var sut = new OmitEnumerableParameterRequestRelay();
             var actual = sut.Create(request, new DelegatingSpecimenContext());
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), actual);
+#pragma warning restore 618
         }
 
         [Theory]
@@ -93,7 +95,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(parameterInfo, dummyContext);
 
+#pragma warning disable 618
             var expected = new NoSpecimen(parameterInfo);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/OmitterTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitterTests.cs
@@ -79,7 +79,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ParameterRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ParameterRequestRelayTest.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonParameterRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonParameterRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -65,12 +67,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var parameterInfo = typeof(SingleParameterType<string>).GetConstructors().First().GetParameters().First();
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen(parameterInfo) };
+#pragma warning restore 618
             var sut = new ParameterRequestRelay();
             // Exercise system
             var result = sut.Create(parameterInfo, container);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(parameterInfo);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/PropertyRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/PropertyRequestRelayTest.cs
@@ -54,7 +54,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonParameterRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonParameterRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -64,12 +66,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var propertyInfo = typeof(PropertyHolder<object>).GetProperty("Property");
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen(propertyInfo) };
+#pragma warning restore 618
             var sut = new PropertyRequestRelay();
             // Exercise system
             var result = sut.Create(propertyInfo, container);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(propertyInfo);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/SeedIgnoringRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SeedIgnoringRelayTest.cs
@@ -48,12 +48,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var anonymousSeed = new SeededRequest(typeof(object), new object());
+#pragma warning disable 618
             var unableContainer = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen(anonymousSeed) };
+#pragma warning restore 618
             var sut = new SeedIgnoringRelay();
             // Exercise system
             var result = sut.Create(anonymousSeed, unableContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(anonymousSeed);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/SeededFactoryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SeededFactoryTest.cs
@@ -51,7 +51,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -68,7 +70,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -88,7 +92,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(seededRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(seededRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithDoubleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithDoubleParameterFuncTest.cs
@@ -66,7 +66,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var container = new DelegatingSpecimenContext();
             container.OnResolve = r => (from x in subRequests
                                         where x.ExpectedRequest.Equals(r)
+#pragma warning disable 618
                                         select x.Specimen).DefaultIfEmpty(new NoSpecimen(r)).SingleOrDefault();
+#pragma warning restore 618
 
             Func<decimal, TimeSpan, object> f = (d, ts) => param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) ? expectedSpecimen : new NoSpecimen();
             var sut = new SpecimenFactory<decimal, TimeSpan, object>(f);

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithQuadrupleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithQuadrupleParameterFuncTest.cs
@@ -69,7 +69,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var container = new DelegatingSpecimenContext();
             container.OnResolve = r => (from x in subRequests
                                         where x.ExpectedRequest.Equals(r)
+#pragma warning disable 618
                                         select x.Specimen).DefaultIfEmpty(new NoSpecimen(r)).SingleOrDefault();
+#pragma warning restore 618
 
             Func<decimal, TimeSpan, string, int, object> f = (d, ts, s, i) =>
                 param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) && param3.Specimen.Equals(s) && param4.Specimen.Equals(i) ? expectedSpecimen : new NoSpecimen();

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithSingleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithSingleParameterFuncTest.cs
@@ -60,9 +60,11 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             var dtSpecimen = DateTimeOffset.Now;
             var expectedParameterRequest = typeof(DateTimeOffset);
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => expectedParameterRequest.Equals(r) ? (object)dtSpecimen : new NoSpecimen(r) };
 
             Func<DateTimeOffset, object> f = dt => dtSpecimen.Equals(dt) ? expectedSpecimen : new NoSpecimen(dt);
+#pragma warning restore 618
             var sut = new SpecimenFactory<DateTimeOffset, object>(f);
             // Exercise system
             var dummyRequest = new object();

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithTripleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithTripleParameterFuncTest.cs
@@ -67,7 +67,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var container = new DelegatingSpecimenContext();
             container.OnResolve = r => (from x in subRequests
                                         where x.ExpectedRequest.Equals(r)
+#pragma warning disable 618
                                         select x.Specimen).DefaultIfEmpty(new NoSpecimen(r)).SingleOrDefault();
+#pragma warning restore 618
 
             Func<decimal, TimeSpan, string, object> f = (d, ts, s) => 
                 param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) && param3.Specimen.Equals(s) ? expectedSpecimen : new NoSpecimen();

--- a/Src/AutoFixtureUnitTest/Kernel/StableFiniteSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/StableFiniteSequenceRelayTest.cs
@@ -42,7 +42,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -59,7 +61,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -92,7 +96,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var count = 3;
             var manyRequest = new FiniteSequenceRequest(request, count);
 
+#pragma warning disable 618
             var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? new object() : new NoSpecimen(r) };
+#pragma warning restore 618
 
             var sut = new StableFiniteSequenceRelay();
             // Exercise system
@@ -120,7 +126,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var q = new Queue<object>(results);
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => request.Equals(r) ? q.Dequeue() : new NoSpecimen(r)
+#pragma warning restore 618
             };
 
             var sut = new StableFiniteSequenceRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
@@ -247,7 +247,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                 new DelegatingTracingBuilder(
                     new DelegatingSpecimenBuilder
                     {
+#pragma warning disable 618
                         OnCreate = (r, c) => new NoSpecimen(request)
+#pragma warning restore 618
                     });
             var sut = new TerminatingWithPathSpecimenBuilder(tracer);
 

--- a/Src/AutoFixtureUnitTest/Kernel/TypeRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TypeRelayTests.cs
@@ -48,7 +48,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/LazyRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/LazyRelayTest.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }
@@ -73,7 +75,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }
@@ -91,7 +95,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/MailAddressGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/MailAddressGeneratorTests.cs
@@ -43,7 +43,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -109,7 +111,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -133,7 +137,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -164,7 +170,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/MutableValueTypeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/MutableValueTypeGeneratorTest.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonValueTypeRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonValueTypeRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -70,7 +72,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonValueTypeRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonValueTypeRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/NumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/NumericSequenceGeneratorTest.cs
@@ -56,7 +56,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -73,7 +75,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/RandomBooleanSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomBooleanSequenceGeneratorTest.cs
@@ -54,7 +54,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonBooleanRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonBooleanRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/RandomCharSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomCharSequenceGeneratorTest.cs
@@ -68,7 +68,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -89,7 +91,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/RandomDateTimeSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomDateTimeSequenceGeneratorTest.cs
@@ -80,7 +80,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), result);
+#pragma warning restore 618
             // Teardown
         }
 
@@ -97,7 +99,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), result);
+#pragma warning restore 618
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -161,7 +161,9 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var dummyContext = new DelegatingSpecimenContext();
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             var sut = new RandomNumericSequenceGenerator();
             // Exercise system
             object result = sut.Create(request, dummyContext);
@@ -178,7 +180,9 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var dummyContext = new DelegatingSpecimenContext();
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             var sut = new RandomNumericSequenceGenerator();
             // Exercise system
             object result = sut.Create(request, dummyContext);

--- a/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
@@ -59,7 +59,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(dummyRequest), result);
+#pragma warning restore 618
             // Teardown
         }
 
@@ -76,7 +78,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), result);
+#pragma warning restore 618
         }
 
 

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -58,7 +58,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(dummyRequest), result);
+#pragma warning restore 618
             // Teardown
         }
 
@@ -184,7 +186,9 @@ namespace Ploeh.AutoFixtureUnitTest
             };
             var loopTest = new LoopTest<RangedNumberGenerator, object>(sut => (object)sut.Create(request, context));
             // Exercise system and verify outcome
+#pragma warning disable 618
             loopTest.Execute(2, new NoSpecimen(request));
+#pragma warning restore 618
             // Teardown
         }
 
@@ -227,7 +231,9 @@ namespace Ploeh.AutoFixtureUnitTest
                     if (r.Equals(typeof(decimal)))
                         return Convert.ToDecimal(numbers.Next());
 
+#pragma warning disable 618
                     return new NoSpecimen(r);
+#pragma warning restore 618
                 }
             };
             var sut = new RangedNumberGenerator();
@@ -348,8 +354,10 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 20, contextValue: 20, expectedResult: 20);
                 yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 20, contextValue: 21, expectedResult: 10);
                 yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 13, contextValue:  4, expectedResult: 10);
-                yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 20, contextValue: new object(), 
+                yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 20, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(int), 10, 20)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue:  1, expectedResult: (uint)11);
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue:  2, expectedResult: (uint)12);
@@ -360,7 +368,9 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (uint)10);
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 13, contextValue:  4, expectedResult: (uint)10);
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(uint), 10, 20)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(double), minimum: -5.0, maximum: -1.0, contextValue:  1.0, expectedResult: -5.0);
                 yield return CreateTestCase(operandType: typeof(double), minimum: -5.0, maximum: -1.0, contextValue: -1.0, expectedResult: -1.0);
@@ -374,8 +384,10 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 20.0, contextValue: 20.0, expectedResult: 20.0);
                 yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 20.0, contextValue: 21.0, expectedResult: 10.0);
                 yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 13.0, contextValue:  4.0, expectedResult: 10.0);
-                yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 20.0, contextValue: new object(), 
+                yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 20.0, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(double), 10.0, 20.0)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(long), minimum: -50000000000, maximum: -10000000000, contextValue:  10000000000, expectedResult: -50000000000);
                 yield return CreateTestCase(operandType: typeof(long), minimum: -50000000000, maximum: -10000000000, contextValue: -10000000000, expectedResult: -10000000000);
@@ -389,8 +401,10 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 200000000000, contextValue: 200000000000, expectedResult: 200000000000);
                 yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 200000000000, contextValue: 210000000000, expectedResult: 100000000000);
                 yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 130000000000, contextValue:  40000000000, expectedResult: 100000000000);
-                yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 200000000000, contextValue: new object(), 
+                yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 200000000000, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(long), 100000000000, 200000000000)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue:  1, expectedResult: (ulong)11);
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue:  2, expectedResult: (ulong)12);
@@ -401,7 +415,9 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (ulong)10);
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 13, contextValue:  4, expectedResult: (ulong)10);
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(ulong), 10, 20)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: -5.0m, maximum: -1.0m, contextValue:  1.0m, expectedResult: -5.0m);
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: -5.0m, maximum: -1.0m, contextValue: -1.0m, expectedResult: -1.0m);
@@ -415,14 +431,18 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 20.0m, contextValue: 20.0m, expectedResult: 20.0m);
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 20.0m, contextValue: 21.0m, expectedResult: 10.0m);
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 13.0m, contextValue:  4.0m, expectedResult: 10.0m);
-                yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 20.0m, contextValue: new object(), 
+                yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 20.0m, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(decimal), 10.0m, 20.0m)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(char), minimum: 'a', maximum: 'b', contextValue: 'a', expectedResult: 'a');
                 yield return CreateTestCase(operandType: typeof(char), minimum: 'a', maximum: 'b', contextValue: 'b', expectedResult: 'b');
                 yield return CreateTestCase(operandType: typeof(char), minimum: 'a', maximum: 'b', contextValue: 'c', expectedResult: 'a');
-                yield return CreateTestCase(operandType: typeof(char), minimum: 'b', maximum: 'c', contextValue: 'a', 
+                yield return CreateTestCase(operandType: typeof(char), minimum: 'b', maximum: 'c', contextValue: 'a',
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(char), 'b', 'c')));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue:  1, expectedResult: (byte)11);
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue:  2, expectedResult: (byte)12);
@@ -433,7 +453,9 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (byte)10);
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 13, contextValue:  4, expectedResult: (byte)10);
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(byte), 10, 20)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: -5, maximum: -1, contextValue:  1, expectedResult: (sbyte)-5);
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: -5, maximum: -1, contextValue: -1, expectedResult: (sbyte)-1);
@@ -448,7 +470,9 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (sbyte)10);
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 13, contextValue:  4, expectedResult: (sbyte)10);
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(sbyte), 10, 20)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(float), minimum: -5.0f, maximum: -1.0f, contextValue:  1.0f, expectedResult: -5.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: -5.0f, maximum: -1.0f, contextValue: -1.0f, expectedResult: -1.0f);
@@ -462,8 +486,10 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 20.0f, contextValue: 20.0f, expectedResult: 20.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 20.0f, contextValue: 21.0f, expectedResult: 10.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 13.0f, contextValue:  4.0f, expectedResult: 10.0f);
-                yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 20.0f, contextValue: new object(), 
+                yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 20.0f, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(float), 10.0f, 20.0f)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(short), minimum: -5, maximum: -1, contextValue:  1, expectedResult: (short)-5);
                 yield return CreateTestCase(operandType: typeof(short), minimum: -5, maximum: -1, contextValue: -1, expectedResult: (short)-1);
@@ -478,7 +504,9 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(short), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (short)10);
                 yield return CreateTestCase(operandType: typeof(short), minimum: 10, maximum: 13, contextValue:  4, expectedResult: (short)10);
                 yield return CreateTestCase(operandType: typeof(short), minimum: 10, maximum: 20, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(short), 10, 20)));
+#pragma warning restore 618
 
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue:  1, expectedResult: (ushort)11);
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue:  2, expectedResult: (ushort)12);
@@ -489,7 +517,9 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (ushort)10);
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 13, contextValue:  4, expectedResult: (ushort)10);
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue: new object(),
+#pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(ushort), 10, 20)));
+#pragma warning restore 618
             }
 
             IEnumerator IEnumerable.GetEnumerator()

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -45,7 +45,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), result);
+#pragma warning restore 618
             // Teardown
         }
 
@@ -73,7 +75,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             Assert.Equal(new NoSpecimen(request), result);
+#pragma warning restore 618
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/SByteSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/SByteSequenceGeneratorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonSByteRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonSByteRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/SingleSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/SingleSequenceGeneratorTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonSingleRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonSingleRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/SpecimenFactoryTest.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenFactoryTest.cs
@@ -90,7 +90,9 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             object expectedResult = 1;
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(int), 0)) ? expectedResult : new NoSpecimen(r) };
+#pragma warning restore 618
             // Exercise system
             var result = container.Create<int>();
             // Verify outcome
@@ -202,7 +204,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var seed = TimeSpan.FromMinutes(8);
             object expectedResult = TimeSpan.FromHours(2);
+#pragma warning disable 618
             var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : new NoSpecimen(r) };
+#pragma warning restore 618
             // Exercise system
             var result = container.Create(seed);
             // Verify outcome
@@ -333,8 +337,10 @@ namespace Ploeh.AutoFixtureUnitTest
             var container = new DelegatingSpecimenContext
             {
                 OnResolve = r => r.Equals(new MultipleRequest(new SeededRequest(typeof(int), 0))) ? 
-                    (object)expectedResult.Cast<object>() : 
-                    new NoSpecimen(r) 
+                    (object)expectedResult.Cast<object>() :
+#pragma warning disable 618
+                    new NoSpecimen(r)
+#pragma warning restore 618
             };
             // Exercise system
             var result = container.CreateMany<int>();
@@ -420,7 +426,9 @@ namespace Ploeh.AutoFixtureUnitTest
             {
                 OnResolve = r => r.Equals(new MultipleRequest(new SeededRequest(typeof(Version), seed))) ?
                     (object)expectedResult.Cast<object>() :
+#pragma warning disable 618
                     new NoSpecimen(r)
+#pragma warning restore 618
             };
             // Exercise system
             var result = container.CreateMany(seed);
@@ -487,7 +495,9 @@ namespace Ploeh.AutoFixtureUnitTest
             {
                 OnResolve = r => r.Equals(new FiniteSequenceRequest(new SeededRequest(typeof(DateTime), default(DateTime)), count)) ?
                     (object)expectedResult.Cast<object>() :
+#pragma warning disable 618
                     new NoSpecimen(r)
+#pragma warning restore 618
             };
             // Exercise system
             var result = container.CreateMany<DateTime>(count);
@@ -577,7 +587,9 @@ namespace Ploeh.AutoFixtureUnitTest
             {
                 OnResolve = r => r.Equals(new FiniteSequenceRequest(new SeededRequest(typeof(Version), seed), count)) ?
                     (object)expectedResult.Cast<object>() :
+#pragma warning disable 618
                     new NoSpecimen(r)
+#pragma warning restore 618
             };
             // Exercise system
             var result = container.CreateMany(seed, count);

--- a/Src/AutoFixtureUnitTest/StrictlyMonotonicallyIncreasingDateTimeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/StrictlyMonotonicallyIncreasingDateTimeGeneratorTest.cs
@@ -50,7 +50,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -69,7 +71,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/StringGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/StringGeneratorTest.cs
@@ -80,7 +80,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonStringRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonStringRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -112,7 +114,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(stringRequest, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(stringRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/StringSeedRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/StringSeedRelayTest.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonSeed, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonSeed);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -70,7 +72,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonStringRequestSeed, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonStringRequestSeed);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -85,7 +89,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonStringSeed, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonStringSeed);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -96,11 +102,15 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var sut = new StringSeedRelay();
             var stringSeed = new SeededRequest(typeof(string), "Anonymous value");
+#pragma warning disable 618
             var unableContainer = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen(stringSeed) };
+#pragma warning restore 618
             // Exercise system
             var result = sut.Create(stringSeed, unableContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(stringSeed);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/TypeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/TypeGeneratorTest.cs
@@ -36,7 +36,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/UInt16SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt16SequenceGeneratorTest.cs
@@ -71,7 +71,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonUInt16Request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonUInt16Request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/UInt32SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt32SequenceGeneratorTest.cs
@@ -71,7 +71,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonUInt32Request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonUInt32Request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/UInt64SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt64SequenceGeneratorTest.cs
@@ -71,7 +71,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonUInt64Request, dummyContainer);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(nonUInt64Request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/UriGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UriGeneratorTest.cs
@@ -53,7 +53,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -66,12 +68,16 @@ namespace Ploeh.AutoFixtureUnitTest
             object expectedValue = null;
             var context = new DelegatingSpecimenContext
             {
+#pragma warning disable 618
                 OnResolve = r => typeof(UriScheme).Equals(r) ? expectedValue : new NoSpecimen(r)
+#pragma warning restore 618
             };
             var sut = new UriGenerator();
             // Exercise system and verify outcome
             var result = sut.Create(request, context);
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -96,13 +102,17 @@ namespace Ploeh.AutoFixtureUnitTest
                         return expectedValue;
                     }
 
+#pragma warning disable 618
                     return new NoSpecimen(r);
+#pragma warning restore 618
                 }
             };
             var sut = new UriGenerator();
             // Exercise system and verify outcome
             var result = sut.Create(request, context);
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -127,7 +137,9 @@ namespace Ploeh.AutoFixtureUnitTest
                         return Guid.NewGuid().ToString();
                     }
 
+#pragma warning disable 618
                     return new NoSpecimen(r);
+#pragma warning restore 618
                 }
             };
             var sut = new UriGenerator();
@@ -158,7 +170,9 @@ namespace Ploeh.AutoFixtureUnitTest
                         return expectedAuthority;
                     }
 
+#pragma warning disable 618
                     return new NoSpecimen(r);
+#pragma warning restore 618
                 }
             };
             var sut = new UriGenerator();
@@ -190,7 +204,9 @@ namespace Ploeh.AutoFixtureUnitTest
                         return expectedAuthority;
                     }
 
+#pragma warning disable 618
                     return new NoSpecimen(r);
+#pragma warning restore 618
                 }
             };
             var sut = new UriGenerator();

--- a/Src/AutoFixtureUnitTest/UriSchemeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UriSchemeGeneratorTest.cs
@@ -52,7 +52,9 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(dummyRequest);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoMoq/MockPostprocessor.cs
+++ b/Src/AutoMoq/MockPostprocessor.cs
@@ -51,8 +51,10 @@ namespace Ploeh.AutoFixture.AutoMoq
             var t = request as Type;
             if (!t.IsMock())
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
-            }            
+#pragma warning restore 618
+            }
 
             var specimen = this.builder.Create(request, context);
             if (specimen is NoSpecimen || specimen is OmitSpecimen || specimen == null)
@@ -61,13 +63,17 @@ namespace Ploeh.AutoFixture.AutoMoq
             var m = specimen as Mock;
             if (m == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var mockType = t.GetMockedType();
             if (m.GetType().GetMockedType() != mockType)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var configurator = (IMockConfigurator)Activator.CreateInstance(typeof(MockConfigurator<>).MakeGenericType(mockType));

--- a/Src/AutoMoq/MockRelay.cs
+++ b/Src/AutoMoq/MockRelay.cs
@@ -74,11 +74,15 @@ namespace Ploeh.AutoFixture.AutoMoq
                 throw new ArgumentNullException("context");
 
             if (!this.mockableSpecification.IsSatisfiedBy(request))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var t = request as Type;
             if (t == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var result = MockRelay.ResolveMock(t, context);
             // Note: null is a valid specimen (e.g., returned by NullRecursionHandler)
@@ -87,7 +91,9 @@ namespace Ploeh.AutoFixture.AutoMoq
 
             var m = result as Mock;
             if (m == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return m.Object;
         }

--- a/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
+++ b/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
@@ -60,7 +60,9 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var dummyContext = new Mock<ISpecimenContext>().Object;
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -119,7 +121,9 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoMoqUnitTest/MockRelayTest.cs
+++ b/Src/AutoMoqUnitTest/MockRelayTest.cs
@@ -83,7 +83,9 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -122,7 +124,9 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             var result = sut.Create(request, contextStub.Object);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -192,7 +196,9 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var dummyContext = new Mock<ISpecimenContext>().Object;
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoNSubstitute/NSubstituteBuilder.cs
+++ b/Src/AutoNSubstitute/NSubstituteBuilder.cs
@@ -75,11 +75,15 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
         public object Create(object request, ISpecimenContext context)
         {
             if (!SubstitutionSpecification.IsSatisfiedBy(request))
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             var substitute = Builder.Create(request, context);
             if (substitute == null)
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
 
             return substitute;
         }

--- a/Src/AutoNSubstitute/SubstituteAttributeRelay.cs
+++ b/Src/AutoNSubstitute/SubstituteAttributeRelay.cs
@@ -31,14 +31,18 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var attribute = customAttributeProvider.GetCustomAttributes(typeof(SubstituteAttribute), true)
                     .OfType<SubstituteAttribute>().FirstOrDefault();
             if (attribute == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             object substituteRequest = CreateSubstituteRequest(customAttributeProvider, attribute);

--- a/Src/AutoNSubstitute/SubstituteRelay.cs
+++ b/Src/AutoNSubstitute/SubstituteRelay.cs
@@ -38,7 +38,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             var requestedType = request as Type;
             if (requestedType == null || !requestedType.IsAbstract)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             object substitute = context.Resolve(new SubstituteRequest(requestedType));

--- a/Src/AutoNSubstitute/SubstituteRequestHandler.cs
+++ b/Src/AutoNSubstitute/SubstituteRequestHandler.cs
@@ -55,7 +55,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             var substituteRequest = request as SubstituteRequest;
             if (substituteRequest == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return this.substituteFactory.Create(substituteRequest.TargetType, context);

--- a/Src/AutoNSubstituteUnitTest/NSubstituteBuilderTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteBuilderTest.cs
@@ -101,7 +101,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var result = sut.Create(request, context);
 
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, result);
         }
 
@@ -137,7 +139,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var result = sut.Create(request, context);
 
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, result);
         }
 
@@ -156,7 +160,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var result = sut.Create(request, context);
 
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, result);
         }
     }

--- a/Src/AutoNSubstituteUnitTest/SubstituteAttributeRelayTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteAttributeRelayTest.cs
@@ -28,7 +28,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Exercise system
             object specimen = sut.Create(null, context);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(null);
+#pragma warning restore 618
             Assert.Equal(expected, specimen);
             // Teardown
         }
@@ -43,7 +45,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Exercise system
             object specimen = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, specimen);
             // Teardown
         }
@@ -59,7 +63,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Exercise system
             object specimen = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, specimen);
             // Teardown
         }

--- a/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
@@ -43,7 +43,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Exercise system
             object result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, result);
             // Teardown
         }
@@ -58,7 +60,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Exercise system
             object result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, result);
             // Teardown
         }

--- a/Src/AutoNSubstituteUnitTest/SubstituteRequestHandlerTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteRequestHandlerTest.cs
@@ -51,7 +51,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Exercise system
             object result = sut.Create(request, context);
             // Verify outcome
+#pragma warning disable 618
             var expected = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expected, result);
             // Teardown
         }

--- a/Src/AutoRhinoMock/RhinoMockAroundAdvice.cs
+++ b/Src/AutoRhinoMock/RhinoMockAroundAdvice.cs
@@ -68,14 +68,18 @@ namespace Ploeh.AutoFixture.AutoRhinoMock
         {
             if (!request.IsMockable())
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             var built = this.builder.Create(request, context);
             var m = built as IMockedObject;
             if (m == null)
             {
+#pragma warning disable 618
                 return new NoSpecimen(request);
+#pragma warning restore 618
             }
 
             return m;

--- a/Src/AutoRhinoMockUnitTest/RhinoMockAroundAdviceTest.cs
+++ b/Src/AutoRhinoMockUnitTest/RhinoMockAroundAdviceTest.cs
@@ -57,7 +57,9 @@ namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
             var dummyContext = MockRepository.GenerateMock<ISpecimenContext>();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
+#pragma warning disable 618
             var expectedResult = new NoSpecimen(request);
+#pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
         }


### PR DESCRIPTION
and the corresponding constructor. The reason for this is that Request is
never used, but the design makes it look like it is. For consistency's
sake, we ask contributors to adhere to the established standard of
returning `new NoSpecimen(request)` even when everything works fine
without it. The design would be slightly simpler if Request was simply
omitted.

This also paves the way towards making NoSpecimen a Singleton, although
measurements carried out by Adam Chester indicate that it would only give
a marginal performance boost
(https://github.com/AutoFixture/AutoFixture/issues/221#issuecomment-31623706).

Only two [Obsolete] attributes are added in this commit, both in
Src/AutoFixture/Kernel/NoSpecimen.cs. The rest of the files only contain
myriads of warning suppressions, because of the deprecation.

This commit changes no behaviour, because that might be a breaking change
(although I doubt it). Instead, all warnings related to deprecation of
NoSpecimen.Request are suppressed, in order to keep the behaviour as is.