### PR TITLE
Use C# 6 features (see #500)

### DIFF
--- a/BuildRelease.ps1
+++ b/BuildRelease.ps1
@@ -10,4 +10,4 @@ function Get-VsVersion ()
     }
 }
 
-Start-Process -NoNewWindow -Wait -FilePath $env:windir\Microsoft.NET\Framework\v4.0.30319\MSBuild -ArgumentList ('BuildRelease.msbuild', (Get-VsVersion))
+Start-Process -NoNewWindow -Wait -FilePath ${env:ProgramFiles(x86)}\MSBuild\14.0\Bin\MsBuild.exe -ArgumentList ('BuildRelease.msbuild', (Get-VsVersion))

--- a/Src/AutoFixture/AutoPropertiesTarget.cs
+++ b/Src/AutoFixture/AutoPropertiesTarget.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture
         public AutoPropertiesTarget(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/AutoPropertiesTarget.cs
+++ b/Src/AutoFixture/AutoPropertiesTarget.cs
@@ -18,8 +18,6 @@ namespace Ploeh.AutoFixture
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class AutoPropertiesTarget : ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="AutoPropertiesTarget" /> class.
@@ -40,7 +38,7 @@ namespace Ploeh.AutoFixture
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
-            this.builder = builder;
+            this.Builder = builder;
         }
         
         /// <summary>Composes the supplied builders.</summary>
@@ -76,7 +74,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.builder.Create(request, context);
+            return this.Builder.Create(request, context);
         }
 
         /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -84,7 +82,7 @@ namespace Ploeh.AutoFixture
         /// <seealso cref="Builder" />
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         /// <summary>
@@ -103,9 +101,6 @@ namespace Ploeh.AutoFixture
         /// <summary>Gets the builder decorated by this instance.</summary>
         /// <value>The builder originally supplied via the constructor.</value>
         /// <seealso cref="AutoPropertiesTarget(ISpecimenBuilder)" />
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
     }
 }

--- a/Src/AutoFixture/BehaviorRoot.cs
+++ b/Src/AutoFixture/BehaviorRoot.cs
@@ -18,8 +18,6 @@ namespace Ploeh.AutoFixture
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class BehaviorRoot : ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BehaviorRoot" />
         /// class.
@@ -40,7 +38,7 @@ namespace Ploeh.AutoFixture
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
-            this.builder = builder;
+            this.Builder = builder;
         }
 
         /// <summary>Composes the supplied builders.</summary>
@@ -76,7 +74,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.builder.Create(request, context);
+            return this.Builder.Create(request, context);
         }
 
         /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -84,7 +82,7 @@ namespace Ploeh.AutoFixture
         /// <seealso cref="Builder" />
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         /// <summary>
@@ -103,9 +101,6 @@ namespace Ploeh.AutoFixture
         /// <summary>Gets the builder decorated by this instance.</summary>
         /// <value>The builder originally supplied via the constructor.</value>
         /// <seealso cref="BehaviorRoot(ISpecimenBuilder)" />
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
     }
 }

--- a/Src/AutoFixture/BehaviorRoot.cs
+++ b/Src/AutoFixture/BehaviorRoot.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture
         public BehaviorRoot(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/CollectionFiller.cs
+++ b/Src/AutoFixture/CollectionFiller.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.AddManyTo(collection, fixture.Create<T>);
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             collection.AddMany(fixture.Create<T>, repeatCount);
@@ -97,7 +97,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             collection.AddMany(creator, fixture.RepeatCount);

--- a/Src/AutoFixture/CompositeCustomization.cs
+++ b/Src/AutoFixture/CompositeCustomization.cs
@@ -9,8 +9,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class CompositeCustomization : ICustomization
     {
-        private readonly IEnumerable<ICustomization> customizations;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositeCustomization"/> class.
         /// </summary>
@@ -31,16 +29,13 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(customizations));
             }
 
-            this.customizations = customizations;
+            this.Customizations = customizations;
         }
 
         /// <summary>
         /// Gets the customizations contained within this instance.
         /// </summary>
-        public IEnumerable<ICustomization> Customizations
-        {
-            get { return this.customizations; }
-        }
+        public IEnumerable<ICustomization> Customizations { get; }
 
         /// <summary>
         /// Customizes the specified fixture.

--- a/Src/AutoFixture/CompositeCustomization.cs
+++ b/Src/AutoFixture/CompositeCustomization.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture
         {
             if (customizations == null)
             {
-                throw new ArgumentNullException("customizations");
+                throw new ArgumentNullException(nameof(customizations));
             }
 
             this.customizations = customizations;

--- a/Src/AutoFixture/ConstrainedStringGenerator.cs
+++ b/Src/AutoFixture/ConstrainedStringGenerator.cs
@@ -26,7 +26,7 @@ namespace Ploeh.AutoFixture
 
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var constrain = request as ConstrainedStringRequest;

--- a/Src/AutoFixture/ConstructorCustomization.cs
+++ b/Src/AutoFixture/ConstructorCustomization.cs
@@ -9,9 +9,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class ConstructorCustomization : ICustomization
     {
-        private readonly Type targetType;
-        private readonly IMethodQuery query;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstructorCustomization"/> class.
         /// </summary>
@@ -33,26 +30,20 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(query));
             }
 
-            this.targetType = targetType;
-            this.query = query;
+            this.TargetType = targetType;
+            this.Query = query;
         }
 
         /// <summary>
         /// Gets the <see cref="Type"/> for which <see cref="Query"/> should be used to select the
         /// most appropriate constructor.
         /// </summary>
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// Gets the query that selects a constructor for <see cref="TargetType"/>.
         /// </summary>
-        public IMethodQuery Query
-        {
-            get { return this.query; }
-        }
+        public IMethodQuery Query { get; }
 
         /// <summary>
         /// Customizes the specified fixture by modifying <see cref="TargetType"/> to use
@@ -68,7 +59,7 @@ namespace Ploeh.AutoFixture
 
             var factory = new MethodInvoker(this.Query);
             var builder = SpecimenBuilderNodeFactory.CreateTypedNode(
-                this.targetType,
+                this.TargetType,
                 factory);
 
             fixture.Customizations.Insert(0, builder);

--- a/Src/AutoFixture/ConstructorCustomization.cs
+++ b/Src/AutoFixture/ConstructorCustomization.cs
@@ -26,11 +26,11 @@ namespace Ploeh.AutoFixture
         {
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
             if (query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             this.targetType = targetType;
@@ -63,7 +63,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var factory = new MethodInvoker(this.Query);

--- a/Src/AutoFixture/CurrentDateTimeCustomization.cs
+++ b/Src/AutoFixture/CurrentDateTimeCustomization.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customizations.Add(new CurrentDateTimeGenerator());

--- a/Src/AutoFixture/CustomizationNode.cs
+++ b/Src/AutoFixture/CustomizationNode.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture
         public CustomizationNode(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/CustomizationNode.cs
+++ b/Src/AutoFixture/CustomizationNode.cs
@@ -18,8 +18,6 @@ namespace Ploeh.AutoFixture
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class CustomizationNode : ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomizationNode" />
         /// class.
@@ -40,7 +38,7 @@ namespace Ploeh.AutoFixture
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
-            this.builder = builder;
+            this.Builder = builder;
         }
         
         /// <summary>Composes the supplied builders.</summary>
@@ -76,7 +74,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.builder.Create(request, context);
+            return this.Builder.Create(request, context);
         }
 
         /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -84,7 +82,7 @@ namespace Ploeh.AutoFixture
         /// <seealso cref="Builder" />
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         /// <summary>
@@ -103,9 +101,6 @@ namespace Ploeh.AutoFixture
         /// <summary>Gets the builder decorated by this instance.</summary>
         /// <value>The builder originally supplied via the constructor.</value>
         /// <seealso cref="CustomizationNode(ISpecimenBuilder)" />
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
     }
 }

--- a/Src/AutoFixture/DataAnnotations/Automaton.cs
+++ b/Src/AutoFixture/DataAnnotations/Automaton.cs
@@ -124,10 +124,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// </code>
         /// ).
         /// </summary>
-        internal static int Minimization
-        {
-            get { return Automaton.MinimizeHopcroft; }
-        }
+        internal static int Minimization => Automaton.MinimizeHopcroft;
 
         /// <summary>
         /// Gets or sets a value indicating whether operations may modify the input automata.
@@ -183,10 +180,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// <value>
         /// <c>true</c> if this instance is singleton; otherwise, <c>false</c>.
         /// </value>
-        internal bool IsSingleton
-        {
-            get { return this.Singleton != null; }
-        }
+        internal bool IsSingleton => this.Singleton != null;
 
         /// <summary>
         /// Gets or sets a value indicating whether this instance is debug.

--- a/Src/AutoFixture/DataAnnotations/MinimizationOperations.cs
+++ b/Src/AutoFixture/DataAnnotations/MinimizationOperations.cs
@@ -539,24 +539,15 @@ namespace Ploeh.AutoFixture.DataAnnotations
 
         private sealed class IntPair
         {
-            private readonly int n1;
-            private readonly int n2;
-
             internal IntPair(int n1, int n2)
             {
-                this.n1 = n1;
-                this.n2 = n2;
+                this.N1 = n1;
+                this.N2 = n2;
             }
 
-            internal int N1
-            {
-                get { return n1; }
-            }
+            internal int N1 { get; }
 
-            internal int N2
-            {
-                get { return n2; }
-            }
+            internal int N2 { get; }
         }
 
         #endregion

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
 
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var customAttributeProvider = request as ICustomAttributeProvider;

--- a/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
 
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var customAttributeProvider = request as ICustomAttributeProvider;

--- a/Src/AutoFixture/DataAnnotations/State.cs
+++ b/Src/AutoFixture/DataAnnotations/State.cs
@@ -43,7 +43,6 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// </summary>
     internal sealed class State : IEquatable<State>, IComparable<State>
     {
-        private readonly int id;
         private static int nextId;
 
         /// <summary>
@@ -53,16 +52,13 @@ namespace Ploeh.AutoFixture.DataAnnotations
         internal State()
         {
             this.ResetTransitions();
-            id = Interlocked.Increment(ref nextId);
+            Id = Interlocked.Increment(ref nextId);
         }
 
         /// <summary>
         /// Gets the id.
         /// </summary>
-        internal int Id
-        {
-            get { return this.id; }
-        }
+        internal int Id { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this State is Accept.
@@ -149,7 +145,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         {
             unchecked
             {
-                int result = id;
+                int result = Id;
                 result = (result * 397) ^ Accept.GetHashCode();
                 result = (result * 397) ^ Number;
                 return result;
@@ -176,7 +172,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 return true;
             }
 
-            return other.id == id 
+            return other.Id == Id 
                 && other.Accept.Equals(Accept)
                 && other.Number == Number;
         }

--- a/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
 
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var customAttributeProvider = request as ICustomAttributeProvider;

--- a/Src/AutoFixture/DataAnnotations/Transition.cs
+++ b/Src/AutoFixture/DataAnnotations/Transition.cs
@@ -45,10 +45,6 @@ namespace Ploeh.AutoFixture.DataAnnotations
     ///</summary>
     internal sealed class Transition : IEquatable<Transition>
     {
-        private readonly char max;
-        private readonly char min;
-        private readonly State to;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Transition"/> class.
         /// (Constructs a new singleton interval transition).
@@ -57,8 +53,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// <param name="to">The destination state.</param>
         internal Transition(char c, State to)
         {
-            this.min = this.max = c;
-            this.to = to;
+            this.Min = this.Max = c;
+            this.To = to;
         }
 
         /// <summary>
@@ -77,34 +73,25 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 min = t;
             }
 
-            this.min = min;
-            this.max = max;
-            this.to = to;
+            this.Min = min;
+            this.Max = max;
+            this.To = to;
         }
 
         /// <summary>
         /// Gets the minimum of this transition interval.
         /// </summary>
-        internal char Min
-        {
-            get { return this.min; }
-        }
+        internal char Min { get; }
 
         /// <summary>
         /// Gets the maximum of this transition interval.
         /// </summary>
-        internal char Max
-        {
-            get { return this.max; }
-        }
+        internal char Max { get; }
 
         /// <summary>
         /// Gets the destination of this transition.
         /// </summary>
-        internal State To
-        {
-            get { return this.to; }
-        }
+        internal State To { get; }
 
         /// <summary>
         /// Implements the operator ==.
@@ -141,14 +128,14 @@ namespace Ploeh.AutoFixture.DataAnnotations
         public override string ToString()
         {
             var sb = new StringBuilder();
-            Transition.AppendCharString(min, sb);
-            if (min != max)
+            Transition.AppendCharString(Min, sb);
+            if (Min != Max)
             {
                 sb.Append("-");
-                Transition.AppendCharString(max, sb);
+                Transition.AppendCharString(Max, sb);
             }
 
-            sb.Append(" -> ").Append(to.Number);
+            sb.Append(" -> ").Append(To.Number);
             return sb.ToString();
         }
 
@@ -198,9 +185,9 @@ namespace Ploeh.AutoFixture.DataAnnotations
         {
             unchecked
             {
-                int result = min.GetHashCode();
-                result = (result*397) ^ max.GetHashCode();
-                result = (result*397) ^ (to != null ? to.GetHashCode() : 0);
+                int result = Min.GetHashCode();
+                result = (result*397) ^ Max.GetHashCode();
+                result = (result*397) ^ (To != null ? To.GetHashCode() : 0);
                 return result;
             }
         }
@@ -225,9 +212,9 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 return true;
             }
 
-            return other.min == min
-                   && other.max == max
-                   && object.Equals(other.to, to);
+            return other.Min == Min
+                   && other.Max == Max
+                   && object.Equals(other.To, To);
         }
 
         private static void AppendCharString(char c, StringBuilder sb)

--- a/Src/AutoFixture/DataAnnotations/Xeger.cs
+++ b/Src/AutoFixture/DataAnnotations/Xeger.cs
@@ -43,12 +43,12 @@ namespace Ploeh.AutoFixture.DataAnnotations
         {
             if (string.IsNullOrEmpty(regex))
             {
-                throw new ArgumentNullException("regex");
+                throw new ArgumentNullException(nameof(regex));
             }
 
             if (random == null)
             {
-                throw new ArgumentNullException("random");
+                throw new ArgumentNullException(nameof(random));
             }
 
             this.automaton = new RegExp(regex, AllExceptAnyString).ToAutomaton();

--- a/Src/AutoFixture/DefaultEngineParts.cs
+++ b/Src/AutoFixture/DefaultEngineParts.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture
         {
             if (primitiveBuilders == null)
             {
-                throw new ArgumentNullException("primitiveBuilders");
+                throw new ArgumentNullException(nameof(primitiveBuilders));
             }
 
             this.primitiveBuilders = primitiveBuilders;

--- a/Src/AutoFixture/DictionaryFiller.cs
+++ b/Src/AutoFixture/DictionaryFiller.cs
@@ -44,16 +44,16 @@ namespace Ploeh.AutoFixture
         public void Execute(object specimen, ISpecimenContext context)
         {
             if (specimen == null)
-                throw new ArgumentNullException("specimen");
+                throw new ArgumentNullException(nameof(specimen));
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var typeArguments = specimen.GetType().GetGenericArguments();
             if (typeArguments.Length != 2)
-                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", "specimen");
+                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 
             if (!typeof(IDictionary<,>).MakeGenericType(typeArguments).IsAssignableFrom(specimen.GetType()))
-                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", "specimen");
+                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 
             var filler = (ISpecimenCommand)Activator.CreateInstance(
                 typeof(Filler<,>).MakeGenericType(typeArguments));

--- a/Src/AutoFixture/DisposableTrackingCustomization.cs
+++ b/Src/AutoFixture/DisposableTrackingCustomization.cs
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Behaviors.Add(this.Behavior);

--- a/Src/AutoFixture/DisposableTrackingCustomization.cs
+++ b/Src/AutoFixture/DisposableTrackingCustomization.cs
@@ -16,19 +16,26 @@ namespace Ploeh.AutoFixture
     /// <seealso cref="DisposableTrackingBehavior"/>
     public class DisposableTrackingCustomization : ICustomization, IDisposable
     {
+        private readonly DisposableTrackingBehavior behavior;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DisposableTrackingCustomization"/> class.
         /// </summary>
         public DisposableTrackingCustomization()
         {
-            this.Behavior = new DisposableTrackingBehavior();
+            this.behavior = new DisposableTrackingBehavior();
         }
 
         /// <summary>
         /// Gets the behavior that this customization adds to <see cref="IFixture"/> instances.
         /// </summary>
         /// <seealso cref="DisposableTrackingBehavior"/>
-        public DisposableTrackingBehavior Behavior { get; }
+        /// <remarks>
+        /// This property is not a getter-only auto-property as the backing-field
+        /// implements IDisposable and should thus be disposed, which is not possible
+        /// when using an auto-property.
+        /// </remarks>
+        public DisposableTrackingBehavior Behavior => behavior;
 
         /// <summary>
         /// Customizes the specified fixture by applying <see cref="Behavior"/>.
@@ -64,7 +71,7 @@ namespace Ploeh.AutoFixture
         {
             if (disposing)
             {
-                this.Behavior.Dispose();
+                this.behavior.Dispose();
             }
         }
     }

--- a/Src/AutoFixture/DisposableTrackingCustomization.cs
+++ b/Src/AutoFixture/DisposableTrackingCustomization.cs
@@ -16,24 +16,19 @@ namespace Ploeh.AutoFixture
     /// <seealso cref="DisposableTrackingBehavior"/>
     public class DisposableTrackingCustomization : ICustomization, IDisposable
     {
-        private readonly DisposableTrackingBehavior behavior;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DisposableTrackingCustomization"/> class.
         /// </summary>
         public DisposableTrackingCustomization()
         {
-            this.behavior = new DisposableTrackingBehavior();
+            this.Behavior = new DisposableTrackingBehavior();
         }
 
         /// <summary>
         /// Gets the behavior that this customization adds to <see cref="IFixture"/> instances.
         /// </summary>
         /// <seealso cref="DisposableTrackingBehavior"/>
-        public DisposableTrackingBehavior Behavior
-        {
-            get { return this.behavior; }
-        }
+        public DisposableTrackingBehavior Behavior { get; }
 
         /// <summary>
         /// Customizes the specified fixture by applying <see cref="Behavior"/>.
@@ -69,7 +64,7 @@ namespace Ploeh.AutoFixture
         {
             if (disposing)
             {
-                this.behavior.Dispose();
+                this.Behavior.Dispose();
             }
         }
     }

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -7,8 +7,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class DomainName
     {
-        private string domainName;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DomainName"/> class. Throws ArgumentNullException
         /// if domainName is null. Throws ArgumentException if domainName is empty.
@@ -19,19 +17,13 @@ namespace Ploeh.AutoFixture
             {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            this.domainName = domainName;
+            this.Domain = domainName;
         }
 
         /// <summary>
         /// Get the name of the domain.
         /// </summary>
-        public string Domain
-        {
-            get
-            {
-                return this.domainName;
-            }
-        }
+        public string Domain { get; }
 
         /// <summary>
         /// Returns a <see cref="System.String"/> that represents the domain name for this instance.
@@ -41,7 +33,7 @@ namespace Ploeh.AutoFixture
         /// </returns>
         public override string ToString()
         {
-            return this.domainName;
+            return this.Domain;
         }
 
         /// <summary>
@@ -62,7 +54,7 @@ namespace Ploeh.AutoFixture
 
             if (other != null)
             {
-                return this.domainName.Equals(other.domainName);
+                return this.Domain.Equals(other.Domain);
             }
             return base.Equals(obj);
         }
@@ -76,7 +68,7 @@ namespace Ploeh.AutoFixture
         /// </returns>
         public override int GetHashCode()
         {
-            return this.domainName.GetHashCode();
+            return this.Domain.GetHashCode();
         }
     }
 }

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -17,7 +17,7 @@ namespace Ploeh.AutoFixture
         {
             if (domainName == null)
             {
-                throw new ArgumentNullException("domainName");
+                throw new ArgumentNullException(nameof(domainName));
             }
             this.domainName = domainName;
         }

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -40,7 +40,7 @@ namespace Ploeh.AutoFixture.Dsl
         public CompositeNodeComposer(ISpecimenBuilderNode node)
         {
             if (node == null)
-                throw new ArgumentNullException("node");
+                throw new ArgumentNullException(nameof(node));
 
             this.node = node;
         }

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -24,8 +24,6 @@ namespace Ploeh.AutoFixture.Dsl
         ICustomizationComposer<T>,
         ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilderNode node;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="CompositeNodeComposer{T}" /> class.
@@ -42,7 +40,7 @@ namespace Ploeh.AutoFixture.Dsl
             if (node == null)
                 throw new ArgumentNullException(nameof(node));
 
-            this.node = node;
+            this.Node = node;
         }
 
         /// <summary>
@@ -426,7 +424,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.node.Create(request, context);
+            return this.Node.Create(request, context);
         }
 
         /// <summary>
@@ -438,7 +436,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.node;
+            yield return this.Node;
         }
 
         /// <summary>
@@ -456,9 +454,6 @@ namespace Ploeh.AutoFixture.Dsl
         /// <summary>Gets the encapsulated node.</summary>
         /// <value>The encapsulated node.</value>
         /// <seealso cref="CompositeNodeComposer{T}(ISpecimenBuilderNode)" />
-        public ISpecimenBuilderNode Node
-        {
-            get { return this.node; }
-        }
+        public ISpecimenBuilderNode Node { get; }
     }
 }

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -12,8 +12,6 @@ namespace Ploeh.AutoFixture.Dsl
     /// <typeparam name="T">The type of specimen to customize.</typeparam>
     public class CompositePostprocessComposer<T> : IPostprocessComposer<T>
     {
-        private readonly IEnumerable<IPostprocessComposer<T>> composers;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositePostprocessComposer&lt;T&gt;"/>
         /// class with a sequence of <see cref="IPostprocessComposer{T}"/> instances.
@@ -36,16 +34,13 @@ namespace Ploeh.AutoFixture.Dsl
                 throw new ArgumentNullException(nameof(composers));
             }
 
-            this.composers = composers;
+            this.Composers = composers;
         }
 
         /// <summary>
         /// Gets the aggregated composers.
         /// </summary>
-        public IEnumerable<IPostprocessComposer<T>> Composers
-        {
-            get { return this.composers; }
-        }
+        public IEnumerable<IPostprocessComposer<T>> Composers { get; }
 
         /// <summary>
         /// Performs the specified action on a specimen.
@@ -57,7 +52,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> Do(Action<T> action)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.Do(action));
         }
 
@@ -70,7 +65,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> OmitAutoProperties()
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.OmitAutoProperties());
         }
 
@@ -89,7 +84,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.With(propertyPicker));
         }
 
@@ -112,7 +107,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.With(propertyPicker, value));
         }
 
@@ -125,7 +120,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> WithAutoProperties()
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.WithAutoProperties());
         }
 
@@ -143,7 +138,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.Without(propertyPicker));
         }
 
@@ -167,7 +162,7 @@ namespace Ploeh.AutoFixture.Dsl
         public object Create(object request, ISpecimenContext context)
         {
             return new CompositeSpecimenBuilder(
-                this.composers.Cast<ISpecimenBuilder>())
+                this.Composers.Cast<ISpecimenBuilder>())
                 .Create(
                     request,
                     context);

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -33,7 +33,7 @@ namespace Ploeh.AutoFixture.Dsl
         {
             if (composers == null)
             {
-                throw new ArgumentNullException("composers");
+                throw new ArgumentNullException(nameof(composers));
             }
 
             this.composers = composers;

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -16,8 +16,6 @@ namespace Ploeh.AutoFixture.Dsl
         ICustomizationComposer<T>,
         ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NodeComposer{T}" />
         /// class.
@@ -35,7 +33,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// <seealso cref="Builder" />
         public NodeComposer(ISpecimenBuilder builder)
         {
-            this.builder = builder;
+            this.Builder = builder;
         }
 
         /// <summary>
@@ -493,7 +491,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.builder.Create(request, context);
+            return this.Builder.Create(request, context);
         }
 
         /// <summary>
@@ -505,7 +503,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         /// <summary>
@@ -523,10 +521,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// <summary>Gets the encapsulated builder.</summary>
         /// <value>The encapsulated builder.</value>
         /// <seealso cref="NodeComposer{T}(ISpecimenBuilder)" />
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         private ISpecimenBuilderNode WithoutSeedIgnoringRelay()
         {

--- a/Src/AutoFixture/Dsl/NullComposer.cs
+++ b/Src/AutoFixture/Dsl/NullComposer.cs
@@ -40,7 +40,7 @@ namespace Ploeh.AutoFixture.Dsl
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             this.compose = () => builder;
@@ -57,7 +57,7 @@ namespace Ploeh.AutoFixture.Dsl
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             this.compose = factory;

--- a/Src/AutoFixture/ElementsBuilder.cs
+++ b/Src/AutoFixture/ElementsBuilder.cs
@@ -28,12 +28,12 @@ namespace Ploeh.AutoFixture
         public ElementsBuilder(IEnumerable<T> elements)
         {
             if (elements == null)
-                throw new ArgumentNullException("elements");
+                throw new ArgumentNullException(nameof(elements));
 
             this.elements = elements.ToArray();
 
             if (this.elements.Length < 1)
-                throw new ArgumentException("The supplied collection of elements must contain at least one element. This collection is expected to contain the elements from which the randomized algorithm will draw; if the collection is empty, there are no elements to draw.", "elements");
+                throw new ArgumentException("The supplied collection of elements must contain at least one element. This collection is expected to contain the elements from which the randomized algorithm will draw; if the collection is empty, there are no elements to draw.", nameof(elements));
 
             //The RandomNumericSequenceGenerator is only created for collections of minimum 2 elements
             if (this.elements.Length > 1)

--- a/Src/AutoFixture/EmailAddressLocalPart.cs
+++ b/Src/AutoFixture/EmailAddressLocalPart.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixture
         {
             if (localPart == null)
             {
-                throw new ArgumentNullException("localPart");
+                throw new ArgumentNullException(nameof(localPart));
             }
 
             if (localPart.Length == 0)

--- a/Src/AutoFixture/EmailAddressLocalPart.cs
+++ b/Src/AutoFixture/EmailAddressLocalPart.cs
@@ -13,8 +13,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class EmailAddressLocalPart
     {
-        private readonly string localPart;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="EmailAddressLocalPart"/> class. Throws ArgumentNullException
         /// if localPart is null.  Throws ArgumentException if localPart is empty.
@@ -32,16 +30,13 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentException("localPart cannot be empty");
             }
 
-            this.localPart = localPart;
+            this.LocalPart = localPart;
         }
 
         /// <summary>
         /// Get the local part.
         /// </summary>
-        public string LocalPart
-        {
-            get { return this.localPart; }
-        }
+        public string LocalPart { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
@@ -60,7 +55,7 @@ namespace Ploeh.AutoFixture
             var other = obj as EmailAddressLocalPart;
             if (other != null)
             {
-                return this.localPart.Equals(other.localPart);
+                return this.LocalPart.Equals(other.LocalPart);
             }
 
             return base.Equals(obj);
@@ -75,7 +70,7 @@ namespace Ploeh.AutoFixture
         /// </returns>
         public override int GetHashCode()
         {
-            return this.localPart.GetHashCode();
+            return this.LocalPart.GetHashCode();
         }
 
         /// <summary>
@@ -86,7 +81,7 @@ namespace Ploeh.AutoFixture
         /// </returns>
         public override string ToString()
         {
-            return this.localPart;
+            return this.LocalPart;
         }
     }
 }

--- a/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
+++ b/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (request == null || !typeof(EmailAddressLocalPart).Equals(request))

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -88,7 +88,7 @@ namespace Ploeh.AutoFixture
             {
                 if (enumType == null)
                 {
-                    throw new ArgumentNullException("enumType");
+                    throw new ArgumentNullException(nameof(enumType));
                 }
 
                 this.values = Enum.GetValues(enumType).Cast<object>();

--- a/Src/AutoFixture/EnumerableList.cs
+++ b/Src/AutoFixture/EnumerableList.cs
@@ -34,11 +34,11 @@ namespace Ploeh.AutoFixture
         internal static IEnumerable<T> SetItem<T>(this IEnumerable<T> items, int index, T item)
         {
             if (index < 0)
-                throw new ArgumentOutOfRangeException("index", string.Format(CultureInfo.CurrentCulture, "The supplied index was less than zero ({0}). Only zero and positive index numbers are supported.", index));
+                throw new ArgumentOutOfRangeException(nameof(index), string.Format(CultureInfo.CurrentCulture, "The supplied index was less than zero ({0}). Only zero and positive index numbers are supported.", index));
 
             var a = items.ToArray();
             if (a.Length <= index)
-                throw new ArgumentOutOfRangeException("index", string.Format(CultureInfo.CurrentCulture, "The supplied index ({0}) exceeds the addressable space of the current sequence. The length of the sequence is only {1}.", index, a.Length));
+                throw new ArgumentOutOfRangeException(nameof(index), string.Format(CultureInfo.CurrentCulture, "The supplied index ({0}) exceeds the addressable space of the current sequence. The length of the sequence is only {1}.", index, a.Length));
 
             return a.Take(index).Concat(new[] { item }).Concat(a.Skip(index + 1));
         }

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -136,10 +136,7 @@ namespace Ploeh.AutoFixture
         /// <summary>
         /// Gets the behaviors that wrap around the rest of the graph.
         /// </summary>
-        public IList<ISpecimenBuilderTransformation> Behaviors
-        {
-            get { return this.behaviors; }
-        }
+        public IList<ISpecimenBuilderTransformation> Behaviors => this.behaviors;
 
         /// <summary>
         /// Gets the customizations that intercept the <see cref="Engine"/>.
@@ -156,10 +153,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         /// <seealso cref="Engine"/>
         /// <seealso cref="ResidueCollectors"/>
-        public IList<ISpecimenBuilder> Customizations
-        {
-            get { return this.customizer; }
-        }
+        public IList<ISpecimenBuilder> Customizations => this.customizer;
 
         /// <summary>
         /// Gets the core engine of the <see cref="Fixture"/> instance.
@@ -255,10 +249,7 @@ namespace Ploeh.AutoFixture
         /// to deal with unresolved requests.
         /// </para>
         /// </remarks>
-        public IList<ISpecimenBuilder> ResidueCollectors
-        {
-            get { return this.residueCollector; }
-        }
+        public IList<ISpecimenBuilder> ResidueCollectors => this.residueCollector;
 
         /// <summary>
         /// Customizes the creation algorithm for a single object, effectively turning off all
@@ -406,10 +397,7 @@ namespace Ploeh.AutoFixture
             return this.GetEnumerator();
         }
 
-        private bool EnableAutoProperties
-        {
-            get { return !this.OmitAutoProperties; }
-        }
+        private bool EnableAutoProperties => !this.OmitAutoProperties;
 
         private void OnGraphChanged(object sender, SpecimenBuilderNodeEventArgs e)
         {

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -15,7 +15,6 @@ namespace Ploeh.AutoFixture
     {
         private SingletonSpecimenBuilderNodeStackAdapterCollection behaviors;
         private SpecimenBuilderNodeAdapterCollection customizer;
-        private readonly ISpecimenBuilder engine;
         private SpecimenBuilderNodeAdapterCollection residueCollector;
         private readonly MultipleRelay multiple;
 
@@ -57,7 +56,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(multiple));
             }
 
-            this.engine = engine;
+            this.Engine = engine;
             this.multiple = multiple;
 
             this.graph =
@@ -175,10 +174,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         /// <see cref="Customizations"/>
         /// <see cref="ResidueCollectors"/>
-        public ISpecimenBuilder Engine
-        {
-            get { return this.engine; }
-        }
+        public ISpecimenBuilder Engine { get; }
 
         /// <summary>
         /// Gets or sets if writable properties should generally be assigned a value when 

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -50,11 +50,11 @@ namespace Ploeh.AutoFixture
         {
             if (engine == null)
             {
-                throw new ArgumentNullException("engine");
+                throw new ArgumentNullException(nameof(engine));
             }
             if (multiple == null)
             {
-                throw new ArgumentNullException("multiple");
+                throw new ArgumentNullException(nameof(multiple));
             }
 
             this.engine = engine;
@@ -311,7 +311,7 @@ namespace Ploeh.AutoFixture
         {
             if (customization == null)
             {
-                throw new ArgumentNullException("customization");
+                throw new ArgumentNullException(nameof(customization));
             }
 
             customization.Customize(this);
@@ -335,7 +335,7 @@ namespace Ploeh.AutoFixture
         {
             if (composerTransformation == null)
             {
-                throw new ArgumentNullException("composerTransformation");
+                throw new ArgumentNullException(nameof(composerTransformation));
             }
 
             var c = composerTransformation(SpecimenBuilderNodeFactory.CreateComposer<T>().WithAutoProperties(this.EnableAutoProperties));

--- a/Src/AutoFixture/FixtureFreezer.cs
+++ b/Src/AutoFixture/FixtureFreezer.cs
@@ -32,7 +32,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var value = fixture.Create<T>();
@@ -75,7 +75,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var value = fixture.Create<T>(seed);
@@ -110,11 +110,11 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
             if (composerTransformation == null)
             {
-                throw new ArgumentNullException("composerTransformation");
+                throw new ArgumentNullException(nameof(composerTransformation));
             }
 
             var c = fixture.Build<T>();

--- a/Src/AutoFixture/FixtureRegistrar.cs
+++ b/Src/AutoFixture/FixtureRegistrar.cs
@@ -77,7 +77,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Register(() => item);
@@ -98,7 +98,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customize<T>(c => c.FromFactory(creator).OmitAutoProperties());
@@ -123,7 +123,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customize<T>(c => c.FromFactory(creator).OmitAutoProperties());
@@ -151,7 +151,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customize<T>(c => c.FromFactory(creator).OmitAutoProperties());
@@ -182,7 +182,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customize<T>(c => c.FromFactory(creator).OmitAutoProperties());
@@ -216,7 +216,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customize<T>(c => c.FromFactory(creator).OmitAutoProperties());

--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -54,12 +54,12 @@ namespace Ploeh.AutoFixture
         {
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
 
             if (matcher == null)
             {
-                throw new ArgumentNullException("matcher");
+                throw new ArgumentNullException(nameof(matcher));
             }
 
             this.targetType = targetType;
@@ -91,7 +91,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             FreezeTypeForMatchingRequests(fixture);

--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -17,9 +17,6 @@ namespace Ploeh.AutoFixture
     /// </remarks>
     public class FreezeOnMatchCustomization : ICustomization
     {
-        private readonly Type targetType;
-        private readonly IRequestSpecification matcher;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FreezeOnMatchCustomization"/> class.
         /// </summary>
@@ -62,26 +59,20 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(matcher));
             }
 
-            this.targetType = targetType;
-            this.matcher = matcher;
+            this.TargetType = targetType;
+            this.Matcher = matcher;
         }
 
         /// <summary>
         /// The <see cref="Type"/> of the frozen specimen.
         /// </summary>
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// The <see cref="IRequestSpecification"/> used to match the requests
         /// that will be satisfied by the frozen specimen.
         /// </summary>
-        public IRequestSpecification Matcher
-        {
-            get { return this.matcher; }
-        }
+        public IRequestSpecification Matcher { get; }
 
         /// <summary>
         /// Customizes the specified fixture.
@@ -103,13 +94,13 @@ namespace Ploeh.AutoFixture
                 0,
                 new FilteringSpecimenBuilder(
                     FreezeTargetType(fixture),
-                    this.matcher));
+                    this.Matcher));
         }
 
         private ISpecimenBuilder FreezeTargetType(IFixture fixture)
         {
             var context = new SpecimenContext(fixture);
-            var specimen = context.Resolve(this.targetType);
+            var specimen = context.Resolve(this.TargetType);
             return new FixedBuilder(specimen);
         }
     }

--- a/Src/AutoFixture/FreezingCustomization.cs
+++ b/Src/AutoFixture/FreezingCustomization.cs
@@ -42,12 +42,12 @@ namespace Ploeh.AutoFixture
         {
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
 
             if (registeredType == null)
             {
-                throw new ArgumentNullException("registeredType");
+                throw new ArgumentNullException(nameof(registeredType));
             }
 
             if (!registeredType.IsAssignableFrom(targetType))
@@ -92,7 +92,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var specimen = fixture.Create(

--- a/Src/AutoFixture/FreezingCustomization.cs
+++ b/Src/AutoFixture/FreezingCustomization.cs
@@ -10,9 +10,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class FreezingCustomization : ICustomization
     {
-        private readonly Type targetType;
-        private readonly Type registeredType;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FreezingCustomization"/> class.
         /// </summary>
@@ -60,26 +57,20 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentException(message);
             }
 
-            this.targetType = targetType;
-            this.registeredType = registeredType;
+            this.TargetType = targetType;
+            this.RegisteredType = registeredType;
         }
 
         /// <summary>
         /// Gets the <see cref="Type"/> to freeze.
         /// </summary>
-        public Type TargetType
-        {
-            get { return targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// Gets the <see cref="Type"/> to which the frozen <see cref="TargetType"/> value
         /// should be mapped to. Defaults to the same <see cref="Type"/> as <see cref="TargetType"/>.
         /// </summary>
-        public Type RegisteredType
-        {
-            get { return registeredType; }
-        }
+        public Type RegisteredType { get; }
 
         /// <summary>
         /// Customizes the fixture by freezing the value of <see cref="TargetType"/>.
@@ -96,13 +87,13 @@ namespace Ploeh.AutoFixture
             }
 
             var specimen = fixture.Create(
-                    this.targetType);
+                    this.TargetType);
             var fixedBuilder = new FixedBuilder(specimen);
 
             var types = new[]
                 {
-                    this.targetType,
-                    this.registeredType 
+                    this.TargetType,
+                    this.RegisteredType 
                 };
 
             var builder = new CompositeSpecimenBuilder(

--- a/Src/AutoFixture/Generator.cs
+++ b/Src/AutoFixture/Generator.cs
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture
         public Generator(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/IncrementingDateTimeCustomization.cs
+++ b/Src/AutoFixture/IncrementingDateTimeCustomization.cs
@@ -25,7 +25,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customizations.Add(new StrictlyMonotonicallyIncreasingDateTimeGenerator(DateTime.Now));

--- a/Src/AutoFixture/Kernel/AbstractTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/AbstractTypeSpecification.cs
@@ -19,7 +19,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             var type = request as Type;

--- a/Src/AutoFixture/Kernel/AndRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/AndRequestSpecification.cs
@@ -9,8 +9,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class AndRequestSpecification : IRequestSpecification
     {
-        private readonly IEnumerable<IRequestSpecification> specifications;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AndRequestSpecification"/> with the
         /// supplied specifications.
@@ -23,7 +21,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(specifications));
             }
 
-            this.specifications = specifications;
+            this.Specifications = specifications;
         }
 
         /// <summary>
@@ -39,10 +37,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the decorated specifications.
         /// </summary>
-        public IEnumerable<IRequestSpecification> Specifications
-        {
-            get { return this.specifications; }
-        }
+        public IEnumerable<IRequestSpecification> Specifications { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.
@@ -54,7 +49,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public bool IsSatisfiedBy(object request)
         {
-            return this.specifications
+            return this.Specifications
                 .Select(s => s.IsSatisfiedBy(request))
                 .DefaultIfEmpty(false)
                 .All(b => b);

--- a/Src/AutoFixture/Kernel/AndRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/AndRequestSpecification.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (specifications == null)
             {
-                throw new ArgumentNullException("specifications");
+                throw new ArgumentNullException(nameof(specifications));
             }
 
             this.specifications = specifications;

--- a/Src/AutoFixture/Kernel/AnyTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/AnyTypeSpecification.cs
@@ -19,7 +19,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             return request is Type;

--- a/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
@@ -37,7 +37,7 @@ namespace Ploeh.AutoFixture.Kernel
         public IEnumerable<IMethod> SelectMethods(Type type)
         {
             if (type == null)
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
 
             return from ci in type.GetConstructors()
                    let score = new ArrayParameterScore(ci.GetParameters())
@@ -52,7 +52,7 @@ namespace Ploeh.AutoFixture.Kernel
             public ArrayParameterScore(IEnumerable<ParameterInfo> parameters)
             {
                 if (parameters == null)
-                    throw new ArgumentNullException("parameters");
+                    throw new ArgumentNullException(nameof(parameters));
 
                 this.score = ArrayParameterScore.CalculateScore(parameters);
             }

--- a/Src/AutoFixture/Kernel/ArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/ArrayRelay.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             // This is performance-sensitive code when used repeatedly over many requests.

--- a/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
+++ b/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
@@ -35,7 +35,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (specimenType == null)
             {
-                throw new ArgumentNullException("specimenType");
+                throw new ArgumentNullException(nameof(specimenType));
             }
 
             this.getSpecimenType = s => specimenType;
@@ -130,7 +130,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (specification == null)
             {
-                throw new ArgumentNullException("specification");
+                throw new ArgumentNullException(nameof(specification));
             }
 
             this.specification = specification;
@@ -149,11 +149,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (specimen == null)
             {
-                throw new ArgumentNullException("specimen");
+                throw new ArgumentNullException(nameof(specimen));
             }
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             foreach (var pi in this.GetProperties(specimen))
@@ -184,7 +184,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             if (this.GetProperties(request).Any(pi => pi.Equals(request)))
@@ -246,9 +246,9 @@ namespace Ploeh.AutoFixture.Kernel
         public void Execute(object specimen, ISpecimenContext context)
         {
             if (specimen == null)
-                throw new ArgumentNullException("specimen");
+                throw new ArgumentNullException(nameof(specimen));
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             foreach (var pi in this.GetProperties(specimen))
             {

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -35,7 +35,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (propertyPicker == null)
             {
-                throw new ArgumentNullException("propertyPicker");
+                throw new ArgumentNullException(nameof(propertyPicker));
             }
 
             this.member = propertyPicker.GetWritableMember().Member;
@@ -56,7 +56,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (propertyPicker == null)
             {
-                throw new ArgumentNullException("propertyPicker");
+                throw new ArgumentNullException(nameof(propertyPicker));
             }
 
             this.member = propertyPicker.GetWritableMember().Member;
@@ -77,11 +77,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (propertyPicker == null)
             {
-                throw new ArgumentNullException("propertyPicker");
+                throw new ArgumentNullException(nameof(propertyPicker));
             }
             if (valueCreator == null)
             {
-                throw new ArgumentNullException("valueCreator");
+                throw new ArgumentNullException(nameof(valueCreator));
             }
 
             this.member = propertyPicker.GetWritableMember().Member;
@@ -127,11 +127,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (specimen == null)
             {
-                throw new ArgumentNullException("specimen");
+                throw new ArgumentNullException(nameof(specimen));
             }
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var bindingValue = this.createBindingValue(context);
@@ -162,7 +162,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             IEqualityComparer comparer = new MemberInfoEqualityComparer();
@@ -202,9 +202,9 @@ namespace Ploeh.AutoFixture.Kernel
         public void Execute(object specimen, ISpecimenContext context)
         {
             if (specimen == null)
-                throw new ArgumentNullException("specimen");
+                throw new ArgumentNullException(nameof(specimen));
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var bindingValue = this.createBindingValue(context);
 

--- a/Src/AutoFixture/Kernel/CollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/CollectionRelay.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             // This is performance-sensitive code when used repeatedly over many requests.

--- a/Src/AutoFixture/Kernel/CompositeConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/CompositeConstructorQuery.cs
@@ -29,7 +29,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (queries == null)
             {
-                throw new ArgumentNullException("queries");
+                throw new ArgumentNullException(nameof(queries));
             }
 
             this.queries = queries;

--- a/Src/AutoFixture/Kernel/CompositeConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/CompositeConstructorQuery.cs
@@ -10,8 +10,6 @@ namespace Ploeh.AutoFixture.Kernel
     [Obsolete("Use CompositeMethodQuery instead.", true)]
     public class CompositeConstructorQuery : IConstructorQuery
     {
-        private readonly IEnumerable<IConstructorQuery> queries;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositeConstructorQuery"/> class.
         /// </summary>
@@ -32,16 +30,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(queries));
             }
 
-            this.queries = queries;
+            this.Queries = queries;
         }
 
         /// <summary>
         /// Gets the child builders.
         /// </summary>
-        public IEnumerable<IConstructorQuery> Queries
-        {
-            get { return this.queries; }
-        }
+        public IEnumerable<IConstructorQuery> Queries { get; }
 
         /// <summary>
         /// Selects the constructors for the supplied type by delegating to <see cref="Queries"/>.

--- a/Src/AutoFixture/Kernel/CompositeMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/CompositeMethodQuery.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (queries == null)
             {
-                throw new ArgumentNullException("queries");
+                throw new ArgumentNullException(nameof(queries));
             }
             
             this.queries = queries;

--- a/Src/AutoFixture/Kernel/CompositeMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/CompositeMethodQuery.cs
@@ -9,8 +9,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class CompositeMethodQuery : IMethodQuery
     {
-        private readonly IEnumerable<IMethodQuery> queries;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositeMethodQuery"/> class.
         /// </summary>
@@ -31,16 +29,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(queries));
             }
             
-            this.queries = queries;
+            this.Queries = queries;
         }
 
         /// <summary>
         /// Gets the queries supplied through one of the constructors.
         /// </summary>
-        public IEnumerable<IMethodQuery> Queries
-        {
-            get { return this.queries; }
-        }
+        public IEnumerable<IMethodQuery> Queries { get; }
 
         /// <summary>
         /// Selects the methods for the supplied type.
@@ -49,7 +44,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>Methods for <paramref name="type"/>.</returns>
         public IEnumerable<IMethod> SelectMethods(Type type)
         {
-            return from q in this.queries
+            return from q in this.Queries
                    from m in q.SelectMethods(type)
                    select m;
         }

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builders == null)
             {
-                throw new ArgumentNullException("builders");
+                throw new ArgumentNullException(nameof(builders));
             }
 
             this.composedBuilders = builders;

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -40,10 +40,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the child builders.
         /// </summary>
-        public IEnumerable<ISpecimenBuilder> Builders
-        {
-            get { return this.composedBuilders; }
-        }
+        public IEnumerable<ISpecimenBuilder> Builders => this.composedBuilders;
 
         /// <summary>
         /// Creates a new specimen by delegating to <see cref="Builders"/>.

--- a/Src/AutoFixture/Kernel/CompositeSpecimenCommand.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenCommand.cs
@@ -36,10 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the child commands.
         /// </summary>
-        public IEnumerable<ISpecimenCommand> Commands
-        {
-            get { return commands; }
-        }
+        public IEnumerable<ISpecimenCommand> Commands => commands;
 
         /// <summary>
         /// Executes all child commands using a given specimen and context.

--- a/Src/AutoFixture/Kernel/CompositeSpecimenCommand.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenCommand.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <param name="commands">The child commands.</param>
         public CompositeSpecimenCommand(params ISpecimenCommand[] commands)
         {
-            if (commands == null) throw new ArgumentNullException("commands");
+            if (commands == null) throw new ArgumentNullException(nameof(commands));
 
             this.commands = commands;
         }

--- a/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
+++ b/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
@@ -7,9 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class ConstrainedStringRequest : IEquatable<ConstrainedStringRequest>
     {
-        private readonly int maximumLength;
-        private readonly int minimumLength;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstrainedStringRequest"/> class.
         /// </summary>
@@ -32,8 +29,8 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentOutOfRangeException(nameof(maximumLength), "Maximum length must be equal or greater than Minimum length.");
             }
 
-            this.minimumLength = minimumLength;
-            this.maximumLength = maximumLength;
+            this.MinimumLength = minimumLength;
+            this.MaximumLength = maximumLength;
         }
 
         /// <summary>
@@ -48,24 +45,12 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the minimum length.
         /// </summary>
-        public int MinimumLength
-        {
-            get
-            {
-                return this.minimumLength;
-            }
-        }
+        public int MinimumLength { get; }
 
         /// <summary>
         /// Gets the maximum length.
         /// </summary>
-        public int MaximumLength
-        {
-            get
-            {
-                return this.maximumLength;
-            }
-        }
+        public int MaximumLength { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.

--- a/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
+++ b/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
@@ -19,17 +19,17 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (minimumLength < 0)
             {
-                throw new ArgumentOutOfRangeException("minimumLength", "Minimum length must be equal or greater than 0.");
+                throw new ArgumentOutOfRangeException(nameof(minimumLength), "Minimum length must be equal or greater than 0.");
             }
 
             if (maximumLength < 0)
             {
-                throw new ArgumentOutOfRangeException("maximumLength", "Maximum length must be equal or greater than 0.");
+                throw new ArgumentOutOfRangeException(nameof(maximumLength), "Maximum length must be equal or greater than 0.");
             }
 
             if (maximumLength < minimumLength)
             {
-                throw new ArgumentOutOfRangeException("maximumLength", "Maximum length must be equal or greater than Minimum length.");
+                throw new ArgumentOutOfRangeException(nameof(maximumLength), "Maximum length must be equal or greater than Minimum length.");
             }
 
             this.minimumLength = minimumLength;

--- a/Src/AutoFixture/Kernel/ConstructorInvoker.cs
+++ b/Src/AutoFixture/Kernel/ConstructorInvoker.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             this.query = query;
@@ -59,7 +59,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             foreach (var ci in this.GetConstructors(request))

--- a/Src/AutoFixture/Kernel/ConstructorInvoker.cs
+++ b/Src/AutoFixture/Kernel/ConstructorInvoker.cs
@@ -11,8 +11,6 @@ namespace Ploeh.AutoFixture.Kernel
     [Obsolete("Use MethodInvoker instead.", true)]
     public class ConstructorInvoker : ISpecimenBuilder
     {
-        private readonly IConstructorQuery query;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstructorInvoker"/> class with the
         /// supplied <see cref="IConstructorQuery"/>.
@@ -27,17 +25,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(query));
             }
 
-            this.query = query;
+            this.Query = query;
         }
 
         /// <summary>
         /// Gets the <see cref="IConstructorQuery"/> that defines which constructors will be
         /// attempted.
         /// </summary>
-        public IConstructorQuery Query
-        {
-            get { return this.query; }
-        }
+        public IConstructorQuery Query { get; }
 
         /// <summary>
         /// Creates a specimen of the requested type by invoking the first constructor it can
@@ -84,7 +79,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return Enumerable.Empty<IMethod>();
             }
 
-            return this.query.SelectConstructors(requestedType);
+            return this.Query.SelectConstructors(requestedType);
         }
 
         private static bool IsValueValid(object value)

--- a/Src/AutoFixture/Kernel/ConstructorMethod.cs
+++ b/Src/AutoFixture/Kernel/ConstructorMethod.cs
@@ -22,7 +22,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (constructor == null)
             {
-                throw new ArgumentNullException("constructor");
+                throw new ArgumentNullException(nameof(constructor));
             }
 
             this.constructor = constructor;

--- a/Src/AutoFixture/Kernel/ConstructorMethod.cs
+++ b/Src/AutoFixture/Kernel/ConstructorMethod.cs
@@ -11,7 +11,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class ConstructorMethod : IMethod, IEquatable<ConstructorMethod>
     {
-        private readonly ConstructorInfo constructor;
         private readonly ParameterInfo[] paramInfos;
 
         /// <summary>
@@ -25,17 +24,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(constructor));
             }
 
-            this.constructor = constructor;
-            this.paramInfos = this.constructor.GetParameters();
+            this.Constructor = constructor;
+            this.paramInfos = this.Constructor.GetParameters();
         }
 
         /// <summary>
         /// Gets the constructor.
         /// </summary>
-        public ConstructorInfo Constructor
-        {
-            get { return this.constructor; }
-        }
+        public ConstructorInfo Constructor { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
@@ -110,7 +106,7 @@ This will cause AutoFixture to create an instance of TestDouble every time Abstr
                                 );
 
             }
-            return this.constructor.Invoke(parameters.ToArray());
+            return this.Constructor.Invoke(parameters.ToArray());
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/ConstructorMethod.cs
+++ b/Src/AutoFixture/Kernel/ConstructorMethod.cs
@@ -66,10 +66,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets information about the parameters of the method.
         /// </summary>
-        public IEnumerable<ParameterInfo> Parameters
-        {
-            get { return this.paramInfos; }
-        }
+        public IEnumerable<ParameterInfo> Parameters => this.paramInfos;
 
         /// <summary>
         /// Invokes the method with the supplied parameters.

--- a/Src/AutoFixture/Kernel/Criterion.cs
+++ b/Src/AutoFixture/Kernel/Criterion.cs
@@ -25,9 +25,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </remarks>
     public class Criterion<T> : IEquatable<T>
     {
-        private readonly T target;
-        private readonly IEqualityComparer<T> comparer;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Criterion{T}" />
         /// class.
@@ -50,8 +47,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            this.target = target;
-            this.comparer = comparer;
+            this.Target = target;
+            this.Comparer = comparer;
         }
 
         /// <summary>
@@ -76,7 +73,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </remarks>
         public bool Equals(T other)
         {
-            return this.comparer.Equals(this.target, other);
+            return this.Comparer.Equals(this.Target, other);
         }
 
         /// <summary>
@@ -92,26 +89,20 @@ namespace Ploeh.AutoFixture.Kernel
             var other = obj as Criterion<T>;
             if (other == null)
                 return base.Equals(obj);
-            return object.Equals(this.target, other.target)
-                && object.Equals(this.comparer, other.comparer);
+            return object.Equals(this.Target, other.Target)
+                && object.Equals(this.Comparer, other.Comparer);
         }
 
         /// <summary>
         /// The desired target value, as supplied via the constructor.
         /// </summary>
-        public T Target
-        {
-            get { return this.target; }
-        }
+        public T Target { get; }
 
         /// <summary>
         /// The comparison method used to compare <see cref="Target" /> to
         /// candidates.
         /// </summary>
-        public IEqualityComparer<T> Comparer
-        {
-            get { return this.comparer; }
-        }
+        public IEqualityComparer<T> Comparer { get; }
 
         /// <summary>
         /// Returns the hash code for the object.
@@ -119,7 +110,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
-            return this.target.GetHashCode() ^ this.comparer.GetHashCode();
+            return this.Target.GetHashCode() ^ this.Comparer.GetHashCode();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/Criterion.cs
+++ b/Src/AutoFixture/Kernel/Criterion.cs
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixture.Kernel
         public Criterion(T target, IEqualityComparer<T> comparer)
         {
             if (comparer == null)
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
 
             this.target = target;
             this.comparer = comparer;

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -25,7 +25,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var delegateType = request as Type;

--- a/Src/AutoFixture/Kernel/DictionaryRelay.cs
+++ b/Src/AutoFixture/Kernel/DictionaryRelay.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             // This is performance-sensitive code when used repeatedly over many requests.

--- a/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
@@ -8,8 +8,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class DirectBaseTypeSpecification : IRequestSpecification
     {
-        private readonly Type targetType;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DirectBaseTypeSpecification"/> class.
         /// </summary>
@@ -27,17 +25,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(targetType));
             }
 
-            this.targetType = targetType;
+            this.TargetType = targetType;
         }
 
         /// <summary>
         /// The <see cref="Type"/> from which
         /// the requested type should directly inherit.
         /// </summary>
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.
@@ -71,12 +66,12 @@ namespace Ploeh.AutoFixture.Kernel
 
         private bool IsSameAsTargetType(object request)
         {
-            return (Type)request == this.targetType;
+            return (Type)request == this.TargetType;
         }
 
         private bool IsDirectBaseOfTargetType(object request)
         {
-            return (Type)request == this.targetType.BaseType;
+            return (Type)request == this.TargetType.BaseType;
         }
     }
 }

--- a/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
 
             this.targetType = targetType;
@@ -51,7 +51,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             return IsRequestForType(request) &&

--- a/Src/AutoFixture/Kernel/DisposableTracker.cs
+++ b/Src/AutoFixture/Kernel/DisposableTracker.cs
@@ -61,10 +61,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// method.
         /// </para>
         /// </remarks>
-        public IEnumerable<IDisposable> Disposables
-        {
-            get { return this.disposables; }
-        }
+        public IEnumerable<IDisposable> Disposables => this.disposables;
 
         /// <summary>
         /// Creates a new specimen based on a request.

--- a/Src/AutoFixture/Kernel/DisposableTracker.cs
+++ b/Src/AutoFixture/Kernel/DisposableTracker.cs
@@ -18,7 +18,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class DisposableTracker : ISpecimenBuilderNode, IDisposable
     {
-        private readonly ISpecimenBuilder builder;
         private readonly HashSet<IDisposable> disposables;
 
         /// <summary>
@@ -38,7 +37,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            this.builder = builder;
+            this.Builder = builder;
             this.disposables = new HashSet<IDisposable>();
         }
 
@@ -51,10 +50,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </para>
         /// </remarks>
         /// <seealso cref="DisposableTracker(ISpecimenBuilder)"/>
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>
         /// Gets the disposable specimens currently tracked by this instance.
@@ -121,7 +117,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/DisposableTracker.cs
+++ b/Src/AutoFixture/Kernel/DisposableTracker.cs
@@ -35,7 +35,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             this.builder = builder;

--- a/Src/AutoFixture/Kernel/DisposableTrackingBehavior.cs
+++ b/Src/AutoFixture/Kernel/DisposableTrackingBehavior.cs
@@ -25,10 +25,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// invoked, a new <see cref="DisposableTracker"/> instance is created and added to this
         /// list.
         /// </summary>
-        public IEnumerable<DisposableTracker> Trackers
-        {
-            get { return this.trackers; }
-        }
+        public IEnumerable<DisposableTracker> Trackers => this.trackers;
 
         /// <summary>
         /// Decorates the supplied builder with a <see cref="DisposableTracker"/>.

--- a/Src/AutoFixture/Kernel/EnumerableFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/EnumerableFavoringConstructorQuery.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return from ci in type.GetConstructors()

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -32,7 +32,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             // This is performance-sensitive code when used repeatedly over many requests.
@@ -74,7 +74,7 @@ namespace Ploeh.AutoFixture.Kernel
             {
                 if (enumerable == null)
                 {
-                    throw new ArgumentNullException("enumerable");
+                    throw new ArgumentNullException(nameof(enumerable));
                 }
 
                 this.enumerable = enumerable;

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var t = request as Type;
             if (t == null)
@@ -62,7 +62,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var t = request as Type;
             if (t == null)

--- a/Src/AutoFixture/Kernel/EqualRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/EqualRequestSpecification.cs
@@ -45,9 +45,9 @@ namespace Ploeh.AutoFixture.Kernel
             IEqualityComparer comparer)
         {
             if (target == null)
-                throw new ArgumentNullException("target");
+                throw new ArgumentNullException(nameof(target));
             if (comparer == null)
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
 
             this.target = target;
             this.comparer = comparer;

--- a/Src/AutoFixture/Kernel/EqualRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/EqualRequestSpecification.cs
@@ -11,9 +11,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class EqualRequestSpecification : IRequestSpecification
     {
-        private readonly object target;
-        private readonly IEqualityComparer comparer;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="EqualRequestSpecification" /> class.
@@ -49,8 +46,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            this.target = target;
-            this.comparer = comparer;
+            this.Target = target;
+            this.Comparer = comparer;
         }
 
         /// <summary>
@@ -64,7 +61,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public bool IsSatisfiedBy(object request)
         {
-            return this.comparer.Equals(this.target, request);
+            return this.Comparer.Equals(this.Target, request);
         }
 
         /// <summary>
@@ -75,10 +72,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </value>
         /// <seealso cref="EqualRequestSpecification(object)" />
         /// <seealso cref="EqualRequestSpecification(object, IEqualityComparer)" />
-        public object Target
-        {
-            get { return this.target; }
-        }
+        public object Target { get; }
 
         /// <summary>
         /// Gets the equality comparer used to compare a request to the
@@ -88,9 +82,6 @@ namespace Ploeh.AutoFixture.Kernel
         /// The equality comparer, optionally supplied via a constructor.
         /// </value>
         /// <seealso cref="EqualRequestSpecification(object, IEqualityComparer)" />
-        public IEqualityComparer Comparer 
-        {
-            get { return this.comparer; }
-        }
+        public IEqualityComparer Comparer { get; }
     }
 }

--- a/Src/AutoFixture/Kernel/ExactTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/ExactTypeSpecification.cs
@@ -7,8 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class ExactTypeSpecification : IRequestSpecification
     {
-        private readonly Type targetType;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ExactTypeSpecification"/> class.
         /// </summary>
@@ -20,16 +18,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            this.targetType = type;
+            this.TargetType = type;
         }
 
         /// <summary>
         /// Gets the type targeted by this <see cref="IRequestSpecification"/>.
         /// </summary>
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.
@@ -46,7 +41,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(request));
             }
 
-            return this.targetType.Equals(request);
+            return this.TargetType.Equals(request);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ExactTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/ExactTypeSpecification.cs
@@ -17,7 +17,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             this.targetType = type;
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             return this.targetType.Equals(request);

--- a/Src/AutoFixture/Kernel/ExpressionReflector.cs
+++ b/Src/AutoFixture/Kernel/ExpressionReflector.cs
@@ -13,12 +13,12 @@ namespace Ploeh.AutoFixture.Kernel
             if (me == null)
                 me = propertyPicker.TryUnwrapConversion();
             if (me == null)
-                throw new ArgumentException("The expression's Body is not a MemberExpression. Most likely this is because it does not represent access to a property or field.", "propertyPicker");
+                throw new ArgumentException("The expression's Body is not a MemberExpression. Most likely this is because it does not represent access to a property or field.", nameof(propertyPicker));
 
             var pi = me.Member as PropertyInfo;
             if (pi != null && pi.GetSetMethod() == null)
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "The property \"{0}\" is read-only.", pi.Name), "propertyPicker");
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "The property \"{0}\" is read-only.", pi.Name), nameof(propertyPicker));
             }
             return me;
         }

--- a/Src/AutoFixture/Kernel/FactoryMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/FactoryMethodQuery.cs
@@ -33,7 +33,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return from mi in type.GetMethods(BindingFlags.Static | BindingFlags.Public)

--- a/Src/AutoFixture/Kernel/FieldRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/FieldRequestRelay.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var fieldInfo = request as FieldInfo;

--- a/Src/AutoFixture/Kernel/FieldSpecification.cs
+++ b/Src/AutoFixture/Kernel/FieldSpecification.cs
@@ -41,9 +41,9 @@ namespace Ploeh.AutoFixture.Kernel
             string targetName)
         {
             if (targetType == null)
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             if (targetName == null)
-                throw new ArgumentNullException("targetName");
+                throw new ArgumentNullException(nameof(targetName));
 
             return new FieldTypeAndNameCriterion(
                 new Criterion<Type>(
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture.Kernel
         public FieldSpecification(IEquatable<FieldInfo> target)
         {
             if (target == null)
-                throw new ArgumentNullException("target");
+                throw new ArgumentNullException(nameof(target));
 
             this.target = target;
         }
@@ -103,7 +103,7 @@ namespace Ploeh.AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             if (request == null)
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
 
             var f = request as FieldInfo;
             if (f == null)

--- a/Src/AutoFixture/Kernel/FieldSpecification.cs
+++ b/Src/AutoFixture/Kernel/FieldSpecification.cs
@@ -11,6 +11,8 @@ namespace Ploeh.AutoFixture.Kernel
     public class FieldSpecification : IRequestSpecification
     {
         private readonly IEquatable<FieldInfo> target;
+        private readonly Type targetType;
+        private readonly string targetName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldSpecification"/> class.
@@ -30,8 +32,8 @@ namespace Ploeh.AutoFixture.Kernel
         public FieldSpecification(Type targetType, string targetName)
             : this(CreateDefaultTarget(targetType, targetName))
         {
-            this.TargetType = targetType;
-            this.TargetName = targetName;
+            this.targetType = targetType;
+            this.targetName = targetName;
         }
 
         private static IEquatable<FieldInfo> CreateDefaultTarget(
@@ -74,15 +76,23 @@ namespace Ploeh.AutoFixture.Kernel
         /// The <see cref="Type"/> with which the requested
         /// <see cref="FieldInfo"/> type should be compatible.
         /// </summary>
+        /// <remarks>
+        /// This property is not a getter-only auto-property as Release 
+        /// builds will generate an error due to the Obsolete attribute.
+        /// </remarks>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public Type TargetType { get; }
+        public Type TargetType => targetType;
 
         /// <summary>
         /// The name which the requested <see cref="FieldInfo"/> name
         /// should match exactly.
         /// </summary>
+        /// <remarks>
+        /// This property is not a getter-only auto-property as Release 
+        /// builds will generate an error due to the Obsolete attribute.
+        /// </remarks>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public string TargetName { get; }
+        public string TargetName => targetName;
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/FieldSpecification.cs
+++ b/Src/AutoFixture/Kernel/FieldSpecification.cs
@@ -10,8 +10,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class FieldSpecification : IRequestSpecification
     {
-        private readonly Type targetType;
-        private readonly string targetName;
         private readonly IEquatable<FieldInfo> target;
 
         /// <summary>
@@ -32,8 +30,8 @@ namespace Ploeh.AutoFixture.Kernel
         public FieldSpecification(Type targetType, string targetName)
             : this(CreateDefaultTarget(targetType, targetName))
         {
-            this.targetType = targetType;
-            this.targetName = targetName;
+            this.TargetType = targetType;
+            this.TargetName = targetName;
         }
 
         private static IEquatable<FieldInfo> CreateDefaultTarget(
@@ -77,20 +75,14 @@ namespace Ploeh.AutoFixture.Kernel
         /// <see cref="FieldInfo"/> type should be compatible.
         /// </summary>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// The name which the requested <see cref="FieldInfo"/> name
         /// should match exactly.
         /// </summary>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public string TargetName
-        {
-            get { return this.targetName; }
-        }
+        public string TargetName { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
@@ -21,9 +21,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// <seealso cref="PropertyTypeAndNameCriterion" />
     public class FieldTypeAndNameCriterion : IEquatable<FieldInfo>
     {
-        private readonly IEquatable<Type> typeCriterion;
-        private readonly IEquatable<string> nameCriterion;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="FieldTypeAndNameCriterion" /> class with the desired
@@ -48,8 +45,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (nameCriterion == null)
                 throw new ArgumentNullException(nameof(nameCriterion));
 
-            this.typeCriterion = typeCriterion;
-            this.nameCriterion = nameCriterion;
+            this.TypeCriterion = typeCriterion;
+            this.NameCriterion = nameCriterion;
         }
 
         /// <summary>
@@ -77,25 +74,19 @@ namespace Ploeh.AutoFixture.Kernel
             if (other == null)
                 return false;
 
-            return this.typeCriterion.Equals(other.FieldType)
-                && this.nameCriterion.Equals(other.Name);
+            return this.TypeCriterion.Equals(other.FieldType)
+                && this.NameCriterion.Equals(other.Name);
         }
 
         /// <summary>
         /// The type criterion originally passed in via the class' constructor.
         /// </summary>
-        public IEquatable<Type> TypeCriterion
-        {
-            get { return this.typeCriterion; }
-        }
+        public IEquatable<Type> TypeCriterion { get; }
 
         /// <summary>
         /// The name criterion originally passed in via the class' constructor.
         /// </summary>
-        public IEquatable<string> NameCriterion
-        {
-            get { return this.nameCriterion; }
-        }
+        public IEquatable<string> NameCriterion { get; }
 
         /// <summary>
         /// Determines whether this object is equal to another object.
@@ -112,8 +103,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (other == null)
                 return base.Equals(obj);
 
-            return object.Equals(this.typeCriterion, other.typeCriterion)
-                && object.Equals(this.nameCriterion, other.nameCriterion);
+            return object.Equals(this.TypeCriterion, other.TypeCriterion)
+                && object.Equals(this.NameCriterion, other.NameCriterion);
         }
 
         /// <summary>
@@ -123,8 +114,8 @@ namespace Ploeh.AutoFixture.Kernel
         public override int GetHashCode()
         {
             return 
-                this.typeCriterion.GetHashCode() ^
-                this.nameCriterion.GetHashCode();
+                this.TypeCriterion.GetHashCode() ^
+                this.NameCriterion.GetHashCode();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
@@ -44,9 +44,9 @@ namespace Ploeh.AutoFixture.Kernel
             IEquatable<string> nameCriterion)
         {
             if (typeCriterion == null)
-                throw new ArgumentNullException("typeCriterion");
+                throw new ArgumentNullException(nameof(typeCriterion));
             if (nameCriterion == null)
-                throw new ArgumentNullException("nameCriterion");
+                throw new ArgumentNullException(nameof(nameCriterion));
 
             this.typeCriterion = typeCriterion;
             this.nameCriterion = nameCriterion;

--- a/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
@@ -24,11 +24,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }        
             if (specification == null)
             {
-                throw new ArgumentNullException("specification");
+                throw new ArgumentNullException(nameof(specification));
             }
 
             this.builder = builder;

--- a/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
@@ -10,9 +10,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class FilteringSpecimenBuilder : ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-        private readonly IRequestSpecification specification;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FilteringSpecimenBuilder"/> class.
         /// </summary>
@@ -31,26 +28,20 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(specification));
             }
 
-            this.builder = builder;
-            this.specification = specification;
+            this.Builder = builder;
+            this.Specification = specification;
         }
 
         /// <summary>
         /// Gets the decorated builder.
         /// </summary>
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>
         /// Gets the specification that determines whether <see cref="Builder"/> will be invoked or
         /// not.
         /// </summary>
-        public IRequestSpecification Specification
-        {
-            get { return this.specification; }
-        }
+        public IRequestSpecification Specification { get; }
 
         /// <summary>
         /// Creates a new specimen based on a request.
@@ -63,14 +54,14 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (!this.specification.IsSatisfiedBy(request))
+            if (!this.Specification.IsSatisfiedBy(request))
             {
 #pragma warning disable 618
                 return new NoSpecimen(request);
 #pragma warning restore 618
             }
 
-            return this.builder.Create(request, context);
+            return this.Builder.Create(request, context);
         }
 
         /// <summary>Composes the supplied builders.</summary>
@@ -82,7 +73,7 @@ namespace Ploeh.AutoFixture.Kernel
         public virtual ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
             var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-            return new FilteringSpecimenBuilder(composedBuilder, this.specification);
+            return new FilteringSpecimenBuilder(composedBuilder, this.Specification);
         }
 
         /// <summary>
@@ -94,7 +85,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
@@ -29,7 +29,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var manyRequest = request as FiniteSequenceRequest;

--- a/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
@@ -22,11 +22,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
             if (count < 0)
             {
-                throw new ArgumentOutOfRangeException("count", string.Format(CultureInfo.CurrentCulture, "The requested count must be a positive number (or zero), but was {0}.", count));
+                throw new ArgumentOutOfRangeException(nameof(count), string.Format(CultureInfo.CurrentCulture, "The requested count must be a positive number (or zero), but was {0}.", count));
             }        
 
             this.request = request;

--- a/Src/AutoFixture/Kernel/GenericMethod.cs
+++ b/Src/AutoFixture/Kernel/GenericMethod.cs
@@ -10,9 +10,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class GenericMethod : IMethod
     {
-        private readonly MethodInfo method;
         private readonly ParameterInfo[] parametersInfo;
-        private readonly IMethodFactory factory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericMethod"/> class.
@@ -30,8 +28,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (factory == null)
                 throw new ArgumentNullException(nameof(factory));
 
-            this.method = method;
-            this.factory = factory;
+            this.Method = method;
+            this.Factory = factory;
             this.parametersInfo = method.GetParameters();
         }
 
@@ -46,19 +44,13 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets information about the method.
         /// </summary>
-        public MethodInfo Method
-        {
-            get { return method; }
-        }
+        public MethodInfo Method { get; }
 
         /// <summary>
         /// Gets information about the factory to create <see cref="IMethod" /> from
         /// <see cref="MethodInfo" />
         /// </summary>
-        public IMethodFactory Factory
-        {
-            get { return factory; }
-        }
+        public IMethodFactory Factory { get; }
 
         private static IEnumerable<Tuple<Type, Type>> ResolveGenericType(Type argument, Type parameter)
         {

--- a/Src/AutoFixture/Kernel/GenericMethod.cs
+++ b/Src/AutoFixture/Kernel/GenericMethod.cs
@@ -36,10 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets information about the parameters of the method.
         /// </summary>
-        public IEnumerable<ParameterInfo> Parameters
-        {
-            get { return this.parametersInfo; }
-        }
+        public IEnumerable<ParameterInfo> Parameters => this.parametersInfo;
 
         /// <summary>
         /// Gets information about the method.

--- a/Src/AutoFixture/Kernel/GenericMethod.cs
+++ b/Src/AutoFixture/Kernel/GenericMethod.cs
@@ -25,10 +25,10 @@ namespace Ploeh.AutoFixture.Kernel
         public GenericMethod(MethodInfo method, IMethodFactory factory)
         {
             if (method == null)
-                throw new ArgumentNullException("method");
+                throw new ArgumentNullException(nameof(method));
 
             if (factory == null)
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
 
             this.method = method;
             this.factory = factory;

--- a/Src/AutoFixture/Kernel/GreedyConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/GreedyConstructorQuery.cs
@@ -33,7 +33,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return from ci in type.GetConstructors()

--- a/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
+++ b/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
@@ -9,8 +9,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class ImplementedInterfaceSpecification : IRequestSpecification
     {
-        private readonly Type targetType;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ImplementedInterfaceSpecification"/> class.
         /// </summary>
@@ -28,17 +26,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(targetType));
             }
 
-            this.targetType = targetType;
+            this.TargetType = targetType;
         }
 
         /// <summary>
         /// The interface <see cref="Type"/> which
         /// the requested type should implement.
         /// </summary>
-        public Type TargetType
-        {
-            get { return targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.
@@ -72,12 +67,12 @@ namespace Ploeh.AutoFixture.Kernel
 
         private bool IsSameAsTargetType(object request)
         {
-            return (Type)request == this.targetType;
+            return (Type)request == this.TargetType;
         }
 
         private bool IsInterfaceImplementedByTargetType(object request)
         {
-            return this.targetType
+            return this.TargetType
                        .GetInterfaces()
                        .Contains((Type)request);
         }

--- a/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
+++ b/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
@@ -25,7 +25,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
 
             this.targetType = targetType;
@@ -52,7 +52,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             return IsRequestForType(request) &&

--- a/Src/AutoFixture/Kernel/InstanceMethod.cs
+++ b/Src/AutoFixture/Kernel/InstanceMethod.cs
@@ -91,10 +91,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets information about the parameters of the method.
         /// </summary>
-        public IEnumerable<ParameterInfo> Parameters
-        {
-            get { return this.paramInfos; }
-        }
+        public IEnumerable<ParameterInfo> Parameters => this.paramInfos;
 
         /// <summary>
         /// Invokes the method with the supplied parameters.

--- a/Src/AutoFixture/Kernel/InstanceMethod.cs
+++ b/Src/AutoFixture/Kernel/InstanceMethod.cs
@@ -33,11 +33,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (instanceMethod == null)
             {
-                throw new ArgumentNullException("instanceMethod");
+                throw new ArgumentNullException(nameof(instanceMethod));
             }
             if (owner == null)
             {
-                throw new ArgumentNullException("owner");
+                throw new ArgumentNullException(nameof(owner));
             }
 
             this.method = instanceMethod;

--- a/Src/AutoFixture/Kernel/InstanceMethod.cs
+++ b/Src/AutoFixture/Kernel/InstanceMethod.cs
@@ -11,9 +11,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class InstanceMethod : IMethod, IEquatable<InstanceMethod>
     {
-        private readonly MethodInfo method;
         private readonly ParameterInfo[] paramInfos;
-        private readonly object owner;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstanceMethod"/> class.
@@ -40,28 +38,22 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(owner));
             }
 
-            this.method = instanceMethod;
-            this.paramInfos = this.method.GetParameters();
-            this.owner = owner;
+            this.Method = instanceMethod;
+            this.paramInfos = this.Method.GetParameters();
+            this.Owner = owner;
         }
 
         /// <summary>
         /// Gets the method originally supplied through the constructor.
         /// </summary>
         /// <seealso cref="InstanceMethod(MethodInfo, object)" />
-        public MethodInfo Method
-        {
-            get { return this.method; }
-        }
+        public MethodInfo Method { get; }
 
         /// <summary>
         /// Gets the owner originally supplied through the constructor.
         /// </summary>
         /// <seealso cref="InstanceMethod(MethodInfo, object)" />
-        public object Owner
-        {
-            get { return this.owner; }
-        }
+        public object Owner { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
@@ -111,7 +103,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>The result of the method call.</returns>
         public object Invoke(IEnumerable<object> parameters)
         {
-            return this.method.Invoke(this.owner, parameters.ToArray());
+            return this.Method.Invoke(this.Owner, parameters.ToArray());
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/InverseRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/InverseRequestSpecification.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (specification == null)
             {
-                throw new ArgumentNullException("specification");
+                throw new ArgumentNullException(nameof(specification));
             }
 
             this.spec = specification;

--- a/Src/AutoFixture/Kernel/InverseRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/InverseRequestSpecification.cs
@@ -7,8 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class InverseRequestSpecification : IRequestSpecification
     {
-        private readonly IRequestSpecification spec;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InverseRequestSpecification"/> by
         /// decorating the supplied specification.
@@ -23,7 +21,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(specification));
             }
 
-            this.spec = specification;
+            this.Specification = specification;
         }
 
         /// <summary>
@@ -34,10 +32,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// This is the <see cref="IRequestSpecification"/> that will be inverted.
         /// </para>
         /// </remarks>
-        public IRequestSpecification Specification
-        {
-            get { return this.spec; }
-        }
+        public IRequestSpecification Specification { get; }
 
         /// <summary>
         /// Returns the opposite result as the decorated <see cref="IRequestSpecification"/>.
@@ -49,7 +44,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public bool IsSatisfiedBy(object request)
         {
-            return !this.spec.IsSatisfiedBy(request);
+            return !this.Specification.IsSatisfiedBy(request);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ListFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ListFavoringConstructorQuery.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return from ci in type.GetConstructors()

--- a/Src/AutoFixture/Kernel/ListRelay.cs
+++ b/Src/AutoFixture/Kernel/ListRelay.cs
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var t = request as Type;
             if (t == null)

--- a/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
+++ b/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
@@ -77,7 +77,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj");
+                throw new ArgumentNullException(nameof(obj));
             }
 
             if (obj.DeclaringType == null)
@@ -113,7 +113,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj");
+                throw new ArgumentNullException(nameof(obj));
             }
 
             var mi = obj as MemberInfo;

--- a/Src/AutoFixture/Kernel/MethodInvoker.cs
+++ b/Src/AutoFixture/Kernel/MethodInvoker.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             this.query = query;
@@ -58,7 +58,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             foreach (var ci in this.GetConstructors(request))

--- a/Src/AutoFixture/Kernel/MethodInvoker.cs
+++ b/Src/AutoFixture/Kernel/MethodInvoker.cs
@@ -10,8 +10,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class MethodInvoker : ISpecimenBuilder
     {
-        private readonly IMethodQuery query;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MethodInvoker"/> class with the supplied
         /// <see cref="IMethodQuery" />.
@@ -26,17 +24,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(query));
             }
 
-            this.query = query;
+            this.Query = query;
         }
 
         /// <summary>
         /// Gets the <see cref="IMethodQuery"/> that defines which constructors will be
         /// attempted.
         /// </summary>
-        public IMethodQuery Query
-        {
-            get { return this.query; }
-        }
+        public IMethodQuery Query { get; }
 
         /// <summary>
         /// Creates a specimen of the requested type by invoking the first constructor or method it
@@ -85,7 +80,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return Enumerable.Empty<IMethod>();
             }
 
-            return this.query.SelectMethods(requestedType);
+            return this.Query.SelectMethods(requestedType);
         }
 
         private static bool IsValueValid(object value)

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
@@ -30,10 +30,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets information about the parameters of the method.
         /// </summary>
-        public IEnumerable<ParameterInfo> Parameters
-        {
-            get { return Method.Parameters; }
-        }
+        public IEnumerable<ParameterInfo> Parameters => Method.Parameters;
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
@@ -19,7 +19,7 @@ namespace Ploeh.AutoFixture.Kernel
         public MissingParametersSupplyingMethod(IMethod method)
         {
             if (method == null)
-                throw new ArgumentNullException("method");
+                throw new ArgumentNullException(nameof(method));
 
             this.method = method;
         }

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
@@ -10,8 +10,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class MissingParametersSupplyingMethod : IMethod, IEquatable<MissingParametersSupplyingMethod>
     {
-        private readonly IMethod method;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MissingParametersSupplyingMethod"/> class.
         /// </summary>
@@ -21,16 +19,13 @@ namespace Ploeh.AutoFixture.Kernel
             if (method == null)
                 throw new ArgumentNullException(nameof(method));
 
-            this.method = method;
+            this.Method = method;
         }
 
         /// <summary>
         /// Gets the decorated method
         /// </summary>
-        public IMethod Method
-        {
-            get { return this.method; }
-        }
+        public IMethod Method { get; }
 
         /// <summary>
         /// Gets information about the parameters of the method.

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethodFactory.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethodFactory.cs
@@ -19,7 +19,7 @@ namespace Ploeh.AutoFixture.Kernel
         public MissingParametersSupplyingMethodFactory(object owner)
         {
             if (owner == null)
-                throw new ArgumentNullException("owner");
+                throw new ArgumentNullException(nameof(owner));
 
             this.owner = owner;
         }

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethodFactory.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethodFactory.cs
@@ -9,8 +9,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class MissingParametersSupplyingMethodFactory : IMethodFactory
     {
-        private readonly object owner;
-
         /// <summary>
         /// Initializes a new instance of the 
         /// <see cref="MissingParametersSupplyingMethodFactory"/> class.
@@ -21,17 +19,14 @@ namespace Ploeh.AutoFixture.Kernel
             if (owner == null)
                 throw new ArgumentNullException(nameof(owner));
 
-            this.owner = owner;
+            this.Owner = owner;
         }
 
         /// <summary>
         /// Gets the owner originally supplied through the constructor.
         /// </summary>
         /// <seealso cref="MissingParametersSupplyingMethodFactory(object)" />
-        public object Owner
-        {
-            get { return owner; }
-        }
+        public object Owner { get; }
 
         /// <summary>
         /// Creates a <see cref="InstanceMethod" /> decorated with 

--- a/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
@@ -33,7 +33,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return from ci in type.GetConstructors()

--- a/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
@@ -25,7 +25,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var arrayType = request as Type;
             if (arrayType == null || !IsMultidimensionalArray(arrayType))

--- a/Src/AutoFixture/Kernel/MultipleRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleRelay.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture.Kernel
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("value", "Count cannot be negative.");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Count cannot be negative.");
                 }
                 this.count = value;
             }
@@ -51,7 +51,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var manyRequest = request as MultipleRequest;

--- a/Src/AutoFixture/Kernel/MultipleRequest.cs
+++ b/Src/AutoFixture/Kernel/MultipleRequest.cs
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             this.request = request;

--- a/Src/AutoFixture/Kernel/MultipleRequest.cs
+++ b/Src/AutoFixture/Kernel/MultipleRequest.cs
@@ -20,8 +20,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// <seealso cref="MultipleRelay"/>
     public class MultipleRequest : IEquatable<MultipleRequest>
     {
-        private readonly object request;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MultipleRequest"/> class.
         /// </summary>
@@ -33,16 +31,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(request));
             }
 
-            this.request = request;
+            this.Request = request;
         }
 
         /// <summary>
         /// Gets the request to multiply.
         /// </summary>
-        public object Request
-        {
-            get { return this.request; }
-        }
+        public object Request { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.

--- a/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             
             var multipleRequest = request as MultipleRequest;
             if (multipleRequest == null)

--- a/Src/AutoFixture/Kernel/NoConstructorsSpecification.cs
+++ b/Src/AutoFixture/Kernel/NoConstructorsSpecification.cs
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             var type = request as Type;

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -14,8 +14,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </remarks>
     public class NoSpecimen : IEquatable<NoSpecimen>
     {
-        private readonly object request;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSpecimen"/> class with a null request.
         /// </summary>
@@ -33,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         [Obsolete("The Request property, and the constructor that populates it, is being retired in future versions of AutoFixture, as it has turned out that no one uses it. If you're seeing this warning in AutoFixture 3.x, and, despite expectations, have a real need to use the Request property, please provide feedback on https://github.com/AutoFixture/AutoFixture/issues/475 .")]
         public NoSpecimen(object request)
         {
-            this.request = request;
+            this.Request = request;
         }
 
         /// <summary>
@@ -45,10 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </para>
         /// </remarks>
         [Obsolete("The Request property is being retired in future versions of AutoFixture, as it has turned out that no one uses it. If you're seeing this warning in AutoFixture 3.x, and, despite expectations, have a real need to use the Request property, please provide feedback on https://github.com/AutoFixture/AutoFixture/issues/475 .")]
-        public object Request
-        {
-            get { return this.request; }
-        }
+        public object Request { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current

--- a/Src/AutoFixture/Kernel/NoSpecimenOutputGuard.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimenOutputGuard.cs
@@ -11,9 +11,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class NoSpecimenOutputGuard : ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-        private readonly IRequestSpecification specification;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSpecimenOutputGuard"/> class with an 
         /// <see cref="ISpecimenBuilder"/> to decorate.
@@ -42,8 +39,8 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(specification));
             }
 
-            this.builder = builder;
-            this.specification = specification;
+            this.Builder = builder;
+            this.Specification = specification;
         }
 
         /// <summary>
@@ -52,10 +49,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <value>The <see cref="ISpecimenBuilder"/> supplied via the constructor.</value>
         /// <seealso cref="NoSpecimenOutputGuard(ISpecimenBuilder)"/>
         /// <seealso cref="NoSpecimenOutputGuard(ISpecimenBuilder, IRequestSpecification)"/>
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>
         /// Gets the specification that is used to determine whether an exception should be thrown
@@ -64,10 +58,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <value>The <see cref="IRequestSpecification"/> supplied via the constructor.</value>
         /// <seealso cref="NoSpecimenOutputGuard(ISpecimenBuilder)"/>
         /// <seealso cref="NoSpecimenOutputGuard(ISpecimenBuilder, IRequestSpecification)"/>
-        public IRequestSpecification Specification
-        {
-            get { return this.specification; }
-        }
+        public IRequestSpecification Specification { get; }
 
         /// <summary>
         /// Creates a new specimen by delegating to the decorated <see cref="Builder"/>.
@@ -89,7 +80,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             var result = this.Builder.Create(request, context);
             if (result is NoSpecimen 
-                && this.specification.IsSatisfiedBy(request))
+                && this.Specification.IsSatisfiedBy(request))
             {
                 throw new ObjectCreationException(string.Format(CultureInfo.CurrentCulture, "The decorated ISpecimenBuilder could not create a specimen based on the request: {0}. This can happen if the request represents an interface or abstract class; if this is the case, register an ISpecimenBuilder that can create specimens based on the request. If this happens in a strongly typed Build<T> expression, try supplying a factory using one of the IFactoryComposer<T> methods.", request));
             }
@@ -105,7 +96,7 @@ namespace Ploeh.AutoFixture.Kernel
         public ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
             var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-            return new NoSpecimenOutputGuard(composedBuilder, this.specification);
+            return new NoSpecimenOutputGuard(composedBuilder, this.Specification);
         }
 
         /// <summary>
@@ -117,7 +108,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/NoSpecimenOutputGuard.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimenOutputGuard.cs
@@ -35,11 +35,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
             if (specification == null)
             {
-                throw new ArgumentNullException("specification");
+                throw new ArgumentNullException(nameof(specification));
             }
 
             this.builder = builder;

--- a/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
@@ -55,7 +55,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var pi = request as ParameterInfo;
             if (pi == null)

--- a/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
@@ -56,7 +56,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var pi = request as ParameterInfo;
             if (pi == null)

--- a/Src/AutoFixture/Kernel/Omitter.cs
+++ b/Src/AutoFixture/Kernel/Omitter.cs
@@ -11,8 +11,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class Omitter : ISpecimenBuilder
     {
-        private readonly IRequestSpecification specification;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Omitter" /> class.
         /// </summary>
@@ -38,7 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (specification == null)
                 throw new ArgumentNullException(nameof(specification));
 
-            this.specification = specification;
+            this.Specification = specification;
         }
 
         /// <summary>
@@ -63,7 +61,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
-            if (this.specification.IsSatisfiedBy(request))
+            if (this.Specification.IsSatisfiedBy(request))
                 return new OmitSpecimen();
 
 #pragma warning disable 618
@@ -84,9 +82,6 @@ namespace Ploeh.AutoFixture.Kernel
         /// </remarks>
         /// <seealso cref="Create" />
         /// <seealso cref="Omitter(IRequestSpecification)" />
-        public IRequestSpecification Specification
-        {
-            get { return this.specification; }
-        }
+        public IRequestSpecification Specification { get; }
     }
 }

--- a/Src/AutoFixture/Kernel/Omitter.cs
+++ b/Src/AutoFixture/Kernel/Omitter.cs
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
         public Omitter(IRequestSpecification specification)
         {
             if (specification == null)
-                throw new ArgumentNullException("specification");
+                throw new ArgumentNullException(nameof(specification));
 
             this.specification = specification;
         }
@@ -61,7 +61,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (request == null)
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
 
             if (this.specification.IsSatisfiedBy(request))
                 return new OmitSpecimen();

--- a/Src/AutoFixture/Kernel/OrRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/OrRequestSpecification.cs
@@ -39,10 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the decorated specifications.
         /// </summary>
-        public IEnumerable<IRequestSpecification> Specifications
-        {
-            get { return this.specifications; }
-        }
+        public IEnumerable<IRequestSpecification> Specifications => this.specifications;
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/OrRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/OrRequestSpecification.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (specifications == null)
             {
-                throw new ArgumentNullException("specifications");
+                throw new ArgumentNullException(nameof(specifications));
             }
 
             this.specifications = specifications;

--- a/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var paramInfo = request as ParameterInfo;

--- a/Src/AutoFixture/Kernel/ParameterScore.cs
+++ b/Src/AutoFixture/Kernel/ParameterScore.cs
@@ -13,15 +13,15 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (parentType == null)
             {
-                throw new ArgumentNullException("parentType");
+                throw new ArgumentNullException(nameof(parentType));
             }
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
             if (parameters == null)
             {
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
             }
 
             this.score = ParameterScore.CalculateScore(parentType, targetType, parameters);

--- a/Src/AutoFixture/Kernel/ParameterSpecification.cs
+++ b/Src/AutoFixture/Kernel/ParameterSpecification.cs
@@ -11,6 +11,8 @@ namespace Ploeh.AutoFixture.Kernel
     public class ParameterSpecification : IRequestSpecification
     {
         private readonly IEquatable<ParameterInfo> target;
+        private readonly string targetName;
+        private readonly Type targetType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterSpecification"/> class.
@@ -30,8 +32,8 @@ namespace Ploeh.AutoFixture.Kernel
         public ParameterSpecification(Type targetType, string targetName)
             : this(CreateDefaultTarget(targetType, targetName))
         {
-            this.TargetType = targetType;
-            this.TargetName = targetName;
+            this.targetType = targetType;
+            this.targetName = targetName;
         }
 
         private static IEquatable<ParameterInfo> CreateDefaultTarget(
@@ -75,15 +77,23 @@ namespace Ploeh.AutoFixture.Kernel
         /// The <see cref="Type"/> with which the requested
         /// <see cref="ParameterInfo"/> type should be compatible.
         /// </summary>
+        /// <remarks>
+        /// This property is not a getter-only auto-property as Release 
+        /// builds will generate an error due to the Obsolete attribute.
+        /// </remarks>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public Type TargetType { get; }
+        public Type TargetType => targetType;
 
         /// <summary>
         /// The name which the requested <see cref="ParameterInfo"/> name
         /// should match exactly.
         /// </summary>
+        /// <remarks>
+        /// This property is not a getter-only auto-property as Release 
+        /// builds will generate an error due to the Obsolete attribute.
+        /// </remarks>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public string TargetName { get; }
+        public string TargetName => targetName;
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/ParameterSpecification.cs
+++ b/Src/AutoFixture/Kernel/ParameterSpecification.cs
@@ -41,9 +41,9 @@ namespace Ploeh.AutoFixture.Kernel
             string targetName)
         {
             if (targetType == null)
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             if (targetName == null)
-                throw new ArgumentNullException("targetName");
+                throw new ArgumentNullException(nameof(targetName));
 
             return new ParameterTypeAndNameCriterion(
                 new Criterion<Type>(
@@ -68,7 +68,7 @@ namespace Ploeh.AutoFixture.Kernel
             IEquatable<ParameterInfo> target)
         {
             if (target == null)
-                throw new ArgumentNullException("target");
+                throw new ArgumentNullException(nameof(target));
 
             this.target = target;
         }
@@ -104,7 +104,7 @@ namespace Ploeh.AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             if (request == null)
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
 
             var p = request as ParameterInfo;
             if (p == null)

--- a/Src/AutoFixture/Kernel/ParameterSpecification.cs
+++ b/Src/AutoFixture/Kernel/ParameterSpecification.cs
@@ -10,8 +10,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class ParameterSpecification : IRequestSpecification
     {
-        private readonly Type targetType;
-        private readonly string targetName;
         private readonly IEquatable<ParameterInfo> target;
 
         /// <summary>
@@ -32,8 +30,8 @@ namespace Ploeh.AutoFixture.Kernel
         public ParameterSpecification(Type targetType, string targetName)
             : this(CreateDefaultTarget(targetType, targetName))
         {
-            this.targetType = targetType;
-            this.targetName = targetName;
+            this.TargetType = targetType;
+            this.TargetName = targetName;
         }
 
         private static IEquatable<ParameterInfo> CreateDefaultTarget(
@@ -78,20 +76,14 @@ namespace Ploeh.AutoFixture.Kernel
         /// <see cref="ParameterInfo"/> type should be compatible.
         /// </summary>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// The name which the requested <see cref="ParameterInfo"/> name
         /// should match exactly.
         /// </summary>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public string TargetName
-        {
-            get { return this.targetName; }
-        }
+        public string TargetName { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
@@ -21,9 +21,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// <seealso cref="PropertyTypeAndNameCriterion" />
     public class ParameterTypeAndNameCriterion : IEquatable<ParameterInfo>
     {
-        private readonly IEquatable<Type> typeCriterion;
-        private readonly IEquatable<string> nameCriterion;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="ParameterTypeAndNameCriterion" /> class with the desired
@@ -48,8 +45,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (nameCriterion == null)
                 throw new ArgumentNullException(nameof(nameCriterion));
 
-            this.typeCriterion = typeCriterion;
-            this.nameCriterion = nameCriterion;
+            this.TypeCriterion = typeCriterion;
+            this.NameCriterion = nameCriterion;
         }
 
         /// <summary>
@@ -77,25 +74,19 @@ namespace Ploeh.AutoFixture.Kernel
             if (other == null)
                 return false;
 
-            return this.typeCriterion.Equals(other.ParameterType)
-                && this.nameCriterion.Equals(other.Name);
+            return this.TypeCriterion.Equals(other.ParameterType)
+                && this.NameCriterion.Equals(other.Name);
         }
 
         /// <summary>
         /// The type criterion originally passed in via the class' constructor.
         /// </summary>
-        public IEquatable<Type> TypeCriterion
-        {
-            get { return this.typeCriterion; }
-        }
+        public IEquatable<Type> TypeCriterion { get; }
 
         /// <summary>
         /// The name criterion originally passed in via the class' constructor.
         /// </summary>
-        public IEquatable<string> NameCriterion
-        {
-            get { return this.nameCriterion; }
-        }
+        public IEquatable<string> NameCriterion { get; }
 
         /// <summary>
         /// Determines whether this object is equal to another object.
@@ -111,8 +102,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (other == null)
                 return base.Equals(obj);
 
-            return object.Equals(this.typeCriterion, other.typeCriterion)
-                && object.Equals(this.nameCriterion, other.nameCriterion);
+            return object.Equals(this.TypeCriterion, other.TypeCriterion)
+                && object.Equals(this.NameCriterion, other.NameCriterion);
         }
 
         /// <summary>
@@ -122,8 +113,8 @@ namespace Ploeh.AutoFixture.Kernel
         public override int GetHashCode()
         {
             return
-                this.typeCriterion.GetHashCode() ^
-                this.nameCriterion.GetHashCode();
+                this.TypeCriterion.GetHashCode() ^
+                this.NameCriterion.GetHashCode();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
@@ -44,9 +44,9 @@ namespace Ploeh.AutoFixture.Kernel
             IEquatable<string> nameCriterion)
         {
             if (typeCriterion == null)
-                throw new ArgumentNullException("typeCriterion");
+                throw new ArgumentNullException(nameof(typeCriterion));
             if (nameCriterion == null)
-                throw new ArgumentNullException("nameCriterion");
+                throw new ArgumentNullException(nameof(nameCriterion));
 
             this.typeCriterion = typeCriterion;
             this.nameCriterion = nameCriterion;

--- a/Src/AutoFixture/Kernel/Postprocessor.cs
+++ b/Src/AutoFixture/Kernel/Postprocessor.cs
@@ -168,15 +168,15 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
             if (action == null)
             {
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
             }
             if (specification == null)
             {
-                throw new ArgumentNullException("specification");
+                throw new ArgumentNullException(nameof(specification));
             }
 
             this.builder = builder;
@@ -208,11 +208,11 @@ namespace Ploeh.AutoFixture.Kernel
             IRequestSpecification specification)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (command == null)
-                throw new ArgumentNullException("command");
+                throw new ArgumentNullException(nameof(command));
             if (specification == null)
-                throw new ArgumentNullException("specification");
+                throw new ArgumentNullException(nameof(specification));
 
             this.builder = builder;
             this.command = command;

--- a/Src/AutoFixture/Kernel/Postprocessor.cs
+++ b/Src/AutoFixture/Kernel/Postprocessor.cs
@@ -221,10 +221,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// Gets the action to perform on created specimens.
         /// </summary>
         [Obsolete("Use the Command property instead.")]
-        public Action<T, ISpecimenContext> Action
-        {
-            get { return this.action; }
-        }
+        public Action<T, ISpecimenContext> Action => this.action;
 
         /// <summary>
         /// Gets the command, which is applied during postprocessing.

--- a/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var propertyInfo = request as PropertyInfo;

--- a/Src/AutoFixture/Kernel/PropertySpecification.cs
+++ b/Src/AutoFixture/Kernel/PropertySpecification.cs
@@ -11,8 +11,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class PropertySpecification : IRequestSpecification
     {
-        private readonly Type targetType;
-        private readonly string targetName;
         private readonly IEquatable<PropertyInfo> target;
 
         /// <summary>
@@ -33,8 +31,8 @@ namespace Ploeh.AutoFixture.Kernel
         public PropertySpecification(Type targetType, string targetName)
             : this(CreateDefaultTarget(targetType, targetName))
         {
-            this.targetType = targetType;
-            this.targetName = targetName;
+            this.TargetType = targetType;
+            this.TargetName = targetName;
         }
 
         private static IEquatable<PropertyInfo> CreateDefaultTarget(
@@ -79,20 +77,14 @@ namespace Ploeh.AutoFixture.Kernel
         /// <see cref="PropertyInfo"/> type should be compatible.
         /// </summary>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// The name which the requested <see cref="PropertyInfo"/> name
         /// should match exactly.
         /// </summary>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public string TargetName
-        {
-            get { return this.targetName; }
-        }
+        public string TargetName { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/PropertySpecification.cs
+++ b/Src/AutoFixture/Kernel/PropertySpecification.cs
@@ -12,6 +12,8 @@ namespace Ploeh.AutoFixture.Kernel
     public class PropertySpecification : IRequestSpecification
     {
         private readonly IEquatable<PropertyInfo> target;
+        private readonly Type targetType;
+        private readonly string targetName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertySpecification"/> class.
@@ -31,8 +33,8 @@ namespace Ploeh.AutoFixture.Kernel
         public PropertySpecification(Type targetType, string targetName)
             : this(CreateDefaultTarget(targetType, targetName))
         {
-            this.TargetType = targetType;
-            this.TargetName = targetName;
+            this.targetType = targetType;
+            this.targetName = targetName;
         }
 
         private static IEquatable<PropertyInfo> CreateDefaultTarget(
@@ -76,15 +78,23 @@ namespace Ploeh.AutoFixture.Kernel
         /// The <see cref="Type"/> with which the requested
         /// <see cref="PropertyInfo"/> type should be compatible.
         /// </summary>
+        /// <remarks>
+        /// This property is not a getter-only auto-property as Release 
+        /// builds will generate an error due to the Obsolete attribute.
+        /// </remarks>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public Type TargetType { get; }
+        public Type TargetType => targetType;
 
         /// <summary>
         /// The name which the requested <see cref="PropertyInfo"/> name
         /// should match exactly.
         /// </summary>
+        /// <remarks>
+        /// This property is not a getter-only auto-property as Release 
+        /// builds will generate an error due to the Obsolete attribute.
+        /// </remarks>
         [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", false)]
-        public string TargetName { get; }
+        public string TargetName => targetName;
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/PropertySpecification.cs
+++ b/Src/AutoFixture/Kernel/PropertySpecification.cs
@@ -42,9 +42,9 @@ namespace Ploeh.AutoFixture.Kernel
             string targetName)
         {
             if (targetType == null)
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             if (targetName == null)
-                throw new ArgumentNullException("targetName");
+                throw new ArgumentNullException(nameof(targetName));
 
             return new PropertyTypeAndNameCriterion(
                 new Criterion<Type>(
@@ -69,7 +69,7 @@ namespace Ploeh.AutoFixture.Kernel
         public PropertySpecification(IEquatable<PropertyInfo> target)
         {
             if (target == null)
-                throw new ArgumentNullException("target");
+                throw new ArgumentNullException(nameof(target));
 
             this.target = target;
         }
@@ -105,7 +105,7 @@ namespace Ploeh.AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             if (request == null)
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
 
             var p = request as PropertyInfo;
             if (p == null)

--- a/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
@@ -21,9 +21,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// <seealso cref="FieldTypeAndNameCriterion" />
     public class PropertyTypeAndNameCriterion : IEquatable<PropertyInfo>
     {
-        private readonly IEquatable<Type> typeCriterion;
-        private readonly IEquatable<string> nameCriterion;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="PropertyTypeAndNameCriterion" /> class with the desired
@@ -48,8 +45,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (nameCriterion == null)
                 throw new ArgumentNullException(nameof(nameCriterion));
 
-            this.typeCriterion = typeCriterion;
-            this.nameCriterion = nameCriterion;
+            this.TypeCriterion = typeCriterion;
+            this.NameCriterion = nameCriterion;
         }
 
         /// <summary>
@@ -77,8 +74,8 @@ namespace Ploeh.AutoFixture.Kernel
             if (other == null)
                 return false;
 
-            return this.typeCriterion.Equals(other.PropertyType)
-                && this.nameCriterion.Equals(other.Name);
+            return this.TypeCriterion.Equals(other.PropertyType)
+                && this.NameCriterion.Equals(other.Name);
         }
 
         /// <summary>
@@ -95,25 +92,19 @@ namespace Ploeh.AutoFixture.Kernel
             if (other == null)
                 return base.Equals(obj);
 
-            return object.Equals(this.typeCriterion, other.typeCriterion)
-                && object.Equals(this.nameCriterion, other.nameCriterion);
+            return object.Equals(this.TypeCriterion, other.TypeCriterion)
+                && object.Equals(this.NameCriterion, other.NameCriterion);
         }
 
         /// <summary>
         /// The type criterion originally passed in via the class' constructor.
         /// </summary>
-        public IEquatable<Type> TypeCriterion
-        {
-            get { return this.typeCriterion; }
-        }
+        public IEquatable<Type> TypeCriterion { get; }
 
         /// <summary>
         /// The name criterion originally passed in via the class' constructor.
         /// </summary>
-        public IEquatable<string> NameCriterion
-        {
-            get { return this.nameCriterion; }
-        }
+        public IEquatable<string> NameCriterion { get; }
 
         /// <summary>
         /// Returns the hash code for the object.
@@ -122,8 +113,8 @@ namespace Ploeh.AutoFixture.Kernel
         public override int GetHashCode()
         {
             return 
-                this.typeCriterion.GetHashCode() ^
-                this.nameCriterion.GetHashCode();
+                this.TypeCriterion.GetHashCode() ^
+                this.NameCriterion.GetHashCode();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
@@ -44,9 +44,9 @@ namespace Ploeh.AutoFixture.Kernel
             IEquatable<string> nameCriterion)
         {
             if (typeCriterion == null)
-                throw new ArgumentNullException("typeCriterion");
+                throw new ArgumentNullException(nameof(typeCriterion));
             if (nameCriterion == null)
-                throw new ArgumentNullException("nameCriterion");
+                throw new ArgumentNullException(nameof(nameCriterion));
 
             this.typeCriterion = typeCriterion;
             this.nameCriterion = nameCriterion;

--- a/Src/AutoFixture/Kernel/RangedNumberRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedNumberRequest.cs
@@ -8,10 +8,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class RangedNumberRequest : IEquatable<RangedNumberRequest>
     {
-        private readonly Type operandType;
-        private readonly object minimum;
-        private readonly object maximum;
-        
         /// <summary>
         /// Initializes a new instance of the <see cref="RangedNumberRequest"/> class.
         /// </summary>
@@ -40,9 +36,9 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be lower than Maximum.");
             }
 
-            this.operandType = operandType;
-            this.minimum = minimum;
-            this.maximum = maximum;
+            this.OperandType = operandType;
+            this.Minimum = minimum;
+            this.Maximum = maximum;
         }
 
         /// <summary>
@@ -51,35 +47,17 @@ namespace Ploeh.AutoFixture.Kernel
         /// <value>
         /// The type of the operand.
         /// </value>
-        public Type OperandType
-        {
-            get
-            {
-                return this.operandType;
-            }
-        }
+        public Type OperandType { get; }
 
         /// <summary>
         /// Gets the minimum value.
         /// </summary>
-        public object Minimum
-        {
-            get
-            {
-                return this.minimum;
-            }
-        }
+        public object Minimum { get; }
 
         /// <summary>
         /// Gets the maximum value.
         /// </summary>
-        public object Maximum
-        {
-            get
-            {
-                return this.maximum;
-            }
-        }
+        public object Maximum { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.

--- a/Src/AutoFixture/Kernel/RangedNumberRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedNumberRequest.cs
@@ -22,22 +22,22 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (operandType == null)
             {
-                throw new ArgumentNullException("operandType");
+                throw new ArgumentNullException(nameof(operandType));
             }
 
             if (minimum == null)
             {
-                throw new ArgumentNullException("minimum");
+                throw new ArgumentNullException(nameof(minimum));
             }
 
             if (maximum == null)
             {
-                throw new ArgumentNullException("maximum");
+                throw new ArgumentNullException(nameof(maximum));
             }
 
             if (((IComparable)minimum).CompareTo((IComparable)maximum) >= 0)
             {
-                throw new ArgumentOutOfRangeException("minimum", "Minimum must be lower than Maximum.");
+                throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be lower than Maximum.");
             }
 
             this.operandType = operandType;

--- a/Src/AutoFixture/Kernel/RecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/RecursionGuard.cs
@@ -93,11 +93,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
             if (comparer == null)
             {
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
             }
 
             this.builder = builder;
@@ -168,14 +168,14 @@ namespace Ploeh.AutoFixture.Kernel
             int recursionDepth)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (recursionHandler == null)
-                throw new ArgumentNullException("recursionHandler");
+                throw new ArgumentNullException(nameof(recursionHandler));
             if (comparer == null)
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
 
             if (recursionDepth < 1)
-                throw new ArgumentOutOfRangeException("recursionDepth", "Recursion depth must be greater than 0.");
+                throw new ArgumentOutOfRangeException(nameof(recursionDepth), "Recursion depth must be greater than 0.");
 
             this.builder = builder;
             this.recursionHandler = recursionHandler;

--- a/Src/AutoFixture/Kernel/RecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/RecursionGuard.cs
@@ -14,10 +14,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class RecursionGuard : ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-        private readonly IRecursionHandler recursionHandler;
-        private readonly IEqualityComparer comparer;
-
         private readonly ConcurrentDictionary<Thread, Stack<object>>
             _requestsByThread = new ConcurrentDictionary<Thread, Stack<object>>();
 
@@ -25,8 +21,6 @@ namespace Ploeh.AutoFixture.Kernel
         {
             return _requestsByThread.GetOrAdd(Thread.CurrentThread, _ => new Stack<object>());
         }
-
-        private readonly int recursionDepth;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RecursionGuard"/> class.
@@ -100,9 +94,9 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(comparer));
             }
 
-            this.builder = builder;
-            this.comparer = comparer;
-            this.recursionDepth = 1;
+            this.Builder = builder;
+            this.Comparer = comparer;
+            this.RecursionDepth = 1;
         }
 
         /// <summary>
@@ -177,10 +171,10 @@ namespace Ploeh.AutoFixture.Kernel
             if (recursionDepth < 1)
                 throw new ArgumentOutOfRangeException(nameof(recursionDepth), "Recursion depth must be greater than 0.");
 
-            this.builder = builder;
-            this.recursionHandler = recursionHandler;
-            this.comparer = comparer;
-            this.recursionDepth = recursionDepth;
+            this.Builder = builder;
+            this.RecursionHandler = recursionHandler;
+            this.Comparer = comparer;
+            this.RecursionDepth = recursionDepth;
         }
 
         /// <summary>
@@ -188,10 +182,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </summary>
         /// <seealso cref="RecursionGuard(ISpecimenBuilder)"/>
         /// <seealso cref="RecursionGuard(ISpecimenBuilder, IEqualityComparer)" />
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>
         /// Gets the recursion handler originally supplied as a constructor
@@ -202,26 +193,17 @@ namespace Ploeh.AutoFixture.Kernel
         /// </value>
         /// <seealso cref="RecursionGuard(ISpecimenBuilder, IRecursionHandler)" />
         /// <seealso cref="RecursionGuard(ISpecimenBuilder, IRecursionHandler, IEqualityComparer)" />
-        public IRecursionHandler RecursionHandler
-        {
-            get { return this.recursionHandler; }
-        }
+        public IRecursionHandler RecursionHandler { get; }
 
         /// <summary>
         /// The recursion depth at which the request will be treated as a 
         /// recursive request
         /// </summary>
-        public int RecursionDepth
-        {
-            get { return recursionDepth; }
-        }
+        public int RecursionDepth { get; }
 
         /// <summary>Gets the comparer supplied via the constructor.</summary>
         /// <seealso cref="RecursionGuard(ISpecimenBuilder, IEqualityComparer)" />
-        public IEqualityComparer Comparer
-        {
-            get { return this.comparer; }
-        }
+        public IEqualityComparer Comparer { get; }
 
         /// <summary>
         /// Gets the recorded requests so far.
@@ -239,7 +221,7 @@ namespace Ploeh.AutoFixture.Kernel
         [Obsolete("This method will be removed in a future version of AutoFixture. Use IRecursionHandler.HandleRecursiveRequest instead.")]
         public virtual object HandleRecursiveRequest(object request)
         {
-            return this.recursionHandler.HandleRecursiveRequest(
+            return this.RecursionHandler.HandleRecursiveRequest(
                 request,
                 GetMonitoredRequestsForCurrentThread());
         }
@@ -270,7 +252,7 @@ namespace Ploeh.AutoFixture.Kernel
                 for (int i = 0; i < requestsArray.Length; i++)
                 {
                     var existingRequest = requestsArray[i];
-                    if (this.comparer.Equals(existingRequest, request))
+                    if (this.Comparer.Equals(existingRequest, request))
                     {
                         numRequestsSameAsThisOne++;
                     }
@@ -287,7 +269,7 @@ namespace Ploeh.AutoFixture.Kernel
             requestsForCurrentThread.Push(request);
             try
             {
-                return this.builder.Create(request, context);
+                return this.Builder.Create(request, context);
             }
             finally
             {
@@ -325,8 +307,8 @@ namespace Ploeh.AutoFixture.Kernel
                 builders);
             return new RecursionGuard(
                 composedBuilder,
-                this.recursionHandler,
-                this.comparer,
+                this.RecursionHandler,
+                this.Comparer,
                 this.RecursionDepth);
         }
 
@@ -339,7 +321,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public virtual IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/RecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/RecursionGuard.cs
@@ -208,10 +208,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the recorded requests so far.
         /// </summary>
-        protected IEnumerable RecordedRequests
-        {
-            get { return GetMonitoredRequestsForCurrentThread(); }
-        }
+        protected IEnumerable RecordedRequests => GetMonitoredRequestsForCurrentThread();
 
         /// <summary>
         /// Handles a request that would cause recursion.

--- a/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
+++ b/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
@@ -7,8 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class RegularExpressionRequest : IEquatable<RegularExpressionRequest>
     {
-        private readonly string pattern;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="RegularExpressionRequest"/> class.
         /// </summary>
@@ -20,19 +18,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            this.pattern = pattern;
+            this.Pattern = pattern;
         }
 
         /// <summary>
         /// Gets the regular expression pattern.
         /// </summary>
-        public string Pattern
-        {
-            get
-            {
-                return this.pattern;
-            }
-        }
+        public string Pattern { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.

--- a/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
+++ b/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
@@ -17,7 +17,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (pattern == null)
             {
-                throw new ArgumentNullException("pattern");
+                throw new ArgumentNullException(nameof(pattern));
             }
 
             this.pattern = pattern;

--- a/Src/AutoFixture/Kernel/RequestTraceEventArgs.cs
+++ b/Src/AutoFixture/Kernel/RequestTraceEventArgs.cs
@@ -7,9 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class RequestTraceEventArgs : EventArgs
     {
-        private readonly object request;
-        private readonly int depth;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestTraceEventArgs"/> class with the
         /// supplied values.
@@ -20,24 +17,18 @@ namespace Ploeh.AutoFixture.Kernel
         /// </param>
         public RequestTraceEventArgs(object request, int depth)
         {        
-            this.request = request;
-            this.depth = depth;
+            this.Request = request;
+            this.Depth = depth;
         }
 
         /// <summary>
         /// Gets the recursion depth at which <see cref="Request"/> occurred.
         /// </summary>
-        public int Depth
-        {
-            get { return this.depth; }
-        }
+        public int Depth { get; }
 
         /// <summary>
         /// Gets the original request for a specimen
         /// </summary>
-        public object Request
-        {
-            get { return this.request; }
-        }
+        public object Request { get; }
     }
 }

--- a/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
+++ b/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
@@ -33,7 +33,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var seededRequest = request as SeededRequest;

--- a/Src/AutoFixture/Kernel/SeedRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/SeedRequestSpecification.cs
@@ -7,8 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class SeedRequestSpecification : IRequestSpecification
     {
-        private readonly Type targetType;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SeedRequestSpecification"/> class.
         /// </summary>
@@ -20,16 +18,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            this.targetType = type;
+            this.TargetType = type;
         }
 
         /// <summary>
         /// Gets the type targeted by this <see cref="IRequestSpecification"/>.
         /// </summary>
-        public Type TargetType
-        {
-            get { return this.targetType; }
-        }
+        public Type TargetType { get; }
 
         /// <summary>
         /// Evaluates a request for a specimen.

--- a/Src/AutoFixture/Kernel/SeedRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/SeedRequestSpecification.cs
@@ -17,7 +17,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             this.targetType = type;
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             var sr = request as SeededRequest;

--- a/Src/AutoFixture/Kernel/SeededFactory.cs
+++ b/Src/AutoFixture/Kernel/SeededFactory.cs
@@ -18,7 +18,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             this.create = factory;

--- a/Src/AutoFixture/Kernel/SeededFactory.cs
+++ b/Src/AutoFixture/Kernel/SeededFactory.cs
@@ -8,8 +8,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// <typeparam name="T">The type of specimen to create.</typeparam>
     public class SeededFactory<T> : ISpecimenBuilder
     {
-        private readonly Func<T, T> create;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SeededFactory&lt;T&gt;"/> class.
         /// </summary>
@@ -21,16 +19,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            this.create = factory;
+            this.Factory = factory;
         }
 
         /// <summary>
         /// Gets the factory that is used to create specimens from a seed.
         /// </summary>
-        public Func<T, T> Factory
-        {
-            get { return this.create; }
-        }
+        public Func<T, T> Factory { get; }
 
         /// <summary>
         /// Creates a new specimen based on a seeded request.
@@ -46,7 +41,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request != null && request.Equals(typeof(T)))
             {
-                return this.create(default(T));
+                return this.Factory(default(T));
             }
 
             var seededRequest = request as SeededRequest;
@@ -73,7 +68,7 @@ namespace Ploeh.AutoFixture.Kernel
             }
             var seed = (T)seededRequest.Seed;
 
-            return this.create(seed);
+            return this.Factory(seed);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/SeededRequest.cs
+++ b/Src/AutoFixture/Kernel/SeededRequest.cs
@@ -19,7 +19,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
         
             this.request = request;

--- a/Src/AutoFixture/Kernel/SeededRequest.cs
+++ b/Src/AutoFixture/Kernel/SeededRequest.cs
@@ -7,9 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class SeededRequest : IEquatable<SeededRequest>
     {
-        private readonly object request;
-        private readonly object seed;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Seed"/> class.
         /// </summary>
@@ -22,25 +19,19 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(request));
             }
         
-            this.request = request;
-            this.seed = seed;
+            this.Request = request;
+            this.Seed = seed;
         }
 
         /// <summary>
         /// Gets the seed value.
         /// </summary>
-        public object Seed
-        {
-            get { return this.seed; }
-        }
+        public object Seed { get; }
 
         /// <summary>
         /// Gets the inner request for which the seed applies.
         /// </summary>
-        public object Request
-        {
-            get { return this.request; }
-        }
+        public object Request { get; }
 
         /// <summary>
         /// Determines whether this instance equals another instance.

--- a/Src/AutoFixture/Kernel/SpecifiedNullCommand.cs
+++ b/Src/AutoFixture/Kernel/SpecifiedNullCommand.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (propertyPicker == null)
             {
-                throw new ArgumentNullException("propertyPicker");
+                throw new ArgumentNullException(nameof(propertyPicker));
             }
 
             this.member = propertyPicker.GetWritableMember().Member;
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             IEqualityComparer comparer = new MemberInfoEqualityComparer();

--- a/Src/AutoFixture/Kernel/SpecifiedNullCommand.cs
+++ b/Src/AutoFixture/Kernel/SpecifiedNullCommand.cs
@@ -19,8 +19,6 @@ namespace Ploeh.AutoFixture.Kernel
     [Obsolete("This class is no longer used, and will be removed in future versions.")]
     public class SpecifiedNullCommand<T, TProperty> : ISpecifiedSpecimenCommand<T>
     {
-        private readonly MemberInfo member;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="SpecifiedNullCommand{T, TProperty}"/> class with the supplied
@@ -34,16 +32,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(propertyPicker));
             }
 
-            this.member = propertyPicker.GetWritableMember().Member;
+            this.Member = propertyPicker.GetWritableMember().Member;
         }
 
         /// <summary>
         /// Gets the member identified by the expression supplied through the constructor.
         /// </summary>
-        public MemberInfo Member
-        {
-            get { return this.member; }
-        }
+        public MemberInfo Member { get; }
 
         /// <summary>
         /// Does nothing.
@@ -71,7 +66,7 @@ namespace Ploeh.AutoFixture.Kernel
             }
 
             IEqualityComparer comparer = new MemberInfoEqualityComparer();
-            return comparer.Equals(this.member, request);
+            return comparer.Equals(this.Member, request);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/SpecimenBuilderNode.cs
+++ b/Src/AutoFixture/Kernel/SpecimenBuilderNode.cs
@@ -41,9 +41,9 @@ namespace Ploeh.AutoFixture.Kernel
         public static bool GraphEquals(this ISpecimenBuilderNode first, ISpecimenBuilderNode second)
         {
             if (first == null)
-                throw new ArgumentNullException("first");
+                throw new ArgumentNullException(nameof(first));
             if (second == null)
-                throw new ArgumentNullException("second");
+                throw new ArgumentNullException(nameof(second));
 
             return first.GraphEquals(second, EqualityComparer<ISpecimenBuilder>.Default);
         }
@@ -83,11 +83,11 @@ namespace Ploeh.AutoFixture.Kernel
         public static bool GraphEquals(this ISpecimenBuilderNode first, ISpecimenBuilderNode second, IEqualityComparer<ISpecimenBuilder> comparer)
         {
             if (first == null)
-                throw new ArgumentNullException("first");
+                throw new ArgumentNullException(nameof(first));
             if (second == null)
-                throw new ArgumentNullException("second");
+                throw new ArgumentNullException(nameof(second));
             if (comparer == null)
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
 
             if (!comparer.Equals(first, second))
                 return false;

--- a/Src/AutoFixture/Kernel/SpecimenContext.cs
+++ b/Src/AutoFixture/Kernel/SpecimenContext.cs
@@ -7,8 +7,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class SpecimenContext : ISpecimenContext
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of <see cref="SpecimenContext"/> with the supplied
         /// <see cref="ISpecimenBuilder"/>.
@@ -21,16 +19,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            this.builder = builder;
+            this.Builder = builder;
         }
 
         /// <summary>
         /// Gets the <see cref="ISpecimenBuilder"/> contained by the instance.
         /// </summary>
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>
         /// Creates an anonymous variable (specimen) based on a request by delegating the request

--- a/Src/AutoFixture/Kernel/SpecimenContext.cs
+++ b/Src/AutoFixture/Kernel/SpecimenContext.cs
@@ -18,7 +18,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             this.builder = builder;

--- a/Src/AutoFixture/Kernel/SpecimenCreatedEventArgs.cs
+++ b/Src/AutoFixture/Kernel/SpecimenCreatedEventArgs.cs
@@ -5,8 +5,6 @@
     /// </summary>
     public class SpecimenCreatedEventArgs : RequestTraceEventArgs
     {
-        private readonly object specimen;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecimenCreatedEventArgs"/> class with the
         /// supplied values.
@@ -21,15 +19,12 @@
         public SpecimenCreatedEventArgs(object request, object specimen, int depth)
             : base(request, depth)
         {
-            this.specimen = specimen;
+            this.Specimen = specimen;
         }
 
         /// <summary>
         /// Gets the specimen that was created from <see cref="RequestTraceEventArgs.Request"/>.
         /// </summary>
-        public object Specimen
-        {
-            get { return this.specimen; }
-        }
+        public object Specimen { get; }
     }
 }

--- a/Src/AutoFixture/Kernel/SpecimenFactory.cs
+++ b/Src/AutoFixture/Kernel/SpecimenFactory.cs
@@ -8,8 +8,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// <typeparam name="T">The type of specimen to create.</typeparam>
     public class SpecimenFactory<T> : ISpecimenBuilder
     {
-        private readonly Func<T> create;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecimenFactory&lt;T&gt;"/> class.
         /// </summary>
@@ -21,16 +19,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            this.create = factory;
+            this.Factory = factory;
         }
 
         /// <summary>
         /// Gets the factory that will create specimens.
         /// </summary>
-        public Func<T> Factory
-        {
-            get { return this.create; }
-        }
+        public Func<T> Factory { get; }
 
         /// <summary>
         /// Creates a new specimen based on a request.
@@ -48,7 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.create();
+            return this.Factory();
         }
     }
 
@@ -59,8 +54,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// <typeparam name="T">The type of specimen to create.</typeparam>
     public class SpecimenFactory<TInput, T> : ISpecimenBuilder
     {
-        private readonly Func<TInput, T> create;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecimenFactory&lt;TInput, T&gt;"/> class.
         /// </summary>
@@ -78,16 +71,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            this.create = factory;
+            this.Factory = factory;
         }
 
         /// <summary>
         /// Gets the factory that creates specimens.
         /// </summary>
-        public Func<TInput, T> Factory
-        {
-            get { return this.create; }
-        }
+        public Func<TInput, T> Factory { get; }
 
         /// <summary>
         /// Creates a new specimen based on a request.
@@ -112,7 +102,7 @@ namespace Ploeh.AutoFixture.Kernel
             }
 
             var p = (TInput)context.Resolve(typeof(TInput));
-            return this.create(p);
+            return this.Factory(p);
         }
     }
 
@@ -125,8 +115,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1005:AvoidExcessiveParametersOnGenericTypes", Justification = "Necessary to wrap the corresponding Func. However, this particular API is only intended to be used to implement the fluent API, and is not targeted at the typical end-user.")]
     public class SpecimenFactory<TInput1, TInput2, T> : ISpecimenBuilder
     {
-        private readonly Func<TInput1, TInput2, T> create;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="SpecimenFactory&lt;TInput1, TInput2, T&gt;"/> class.
@@ -145,16 +133,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            this.create = factory;
+            this.Factory = factory;
         }
 
         /// <summary>
         /// Gets the factory that creates specimens.
         /// </summary>
-        public Func<TInput1, TInput2, T> Factory
-        {
-            get { return this.create; }
-        }
+        public Func<TInput1, TInput2, T> Factory { get; }
 
         /// <summary>
         /// Creates a new specimen based on a request.
@@ -180,7 +165,7 @@ namespace Ploeh.AutoFixture.Kernel
 
             var p1 = (TInput1)context.Resolve(typeof(TInput1));
             var p2 = (TInput2)context.Resolve(typeof(TInput2));
-            return this.create(p1, p2);
+            return this.Factory(p1, p2);
         }
     }
 
@@ -194,8 +179,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1005:AvoidExcessiveParametersOnGenericTypes", Justification = "Necessary to wrap the corresponding Func. However, this particular API is only intended to be used to implement the fluent API, and is not targeted at the typical end-user.")]
     public class SpecimenFactory<TInput1, TInput2, TInput3, T> : ISpecimenBuilder
     {
-        private readonly Func<TInput1, TInput2, TInput3, T> create;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="SpecimenFactory&lt;TInput1, TInput2, TInput3, T&gt;"/> class.
@@ -214,16 +197,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            this.create = factory;
+            this.Factory = factory;
         }
 
         /// <summary>
         /// Gets the factory that creates specimens.
         /// </summary>
-        public Func<TInput1, TInput2, TInput3, T> Factory
-        {
-            get { return this.create; }
-        }
+        public Func<TInput1, TInput2, TInput3, T> Factory { get; }
 
         /// <summary>
         /// Creates a new specimen based on a request.
@@ -250,7 +230,7 @@ namespace Ploeh.AutoFixture.Kernel
             var p1 = (TInput1)context.Resolve(typeof(TInput1));
             var p2 = (TInput2)context.Resolve(typeof(TInput2));
             var p3 = (TInput3)context.Resolve(typeof(TInput3));
-            return this.create(p1, p2, p3);
+            return this.Factory(p1, p2, p3);
         }
     }
 
@@ -265,8 +245,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1005:AvoidExcessiveParametersOnGenericTypes", Justification = "Necessary to wrap the corresponding Func. However, this particular API is only intended to be used to implement the fluent API, and is not targeted at the typical end-user.")]
     public class SpecimenFactory<TInput1, TInput2, TInput3, TInput4, T> : ISpecimenBuilder
     {
-        private readonly Func<TInput1, TInput2, TInput3, TInput4, T> create;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="SpecimenFactory&lt;TInput1, TInput2, TInput3, TInput4, T&gt;"/> class.
@@ -285,16 +263,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            this.create = factory;
+            this.Factory = factory;
         }
 
         /// <summary>
         /// Gets the factory that creates specimens.
         /// </summary>
-        public Func<TInput1, TInput2, TInput3, TInput4, T> Factory
-        {
-            get { return this.create; }
-        }
+        public Func<TInput1, TInput2, TInput3, TInput4, T> Factory { get; }
 
         /// <summary>
         /// Creates a new specimen based on a request.
@@ -322,7 +297,7 @@ namespace Ploeh.AutoFixture.Kernel
             var p2 = (TInput2)context.Resolve(typeof(TInput2));
             var p3 = (TInput3)context.Resolve(typeof(TInput3));
             var p4 = (TInput4)context.Resolve(typeof(TInput4));
-            return this.create(p1, p2, p3, p4);
+            return this.Factory(p1, p2, p3, p4);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/SpecimenFactory.cs
+++ b/Src/AutoFixture/Kernel/SpecimenFactory.cs
@@ -18,7 +18,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             this.create = factory;
@@ -75,7 +75,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             this.create = factory;
@@ -108,7 +108,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var p = (TInput)context.Resolve(typeof(TInput));
@@ -142,7 +142,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             this.create = factory;
@@ -175,7 +175,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var p1 = (TInput1)context.Resolve(typeof(TInput1));
@@ -211,7 +211,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             this.create = factory;
@@ -244,7 +244,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var p1 = (TInput1)context.Resolve(typeof(TInput1));
@@ -282,7 +282,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             this.create = factory;
@@ -315,7 +315,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var p1 = (TInput1)context.Resolve(typeof(TInput1));

--- a/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
@@ -40,7 +40,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var manyRequest = request as FiniteSequenceRequest;

--- a/Src/AutoFixture/Kernel/StaticMethod.cs
+++ b/Src/AutoFixture/Kernel/StaticMethod.cs
@@ -50,10 +50,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets information about the parameters of the method.
         /// </summary>
-        public IEnumerable<ParameterInfo> Parameters
-        {
-            get { return this.paramInfos; }
-        }
+        public IEnumerable<ParameterInfo> Parameters => this.paramInfos;
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.

--- a/Src/AutoFixture/Kernel/StaticMethod.cs
+++ b/Src/AutoFixture/Kernel/StaticMethod.cs
@@ -31,12 +31,12 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (methodInfo == null)
             {
-                throw new ArgumentNullException("methodInfo");
+                throw new ArgumentNullException(nameof(methodInfo));
             }
 
             if (methodParameters == null)
             {
-                throw new ArgumentNullException("methodParameters");
+                throw new ArgumentNullException(nameof(methodParameters));
             }
 
             this.methodInfo = methodInfo;
@@ -124,7 +124,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (methodInfo == null)
             {
-                throw new ArgumentNullException("methodInfo");
+                throw new ArgumentNullException(nameof(methodInfo));
             }
 
             return methodInfo.GetParameters();

--- a/Src/AutoFixture/Kernel/StaticMethod.cs
+++ b/Src/AutoFixture/Kernel/StaticMethod.cs
@@ -10,7 +10,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class StaticMethod : IMethod, IEquatable<StaticMethod>
     {
-        private readonly MethodInfo methodInfo;
         private readonly ParameterInfo[] paramInfos;
 
         /// <summary>
@@ -39,17 +38,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(methodParameters));
             }
 
-            this.methodInfo = methodInfo;
+            this.Method = methodInfo;
             this.paramInfos = methodParameters;
         }
 
         /// <summary>
         /// Gets the method.
         /// </summary>
-        public MethodInfo Method
-        {
-            get { return this.methodInfo; }
-        }
+        public MethodInfo Method { get; }
 
         /// <summary>
         /// Gets information about the parameters of the method.
@@ -99,7 +95,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>The result of the method call.</returns>
         public object Invoke(IEnumerable<object> parameters)
         {
-            return this.methodInfo.Invoke(null, parameters.ToArray());
+            return this.Method.Invoke(null, parameters.ToArray());
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -21,9 +21,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </remarks>
     public class TemplateMethodQuery : IMethodQuery
     {
-        private readonly MethodInfo template;
-        private readonly object owner;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TemplateMethodQuery"/> class.
         /// </summary>
@@ -33,7 +30,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (template == null)
                 throw new ArgumentNullException(nameof(template));
 
-            this.template = template;
+            this.Template = template;
         }
 
         /// <summary>
@@ -49,25 +46,19 @@ namespace Ploeh.AutoFixture.Kernel
             if (owner == null)
                 throw new ArgumentNullException(nameof(owner));
 
-            this.owner = owner;
-            this.template = template;
+            this.Owner = owner;
+            this.Template = template;
         }
 
         /// <summary>
         /// The template <see cref="MethodInfo" /> to compare.
         /// </summary>
-        public MethodInfo Template
-        {
-            get { return template; }
-        }
+        public MethodInfo Template { get; }
 
         /// <summary>
         /// The owner instance of the <see cref="MethodInfo" />.
         /// </summary>
-        public object Owner
-        {
-            get { return owner; }
-        }
+        public object Owner { get; }
 
         /// <summary>
         /// Selects the methods for the supplied type similar to <see cref="Template" />.

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         public TemplateMethodQuery(MethodInfo template)
         {
             if (template == null)
-                throw new ArgumentNullException("template");
+                throw new ArgumentNullException(nameof(template));
 
             this.template = template;
         }
@@ -44,10 +44,10 @@ namespace Ploeh.AutoFixture.Kernel
         public TemplateMethodQuery(MethodInfo template, object owner)
         {
             if (template == null)
-                throw new ArgumentNullException("template");
+                throw new ArgumentNullException(nameof(template));
 
             if (owner == null)
-                throw new ArgumentNullException("owner");
+                throw new ArgumentNullException(nameof(owner));
 
             this.owner = owner;
             this.template = template;
@@ -97,7 +97,7 @@ namespace Ploeh.AutoFixture.Kernel
         public IEnumerable<IMethod> SelectMethods(Type type)
         {
             if (type == null)
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
 
             return from method in type.GetMethods()
                    where method.Name == Template.Name && (Owner != null || method.IsStatic)
@@ -154,10 +154,10 @@ namespace Ploeh.AutoFixture.Kernel
                 IEnumerable<ParameterInfo> templateParameters)
             {
                 if (methodParameters == null)
-                    throw new ArgumentNullException("methodParameters");
+                    throw new ArgumentNullException(nameof(methodParameters));
 
                 if (templateParameters == null)
-                    throw new ArgumentNullException("templateParameters");
+                    throw new ArgumentNullException(nameof(templateParameters));
 
                 this.score = CalculateScore(methodParameters.Select(p => p.ParameterType), 
                     templateParameters.Select(p => p.ParameterType));

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -61,10 +61,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the observed specimen requests, in the order they were requested.
         /// </summary>
-        public IEnumerable<object> SpecimenRequests
-        {
-            get { return this.GetPathForCurrentThread().Reverse(); }
-        }
+        public IEnumerable<object> SpecimenRequests => this.GetPathForCurrentThread().Reverse();
 
         /// <summary>
         /// Creates a new specimen based on a request by delegating to its decorated builder.

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
         public TerminatingWithPathSpecimenBuilder(TracingBuilder tracer)
         {
             if (tracer == null)
-                throw new ArgumentNullException("tracer");
+                throw new ArgumentNullException(nameof(tracer));
 
             this.tracer = tracer;
             this.tracer.SpecimenRequested += OnSpecimenRequested;

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -18,8 +18,6 @@ namespace Ploeh.AutoFixture.Kernel
         Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
     {
-        private readonly TracingBuilder tracer;
-
         private readonly ConcurrentDictionary<Thread, Stack<object>>
             _requestPathsByThread = new ConcurrentDictionary<Thread, Stack<object>>();
 
@@ -38,9 +36,9 @@ namespace Ploeh.AutoFixture.Kernel
             if (tracer == null)
                 throw new ArgumentNullException(nameof(tracer));
 
-            this.tracer = tracer;
-            this.tracer.SpecimenRequested += OnSpecimenRequested;
-            this.tracer.SpecimenCreated += OnSpecimenCreated;
+            this.Tracer = tracer;
+            this.Tracer.SpecimenRequested += OnSpecimenRequested;
+            this.Tracer.SpecimenCreated += OnSpecimenCreated;
         }
 
         private void OnSpecimenCreated(object sender, SpecimenCreatedEventArgs e)
@@ -58,10 +56,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the <see cref="TracingBuilder"/> decorated by this instance.
         /// </summary>
-        public TracingBuilder Tracer
-        {
-            get { return this.tracer; }
-        }
+        public TracingBuilder Tracer { get; }
 
         /// <summary>
         /// Gets the observed specimen requests, in the order they were requested.
@@ -82,7 +77,7 @@ namespace Ploeh.AutoFixture.Kernel
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         public object Create(object request, ISpecimenContext context)
         {
-            var result = this.tracer.Create(request, context);
+            var result = this.Tracer.Create(request, context);
             if (result is NoSpecimen)
             {
                 try
@@ -203,7 +198,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.tracer.Builder;
+            yield return this.Tracer.Builder;
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/TraceWriter.cs
+++ b/Src/AutoFixture/Kernel/TraceWriter.cs
@@ -12,7 +12,6 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class TraceWriter : ISpecimenBuilderNode
     {
-        private readonly TracingBuilder tracer;
         private readonly TextWriter writer;
         private Action<TextWriter, object, int> writeRequest;
         private Action<TextWriter, object, int> writeSpecimen;
@@ -33,9 +32,9 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(tracer));
             }        
 
-            this.tracer = tracer;
-            this.tracer.SpecimenRequested += (sender, e) => this.writeRequest(writer, e.Request, e.Depth);
-            this.tracer.SpecimenCreated += (sender, e) => this.writeSpecimen(writer, e.Specimen, e.Depth);
+            this.Tracer = tracer;
+            this.Tracer.SpecimenRequested += (sender, e) => this.writeRequest(writer, e.Request, e.Depth);
+            this.Tracer.SpecimenCreated += (sender, e) => this.writeSpecimen(writer, e.Specimen, e.Depth);
 
             this.writer = writer;
             this.TraceRequestFormatter = (tw, r, i) => tw.WriteLine(new string(' ', i * 2) + "Requested: " + r);
@@ -45,10 +44,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <summary>
         /// Gets the <see cref="TracingBuilder"/> decorated by this instance.
         /// </summary>
-        public TracingBuilder Tracer
-        {
-            get { return this.tracer; }
-        }
+        public TracingBuilder Tracer { get; }
 
         /// <summary>
         /// Gets or sets the formatter for tracing a request.
@@ -96,7 +92,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.tracer.Create(request, context);
+            return this.Tracer.Create(request, context);
         }
 
         /// <summary>Composes the supplied builders.</summary>
@@ -124,7 +120,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.tracer.Builder;
+            yield return this.Tracer.Builder;
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/TraceWriter.cs
+++ b/Src/AutoFixture/Kernel/TraceWriter.cs
@@ -26,11 +26,11 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (writer == null)
             {
-                throw new ArgumentNullException("writer");
+                throw new ArgumentNullException(nameof(writer));
             }
             if (tracer == null)
             {
-                throw new ArgumentNullException("tracer");
+                throw new ArgumentNullException(nameof(tracer));
             }        
 
             this.tracer = tracer;
@@ -61,7 +61,7 @@ namespace Ploeh.AutoFixture.Kernel
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 this.writeRequest = value;
@@ -79,7 +79,7 @@ namespace Ploeh.AutoFixture.Kernel
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 this.writeSpecimen = value;

--- a/Src/AutoFixture/Kernel/TracingBuilder.cs
+++ b/Src/AutoFixture/Kernel/TracingBuilder.cs
@@ -8,7 +8,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     public class TracingBuilder : ISpecimenBuilder
     {
-        private readonly ISpecimenBuilder builder;
         private IRequestSpecification filter;
         private int depth;
 
@@ -34,17 +33,14 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            this.builder = builder;
+            this.Builder = builder;
             this.filter = new TrueRequestSpecification();
         }
 
         /// <summary>
         /// Gets the builder decorated by this instance.
         /// </summary>
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>
         /// Gets or sets a filter for tracking
@@ -99,7 +95,7 @@ namespace Ploeh.AutoFixture.Kernel
             object specimen = null;
             try
             {
-                specimen = this.builder.Create(request, context);
+                specimen = this.Builder.Create(request, context);
                 specimenWasCreated = true;
                 return specimen;
             }

--- a/Src/AutoFixture/Kernel/TracingBuilder.cs
+++ b/Src/AutoFixture/Kernel/TracingBuilder.cs
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             this.builder = builder;
@@ -66,7 +66,7 @@ namespace Ploeh.AutoFixture.Kernel
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 this.filter = value;

--- a/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
+++ b/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
@@ -41,7 +41,7 @@ namespace Ploeh.AutoFixture.Kernel
                     ))
         {
             if (methodInfo == null)
-                throw new ArgumentNullException("methodInfo");
+                throw new ArgumentNullException(nameof(methodInfo));
         }
         
         /// <summary>

--- a/Src/AutoFixture/Kernel/TypeRelay.cs
+++ b/Src/AutoFixture/Kernel/TypeRelay.cs
@@ -48,9 +48,9 @@ namespace Ploeh.AutoFixture.Kernel
         public TypeRelay(Type from, Type to)
         {
             if (from == null)
-                throw new ArgumentNullException("from");
+                throw new ArgumentNullException(nameof(@from));
             if (to == null)
-                throw new ArgumentNullException("to");
+                throw new ArgumentNullException(nameof(to));
 
             this.from = from;
             this.to = to;
@@ -80,7 +80,7 @@ namespace Ploeh.AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             
             var t = request as Type;
             if (t == null || t != this.from)

--- a/Src/AutoFixture/Kernel/UnspecifiedSpecimenCommand.cs
+++ b/Src/AutoFixture/Kernel/UnspecifiedSpecimenCommand.cs
@@ -9,8 +9,6 @@ namespace Ploeh.AutoFixture.Kernel
     [Obsolete("This class is no longer used, and will be removed in future versions.")]
     public class UnspecifiedSpecimenCommand<T> : ISpecifiedSpecimenCommand<T>
     {
-        private readonly Action<T> action;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UnspecifiedSpecimenCommand&lt;T&gt;"/>
         /// class.
@@ -23,16 +21,13 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(action));
             }
 
-            this.action = action;
+            this.Action = action;
         }
 
         /// <summary>
         /// Gets the action that can be performed on a specimen.
         /// </summary>
-        public Action<T> Action
-        {
-            get { return this.action; }
-        }
+        public Action<T> Action { get; }
 
         /// <summary>
         /// Executes <see cref="Action"/> on the supplied specimen.

--- a/Src/AutoFixture/Kernel/UnspecifiedSpecimenCommand.cs
+++ b/Src/AutoFixture/Kernel/UnspecifiedSpecimenCommand.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (action == null)
             {
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
             }
 
             this.action = action;

--- a/Src/AutoFixture/Kernel/ValueTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/ValueTypeSpecification.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             if (request == null)
             {
-                throw new ArgumentNullException("request");
+                throw new ArgumentNullException(nameof(request));
             }
 
             var type = request as Type;

--- a/Src/AutoFixture/LazyRelay.cs
+++ b/Src/AutoFixture/LazyRelay.cs
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var t = request as Type;
             if (t == null || !t.IsGenericType)

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -26,7 +26,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (!typeof(MailAddress).Equals(request))

--- a/Src/AutoFixture/MapCreateManyToEnumerable.cs
+++ b/Src/AutoFixture/MapCreateManyToEnumerable.cs
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixture
         public void Customize(IFixture fixture)
         {
             if (fixture == null)
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
 
             fixture.Customizations.Insert(0, new MultipleToEnumerableRelay());
         }

--- a/Src/AutoFixture/MultipleCustomization.cs
+++ b/Src/AutoFixture/MultipleCustomization.cs
@@ -41,7 +41,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.ResidueCollectors.Add(new DictionaryRelay());

--- a/Src/AutoFixture/NoAutoPropertiesCustomization.cs
+++ b/Src/AutoFixture/NoAutoPropertiesCustomization.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixture
         {
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
 
             this.targetType = targetType;
@@ -41,7 +41,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var constructor = new MethodInvoker(new ModestConstructorQuery());

--- a/Src/AutoFixture/NoDataAnnotationsCustomization.cs
+++ b/Src/AutoFixture/NoDataAnnotationsCustomization.cs
@@ -25,7 +25,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var dataAnnotationsRelayTypes = new[]

--- a/Src/AutoFixture/NullRecursionBehavior.cs
+++ b/Src/AutoFixture/NullRecursionBehavior.cs
@@ -42,7 +42,7 @@ namespace Ploeh.AutoFixture
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             return new RecursionGuard(builder, new NullRecursionHandler(), recursionDepth);

--- a/Src/AutoFixture/NumericSequencePerTypeCustomization.cs
+++ b/Src/AutoFixture/NumericSequencePerTypeCustomization.cs
@@ -40,7 +40,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var numericBuilders = new CompositeSpecimenBuilder(new ISpecimenBuilder[]

--- a/Src/AutoFixture/OmitOnRecursionBehavior.cs
+++ b/Src/AutoFixture/OmitOnRecursionBehavior.cs
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture
         public OmitOnRecursionBehavior(int recursionDepth)
         {
             if (recursionDepth < 1)
-                throw new ArgumentOutOfRangeException("recursionDepth", "Recursion depth must be greater than 0.");
+                throw new ArgumentOutOfRangeException(nameof(recursionDepth), "Recursion depth must be greater than 0.");
 
             this.recursionDepth = recursionDepth;
         }
@@ -47,7 +47,7 @@ namespace Ploeh.AutoFixture
         public ISpecimenBuilder Transform(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             return new RecursionGuard(builder, new OmitOnRecursionHandler(), recursionDepth);
         }

--- a/Src/AutoFixture/RandomBooleanSequenceCustomization.cs
+++ b/Src/AutoFixture/RandomBooleanSequenceCustomization.cs
@@ -16,7 +16,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customizations.Add(new RandomBooleanSequenceGenerator());

--- a/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
@@ -55,7 +55,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             return IsNotDateTimeRequest(request)

--- a/Src/AutoFixture/RandomNumericSequenceCustomization.cs
+++ b/Src/AutoFixture/RandomNumericSequenceCustomization.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customizations.Add(new RandomNumericSequenceGenerator());

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -46,12 +46,12 @@ namespace Ploeh.AutoFixture
         {
             if (limits == null)
             {
-                throw new ArgumentNullException("limits");
+                throw new ArgumentNullException(nameof(limits));
             }
 
             if (limits.Length < 2)
             {
-                throw new ArgumentException("Limits must be at least two ascending numbers.", "limits");
+                throw new ArgumentException("Limits must be at least two ascending numbers.", nameof(limits));
             }
 
             ValidateThatLimitsAreStrictlyAscending(limits);
@@ -100,7 +100,7 @@ namespace Ploeh.AutoFixture
         {
             if (limits.Zip(limits.Skip(1), (a, b) => a >= b).Any(b => b))
             {
-                throw new ArgumentOutOfRangeException("limits", "Limits must be ascending numbers.");
+                throw new ArgumentOutOfRangeException(nameof(limits), "Limits must be ascending numbers.");
             }
         }
 

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -69,10 +69,7 @@ namespace Ploeh.AutoFixture
         /// <value>
         /// The sequence of limits.
         /// </value>
-        public IEnumerable<long> Limits
-        {
-            get { return this.limits; }
-        }
+        public IEnumerable<long> Limits => this.limits;
 
         /// <summary>
         /// Creates an anonymous number.

--- a/Src/AutoFixture/RandomRangedNumberCustomization.cs
+++ b/Src/AutoFixture/RandomRangedNumberCustomization.cs
@@ -21,7 +21,7 @@ namespace Ploeh.AutoFixture
         public void Customize(IFixture fixture)
         {
             if (fixture == null)
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
 
             fixture.Customizations.Add(new RandomRangedNumberGenerator());
         }

--- a/Src/AutoFixture/RandomRangedNumberGenerator.cs
+++ b/Src/AutoFixture/RandomRangedNumberGenerator.cs
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture
                 return new NoSpecimen();
 
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var rangedNumberRequest = request as RangedNumberRequest;
             
@@ -139,7 +139,7 @@ namespace Ploeh.AutoFixture
                
             }
 
-            throw new ArgumentException("Limit parameter is non-numeric ", "limit");         
+            throw new ArgumentException("Limit parameter is non-numeric ", nameof(limit));         
         }      
        
     }

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture
 
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var range = request as RangedNumberRequest;

--- a/Src/AutoFixture/ResidueCollectorNode.cs
+++ b/Src/AutoFixture/ResidueCollectorNode.cs
@@ -18,8 +18,6 @@ namespace Ploeh.AutoFixture
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class ResidueCollectorNode : ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="ResidueCollectorNode" /> class.
@@ -40,7 +38,7 @@ namespace Ploeh.AutoFixture
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
-            this.builder = builder;
+            this.Builder = builder;
         }
         
         /// <summary>Composes the supplied builders.</summary>
@@ -76,7 +74,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.builder.Create(request, context);
+            return this.Builder.Create(request, context);
         }
 
         /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -84,7 +82,7 @@ namespace Ploeh.AutoFixture
         /// <seealso cref="Builder" />
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         /// <summary>
@@ -103,9 +101,6 @@ namespace Ploeh.AutoFixture
         /// <summary>Gets the builder decorated by this instance.</summary>
         /// <value>The builder originally supplied via the constructor.</value>
         /// <seealso cref="ResidueCollectorNode(ISpecimenBuilder)" />
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
     }
 }

--- a/Src/AutoFixture/ResidueCollectorNode.cs
+++ b/Src/AutoFixture/ResidueCollectorNode.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture
         public ResidueCollectorNode(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
+++ b/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
@@ -37,7 +37,6 @@ namespace Ploeh.AutoFixture
     /// </remarks>
     public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISpecimenBuilderTransformation>
     {
-        private ISpecimenBuilderNode graph;
         private readonly Func<ISpecimenBuilderNode, bool> isWrappedGraph;
 
         /// <summary>
@@ -75,7 +74,7 @@ namespace Ploeh.AutoFixture
             if (transformations == null)
                 throw new ArgumentNullException(nameof(transformations));
             
-            this.graph = graph;
+            this.Graph = graph;
             this.isWrappedGraph = wrappedGraphPredicate;
 
             foreach (var t in transformations)
@@ -103,10 +102,7 @@ namespace Ploeh.AutoFixture
         /// <see cref="ISpecimenBuilderTransformation" /> instances to the base
         /// graph.
         /// </value>
-        public ISpecimenBuilderNode Graph
-        {
-            get { return this.graph; }
-        }
+        public ISpecimenBuilderNode Graph { get; private set; }
 
         /// <summary>Removes all items from the collection.</summary>
         /// <remarks>
@@ -195,16 +191,16 @@ namespace Ploeh.AutoFixture
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ISpecimenBuilderNode"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ISpecimenBuilderTransformation", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         private void UpdateGraph()
         {
-            ISpecimenBuilder g = this.graph.SelectNodes(this.isWrappedGraph).First();
+            ISpecimenBuilder g = this.Graph.SelectNodes(this.isWrappedGraph).First();
             var builder = this.Aggregate(g, (b, t) => t.Transform(b));
 
             var node = builder as ISpecimenBuilderNode;
             if (node == null)
                 throw new InvalidOperationException("An ISpecimenBuilderTransformation returned a result which cannot be converted to an ISpecimenBuilderNode. To be used in the current context, all ISpecimenBuilderTransformation Transform methods must return an ISpecimenBuilderNode instance.");
 
-            this.graph = node;
+            this.Graph = node;
 
-            this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.graph));
+            this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
         }
     }
 }

--- a/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
+++ b/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
@@ -69,11 +69,11 @@ namespace Ploeh.AutoFixture
             params ISpecimenBuilderTransformation[] transformations)
         {
             if (graph == null)
-                throw new ArgumentNullException("graph");
+                throw new ArgumentNullException(nameof(graph));
             if (wrappedGraphPredicate == null)
-                throw new ArgumentNullException("wrappedGraphPredicate");
+                throw new ArgumentNullException(nameof(wrappedGraphPredicate));
             if (transformations == null)
-                throw new ArgumentNullException("transformations");
+                throw new ArgumentNullException(nameof(transformations));
             
             this.graph = graph;
             this.isWrappedGraph = wrappedGraphPredicate;

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -285,10 +285,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         /// <seealso cref="SpecimenBuilderNodeAdapterCollection" />
         /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
-        public int Count
-        {
-            get { return this.adaptedBuilders.Count(); }
-        }
+        public int Count => this.adaptedBuilders.Count();
 
         /// <summary>
         /// Gets a value indicating whether this instance is read only.
@@ -297,10 +294,7 @@ namespace Ploeh.AutoFixture
         /// <see langword="true" /> if this instance is read only; otherwise,
         /// <see langword="false" />.
         /// </value>
-        public bool IsReadOnly
-        {
-            get { return false; }
-        }
+        public bool IsReadOnly => false;
 
         /// <summary>
         /// Removes the first occurrence of a specific object from the

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -21,7 +21,6 @@ namespace Ploeh.AutoFixture
     /// </remarks>
     public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     {
-        private ISpecimenBuilderNode graph;
         private readonly Func<ISpecimenBuilderNode, bool> isAdaptedBuilder;
         private IEnumerable<ISpecimenBuilder> adaptedBuilders;
 
@@ -51,10 +50,10 @@ namespace Ploeh.AutoFixture
             ISpecimenBuilderNode graph,
             Func<ISpecimenBuilderNode, bool> adaptedBuilderPredicate)
         {
-            this.graph = graph;
+            this.Graph = graph;
             this.isAdaptedBuilder = adaptedBuilderPredicate;
             this.adaptedBuilders = 
-                this.graph.SelectNodes(this.TargetMemo.IsSpecifiedBy).First();
+                this.Graph.SelectNodes(this.TargetMemo.IsSpecifiedBy).First();
         }
 
         /// <summary>
@@ -401,10 +400,7 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         /// <seealso cref="SpecimenBuilderNodeAdapterCollection" />
         /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
-        public ISpecimenBuilderNode Graph
-        {
-            get { return this.graph; }
-        }
+        public ISpecimenBuilderNode Graph { get; private set; }
 
         /// <summary>Raises the <see cref="E:GraphChanged" /> event.</summary>
         /// <param name="e">
@@ -420,13 +416,13 @@ namespace Ploeh.AutoFixture
 
         private void Mutate(IEnumerable<ISpecimenBuilder> builders)
         {
-            this.graph = this.graph.ReplaceNodes(
+            this.Graph = this.Graph.ReplaceNodes(
                 with: builders,
                 when: this.TargetMemo.IsSpecifiedBy);
             this.adaptedBuilders = 
-                this.graph.SelectNodes(this.TargetMemo.IsSpecifiedBy).First();
+                this.Graph.SelectNodes(this.TargetMemo.IsSpecifiedBy).First();
 
-            this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.graph));
+            this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
         }
 
         private TargetSpecification TargetMemo
@@ -434,7 +430,7 @@ namespace Ploeh.AutoFixture
             get
             {
                 var markerNode =
-                    this.graph.SelectNodes(this.isAdaptedBuilder).First();
+                    this.Graph.SelectNodes(this.isAdaptedBuilder).First();
                 var target = (ISpecimenBuilderNode)markerNode.First();
                 return new TargetSpecification(target);
             }

--- a/Src/AutoFixture/SpecimenBuilderNodeEventArgs.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeEventArgs.cs
@@ -12,8 +12,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class SpecimenBuilderNodeEventArgs : EventArgs
     {
-        private readonly ISpecimenBuilderNode graph;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="SpecimenBuilderNodeEventArgs" /> class.
@@ -25,15 +23,12 @@ namespace Ploeh.AutoFixture
             if (graph == null)
                 throw new ArgumentNullException(nameof(graph));
 
-            this.graph = graph;
+            this.Graph = graph;
         }
 
         /// <summary>
         /// Gets the graph associated with an event.
         /// </summary>
-        public ISpecimenBuilderNode Graph
-        {
-            get { return this.graph; }
-        }
+        public ISpecimenBuilderNode Graph { get; }
     }
 }

--- a/Src/AutoFixture/SpecimenBuilderNodeEventArgs.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeEventArgs.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture
         public SpecimenBuilderNodeEventArgs(ISpecimenBuilderNode graph)
         {
             if (graph == null)
-                throw new ArgumentNullException("graph");
+                throw new ArgumentNullException(nameof(graph));
 
             this.graph = graph;
         }

--- a/Src/AutoFixture/SpecimenCommand.cs
+++ b/Src/AutoFixture/SpecimenCommand.cs
@@ -30,9 +30,9 @@ namespace Ploeh.AutoFixture
             Action<T> action)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (action == null)
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
             
             action(builder.Create<T>());
         }
@@ -59,9 +59,9 @@ namespace Ploeh.AutoFixture
             Action<T1, T2> action)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (action == null)
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
             
             action(builder.Create<T1>(), builder.Create<T2>());
         }
@@ -91,9 +91,9 @@ namespace Ploeh.AutoFixture
             Action<T1, T2, T3> action)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (action == null)
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
 
             action(
                 builder.Create<T1>(),
@@ -129,9 +129,9 @@ namespace Ploeh.AutoFixture
             Action<T1, T2, T3, T4> action)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (action == null)
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
 
             action(
                 builder.Create<T1>(),

--- a/Src/AutoFixture/SpecimenFactory.cs
+++ b/Src/AutoFixture/SpecimenFactory.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             return (T)context.Create(default(T));
@@ -119,7 +119,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             return (T)context.Resolve(new SeededRequest(typeof(T), seed));
@@ -309,7 +309,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             return from s in (IEnumerable<object>)context.Resolve(new MultipleRequest(new SeededRequest(typeof(T), seed)))
@@ -472,7 +472,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             return from s in (IEnumerable<object>)context.Resolve(new FiniteSequenceRequest(new SeededRequest(typeof(T), seed), count))

--- a/Src/AutoFixture/SpecimenQuery.cs
+++ b/Src/AutoFixture/SpecimenQuery.cs
@@ -33,9 +33,9 @@ namespace Ploeh.AutoFixture
             Func<T, TResult> function)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (function == null)
-                throw new ArgumentNullException("function");
+                throw new ArgumentNullException(nameof(function));
 
             return function(builder.Create<T>());
         }
@@ -65,9 +65,9 @@ namespace Ploeh.AutoFixture
             Func<T1, T2, TResult> function)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (function == null)
-                throw new ArgumentNullException("function");
+                throw new ArgumentNullException(nameof(function));
 
             return function(builder.Create<T1>(), builder.Create<T2>());
         }
@@ -100,9 +100,9 @@ namespace Ploeh.AutoFixture
             Func<T1, T2, T3, TResult> function)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (function == null)
-                throw new ArgumentNullException("function");
+                throw new ArgumentNullException(nameof(function));
 
             return function(
                 builder.Create<T1>(),
@@ -141,9 +141,9 @@ namespace Ploeh.AutoFixture
             Func<T1, T2, T3, T4, TResult> function)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             if (function == null)
-                throw new ArgumentNullException("function");
+                throw new ArgumentNullException(nameof(function));
 
             return function(
                 builder.Create<T1>(),

--- a/Src/AutoFixture/StableFiniteSequenceCustomization.cs
+++ b/Src/AutoFixture/StableFiniteSequenceCustomization.cs
@@ -32,7 +32,7 @@ namespace Ploeh.AutoFixture
         public void Customize(IFixture fixture)
         {
             if (fixture == null)
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
 
             fixture.Customizations.Add(new StableFiniteSequenceRelay());
         }

--- a/Src/AutoFixture/StringGenerator.cs
+++ b/Src/AutoFixture/StringGenerator.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture
         {
             if (specimenFactory == null)
             {
-                throw new ArgumentNullException("specimenFactory");
+                throw new ArgumentNullException(nameof(specimenFactory));
             }
 
             this.createSpecimen = specimenFactory;

--- a/Src/AutoFixture/StringGenerator.cs
+++ b/Src/AutoFixture/StringGenerator.cs
@@ -8,8 +8,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class StringGenerator : ISpecimenBuilder
     {
-        private readonly Func<object> createSpecimen;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="StringGenerator"/> class with the supplied
         /// specimen factory.
@@ -26,17 +24,14 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(specimenFactory));
             }
 
-            this.createSpecimen = specimenFactory;
+            this.Factory = specimenFactory;
         }
 
         /// <summary>
         /// Gets the factory used to specimens.
         /// </summary>
         /// <seealso cref="StringGenerator(Func{object})"/>
-        public Func<object> Factory
-        {
-            get { return this.createSpecimen; }
-        }
+        public Func<object> Factory { get; }
 
         /// <summary>
         /// Creates string specimens by invoking the supplied specimen factory and calling
@@ -56,7 +51,7 @@ namespace Ploeh.AutoFixture
 #pragma warning restore 618
             }
 
-            var specimen = this.createSpecimen();
+            var specimen = this.Factory();
             if (specimen == null)
             {
 #pragma warning disable 618

--- a/Src/AutoFixture/StringSeedRelay.cs
+++ b/Src/AutoFixture/StringSeedRelay.cs
@@ -29,7 +29,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var seededRequest = request as SeededRequest;

--- a/Src/AutoFixture/SupportMutableValueTypesCustomization.cs
+++ b/Src/AutoFixture/SupportMutableValueTypesCustomization.cs
@@ -18,7 +18,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customizations.Add(

--- a/Src/AutoFixture/TaskGenerator.cs
+++ b/Src/AutoFixture/TaskGenerator.cs
@@ -27,7 +27,7 @@ namespace Ploeh.AutoFixture
         public object Create(object request, ISpecimenContext context)
         {
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var type = request as Type;
             if (type == null)

--- a/Src/AutoFixture/ThrowingRecursionBehavior.cs
+++ b/Src/AutoFixture/ThrowingRecursionBehavior.cs
@@ -21,7 +21,7 @@ namespace Ploeh.AutoFixture
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             return new RecursionGuard(builder, new ThrowingRecursionHandler());

--- a/Src/AutoFixture/TracingBehavior.cs
+++ b/Src/AutoFixture/TracingBehavior.cs
@@ -10,8 +10,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class TracingBehavior : ISpecimenBuilderTransformation
     {
-        private readonly TextWriter writer;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TracingBehavior"/> class with the default
         /// <see cref="Writer"/>, which is <see cref="Console.Out"/>.
@@ -33,16 +31,13 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(writer));
             }
 
-            this.writer = writer;
+            this.Writer = writer;
         }
 
         /// <summary>
         /// Gets the writer to which diagnostics information is written.
         /// </summary>
-        public TextWriter Writer
-        {
-            get { return this.writer; }
-        }
+        public TextWriter Writer { get; }
 
         /// <summary>
         /// Decorates the supplied builder with a <see cref="TraceWriter"/>.
@@ -59,7 +54,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            return new TraceWriter(this.writer, new TracingBuilder(builder));
+            return new TraceWriter(this.Writer, new TracingBuilder(builder));
         }
     }
 }

--- a/Src/AutoFixture/TracingBehavior.cs
+++ b/Src/AutoFixture/TracingBehavior.cs
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture
         {
             if (writer == null)
             {
-                throw new ArgumentNullException("writer");
+                throw new ArgumentNullException(nameof(writer));
             }
 
             this.writer = writer;
@@ -56,7 +56,7 @@ namespace Ploeh.AutoFixture
         {
             if (builder == null)
             {
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
             }
 
             return new TraceWriter(this.writer, new TracingBuilder(builder));

--- a/Src/AutoFixture/TypeFilter.cs
+++ b/Src/AutoFixture/TypeFilter.cs
@@ -19,7 +19,7 @@ namespace Ploeh.AutoFixture
         {
             if (type == null)
             {
-                throw new ArgumentNullException("type");
+                throw new ArgumentNullException(nameof(type));
             }
 
             return type.IsValueType && !type.IsEnum && !type.IsPrimitive;

--- a/Src/AutoFixture/UriGenerator.cs
+++ b/Src/AutoFixture/UriGenerator.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (!typeof(Uri).Equals(request))

--- a/Src/AutoFixture/UriScheme.cs
+++ b/Src/AutoFixture/UriScheme.cs
@@ -10,8 +10,6 @@ namespace Ploeh.AutoFixture
     /// </summary>
     public class UriScheme : IEquatable<UriScheme>
     {
-        private readonly string scheme;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UriScheme"/> class using "scheme" as the
         /// default URI scheme name.
@@ -37,7 +35,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentException("The provided scheme is not valid. Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ('+'), period ('.'), or hyphen ('-').");
             }
 
-            this.scheme = scheme;
+            this.Scheme = scheme;
         }
 
         /// <summary>
@@ -49,7 +47,7 @@ namespace Ploeh.AutoFixture
         /// </returns>
         public override string ToString()
         {
-            return this.scheme;
+            return this.Scheme;
         }
 
         /// <summary>
@@ -90,10 +88,7 @@ namespace Ploeh.AutoFixture
         /// <summary>
         /// Gets the scheme name.
         /// </summary>
-        public string Scheme
-        {
-            get { return this.scheme; }
-        }
+        public string Scheme { get; }
 
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.

--- a/Src/AutoFixture/UriScheme.cs
+++ b/Src/AutoFixture/UriScheme.cs
@@ -29,7 +29,7 @@ namespace Ploeh.AutoFixture
         {
             if (scheme == null)
             {
-                throw new ArgumentNullException("scheme");
+                throw new ArgumentNullException(nameof(scheme));
             }
 
             if (!UriScheme.IsValid(scheme))

--- a/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/DanishPhoneNumber.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/DanishPhoneNumber.cs
@@ -12,7 +12,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Contact.ValidatingValueObject
         {
             if (!DanishPhoneNumber.IsValid(number))
             {
-                throw new ArgumentOutOfRangeException("number");
+                throw new ArgumentOutOfRangeException(nameof(number));
             }
             this.number = number;
         }

--- a/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/DanishPhoneNumber.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/DanishPhoneNumber.cs
@@ -6,15 +6,13 @@ namespace Ploeh.AutoFixtureDocumentationTest.Contact.ValidatingValueObject
     {
         public const int MinValue = 112;
 
-        private readonly int number;
-
         public DanishPhoneNumber(int number)
         {
             if (!DanishPhoneNumber.IsValid(number))
             {
                 throw new ArgumentOutOfRangeException(nameof(number));
             }
-            this.number = number;
+            this.RawNumber = number;
         }
 
         public static bool IsValid(int number)
@@ -23,9 +21,6 @@ namespace Ploeh.AutoFixtureDocumentationTest.Contact.ValidatingValueObject
                 && (number <= 99999999);
         }
 
-        public int RawNumber
-        {
-            get { return this.number; }
-        }
+        public int RawNumber { get; }
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Contact/ValueObject/DanishPhoneNumber.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/ValueObject/DanishPhoneNumber.cs
@@ -2,16 +2,11 @@
 {
     public class DanishPhoneNumber
     {
-        private readonly int number;
-
         public DanishPhoneNumber(int number)
         {
-            this.number = number;
+            this.RawNumber = number;
         }
 
-        public int RawNumber
-        {
-            get { return this.number; }
-        }
+        public int RawNumber { get; }
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Greedy/Bastard.cs
+++ b/Src/AutoFixtureDocumentationTest/Greedy/Bastard.cs
@@ -4,8 +4,6 @@ namespace Ploeh.AutoFixtureDocumentationTest.Greedy
 {
     public class Bastard
     {
-        private readonly IFoo foo;
-
         public Bastard()
             : this(new DefaultFoo())
         {
@@ -18,12 +16,9 @@ namespace Ploeh.AutoFixtureDocumentationTest.Greedy
                 throw new ArgumentNullException(nameof(foo));
             }
 
-            this.foo = foo;
+            this.Foo = foo;
         }
 
-        public IFoo Foo
-        {
-            get { return this.foo; }
-        }
+        public IFoo Foo { get; }
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Greedy/Bastard.cs
+++ b/Src/AutoFixtureDocumentationTest/Greedy/Bastard.cs
@@ -15,7 +15,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Greedy
         {
             if (foo == null)
             {
-                throw new ArgumentNullException("foo");
+                throw new ArgumentNullException(nameof(foo));
             }
 
             this.foo = foo;

--- a/Src/AutoFixtureDocumentationTest/Simple/ComplexChild.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/ComplexChild.cs
@@ -2,23 +2,18 @@
 {
     public class ComplexChild
     {
-        private readonly string name;
-
         public ComplexChild(string name)
         {
-            this.name = name;
+            this.Name = name;
         }
 
         public ComplexChild(string name, int number)
         {
-            this.name = name;
+            this.Name = name;
             this.Number = number;
         }
 
-        public string Name
-        {
-            get { return this.name; }
-        }
+        public string Name { get; }
 
         public int Number { get; set; }
     }

--- a/Src/AutoFixtureDocumentationTest/Simple/ComplexParent.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/ComplexParent.cs
@@ -2,16 +2,11 @@
 {
     public class ComplexParent
     {
-        private readonly ComplexChild child;
-
         public ComplexParent(ComplexChild child)
         {
-            this.child = child;
+            this.Child = child;
         }
 
-        public ComplexChild Child
-        {
-            get { return this.child; }
-        }
+        public ComplexChild Child { get; }
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Simple/Filter.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/Filter.cs
@@ -14,7 +14,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
             {
                 if (value < this.Min)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
                 this.max = value;
             }
@@ -27,7 +27,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
             {
                 if (value > this.Max)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
                 this.min = value;
             }

--- a/Src/AutoFixtureDocumentationTest/Simple/MyViewModel.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/MyViewModel.cs
@@ -13,10 +13,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
             this.availableItems = new List<MyClass>();
         }
 
-        public ICollection<MyClass> AvailableItems
-        {
-            get { return this.availableItems; }
-        }
+        public ICollection<MyClass> AvailableItems => this.availableItems;
 
         public MyClass SelectedItem
         {

--- a/Src/AutoFixtureDocumentationTest/Simple/SomeImp.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/SomeImp.cs
@@ -6,7 +6,6 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
     {
         private MyClass mc;
         private string message;
-        private string transformedMessage;
 
         public string Message
         {
@@ -19,7 +18,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
                 }
 
                 this.message = value;
-                this.transformedMessage = this.mc.DoStuff(value);
+                this.TransformedMessage = this.mc.DoStuff(value);
             }
         }
 
@@ -28,9 +27,6 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
             this.mc = mc;
         }
 
-        public string TransformedMessage
-        {
-            get { return this.transformedMessage; }
-        }
+        public string TransformedMessage { get; private set; }
     }
 }

--- a/Src/AutoFixtureUnitTest/DelegatingRecursionGuard.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingRecursionGuard.cs
@@ -40,10 +40,7 @@ namespace Ploeh.AutoFixtureUnitTest
             return new DelegatingRecursionGuard(new CompositeSpecimenBuilder(builders));
         }
 
-        internal IEnumerable<Object> UnprotectedRecordedRequests
-        {
-            get { return this.RecordedRequests.Cast<object>(); }
-        }
+        internal IEnumerable<Object> UnprotectedRecordedRequests => this.RecordedRequests.Cast<object>();
 
         internal Func<object, object> OnHandleRecursiveRequest { get; set; }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingMethod.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingMethod.cs
@@ -14,10 +14,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             this.OnInvoke = p => null;
         }
 
-        public IEnumerable<ParameterInfo> Parameters
-        {
-            get { return this.OnParameters(); }
-        }
+        public IEnumerable<ParameterInfo> Parameters => this.OnParameters();
 
         public object Invoke(IEnumerable<object> parameters)
         {

--- a/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
@@ -211,7 +211,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                         return new short();
                     }
                 }
-                throw new ArgumentException("Unexpected container request.", "r");
+                throw new ArgumentException("Unexpected container request.", nameof(r));
             };
 
             var sut = new MethodInvoker(new ModestConstructorQuery());

--- a/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
@@ -338,17 +338,12 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
         private abstract class GenericEquatable<T> : IEquatable<T> where T : class
         {
-            private readonly T item;
-
             public GenericEquatable(T item)
             {
-                this.item = item;
+                this.Item = item;
             }
 
-            public T Item
-            {
-                get { return this.item; }
-            }
+            public T Item { get; }
 
             public override bool Equals(object obj)
             {
@@ -360,7 +355,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             public override int GetHashCode()
             {
-                return this.item.GetHashCode();
+                return this.Item.GetHashCode();
             }
 
             public bool Equals(T other)

--- a/Src/AutoFixtureUnitTest/ProvidedAttribute.cs
+++ b/Src/AutoFixtureUnitTest/ProvidedAttribute.cs
@@ -4,29 +4,14 @@ namespace Ploeh.AutoFixtureUnitTest
 {
     internal class ProvidedAttribute
     {
-        private readonly Attribute attribute;
-        private readonly bool inherited;
-
         public ProvidedAttribute(Attribute attribute, bool inherited)
         {
-            this.attribute = attribute;
-            this.inherited = inherited;
+            this.Attribute = attribute;
+            this.Inherited = inherited;
         }
 
-        public Attribute Attribute
-        {
-            get
-            {
-                return this.attribute;
-            }
-        }
+        public Attribute Attribute { get; }
 
-        public bool Inherited
-        {
-            get
-            {
-                return this.inherited;
-            }
-        }
+        public bool Inherited { get; }
     }
 }

--- a/Src/AutoFixtureUnitTest/TaggedNode.cs
+++ b/Src/AutoFixtureUnitTest/TaggedNode.cs
@@ -8,22 +8,17 @@ namespace Ploeh.AutoFixtureUnitTest
 {
     public class TaggedNode : CompositeSpecimenBuilder
     {
-        private readonly object tag;
-
         public TaggedNode(object tag, params ISpecimenBuilder[] builders)
             : base(builders)
         {
-            this.tag = tag;
+            this.Tag = tag;
         }
 
         public override ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
-            return new TaggedNode(this.tag, builders.ToArray());
+            return new TaggedNode(this.Tag, builders.ToArray());
         }
 
-        public object Tag
-        {
-            get { return this.tag; }
-        }
+        public object Tag { get; }
     }
 }

--- a/Src/AutoFixtureUnitTest/TestConsole.cs
+++ b/Src/AutoFixtureUnitTest/TestConsole.cs
@@ -22,10 +22,7 @@ namespace Ploeh.AutoFixtureUnitTest
 
         private class NullWriter : TextWriter
         {
-            public override Encoding Encoding
-            {
-                get { return Encoding.Unicode; }
-            }
+            public override Encoding Encoding => Encoding.Unicode;
         }
     }
 }

--- a/Src/SemanticComparison/Likeness.cs
+++ b/Src/SemanticComparison/Likeness.cs
@@ -185,7 +185,7 @@ namespace Ploeh.SemanticComparison
         {
             if (propertyPicker == null)
             {
-                throw new ArgumentNullException("propertyPicker");
+                throw new ArgumentNullException(nameof(propertyPicker));
             }
 
             var me = (MemberExpression)propertyPicker.Body;
@@ -209,7 +209,7 @@ namespace Ploeh.SemanticComparison
         {
             if (propertyPicker == null)
             {
-                throw new ArgumentNullException("propertyPicker");
+                throw new ArgumentNullException(nameof(propertyPicker));
             }
 
             var me = (MemberExpression)propertyPicker.Body;
@@ -309,7 +309,7 @@ namespace Ploeh.SemanticComparison
         public Likeness(T value, IEqualityComparer<T> comparer)
         {
             if (comparer == null)
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
 
             this.value = value;
             this.comparer = comparer;

--- a/Src/SemanticComparison/Likeness.cs
+++ b/Src/SemanticComparison/Likeness.cs
@@ -21,7 +21,6 @@ namespace Ploeh.SemanticComparison
     /// </typeparam>
     public class Likeness<TSource, TDestination> : IEquatable<TDestination>
     {
-        private readonly TSource value;
         private readonly SemanticComparer<TSource, TDestination> comparer;
 
         /// <summary>
@@ -38,7 +37,7 @@ namespace Ploeh.SemanticComparison
 
         internal Likeness(TSource value, IEnumerable<MemberEvaluator<TSource, TDestination>> evaluators, Func<IEnumerable<MemberInfo>> defaultMembersGenerator)
         {
-            this.value = value;
+            this.Value = value;
             this.comparer = new SemanticComparer<TSource, TDestination>(evaluators, defaultMembersGenerator);
         }
 
@@ -46,10 +45,7 @@ namespace Ploeh.SemanticComparison
         /// Gets the source value against which destination values will be compared when
         /// <see cref="Equals(TDestination)"/> is invoked.
         /// </summary>
-        public TSource Value
-        {
-            get { return this.value; }
-        }
+        public TSource Value { get; }
 
         /// <summary>
         /// Creates a dynamic proxy that overrides Equals using Likeness. 
@@ -61,7 +57,7 @@ namespace Ploeh.SemanticComparison
             try
             {
                 return ProxyGenerator.CreateLikenessProxy<TSource, TDestination>(
-                    this.value,
+                    this.Value,
                     this.comparer,
                     SemanticComparer<TSource, TDestination>.DefaultMembers.Generate<TDestination>());
             }
@@ -283,7 +279,6 @@ namespace Ploeh.SemanticComparison
     /// </typeparam>
     public class Likeness<T> : IEquatable<T>
     {
-        private readonly T value;
         private readonly IEqualityComparer<T> comparer;
 
         /// <summary>
@@ -311,7 +306,7 @@ namespace Ploeh.SemanticComparison
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            this.value = value;
+            this.Value = value;
             this.comparer = comparer;
         }
 
@@ -321,10 +316,7 @@ namespace Ploeh.SemanticComparison
         /// <value>
         /// The supplied value which will be compared for equality.
         /// </value>
-        public T Value
-        {
-            get { return this.value; }
-        }
+        public T Value { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is semantically

--- a/Src/SemanticComparison/LikenessMember.cs
+++ b/Src/SemanticComparison/LikenessMember.cs
@@ -20,11 +20,11 @@ namespace Ploeh.SemanticComparison
         {
             if (likeness == null)
             {
-                throw new ArgumentNullException("likeness");
+                throw new ArgumentNullException(nameof(likeness));
             }
             if (memberInfo == null)
             {
-                throw new ArgumentNullException("memberInfo");
+                throw new ArgumentNullException(nameof(memberInfo));
             }
 
             this.likeness = likeness;

--- a/Src/SemanticComparison/MemberComparer.cs
+++ b/Src/SemanticComparison/MemberComparer.cs
@@ -53,13 +53,13 @@ namespace Ploeh.SemanticComparison
             ISpecification<FieldInfo> fieldSpecification)
         {
             if (comparer == null)
-                throw new ArgumentNullException("comparer");
+                throw new ArgumentNullException(nameof(comparer));
 
             if (propertySpecification == null)
-                throw new ArgumentNullException("propertySpecification");
+                throw new ArgumentNullException(nameof(propertySpecification));
 
             if (fieldSpecification == null)
-                throw new ArgumentNullException("fieldSpecification");
+                throw new ArgumentNullException(nameof(fieldSpecification));
 
             this.comparer = comparer;
             this.propertySpecification = propertySpecification;

--- a/Src/SemanticComparison/MemberComparer.cs
+++ b/Src/SemanticComparison/MemberComparer.cs
@@ -9,10 +9,6 @@ namespace Ploeh.SemanticComparison
     /// </summary>
     public class MemberComparer : IMemberComparer
     {
-        private readonly IEqualityComparer comparer;
-        private readonly ISpecification<PropertyInfo> propertySpecification;
-        private readonly ISpecification<FieldInfo> fieldSpecification;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MemberComparer"/> 
         /// class with the supplied <see cref="IEqualityComparer"/> to support
@@ -61,9 +57,9 @@ namespace Ploeh.SemanticComparison
             if (fieldSpecification == null)
                 throw new ArgumentNullException(nameof(fieldSpecification));
 
-            this.comparer = comparer;
-            this.propertySpecification = propertySpecification;
-            this.fieldSpecification = fieldSpecification;
+            this.Comparer = comparer;
+            this.PropertySpecification = propertySpecification;
+            this.FieldSpecification = fieldSpecification;
         }
 
         /// <summary>
@@ -72,10 +68,7 @@ namespace Ploeh.SemanticComparison
         /// <value>
         /// The supplied <see cref="IEqualityComparer"/>.
         /// </value>
-        public IEqualityComparer Comparer
-        {
-            get { return this.comparer; }
-        }
+        public IEqualityComparer Comparer { get; }
 
         /// <summary>
         /// Gets the supplied Specification used to control whether or not a property
@@ -85,10 +78,7 @@ namespace Ploeh.SemanticComparison
         /// The supplied Specification used to control whether or not a property should
         /// be compared.
         /// </value>
-        public ISpecification<PropertyInfo> PropertySpecification
-        {
-            get { return this.propertySpecification; }
-        }
+        public ISpecification<PropertyInfo> PropertySpecification { get; }
 
         /// <summary>
         /// Gets the supplied Specification used to control whether or not a field
@@ -98,10 +88,7 @@ namespace Ploeh.SemanticComparison
         /// The supplied Specification used to control whether or not a field should
         /// be compared.
         /// </value>
-        public ISpecification<FieldInfo> FieldSpecification
-        {
-            get { return this.fieldSpecification; }
-        }
+        public ISpecification<FieldInfo> FieldSpecification { get; }
 
         /// <summary>
         /// Evaluates a request for comparison of a property.
@@ -110,7 +97,7 @@ namespace Ploeh.SemanticComparison
         /// <returns><see langword="true"/>.</returns>
         public bool IsSatisfiedBy(PropertyInfo request)
         {
-            return this.propertySpecification.IsSatisfiedBy(request);
+            return this.PropertySpecification.IsSatisfiedBy(request);
         }
 
         /// <summary>
@@ -120,7 +107,7 @@ namespace Ploeh.SemanticComparison
         /// <returns><see langword="true"/>.</returns>
         public bool IsSatisfiedBy(FieldInfo request)
         {
-            return this.fieldSpecification.IsSatisfiedBy(request);
+            return this.FieldSpecification.IsSatisfiedBy(request);
         }
 
         /// <summary>
@@ -143,7 +130,7 @@ namespace Ploeh.SemanticComparison
         /// </remarks>
         public new bool Equals(object x, object y)
         {
-            return this.comparer.Equals(x, y);
+            return this.Comparer.Equals(x, y);
         }
 
         /// <summary>
@@ -156,7 +143,7 @@ namespace Ploeh.SemanticComparison
         /// </returns>
         public int GetHashCode(object obj)
         {
-            return this.comparer.GetHashCode(obj);
+            return this.Comparer.GetHashCode(obj);
         }
     }
 }

--- a/Src/SemanticComparison/MemberEvaluator.cs
+++ b/Src/SemanticComparison/MemberEvaluator.cs
@@ -12,11 +12,11 @@ namespace Ploeh.SemanticComparison
         {
             if (member == null)
             {
-                throw new ArgumentNullException("member");
+                throw new ArgumentNullException(nameof(member));
             }
             if (evaluator == null)
             {
-                throw new ArgumentNullException("evaluator");
+                throw new ArgumentNullException(nameof(evaluator));
             }
 
             this.member = member;

--- a/Src/SemanticComparison/MemberEvaluator.cs
+++ b/Src/SemanticComparison/MemberEvaluator.cs
@@ -5,9 +5,6 @@ namespace Ploeh.SemanticComparison
 {
     internal class MemberEvaluator<TSource, TDestination>
     {
-        private readonly MemberInfo member;
-        private readonly Func<TSource, TDestination, bool> evaluator;
-
         public MemberEvaluator(MemberInfo member, Func<TSource, TDestination, bool> evaluator)
         {
             if (member == null)
@@ -19,18 +16,12 @@ namespace Ploeh.SemanticComparison
                 throw new ArgumentNullException(nameof(evaluator));
             }
 
-            this.member = member;
-            this.evaluator = evaluator;
+            this.Member = member;
+            this.Evaluator = evaluator;
         }
 
-        internal Func<TSource, TDestination, bool> Evaluator
-        {
-            get { return this.evaluator; }
-        }
+        internal Func<TSource, TDestination, bool> Evaluator { get; }
 
-        internal MemberInfo Member
-        {
-            get { return this.member; }
-        }
+        internal MemberInfo Member { get; }
     }
 }

--- a/Src/SemanticComparison/MemberInfoExtension.cs
+++ b/Src/SemanticComparison/MemberInfoExtension.cs
@@ -52,7 +52,7 @@ namespace Ploeh.SemanticComparison
                 case MemberTypes.Property:
                     return ((PropertyInfo)member).PropertyType;
                 default:
-                    throw new ArgumentException("MemberInfo must either FieldInfo or PropertyInfo.", "member");
+                    throw new ArgumentException("MemberInfo must either FieldInfo or PropertyInfo.", nameof(member));
             }
         }
     }

--- a/Src/SemanticComparison/MemberInfoNameComparer.cs
+++ b/Src/SemanticComparison/MemberInfoNameComparer.cs
@@ -35,7 +35,7 @@ namespace Ploeh.SemanticComparison
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj");
+                throw new ArgumentNullException(nameof(obj));
             }
 
             return obj.Name.GetHashCode();

--- a/Src/SemanticComparison/ProxyGenerator.cs
+++ b/Src/SemanticComparison/ProxyGenerator.cs
@@ -481,7 +481,7 @@ namespace Ploeh.SemanticComparison
             public SourceTypeValuePair(Type type, object value)
             {
                 if (type == null)
-                    throw new ArgumentNullException("type");
+                    throw new ArgumentNullException(nameof(type));
 
                 this.type = type;
                 this.value = value;

--- a/Src/SemanticComparison/ProxyGenerator.cs
+++ b/Src/SemanticComparison/ProxyGenerator.cs
@@ -475,20 +475,17 @@ namespace Ploeh.SemanticComparison
 
         private class SourceTypeValuePair
         {
-            private readonly Type type;
-            private readonly object value; 
-
             public SourceTypeValuePair(Type type, object value)
             {
                 if (type == null)
                     throw new ArgumentNullException(nameof(type));
 
-                this.type = type;
-                this.value = value;
+                this.Type = type;
+                this.Value = value;
             }
 
-            public Type Type { get { return this.type; } }
-            public object Value { get { return this.value; } }
+            public Type Type { get; }
+            public object Value { get; }
         }
     }
 }

--- a/Src/SemanticComparison/ProxyType.cs
+++ b/Src/SemanticComparison/ProxyType.cs
@@ -15,10 +15,10 @@ namespace Ploeh.SemanticComparison
             params object[] parameters)
         {
             if (constructor == null)
-                throw new ArgumentNullException("constructor");
+                throw new ArgumentNullException(nameof(constructor));
 
             if (parameters == null)
-                throw new ArgumentNullException("parameters");
+                throw new ArgumentNullException(nameof(parameters));
 
             this.constructor = constructor;
             this.parameters = parameters;

--- a/Src/SemanticComparison/ProxyType.cs
+++ b/Src/SemanticComparison/ProxyType.cs
@@ -7,9 +7,6 @@ namespace Ploeh.SemanticComparison
 {
     internal class ProxyType
     {
-        private readonly ConstructorInfo constructor;
-        private readonly IEnumerable<object> parameters;
-
         internal ProxyType(
             ConstructorInfo constructor,
             params object[] parameters)
@@ -20,18 +17,12 @@ namespace Ploeh.SemanticComparison
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));
 
-            this.constructor = constructor;
-            this.parameters = parameters;
+            this.Constructor = constructor;
+            this.Parameters = parameters;
         }
 
-        internal ConstructorInfo Constructor
-        {
-            get { return this.constructor; }
-        }
+        internal ConstructorInfo Constructor { get; }
 
-        internal IEnumerable<object> Parameters
-        {
-            get { return this.parameters; }
-        }
+        internal IEnumerable<object> Parameters { get; }
     }
 }

--- a/Src/SemanticComparison/SemanticComparer.cs
+++ b/Src/SemanticComparison/SemanticComparer.cs
@@ -17,9 +17,6 @@ namespace Ploeh.SemanticComparison
     /// equality against the source value.</typeparam>
     public class SemanticComparer<TSource, TDestination> : IEqualityComparer, IEqualityComparer<object>
     {
-        private readonly IEnumerable<MemberEvaluator<TSource, TDestination>> evaluators;
-        private readonly Func<IEnumerable<MemberInfo>> defaultMembersGenerator;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SemanticComparer&lt;TSource, TDestination&gt;"/> class.
         /// </summary>
@@ -30,19 +27,13 @@ namespace Ploeh.SemanticComparison
 
         internal SemanticComparer(IEnumerable<MemberEvaluator<TSource, TDestination>> evaluators, Func<IEnumerable<MemberInfo>> defaultMembersGenerator)
         {
-            this.evaluators = evaluators;
-            this.defaultMembersGenerator = defaultMembersGenerator;
+            this.Evaluators = evaluators;
+            this.DefaultMembersGenerator = defaultMembersGenerator;
         }
 
-        internal IEnumerable<MemberEvaluator<TSource, TDestination>> Evaluators
-        {
-            get { return evaluators; }
-        }
+        internal IEnumerable<MemberEvaluator<TSource, TDestination>> Evaluators { get; }
 
-        internal Func<IEnumerable<MemberInfo>> DefaultMembersGenerator
-        {
-            get { return defaultMembersGenerator; }
-        }
+        internal Func<IEnumerable<MemberInfo>> DefaultMembersGenerator { get; }
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
@@ -174,8 +165,6 @@ namespace Ploeh.SemanticComparison
     /// </remarks>
     public class SemanticComparer<T> : IEqualityComparer<T>, IEqualityComparer
     {
-        private readonly IEnumerable<IMemberComparer> comparers;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SemanticComparer&lt;T&gt;"/>
         /// class.
@@ -215,7 +204,7 @@ namespace Ploeh.SemanticComparison
             if (comparers == null)
                 throw new ArgumentNullException(nameof(comparers));
 
-            this.comparers = comparers;
+            this.Comparers = comparers;
         }
 
         /// <summary>
@@ -226,10 +215,7 @@ namespace Ploeh.SemanticComparison
         /// The supplied <see cref="IEnumerable&lt;IMemberComparer&gt;" />
         /// instances.
         /// </value>
-        public IEnumerable<IMemberComparer> Comparers
-        {
-            get { return this.comparers; }
-        }
+        public IEnumerable<IMemberComparer> Comparers { get; }
 
         /// <summary>
         /// Determines whether the specified objects are equal.
@@ -253,14 +239,14 @@ namespace Ploeh.SemanticComparison
             var bindingAttributes = BindingFlags.Public | BindingFlags.Instance;
             return typeof(T)
                 .GetProperties(bindingAttributes)
-                .Select(property => this.comparers
+                .Select(property => this.Comparers
                     .Where(c => c.IsSatisfiedBy(property))
                     .Any(c => c.Equals(
                         property.GetValue(x, null),
                         property.GetValue(y, null))))
                 .Concat(typeof(T)
                     .GetFields(bindingAttributes)
-                    .Select(field => this.comparers
+                    .Select(field => this.Comparers
                         .Where(c => c.IsSatisfiedBy(field))
                         .Any(c => c.Equals(
                             field.GetValue(x),

--- a/Src/SemanticComparison/SemanticComparer.cs
+++ b/Src/SemanticComparison/SemanticComparer.cs
@@ -213,7 +213,7 @@ namespace Ploeh.SemanticComparison
         public SemanticComparer(params IMemberComparer[] comparers)
         {
             if (comparers == null)
-                throw new ArgumentNullException("comparers");
+                throw new ArgumentNullException(nameof(comparers));
 
             this.comparers = comparers;
         }

--- a/Src/SemanticComparisonUnitTest/TestTypes/Entity.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/Entity.cs
@@ -13,15 +13,9 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
             this.id = Guid.NewGuid();
         }
 
-        public string Name
-        {
-            get { return this.name; }
-        }
+        public string Name => this.name;
 
-        public Guid Id
-        {
-            get { return this.id; }
-        }
+        public Guid Id => this.id;
 
         public override bool Equals(object obj)
         {

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithDifferentParameterTypesAndProperties.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithDifferentParameterTypesAndProperties.cs
@@ -4,11 +4,6 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
 {
     public class TypeWithDifferentParameterTypesAndProperties
     {
-        private readonly double field1;
-        private readonly string field2;
-        private readonly int field3;
-        private readonly Guid field4;
-
         public TypeWithDifferentParameterTypesAndProperties(
             double field1,
             string field2,
@@ -23,10 +18,10 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
             int field3,
             Guid field4)
         {
-            this.field1 = field1;
-            this.field2 = field2;
-            this.field3 = field3;
-            this.field4 = field4;
+            this.Property1 = field1;
+            this.Property2 = field2;
+            this.Property3 = field3;
+            this.Property4 = field4;
         }
 
         protected TypeWithDifferentParameterTypesAndProperties(object source)
@@ -37,24 +32,12 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
             }
         }
 
-        public double Property1
-        {
-            get { return this.field1; }
-        }
+        public double Property1 { get; }
 
-        public string Property2
-        {
-            get { return this.field2; }
-        }
+        public string Property2 { get; }
 
-        public int Property3
-        {
-            get { return this.field3; }
-        }
+        public int Property3 { get; }
 
-        public Guid Property4
-        {
-            get { return this.field4; }
-        }
+        public Guid Property4 { get; }
     }
 }

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithDifferentParameterTypesAndProperties.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithDifferentParameterTypesAndProperties.cs
@@ -33,7 +33,7 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithIdenticalParameterTypesAndProperties.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithIdenticalParameterTypesAndProperties.cs
@@ -4,20 +4,15 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
 {
     public class TypeWithIdenticalParameterTypesAndProperties
     {
-        private readonly long field1;
-        private readonly long field2;
-        private readonly long field3;
-        private readonly long field4;
-
         public TypeWithIdenticalParameterTypesAndProperties(
             long parameter1,
             long parameter2,
             long parameter3)
         {
-            this.field1 = parameter1;
-            this.field2 = parameter2;
-            this.field3 = parameter3;
-            this.field4 = 400;
+            this.Property1 = parameter1;
+            this.Property2 = parameter2;
+            this.Property3 = parameter3;
+            this.Property4 = 400;
         }
 
         protected TypeWithIdenticalParameterTypesAndProperties(object source)
@@ -28,24 +23,12 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
             }
         }
 
-        public long Property1
-        {
-            get { return this.field1; }
-        }
+        public long Property1 { get; }
 
-        public long Property2
-        {
-            get { return this.field2; }
-        }
+        public long Property2 { get; }
 
-        public long Property3
-        {
-            get { return this.field3; }
-        }
+        public long Property3 { get; }
 
-        public long Property4
-        {
-            get { return this.field4; }
-        }
+        public long Property4 { get; }
     }
 }

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithIdenticalParameterTypesAndProperties.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithIdenticalParameterTypesAndProperties.cs
@@ -24,7 +24,7 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
         }
 

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithIncompatibleAndCompatibleConstructor.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithIncompatibleAndCompatibleConstructor.cs
@@ -4,10 +4,6 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
 {
     public class TypeWithIncompatibleAndCompatibleConstructor
     {
-        private readonly AbstractType value1;
-        private readonly AbstractType value2;
-        private readonly byte value3;
-
         public TypeWithIncompatibleAndCompatibleConstructor(ConcreteType a)
             : this(new ConcreteType(), new CompositeType(a), new byte())
         {
@@ -25,24 +21,15 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
             AbstractType b, 
             byte c)
         {
-            this.value1 = a;
-            this.value2 = b;
-            this.value3 = c;
+            this.Property1 = a;
+            this.Property2 = b;
+            this.Property3 = c;
         }
 
-        public AbstractType Property1
-        {
-            get { return this.value1; }
-        }
+        public AbstractType Property1 { get; }
 
-        public AbstractType Property2
-        {
-            get { return this.value2; }
-        }
+        public AbstractType Property2 { get; }
 
-        public byte Property3
-        {
-            get { return this.value3; }
-        }
+        public byte Property3 { get; }
     }
 }

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithPrivateDefaultCtorAndOtherCtor.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithPrivateDefaultCtorAndOtherCtor.cs
@@ -14,7 +14,7 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             this.property = value;

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithPrivateDefaultCtorAndOtherCtor.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithPrivateDefaultCtorAndOtherCtor.cs
@@ -4,8 +4,6 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
 {
     public class TypeWithPrivateDefaultCtorAndOtherCtor<T>
     {
-        private readonly T property;
-
         private TypeWithPrivateDefaultCtorAndOtherCtor()
         {
             
@@ -17,13 +15,9 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
                 throw new ArgumentNullException(nameof(value));
             }
 
-            this.property = value;
+            this.Property = value;
         }
 
-        public T Property
-        {
-            get { return this.property; }
-        }
-
+        public T Property { get; }
     }
 }

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithPublicFieldsAndProperties.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithPublicFieldsAndProperties.cs
@@ -4,13 +4,7 @@
     {
         public string Field;
 
-        private long number;
-
-        public long Number
-        {
-            get { return this.number; }
-            set { this.number = value; }
-        }
+        public long Number { get; set; }
 
         public decimal AutomaticProperty { get; set; }
     }

--- a/Src/SemanticComparisonUnitTest/TestTypes/TypeWithUnorderedProperties.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/TypeWithUnorderedProperties.cs
@@ -4,30 +4,17 @@ namespace Ploeh.SemanticComparison.UnitTest.TestTypes
 {
     public class TypeWithUnorderedProperties
     {
-        private readonly AbstractType value1;
-        private readonly AbstractType value2;
-        private readonly byte value3;
-
         public TypeWithUnorderedProperties(ConcreteType a, AbstractType b, byte c)
         {
-            this.value1 = a;
-            this.value2 = b;
-            this.value3 = c;
+            this.Property1 = a;
+            this.Property2 = b;
+            this.Property3 = c;
         }
 
-        public byte Property3
-        {
-            get { return this.value3; }
-        }
+        public byte Property3 { get; }
 
-        public AbstractType Property1
-        {
-            get { return this.value1; }
-        }
+        public AbstractType Property1 { get; }
 
-        public AbstractType Property2
-        {
-            get { return this.value2; }
-        }
+        public AbstractType Property2 { get; }
     }
 }

--- a/Src/SemanticComparisonUnitTest/TestTypes/ValueObject.cs
+++ b/Src/SemanticComparisonUnitTest/TestTypes/ValueObject.cs
@@ -11,15 +11,9 @@
             this.y = y;
         }
 
-        public int X
-        {
-            get { return x; }
-        }
+        public int X => x;
 
-        public int Y
-        {
-            get { return y; }
-        }
+        public int Y => y;
 
         public override bool Equals(object obj)
         {

--- a/Src/TestTypeFoundation/AbstractGenericType.cs
+++ b/Src/TestTypeFoundation/AbstractGenericType.cs
@@ -2,13 +2,11 @@ namespace Ploeh.TestTypeFoundation
 {
     public abstract class AbstractGenericType<T>
     {
-        private readonly T t;
-
         protected AbstractGenericType(T t)
         {
-            this.t = t;
+            this.Value = t;
         }
 
-        public T Value { get { return this.t; }}
+        public T Value { get; }
     }
 }

--- a/Src/TestTypeFoundation/AbstractTypeWithConstructorWithMultipleParameters.cs
+++ b/Src/TestTypeFoundation/AbstractTypeWithConstructorWithMultipleParameters.cs
@@ -7,25 +7,16 @@ namespace Ploeh.TestTypeFoundation
 {
     public abstract class AbstractTypeWithConstructorWithMultipleParameters<T1, T2>
     {
-        private readonly T1 property1;
-        private readonly T2 property2;
-
         protected AbstractTypeWithConstructorWithMultipleParameters(
             T1 parameter1,
             T2 parameter2)
         {
-            this.property1 = parameter1;
-            this.property2 = parameter2;
+            this.Property1 = parameter1;
+            this.Property2 = parameter2;
         }
 
-        public T1 Property1
-        {
-            get { return property1; }
-        }
+        public T1 Property1 { get; }
 
-        public T2 Property2
-        {
-            get { return property2; }
-        }
+        public T2 Property2 { get; }
     }
 }

--- a/Src/TestTypeFoundation/AbstractTypeWithNonDefaultConstructor.cs
+++ b/Src/TestTypeFoundation/AbstractTypeWithNonDefaultConstructor.cs
@@ -4,8 +4,6 @@ namespace Ploeh.TestTypeFoundation
 {
     public abstract class AbstractTypeWithNonDefaultConstructor<T>
     {
-        private readonly T property;
-
         protected AbstractTypeWithNonDefaultConstructor(T value)
         {
             if (value == null)
@@ -13,12 +11,9 @@ namespace Ploeh.TestTypeFoundation
                 throw new ArgumentNullException(nameof(value));
             }
 
-            this.property = value;
+            this.Property = value;
         }
 
-        public T Property
-        {
-            get { return this.property; }
-        }
+        public T Property { get; }
     }
 }

--- a/Src/TestTypeFoundation/AbstractTypeWithNonDefaultConstructor.cs
+++ b/Src/TestTypeFoundation/AbstractTypeWithNonDefaultConstructor.cs
@@ -10,7 +10,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             this.property = value;

--- a/Src/TestTypeFoundation/CompositeType.cs
+++ b/Src/TestTypeFoundation/CompositeType.cs
@@ -6,8 +6,6 @@ namespace Ploeh.TestTypeFoundation
 {
     public class CompositeType : AbstractType
     {
-        private readonly IEnumerable<AbstractType> types;
-
         public CompositeType(IEnumerable<AbstractType> types)
             : this(types.ToArray())
         {
@@ -20,12 +18,9 @@ namespace Ploeh.TestTypeFoundation
                 throw new ArgumentNullException(nameof(types));
             }
 
-            this.types = types;
+            this.Types = types;
         }
 
-        public IEnumerable<AbstractType> Types
-        {
-            get { return this.types; }
-        }
+        public IEnumerable<AbstractType> Types { get; }
     }
 }

--- a/Src/TestTypeFoundation/CompositeType.cs
+++ b/Src/TestTypeFoundation/CompositeType.cs
@@ -17,7 +17,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (types == null)
             {
-                throw new ArgumentNullException("types");
+                throw new ArgumentNullException(nameof(types));
             }
 
             this.types = types;

--- a/Src/TestTypeFoundation/DataErrorInfo.cs
+++ b/Src/TestTypeFoundation/DataErrorInfo.cs
@@ -4,14 +4,8 @@ namespace Ploeh.TestTypeFoundation
 {
     public class DataErrorInfo : IDataErrorInfo
     {
-        public string Error
-        {
-            get { return string.Empty; }
-        }
+        public string Error => string.Empty;
 
-        public string this[string columnName]
-        {
-            get { return string.Empty; }
-        }
+        public string this[string columnName] => string.Empty;
     }
 }

--- a/Src/TestTypeFoundation/GenericType.cs
+++ b/Src/TestTypeFoundation/GenericType.cs
@@ -4,8 +4,6 @@ namespace Ploeh.TestTypeFoundation
 {
     public class GenericType<T> where T : class
     {
-        private readonly T t;
-
         public GenericType(T t)
         {
             if (t == null)
@@ -13,9 +11,9 @@ namespace Ploeh.TestTypeFoundation
                 throw new ArgumentNullException(nameof(t));
             }
 
-            this.t = t;
+            this.Value = t;
         }
 
-        T Value { get { return this.t; }}
+        private T Value { get; }
     }
 }

--- a/Src/TestTypeFoundation/GenericType.cs
+++ b/Src/TestTypeFoundation/GenericType.cs
@@ -10,7 +10,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (t == null)
             {
-                throw new ArgumentNullException("t");
+                throw new ArgumentNullException(nameof(t));
             }
 
             this.t = t;

--- a/Src/TestTypeFoundation/GuardedConstructorHost.cs
+++ b/Src/TestTypeFoundation/GuardedConstructorHost.cs
@@ -10,7 +10,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (item == null)
             {
-                throw new ArgumentNullException("item");
+                throw new ArgumentNullException(nameof(item));
             }
 
             this.item = item;

--- a/Src/TestTypeFoundation/GuardedConstructorHost.cs
+++ b/Src/TestTypeFoundation/GuardedConstructorHost.cs
@@ -4,8 +4,6 @@ namespace Ploeh.TestTypeFoundation
 {
     public class GuardedConstructorHost<T> where T : class
     {
-        private readonly T item;
-
         public GuardedConstructorHost(T item)
         {
             if (item == null)
@@ -13,12 +11,9 @@ namespace Ploeh.TestTypeFoundation
                 throw new ArgumentNullException(nameof(item));
             }
 
-            this.item = item;
+            this.Item = item;
         }
 
-        public T Item
-        {
-            get { return this.item; }
-        }
+        public T Item { get; }
     }
 }

--- a/Src/TestTypeFoundation/GuardedMethodHost.cs
+++ b/Src/TestTypeFoundation/GuardedMethodHost.cs
@@ -8,11 +8,11 @@ namespace Ploeh.TestTypeFoundation
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
             if (s.Length == 0)
             {
-                throw new ArgumentException("String cannot be empty.", "s");
+                throw new ArgumentException("String cannot be empty.", nameof(s));
             }
         }
 
@@ -24,7 +24,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (g == Guid.Empty)
             {
-                throw new ArgumentException("Guid cannot be empty.", "g");
+                throw new ArgumentException("Guid cannot be empty.", nameof(g));
             }
         }
 
@@ -32,11 +32,11 @@ namespace Ploeh.TestTypeFoundation
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
             if (s.Length == 0)
             {
-                throw new ArgumentException("String cannot be empty.", "s");
+                throw new ArgumentException("String cannot be empty.", nameof(s));
             }
         }
 
@@ -44,15 +44,15 @@ namespace Ploeh.TestTypeFoundation
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
             if (s.Length == 0)
             {
-                throw new ArgumentException("String cannot be empty.", "s");
+                throw new ArgumentException("String cannot be empty.", nameof(s));
             }
             if (g == Guid.Empty)
             {
-                throw new ArgumentException("Guid cannot be empty.", "g");
+                throw new ArgumentException("Guid cannot be empty.", nameof(g));
             }
         }
 
@@ -60,7 +60,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (g == Guid.Empty)
             {
-                throw new ArgumentException("Guid cannot be empty.", "g");
+                throw new ArgumentException("Guid cannot be empty.", nameof(g));
             }
         }
 
@@ -68,15 +68,15 @@ namespace Ploeh.TestTypeFoundation
         {
             if (s == null)
             {
-                throw new ArgumentNullException("s");
+                throw new ArgumentNullException(nameof(s));
             }
             if (s.Length == 0)
             {
-                throw new ArgumentException("String cannot be empty.", "s");
+                throw new ArgumentException("String cannot be empty.", nameof(s));
             }
             if (g == Guid.Empty)
             {
-                throw new ArgumentException("Guid cannot be empty.", "g");
+                throw new ArgumentException("Guid cannot be empty.", nameof(g));
             }
         }
     }

--- a/Src/TestTypeFoundation/GuardedPropertyHolder.cs
+++ b/Src/TestTypeFoundation/GuardedPropertyHolder.cs
@@ -17,7 +17,7 @@ namespace Ploeh.TestTypeFoundation
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 this.property = value;     

--- a/Src/TestTypeFoundation/ItemContainer.cs
+++ b/Src/TestTypeFoundation/ItemContainer.cs
@@ -5,11 +5,9 @@ namespace Ploeh.TestTypeFoundation
 {
     public class ItemContainer<T>
     {
-        private readonly IEnumerable<T> items;
-
         public ItemContainer(params T[] items)
         {
-            this.items = items;
+            this.Items = items;
         }
 
         public ItemContainer(IEnumerable<T> items)
@@ -22,9 +20,6 @@ namespace Ploeh.TestTypeFoundation
         {
         }
 
-        public IEnumerable<T> Items
-        {
-            get { return this.items; }
-        }
+        public IEnumerable<T> Items { get; }
     }
 }

--- a/Src/TestTypeFoundation/ItemHolder.cs
+++ b/Src/TestTypeFoundation/ItemHolder.cs
@@ -4,9 +4,6 @@ namespace Ploeh.TestTypeFoundation
 {
     public class ItemHolder<T1, T2>
     {
-        private readonly IEnumerable<T1> t1s;
-        private readonly IEnumerable<T2> t2s;
-
         public ItemHolder()
         {
         }
@@ -23,19 +20,13 @@ namespace Ploeh.TestTypeFoundation
 
         private ItemHolder(T1[] t1s, T2[] t2s)
         {
-            this.t1s = t1s;
-            this.t2s = t2s;
+            this.Item1s = t1s;
+            this.Item2s = t2s;
         }
 
-        public IEnumerable<T1> Item1s
-        {
-            get { return this.t1s; }
-        }
+        public IEnumerable<T1> Item1s { get; }
 
-        public IEnumerable<T2> Item2s
-        {
-            get { return this.t2s; }
-        }
+        public IEnumerable<T2> Item2s { get; }
     }
 
     /* Note that constructors must be unordered because this class is used to test that
@@ -43,8 +34,6 @@ namespace Ploeh.TestTypeFoundation
      * reason, please don't be a boy scout and order constructors 'nicely'. */
     public class ItemHolder<T>
     {
-        private readonly IEnumerable<T> items;
-
         public ItemHolder(T x, T y, T z)
             : this(new[] { x, y, z })
         {
@@ -66,12 +55,9 @@ namespace Ploeh.TestTypeFoundation
 
         private ItemHolder(T[] items)
         {
-            this.items = items;
+            this.Items = items;
         }
 
-        public IEnumerable<T> Items
-        {
-            get { return this.items; }
-        }
+        public IEnumerable<T> Items { get; }
     }
 }

--- a/Src/TestTypeFoundation/MultiUnorderedConstructorType.cs
+++ b/Src/TestTypeFoundation/MultiUnorderedConstructorType.cs
@@ -4,9 +4,6 @@ namespace Ploeh.TestTypeFoundation
 {
     public class MultiUnorderedConstructorType
     {
-        private readonly string text;
-        private readonly int number;
-
         public MultiUnorderedConstructorType(ParameterObject paramObj)
             : this(paramObj.Text, paramObj.Number)
         {
@@ -24,25 +21,16 @@ namespace Ploeh.TestTypeFoundation
                 throw new ArgumentNullException(nameof(text));
             }
 
-            this.text = text;
-            this.number = number;
+            this.Text = text;
+            this.Number = number;
         }
 
-        public string Text
-        {
-            get { return this.text; }
-        }
+        public string Text { get; }
 
-        public int Number
-        {
-            get { return this.number; }
-        }
+        public int Number { get; }
 
         public class ParameterObject
         {
-            private readonly string text;
-            private readonly int number;
-
             public ParameterObject(string text, int number)
             {
                 if (text == null)
@@ -50,19 +38,13 @@ namespace Ploeh.TestTypeFoundation
                     throw new ArgumentNullException(nameof(text));
                 }
 
-                this.text = text;
-                this.number = number;
+                this.Text = text;
+                this.Number = number;
             }
 
-            public string Text
-            {
-                get { return this.text; }
-            }
+            public string Text { get; }
 
-            public int Number
-            {
-                get { return this.number; }
-            }
+            public int Number { get; }
         }
     }
 }

--- a/Src/TestTypeFoundation/MultiUnorderedConstructorType.cs
+++ b/Src/TestTypeFoundation/MultiUnorderedConstructorType.cs
@@ -21,7 +21,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (text == null)
             {
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
             }
 
             this.text = text;
@@ -47,7 +47,7 @@ namespace Ploeh.TestTypeFoundation
             {
                 if (text == null)
                 {
-                    throw new ArgumentNullException("text");
+                    throw new ArgumentNullException(nameof(text));
                 }
 
                 this.text = text;

--- a/Src/TestTypeFoundation/TypeWithFactoryProperty.cs
+++ b/Src/TestTypeFoundation/TypeWithFactoryProperty.cs
@@ -6,12 +6,6 @@
         {
         }
 
-        public static TypeWithFactoryProperty Factory
-        {
-            get
-            {
-                return new TypeWithFactoryProperty();
-            }
-        }
+        public static TypeWithFactoryProperty Factory => new TypeWithFactoryProperty();
     }
 }

--- a/Src/TestTypeFoundation/TypeWithRefMethod.cs
+++ b/Src/TestTypeFoundation/TypeWithRefMethod.cs
@@ -10,9 +10,9 @@ namespace Ploeh.TestTypeFoundation
         public void InvokeIt(T x, ref T y)
         {
             if (x == null)
-                throw new ArgumentNullException("x");
+                throw new ArgumentNullException(nameof(x));
             if (y == null)
-                throw new ArgumentNullException("y");
+                throw new ArgumentNullException(nameof(y));
         }
     }
 }

--- a/Src/TestTypeFoundation/UnguardedConstructorHost.cs
+++ b/Src/TestTypeFoundation/UnguardedConstructorHost.cs
@@ -2,16 +2,11 @@
 {
     public class UnguardedConstructorHost<T>
     {
-        private readonly T item;
-
         public UnguardedConstructorHost(T item)
         {
-            this.item = item;
+            this.Item = item;
         }
 
-        public T Item
-        {
-            get { return this.item; }
-        }
+        public T Item { get; }
     }
 }

--- a/Src/TestTypeFoundation/UnguardedMethodHost.cs
+++ b/Src/TestTypeFoundation/UnguardedMethodHost.cs
@@ -12,7 +12,7 @@ namespace Ploeh.TestTypeFoundation
         {
             if (g == Guid.Empty)
             {
-                throw new ArgumentException("Guid cannot be empty.", "g");
+                throw new ArgumentException("Guid cannot be empty.", nameof(g));
             }
         }
     }


### PR DESCRIPTION
The first version of my PR is done. It includes the following things:

- Argument strings are converted to `nameof` operator calls.
- Getter-only properties (essentially readonly properties) are converted to auto-implemented getter-only properties.
- Getter-only properties that could not be converted to auto-implemented properties are converted to expression-bodied members.
- Converted the `buildrelease.ps1` script to use MSBuild as located in the "Program files (x86)\MSBuild" directory, instead of the version in the "Windows\.NET Framework" directory.

To make it easy to see what happened in each step, this PR has several, separate commits.

What I did not do is convert methods to expression-bodies, as most people I know don't really like them. As an example, the following code:

```csharp
public int GetHashCode(Type obj)
{
    return 0;
}
```

could be converted to:

```csharp
public int GetHashCode(Type obj) => 0;
```

Is that something you'd like to see?

Furthermore, as written in the comments in #500, what should I do with the `buildrelease.sh` file? It refers to $WINDIR/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe, so I suspect that it won't work with C# 6. To what should I change the call?

I will probably not be able to do anything internet-related the next week, so I think that is a nice time for everyone to consider if they like what I have done here :)