### PR TITLE
Remove some more usages of request overload for no specimen

### DIFF
--- a/Src/AutoFixture/Kernel/ListRelay.cs
+++ b/Src/AutoFixture/Kernel/ListRelay.cs
@@ -34,16 +34,12 @@ namespace Ploeh.AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             var typeArguments = t.GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof(IList<>) != t.GetGenericTypeDefinition())
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             return context.Resolve(
                 typeof(List<>).MakeGenericType(typeArguments));

--- a/Src/AutoFixture/Kernel/MethodInvoker.cs
+++ b/Src/AutoFixture/Kernel/MethodInvoker.cs
@@ -72,9 +72,7 @@ namespace Ploeh.AutoFixture.Kernel
                 }
             }
 
-#pragma warning disable 618
-            return new NoSpecimen(request);
-#pragma warning restore 618
+            return new NoSpecimen();
         }
 
         private IEnumerable<IMethod> GetConstructors(object request)

--- a/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
@@ -29,9 +29,7 @@ namespace Ploeh.AutoFixture.Kernel
 
             var arrayType = request as Type;
             if (arrayType == null || !IsMultidimensionalArray(arrayType))
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             return CreateMultidimensionalArray(arrayType, context);
         }

--- a/Src/AutoFixture/Kernel/MultipleRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleRelay.cs
@@ -57,9 +57,7 @@ namespace Ploeh.AutoFixture.Kernel
             var manyRequest = request as MultipleRequest;
             if (manyRequest == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(new FiniteSequenceRequest(manyRequest.Request, this.Count));

--- a/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
@@ -50,17 +50,13 @@ namespace Ploeh.AutoFixture.Kernel
             
             var multipleRequest = request as MultipleRequest;
             if (multipleRequest == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             var innerRequest = GetInnerRequest(multipleRequest);
 
             var itemType = innerRequest as Type;
             if (itemType == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             return context.Resolve(
                 typeof(IEnumerable<>).MakeGenericType(itemType));

--- a/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
@@ -59,14 +59,10 @@ namespace Ploeh.AutoFixture.Kernel
 
             var pi = request as ParameterInfo;
             if (pi == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             if (!pi.ParameterType.IsArray)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             var returnValue = context.Resolve(
                 new SeededRequest(

--- a/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
@@ -60,19 +60,13 @@ namespace Ploeh.AutoFixture.Kernel
 
             var pi = request as ParameterInfo;
             if (pi == null)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             if (!pi.ParameterType.IsGenericType)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             if (IsNotEnumerable(pi))
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             var returnValue = context.Resolve(
                 new SeededRequest(

--- a/Src/AutoFixture/Kernel/Omitter.cs
+++ b/Src/AutoFixture/Kernel/Omitter.cs
@@ -65,10 +65,8 @@ namespace Ploeh.AutoFixture.Kernel
 
             if (this.specification.IsSatisfiedBy(request))
                 return new OmitSpecimen();
-
-#pragma warning disable 618
-            return new NoSpecimen(request);
-#pragma warning restore 618
+            
+            return new NoSpecimen();
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
@@ -29,9 +29,7 @@ namespace Ploeh.AutoFixture.Kernel
             var paramInfo = request as ParameterInfo;
             if (paramInfo == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(new SeededRequest(paramInfo.ParameterType, paramInfo.Name));

--- a/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
@@ -29,9 +29,7 @@ namespace Ploeh.AutoFixture.Kernel
             var propertyInfo = request as PropertyInfo;
             if (propertyInfo == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(new SeededRequest(propertyInfo.PropertyType, propertyInfo.Name));

--- a/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
+++ b/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
@@ -39,9 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
             var seededRequest = request as SeededRequest;
             if (seededRequest == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return context.Resolve(seededRequest.Request);

--- a/Src/AutoFixture/Kernel/SeededFactory.cs
+++ b/Src/AutoFixture/Kernel/SeededFactory.cs
@@ -52,24 +52,18 @@ namespace Ploeh.AutoFixture.Kernel
             var seededRequest = request as SeededRequest;
             if (seededRequest == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             if (!seededRequest.Request.Equals(typeof(T)))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             if ((seededRequest.Seed != null)
                 && !(seededRequest.Seed is T))
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
             var seed = (T)seededRequest.Seed;
 

--- a/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
@@ -46,9 +46,7 @@ namespace Ploeh.AutoFixture.Kernel
             var manyRequest = request as FiniteSequenceRequest;
             if (manyRequest == null)
             {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
             }
 
             return (from req in manyRequest.CreateRequests()

--- a/Src/AutoFixture/Kernel/TypeRelay.cs
+++ b/Src/AutoFixture/Kernel/TypeRelay.cs
@@ -84,9 +84,7 @@ namespace Ploeh.AutoFixture.Kernel
             
             var t = request as Type;
             if (t == null || t != this.from)
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
+                return new NoSpecimen();
 
             return context.Resolve(this.to);
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
@@ -55,9 +55,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
@@ -80,9 +80,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(nonTypeRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonTypeRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -98,9 +96,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(dummyRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -110,16 +106,12 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var type = typeof(string);
-#pragma warning disable 618
-            var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen(type) };
-#pragma warning restore 618
+            var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen() };
             var sut = new MethodInvoker(new ModestConstructorQuery());
             // Exercise system
             var result = sut.Create(type, container);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(type);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -133,9 +125,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.Create(typeof(AbstractType), container);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(typeof(AbstractType));
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
@@ -41,9 +41,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             {
                 var sut = new MultidimensionalArrayRelay();
                 var dummyContext = new DelegatingSpecimenContext();
-#pragma warning disable 618
-                var expected = new NoSpecimen(r);
-#pragma warning restore 618
+                var expected = new NoSpecimen();
 
                 var actual = sut.Create(r, dummyContext);
 

--- a/Src/AutoFixtureUnitTest/Kernel/MultipleRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultipleRelayTest.cs
@@ -79,9 +79,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -98,9 +96,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
@@ -33,9 +33,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expected = new NoSpecimen(request);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, actual);
             // Teardown
         }
@@ -87,9 +85,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expected = new NoSpecimen(request);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, actual);
             // Teardown
         }
@@ -145,9 +141,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expected = new NoSpecimen(request);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/OmitArrayParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitArrayParameterRequestRelayTests.cs
@@ -69,9 +69,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             var sut = new OmitArrayParameterRequestRelay();
             var actual = sut.Create(request, new DelegatingSpecimenContext());
-#pragma warning disable 618
-            Assert.Equal(new NoSpecimen(request), actual);
-#pragma warning restore 618
+            Assert.Equal(new NoSpecimen(), actual);
         }
 
         [Theory]
@@ -95,9 +93,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(parameterInfo, dummyContext);
 
-#pragma warning disable 618
-            var expected = new NoSpecimen(parameterInfo);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
@@ -69,9 +69,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             var sut = new OmitEnumerableParameterRequestRelay();
             var actual = sut.Create(request, new DelegatingSpecimenContext());
-#pragma warning disable 618
-            Assert.Equal(new NoSpecimen(request), actual);
-#pragma warning restore 618
+            Assert.Equal(new NoSpecimen(), actual);
         }
 
         [Theory]
@@ -95,9 +93,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(parameterInfo, dummyContext);
 
-#pragma warning disable 618
-            var expected = new NoSpecimen(parameterInfo);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/OmitterTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitterTests.cs
@@ -79,9 +79,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expected = new NoSpecimen(request);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, actual);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ParameterRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ParameterRequestRelayTest.cs
@@ -55,9 +55,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonParameterRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonParameterRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/PropertyRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/PropertyRequestRelayTest.cs
@@ -54,9 +54,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonParameterRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(nonParameterRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/SeededFactoryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SeededFactoryTest.cs
@@ -51,9 +51,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -70,9 +68,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -92,9 +88,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(seededRequest, dummyContainer);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(seededRequest);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/StableFiniteSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/StableFiniteSequenceRelayTest.cs
@@ -42,9 +42,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }
@@ -61,9 +59,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expectedResult = new NoSpecimen(request);
-#pragma warning restore 618
+            var expectedResult = new NoSpecimen();
             Assert.Equal(expectedResult, result);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/TypeRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TypeRelayTests.cs
@@ -48,9 +48,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Verify outcome
-#pragma warning disable 618
-            var expected = new NoSpecimen(request);
-#pragma warning restore 618
+            var expected = new NoSpecimen();
             Assert.Equal(expected, actual);
             // Teardown
         }


### PR DESCRIPTION
Similar to PR #487 this PR takes us a little further towards addressing #475.

Since it contains breaking changes, it should only be applied to the *v4* branch, if accepted.