### PR TITLE
Use no specimen without request

### DIFF
--- a/Src/AutoFixture/BooleanSwitch.cs
+++ b/Src/AutoFixture/BooleanSwitch.cs
@@ -66,9 +66,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(bool).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/ByteSequenceGenerator.cs
+++ b/Src/AutoFixture/ByteSequenceGenerator.cs
@@ -55,9 +55,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(byte).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/CharSequenceGenerator.cs
+++ b/Src/AutoFixture/CharSequenceGenerator.cs
@@ -30,9 +30,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(char).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/ConstrainedStringGenerator.cs
+++ b/Src/AutoFixture/ConstrainedStringGenerator.cs
@@ -32,9 +32,7 @@ namespace Ploeh.AutoFixture
             var constrain = request as ConstrainedStringRequest;
             if (constrain == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return ConstrainedStringGenerator.Create(constrain.MinimumLength, constrain.MaximumLength, context);

--- a/Src/AutoFixture/CurrentDateTimeGenerator.cs
+++ b/Src/AutoFixture/CurrentDateTimeGenerator.cs
@@ -21,9 +21,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(DateTime).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return DateTime.Now;

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -37,17 +37,13 @@ namespace Ploeh.AutoFixture.DataAnnotations
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             var rangeAttribute = customAttributeProvider.GetCustomAttributes(typeof(RangeAttribute), inherit: true).Cast<RangeAttribute>().SingleOrDefault();
             if (rangeAttribute == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(RangeAttributeRelay.Create(rangeAttribute, request));

--- a/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
@@ -34,17 +34,13 @@ namespace Ploeh.AutoFixture.DataAnnotations
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             var regularExpressionAttribute = customAttributeProvider.GetCustomAttributes(typeof(RegularExpressionAttribute), inherit: true).Cast<RegularExpressionAttribute>().SingleOrDefault();
             if (regularExpressionAttribute == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(new RegularExpressionRequest(regularExpressionAttribute.Pattern));

--- a/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
@@ -36,17 +36,13 @@ namespace Ploeh.AutoFixture.DataAnnotations
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             var stringLengthAttribute = customAttributeProvider.GetCustomAttributes(typeof(StringLengthAttribute), inherit: true).Cast<StringLengthAttribute>().SingleOrDefault();
             if (stringLengthAttribute == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(new ConstrainedStringRequest(stringLengthAttribute.MaximumLength));

--- a/Src/AutoFixture/DateTimeGenerator.cs
+++ b/Src/AutoFixture/DateTimeGenerator.cs
@@ -22,7 +22,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(DateTime).Equals(request))
             {
-                return new NoSpecimen(request);
+                return new NoSpecimen();
             }
 
             return DateTime.Now;

--- a/Src/AutoFixture/DecimalSequenceGenerator.cs
+++ b/Src/AutoFixture/DecimalSequenceGenerator.cs
@@ -57,9 +57,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(decimal).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/DomainNameGenerator.cs
+++ b/Src/AutoFixture/DomainNameGenerator.cs
@@ -29,9 +29,7 @@ namespace Ploeh.AutoFixture
         {
             if (request == null || !typeof(DomainName).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             var index = random.Next(0, fictitiousDomains.Length);

--- a/Src/AutoFixture/DoubleSequenceGenerator.cs
+++ b/Src/AutoFixture/DoubleSequenceGenerator.cs
@@ -56,9 +56,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(double).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
+++ b/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
@@ -28,18 +28,14 @@ namespace Ploeh.AutoFixture
 
             if (request == null || !typeof(EmailAddressLocalPart).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             var localPart = context.Resolve(typeof(string)) as string;
 
             if (string.IsNullOrEmpty(localPart))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return new EmailAddressLocalPart(localPart);

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -46,9 +46,7 @@ namespace Ploeh.AutoFixture
             var t = request as Type;
             if (!EnumGenerator.IsEnumType(t))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             lock (this.syncRoot)

--- a/Src/AutoFixture/GuidGenerator.cs
+++ b/Src/AutoFixture/GuidGenerator.cs
@@ -41,9 +41,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(Guid).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return GuidGenerator.Create();

--- a/Src/AutoFixture/Int16SequenceGenerator.cs
+++ b/Src/AutoFixture/Int16SequenceGenerator.cs
@@ -55,9 +55,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(short).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/Int32SequenceGenerator.cs
+++ b/Src/AutoFixture/Int32SequenceGenerator.cs
@@ -51,9 +51,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(int).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/Int64SequenceGenerator.cs
+++ b/Src/AutoFixture/Int64SequenceGenerator.cs
@@ -51,9 +51,7 @@ namespace Ploeh.AutoFixture
         {
             if (!typeof(long).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.Create();

--- a/Src/AutoFixture/Kernel/ArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/ArrayRelay.cs
@@ -38,22 +38,16 @@ namespace Ploeh.AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             if (!type.IsArray)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             var elementType = type.GetElementType();
             var specimen = context.Resolve(new MultipleRequest(elementType));
             if (specimen is OmitSpecimen)
                 return specimen;
             var elements = specimen as IEnumerable;
             if (elements == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             return ArrayRelay.ToArray(elements, elementType);
         }
 

--- a/Src/AutoFixture/Kernel/CollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/CollectionRelay.cs
@@ -37,17 +37,11 @@ namespace Ploeh.AutoFixture.Kernel
             // This is performance-sensitive code when used repeatedly over many requests.
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
-#pragma warning disable 618
-            if (type == null) return new NoSpecimen(request);
-#pragma warning restore 618
+            if (type == null) return new NoSpecimen();
             var typeArguments = type.GetGenericArguments();
-#pragma warning disable 618
-            if (typeArguments.Length != 1) return new NoSpecimen(request);
-#pragma warning restore 618
+            if (typeArguments.Length != 1) return new NoSpecimen();
             var gtd = type.GetGenericTypeDefinition();
-#pragma warning disable 618
-            if (gtd != typeof (ICollection<>)) return new NoSpecimen(request);
-#pragma warning restore 618
+            if (gtd != typeof (ICollection<>)) return new NoSpecimen();
             return context.Resolve(typeof (List<>).MakeGenericType(typeArguments));
         }
     }

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -60,10 +60,8 @@ namespace Ploeh.AutoFixture.Kernel
                 var result = composedBuilders[i].Create(request, context);
                 if (!(result is NoSpecimen)) return result;
             }
-
-#pragma warning disable 618
-            return new NoSpecimen(request);
-#pragma warning restore 618
+            
+            return new NoSpecimen();
         }
 
         /// <summary>Composes the supplied builders.</summary>

--- a/Src/AutoFixture/Kernel/ConstructorInvoker.cs
+++ b/Src/AutoFixture/Kernel/ConstructorInvoker.cs
@@ -73,7 +73,7 @@ namespace Ploeh.AutoFixture.Kernel
                 }
             }
 
-            return new NoSpecimen(request);
+            return new NoSpecimen();
         }
 
         private IEnumerable<IMethod> GetConstructors(object request)

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -32,16 +32,12 @@ namespace Ploeh.AutoFixture.Kernel
 
             if (delegateType == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             if (!typeof(Delegate).IsAssignableFrom(delegateType))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             var delegateMethod = delegateType.GetMethod("Invoke");

--- a/Src/AutoFixture/Kernel/DictionaryRelay.cs
+++ b/Src/AutoFixture/Kernel/DictionaryRelay.cs
@@ -37,17 +37,11 @@ namespace Ploeh.AutoFixture.Kernel
             // This is performance-sensitive code when used repeatedly over many requests.
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
-#pragma warning disable 618
-            if (type == null) return new NoSpecimen(request);
-#pragma warning restore 618
+            if (type == null) return new NoSpecimen();
             var typeArguments = type.GetGenericArguments();
-#pragma warning disable 618
-            if (typeArguments.Length != 2) return new NoSpecimen(request);
-#pragma warning restore 618
+            if (typeArguments.Length != 2) return new NoSpecimen();
             var gtd = type.GetGenericTypeDefinition();
-#pragma warning disable 618
-            if (gtd != typeof(IDictionary<,>)) return new NoSpecimen(request);
-#pragma warning restore 618
+            if (gtd != typeof(IDictionary<,>)) return new NoSpecimen();
             return context.Resolve(typeof(Dictionary<,>).MakeGenericType(typeArguments));
         }
     }

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -39,26 +39,18 @@ namespace Ploeh.AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             var typeArgs = type.GetGenericArguments();
             if (typeArgs.Length != 1)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             if (type.GetGenericTypeDefinition() != typeof(IEnumerable<>))
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             var specimen = context.Resolve(new MultipleRequest(typeArgs[0]));
             if (specimen is OmitSpecimen)
                 return specimen;
             var enumerable = specimen as IEnumerable<object>;
             if (enumerable == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             return typeof (ConvertedEnumerable<>)
                 .MakeGenericType(typeArgs)

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -40,16 +40,12 @@ namespace Ploeh.AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             var typeArguments = t.GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof (IEnumerator<>) != t.GetGenericTypeDefinition())
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             var specimenBuilder = (ISpecimenBuilder) Activator.CreateInstance(
                 typeof (EnumeratorRelay<>).MakeGenericType(typeArguments));
@@ -66,22 +62,16 @@ namespace Ploeh.AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             if (t != typeof(IEnumerator<T>))
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             var enumerable =
                 context.Resolve(typeof (IEnumerable<T>)) as IEnumerable<T>;
 
             if (enumerable == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             return enumerable.GetEnumerator();
         }

--- a/Src/AutoFixture/Kernel/FieldRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/FieldRequestRelay.cs
@@ -29,9 +29,7 @@ namespace Ploeh.AutoFixture.Kernel
             var fieldInfo = request as FieldInfo;
             if (fieldInfo == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(new SeededRequest(fieldInfo.FieldType, fieldInfo.Name));

--- a/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
@@ -65,9 +65,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (!this.specification.IsSatisfiedBy(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return this.builder.Create(request, context);

--- a/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
@@ -35,9 +35,7 @@ namespace Ploeh.AutoFixture.Kernel
             var manyRequest = request as FiniteSequenceRequest;
             if (manyRequest == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return from req in manyRequest.CreateRequests()

--- a/Src/AutoFixture/Kernel/IntPtrGuard.cs
+++ b/Src/AutoFixture/Kernel/IntPtrGuard.cs
@@ -39,9 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (!typeof(IntPtr).Equals(request))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             throw new IllegalRequestException("A request for an IntPtr was detected. This is an unsafe resource that will crash the process if used, so the request is denied. A common source of IntPtr requests are requests for delegates such as Func<T> or Action<T>. If this is the case, the expected workaround is to Customize (Register or Inject) the offending type by specifying a proper creational strategy.");

--- a/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
+++ b/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
@@ -160,9 +160,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonBooleanRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonBooleanRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
@@ -90,9 +90,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonByteRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonByteRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/CharSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/CharSequenceGeneratorTest.cs
@@ -54,9 +54,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(dummyRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
@@ -57,9 +57,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            Assert.Equal(new NoSpecimen(request), result);
-#pragma warning restore 618
+            Assert.Equal(new NoSpecimen(), result);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/CurrentDateTimeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/CurrentDateTimeGeneratorTest.cs
@@ -53,9 +53,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDateTimeRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonDateTimeRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
@@ -58,9 +58,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(dummyRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -81,9 +79,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionAttributeRelayTest.cs
@@ -57,9 +57,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(dummyRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -80,9 +78,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
@@ -57,9 +57,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(dummyRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -80,9 +78,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
@@ -90,9 +90,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDecimalRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonDecimalRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
@@ -41,9 +41,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(nonDomainNameRequest, null);
             // Verify outcome
-#pragma warning disable 618
-            Assert.Equal(new NoSpecimen(nonDomainNameRequest), result);
-#pragma warning restore 618
+            Assert.Equal(new NoSpecimen(), result);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
@@ -90,9 +90,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDoubleRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonDoubleRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
@@ -57,9 +57,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(dummyRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -81,9 +79,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var sut = new EmailAddressLocalPartGenerator();
             // Exercise system and verify outcome
             var result = sut.Create(request, context);
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -130,9 +126,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var result = sut.Create(typeof(EmailAddressLocalPart), context);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
@@ -36,9 +36,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
@@ -102,9 +102,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(nonGuidRequest, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonGuidRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
@@ -90,9 +90,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt16Request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonInt16Request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
@@ -90,9 +90,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt32Request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonInt32Request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
@@ -90,9 +90,7 @@ namespace Ploeh.AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt64Request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonInt64Request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ArrayRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ArrayRelayTest.cs
@@ -47,9 +47,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -110,9 +108,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
@@ -55,9 +55,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/CompositeSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CompositeSpecimenBuilderTest.cs
@@ -186,9 +186,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(anonymousRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expected = new NoSpecimen(anonymousRequest);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
@@ -51,9 +51,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDelegateRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonDelegateRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
@@ -59,9 +59,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/EnumerableRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumerableRelayTest.cs
@@ -56,9 +56,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext { OnResolve = r => Enumerable.Empty<object>() };
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -119,9 +117,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(request, context);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
@@ -40,10 +40,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
 
             var result = sut.Create(request, dummyContext);
-
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
         }
 
@@ -93,10 +91,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var sut = new EnumeratorRelay();
 
             var result = sut.Create(request, context);
-
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/FieldRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FieldRequestRelayTest.cs
@@ -54,9 +54,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonFieldRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonFieldRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/FilteringSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FilteringSpecimenBuilderTest.cs
@@ -80,9 +80,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRelayTest.cs
@@ -42,9 +42,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -61,9 +59,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/IntPtrGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/IntPtrGuardTest.cs
@@ -37,9 +37,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }


### PR DESCRIPTION
This pull request is a partial, incremental move towards further deprecating `NoSpecimen.Request`, as outlined in #475, although that work is far from complete with this.

Since all these changes are breaking, the commits should only be applied to the *v4* branch (in case someone actually decides to accept this).