### PR TITLE
Make AutoFixture.Xunit2 a bit more discoverable

### DIFF
--- a/Nuget/Ploeh.AutoFixture.Xunit.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Xunit.nuspec
@@ -11,7 +11,10 @@
             <dependency id="xunit.extensions" version="[1.8.0.1549,2.0.0)" />
         </dependencies>
         <summary>Extension to AutoFixture that integrates it with xUnit.net.</summary>
-        <description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</description>
+        <description>
+            By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).
+            For xUnit.net 2.0 and newer please use the AutoFixture.Xunit2 NuGet Package.
+        </description>
         <iconUrl>https://raw.githubusercontent.com/AutoFixture/AutoFixture/master/AutoFixtureLogo200x200.png</iconUrl>
         <language>en-US</language>
         <licenseUrl>https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt</licenseUrl>


### PR DESCRIPTION
This Pull Request attempts to	make AutoFixture.Xunit2 a bit more discoverable, by adding a note in the NuGet Package description of AutoFixture.Xunit, as suggested by @adamralph in #294.

Apart from this change, I'm not sure we can add any formatting, as [it looks like it's not currently supported by the .nuspec](http://stackoverflow.com/q/23370532/467754) file format.