### PR TITLE
Add support for creating encodings

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -334,6 +334,7 @@
     <Compile Include="UriScheme.cs" />
     <Compile Include="UriSchemeGenerator.cs" />
     <Compile Include="MailAddressGenerator.cs" />
+    <Compile Include="Utf8EncodingGenerator.cs" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml">

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -106,7 +106,8 @@ namespace Ploeh.AutoFixture
                                 new StringLengthAttributeRelay(),
                                 new RegularExpressionAttributeRelay(),
                                 new EnumGenerator(),
-                                new InvariantCultureGenerator())),
+                                new InvariantCultureGenerator(),
+                                new Utf8EncodingGenerator())),
                         new Postprocessor(
                             new AutoPropertiesTarget(
                                 new CompositeSpecimenBuilder(

--- a/Src/AutoFixture/Utf8EncodingGenerator.cs
+++ b/Src/AutoFixture/Utf8EncodingGenerator.cs
@@ -1,0 +1,17 @@
+﻿using Ploeh.AutoFixture.Kernel;
+using System.Text;
+
+namespace Ploeh.AutoFixture
+{
+    public class Utf8EncodingGenerator : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (typeof(Encoding).Equals(request))
+            {
+                return Encoding.UTF8;
+            }
+            return new NoSpecimen();
+        }
+    }
+}

--- a/Src/AutoFixture/Utf8EncodingGenerator.cs
+++ b/Src/AutoFixture/Utf8EncodingGenerator.cs
@@ -3,10 +3,25 @@ using System.Text;
 
 namespace Ploeh.AutoFixture
 {
+    /// <summary>
+    /// Handles creation requests for <see cref="Encoding"/> instances, 
+    /// returning always the same <see cref="Encoding.UTF8"/>.
+    /// </summary>
     public class Utf8EncodingGenerator : ISpecimenBuilder
     {
         private readonly ExactTypeSpecification encodingTypeSpecification = new ExactTypeSpecification(typeof(Encoding));
 
+        /// <summary>
+        /// Generates a Encoding specimen based on a <see cref="Encoding"/> type request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        /// <remarks>
+        /// The generated Encoding will always be the same as <see cref="Encoding.UTF8"/>.
+        /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
             if (request == null)

--- a/Src/AutoFixture/Utf8EncodingGenerator.cs
+++ b/Src/AutoFixture/Utf8EncodingGenerator.cs
@@ -5,13 +5,21 @@ namespace Ploeh.AutoFixture
 {
     public class Utf8EncodingGenerator : ISpecimenBuilder
     {
+        private readonly ExactTypeSpecification encodingTypeSpecification = new ExactTypeSpecification(typeof(Encoding));
+
         public object Create(object request, ISpecimenContext context)
         {
-            if (typeof(Encoding).Equals(request))
+            if (request == null)
             {
-                return Encoding.UTF8;
+                return new NoSpecimen();
             }
-            return new NoSpecimen();
+
+            if (!this.encodingTypeSpecification.IsSatisfiedBy(request))
+            {
+                return new NoSpecimen();
+            }
+
+            return Encoding.UTF8;
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -337,6 +337,7 @@
     <Compile Include="UriSchemeTest.cs" />
     <Compile Include="UseCultureAttribute.cs" />
     <Compile Include="MailAddressGeneratorTests.cs" />
+    <Compile Include="Utf8EncodingGeneratorTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj">

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5760,6 +5760,14 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
+        public void FixtureCanCreateEncoding()
+        {
+            var fixture = new Fixture();
+            var actual = fixture.Create<System.Text.Encoding>();
+            Assert.NotNull(actual);
+        }
+
+        [Fact]
         public void ReturningNullFromFactoryIsPossible()
         {
             var fixture = new Fixture();

--- a/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
@@ -1,0 +1,68 @@
+﻿using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class Utf8EncodingGeneratorTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            var sut = new Utf8EncodingGenerator();
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void CreateWithEncodingRequestWillReturnUtf8Encoding()
+        {
+            // Arrange
+            var sut = new Utf8EncodingGenerator();
+
+            // Act
+            var result = sut.Create(typeof(Encoding), new DelegatingSpecimenContext());
+
+            // Assert
+            Assert.Equal(Encoding.UTF8, result);
+        }
+
+        [Fact]
+        public void CreateWithNullRequestWillReturnNoSpecimen()
+        {
+            // Arrange
+            var sut = new Utf8EncodingGenerator();
+
+            // Act
+            var result = sut.Create(null, new DelegatingSpecimenContext());
+
+            // Assert
+            Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Fact]
+        public void CreateWithNullContextDoesNotThrow()
+        {
+            // Arrange
+            var sut = new Utf8EncodingGenerator();
+
+            // Act
+            Assert.DoesNotThrow(() => sut.Create(typeof(object), null));
+        }
+
+        [Fact]
+        public void CreateWithNonTypeRequestWillReturnNoSpecimen()
+        {
+            // Arrange
+            var sut = new Utf8EncodingGenerator();
+
+            // Act
+            var result = sut.Create(new object(), new DelegatingSpecimenContext());
+            // Assert
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
@@ -63,6 +63,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Act
             var result = sut.Create(new object(), new DelegatingSpecimenContext());
             // Assert
+            Assert.Equal(new NoSpecimen(), result);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
@@ -45,16 +45,6 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void CreateWithNullContextDoesNotThrow()
-        {
-            // Arrange
-            var sut = new Utf8EncodingGenerator();
-
-            // Act
-            Assert.DoesNotThrow(() => sut.Create(typeof(object), null));
-        }
-
-        [Fact]
         public void CreateWithNonTypeRequestWillReturnNoSpecimen()
         {
             // Arrange


### PR DESCRIPTION
This adds a new `Utf8EncodingGenerator` class that works similar to the `InvariantCultureGenerator`: this will always return `Encoding.UTF8`. This makes it possible to create `MailMessage`s, out of the box, and therefore fixes #490 (though, I didn't add an unit test for creating them, since this PR is about making sure types of `Encoding` can be created, and that it also enables the creation `MailMessage`s to be fixed is nice to have).

I choose UTF8, since that is the most popular encoding these days, so made sense to me. I also considered the fact that this might break stuff for people, however, after some though, I realized that's not really the case. It will make it possible for people that have classes with `Encoding` dependencies to be created without customizations. Before, it either didn't work (the unit test would throw), or they would have customized the fixture instance, and those come first, so those customizations won't be overriden. Therefore, doesn't break anything.

@ploeh I saw you put in a couple issues and PRs that you're travelling, so I don't expect feedback real quickly. That's ok, I'll be on holiday to Iceland starting this Friday, so I might not be able to respond that quickly ;)

/cc @Pvlerick