### PR TITLE
Updating NuGet.config to adhere to standardized schema

### DIFF
--- a/Src/NuGet.config
+++ b/Src/NuGet.config
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<settings>
-  <repositoryPath>..\Packages</repositoryPath>
-</settings>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="../Packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
*Issue:*
* Currently ```<settings><repositoryPath>``` is ignored with NuGet 3.3 (VS 2015) and results in the packages being restored at the solution level (default) 

*Fix/Reasoning:*
* Switched to the [standardized format](https://docs.nuget.org/consume/nuget-config-file)
* Some [discussion from StackOverflow](http://stackoverflow.com/a/33090085/5632583) specifically under VS 2015

*Testing:*
* Tested for backwards compatibility - against NuGet 2.8 (VS 2013)


