### PR TITLE
Exceptions don't need to be serializable in .NET Core because there a…

### DIFF
--- a/Src/AutoFixture/Kernel/IllegalRequestException.cs
+++ b/Src/AutoFixture/Kernel/IllegalRequestException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -13,7 +12,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// </para>
     /// </remarks>
     /// <seealso cref="IntPtrGuard"/>
-    [Serializable]
     public class IllegalRequestException : Exception
     {
         /// <summary>
@@ -43,28 +41,6 @@ namespace Ploeh.AutoFixture.Kernel
         /// <param name="innerException">The inner exception.</param>
         public IllegalRequestException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IllegalRequestException"/> class.
-        /// </summary>
-        /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
-        /// serialized object data about the exception being thrown.
-        /// </param>
-        /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
-        /// contextual information about the source or destination.
-        /// </param>
-        /// <exception cref="T:System.ArgumentNullException">
-        /// The <paramref name="info"/> parameter is null.
-        /// </exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">
-        /// The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).
-        /// </exception>
-        protected IllegalRequestException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
+++ b/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
@@ -2,7 +2,6 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -10,7 +9,6 @@ namespace Ploeh.AutoFixture.Kernel
     /// The exception that is thrown when AutoFixture is unable to infer the type 
     /// parameters of a generic method from its arguments.
     /// </summary>
-    [Serializable]
     public class TypeArgumentsCannotBeInferredException : Exception
     {
         /// <summary>
@@ -68,19 +66,6 @@ namespace Ploeh.AutoFixture.Kernel
         /// </param>
         public TypeArgumentsCannotBeInferredException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TypeArgumentsCannotBeInferredException"/> class with
-        /// serialized data.
-        /// </summary>
-        /// <param name="info">The object that holds the serialized object data.</param>
-        /// <param name="context">
-        /// The contextual information about the source or destination.
-        /// </param>
-        protected TypeArgumentsCannotBeInferredException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
 

--- a/Src/AutoFixture/ObjectCreationException.cs
+++ b/Src/AutoFixture/ObjectCreationException.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Ploeh.AutoFixture
 {
     /// <summary>
     /// The exception that is thrown when AutoFixture is unable to create an object.
     /// </summary>
-    [Serializable]
     public class ObjectCreationException : Exception
     {
         /// <summary>
@@ -42,19 +40,6 @@ namespace Ploeh.AutoFixture
         /// </param>
         public ObjectCreationException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ObjectCreationException"/> class with
-        /// serialized data.
-        /// </summary>
-        /// <param name="info">The object that holds the serialized object data.</param>
-        /// <param name="context">
-        /// The contextual information about the source or destination.
-        /// </param>
-        protected ObjectCreationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/Src/SemanticComparison/LikenessException.cs
+++ b/Src/SemanticComparison/LikenessException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Ploeh.SemanticComparison
 {
@@ -7,7 +6,6 @@ namespace Ploeh.SemanticComparison
     /// Represents an error where two semantically comparable instances were expected to match, but
     /// didn't.
     /// </summary>
-    [Serializable]
     public class LikenessException : Exception
     {
         /// <summary>
@@ -33,28 +31,6 @@ namespace Ploeh.SemanticComparison
         /// <param name="innerException">The inner exception.</param>
         public LikenessException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LikenessException"/> class.
-        /// </summary>
-        /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
-        /// serialized object data about the exception being thrown.
-        /// </param>
-        /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
-        /// contextual information about the source or destination.
-        /// </param>
-        /// <exception cref="T:System.ArgumentNullException">
-        /// The <paramref name="info"/> parameter is null.
-        /// </exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">
-        /// The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).
-        /// </exception>
-        protected LikenessException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/Src/SemanticComparison/ProxyCreationException.cs
+++ b/Src/SemanticComparison/ProxyCreationException.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace Ploeh.SemanticComparison
 {
     /// <summary>
     /// Represents an error during the dynamic proxy creation.
     /// </summary>
-    [Serializable]
     public class ProxyCreationException : Exception
     {
         /// <summary>
@@ -32,28 +30,6 @@ namespace Ploeh.SemanticComparison
         /// <param name="innerException">The inner exception.</param>
         public ProxyCreationException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Ploeh.SemanticComparison.ProxyCreationException"/> class.
-        /// </summary>
-        /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
-        /// serialized object data about the exception being thrown.
-        /// </param>
-        /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
-        /// contextual information about the source or destination.
-        /// </param>
-        /// <exception cref="T:System.ArgumentNullException">
-        /// The <paramref name="info"/> parameter is null.
-        /// </exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">
-        /// The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).
-        /// </exception>
-        protected ProxyCreationException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
…re no AppDomains
@ploeh If you're still not [convinced](https://github.com/AutoFixture/AutoFixture/issues/509#issuecomment-170224097), I'll add the placeholder types for .NET Core.