### PR TITLE
Supported implicit conversions in With expressions

### DIFF
--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5797,5 +5797,31 @@ namespace Ploeh.AutoFixtureUnitTest
 
             Assert.Equal(expected, actual.Field);
         }
+
+        [Fact]
+        public void WithImplicitConversionToNullablePropertyReturnsCorrectResult()
+        {
+            var fixture = new Fixture();
+            var expected = fixture.Create<int>();
+
+            var actual = fixture.Build<PropertyHolder<int?>>()
+                .With(x => x.Property, expected)
+                .Create();
+
+            Assert.Equal(expected, actual.Property);
+        }
+
+        [Fact]
+        public void WithImplicitConversionToNullableFieldReturnsCorrectResult()
+        {
+            var fixture = new Fixture();
+            var expected = fixture.Create<int>();
+
+            var actual = fixture.Build<FieldHolder<int?>>()
+                .With(x => x.Field, expected)
+                .Create();
+
+            Assert.Equal(expected, actual.Field);
+        }
     }
 }


### PR DESCRIPTION
It turns out that the support for conversions in `With` expressions added
previously caused a regression that we've never tested for: when an
implicit conversion exists (implemented by op_Implicit), the `With`
expression used to work, but after explicitly attempting to convert using
Convert.ChangeType, this doesn't always work (e.g. for Nullable<T>).

There seems to be no easy way to use Reflection to figure out if an
implicit conversion already exists, so the pragmatic solution seems to be
to attemp making the conversion in a try block, and then retry with the
conversion if the first attempt fails.

If someone learns of a better way to test for this without resorting to
exception handling, a pull request will be welcome.