### PR TITLE
Provide an msbuild target for just running tests

### DIFF
--- a/BuildRelease.msbuild
+++ b/BuildRelease.msbuild
@@ -97,7 +97,7 @@
     <Target Name="Build" DependsOnTargets="Verify">
         <MSBuild Projects="@(ProjectToBuild)" Properties="Configuration=Release" />
     </Target>
-    <Target Name="Test" DependsOnTargets="Build">
+    <Target Name="TestOnly" >
         <PropertyGroup>
           <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
           <ParallelizeTests Condition="'$(ParallelizeTests)' == ''">false</ParallelizeTests>
@@ -120,6 +120,13 @@
 
         <NUnit ToolPath="$(NUnitToolsFolder)" Assemblies="Src\AutoFixture.NUnit2.UnitTest\bin\Release\Ploeh.AutoFixture.NUnit2.UnitTest.dll" ContinueOnError="true" />
         <NUnit ToolPath="$(NUnitToolsFolder)" Assemblies="Src\AutoFixture.NUnit2.Addins.UnitTest\bin\Release\Ploeh.AutoFixture.NUnit2.Addins.UnitTest.dll" OutputXmlFile="TestResult-Addins.xml" ContinueOnError="true" />
+    </Target>
+    <Target Name="BuildAndTestOnly">
+      <MSBuild Projects="@(ProjectToBuild)" Properties="Configuration=Release" />
+      <CallTarget Targets="TestOnly" />
+    </Target>
+    <Target Name="Test" DependsOnTargets="Build">
+      <CallTarget Targets="TestOnly" />
     </Target>
     <Target Name="DeleteTestResultFiles" DependsOnTargets="Test">
         <Delete Files="TestResult.xml" />


### PR DESCRIPTION
Sometimes, you want to build and run the tests repeatedly from the command line (especially if, like me, you don't trust the built-in visual studio test runners). These new msbuild targets makes that easier, while still preserving the existing behaviour of  /t:Test .

The new msbuild targets are:
•  /t:TestOnly  - only runs the test commands, without attempting clean/rebuild//verify.
•  /t:BuildAndTestOnly  - only runs the build and test targets, without attempting clean/rebuild/verify