### PR TITLE
Use method group where possible

### DIFF
--- a/Src/AutoFixture/CollectionFiller.cs
+++ b/Src/AutoFixture/CollectionFiller.cs
@@ -49,7 +49,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException("fixture");
             }
 
-            fixture.AddManyTo(collection, () => fixture.Create<T>());
+            fixture.AddManyTo(collection, fixture.Create<T>);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException("fixture");
             }
 
-            collection.AddMany(() => fixture.Create<T>(), repeatCount);
+            collection.AddMany(fixture.Create<T>, repeatCount);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR converts to lambda expressions to method groups. Makes the code slightly easier to read IMHO.