### PR TITLE
Created DefaultValueGenerator<T> class to handle construction of problematic types

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using Ploeh.AutoFixture.DataAnnotations;
 using Ploeh.AutoFixture.Dsl;
 using Ploeh.AutoFixture.Kernel;
+using System.Globalization;
+using System.Text;
+using System.Net;
 
 namespace Ploeh.AutoFixture
 {
@@ -106,8 +109,9 @@ namespace Ploeh.AutoFixture
                                 new StringLengthAttributeRelay(),
                                 new RegularExpressionAttributeRelay(),
                                 new EnumGenerator(),
-                                new InvariantCultureGenerator(),
-                                new Utf8EncodingGenerator())),
+                                CreateDefaultValueBuilder(CultureInfo.InvariantCulture),
+                                CreateDefaultValueBuilder(Encoding.UTF8),
+                                CreateDefaultValueBuilder(IPAddress.Loopback))),
                         new Postprocessor(
                             new AutoPropertiesTarget(
                                 new CompositeSpecimenBuilder(
@@ -449,6 +453,13 @@ namespace Ploeh.AutoFixture
         {
             this.behaviors = new SingletonSpecimenBuilderNodeStackAdapterCollection(this.graph, n => n is BehaviorRoot, transformations);
             this.behaviors.GraphChanged += this.OnGraphChanged;
+        }
+
+        private static ISpecimenBuilder CreateDefaultValueBuilder<T>(T value)
+        {
+            return new FilteringSpecimenBuilder(
+                new FixedBuilder(value),
+                new ExactTypeSpecification(typeof(T)));
         }
     }
 }

--- a/Src/AutoFixture/InvariantCultureGenerator.cs
+++ b/Src/AutoFixture/InvariantCultureGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using Ploeh.AutoFixture.Kernel;
+using System;
 
 namespace Ploeh.AutoFixture
 {
@@ -7,6 +8,7 @@ namespace Ploeh.AutoFixture
     /// Handles creation requests for <see cref="CultureInfo"/> instances, 
     /// returning always the same <see cref="CultureInfo.InvariantCulture"/>.
     /// </summary>
+    [Obsolete("Please use a 'Ploeh.AutoFixture.Kernel.FilteringSpecimenBuilder' instead.", false)]
     public class InvariantCultureGenerator : ISpecimenBuilder
     {
         private readonly ExactTypeSpecification cultureTypeSpecification 

--- a/Src/AutoFixture/Utf8EncodingGenerator.cs
+++ b/Src/AutoFixture/Utf8EncodingGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using Ploeh.AutoFixture.Kernel;
+using System;
 using System.Text;
 
 namespace Ploeh.AutoFixture
@@ -7,6 +8,7 @@ namespace Ploeh.AutoFixture
     /// Handles creation requests for <see cref="Encoding"/> instances, 
     /// returning always the same <see cref="Encoding.UTF8"/>.
     /// </summary>
+    [Obsolete("Please use a 'Ploeh.AutoFixture.Kernel.FilteringSpecimenBuilder' instead.", false)]
     public class Utf8EncodingGenerator : ISpecimenBuilder
     {
         private readonly ExactTypeSpecification encodingTypeSpecification = new ExactTypeSpecification(typeof(Encoding));

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -18,6 +18,9 @@ using Ploeh.AutoFixtureUnitTest.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Extensions;
+using System.Text;
+using System.Globalization;
+using System.Net;
 
 namespace Ploeh.AutoFixtureUnitTest
 {
@@ -5765,6 +5768,18 @@ namespace Ploeh.AutoFixtureUnitTest
             var fixture = new Fixture();
             var actual = fixture.Create<System.Text.Encoding>();
             Assert.NotNull(actual);
+        }
+
+        [Fact]
+        public void FixtureCanCreateIPAddress()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            // Exercise system
+            var actual = fixture.Create<System.Net.IPAddress>();
+            // Verify outcome
+            Assert.NotNull(actual);
+            // Teardown 
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/InvariantCultureGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/InvariantCultureGeneratorTest.cs
@@ -11,15 +11,18 @@ namespace Ploeh.AutoFixtureUnitTest
         [Fact]
         public void SutIsSpecimenBuilder()
         {
+#pragma warning disable 618
             var sut = new InvariantCultureGenerator();
+#pragma warning restore 618
             Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
         }
 
         [Fact]
         public void CreateWithNullRequestWillReturnNoSpecimen()
         {
+#pragma warning disable 618
             var sut = new InvariantCultureGenerator();
-
+#pragma warning restore 618
             var actual = sut.Create(null, new DelegatingSpecimenContext());
 
             Assert.Equal(new NoSpecimen(), actual);
@@ -28,14 +31,18 @@ namespace Ploeh.AutoFixtureUnitTest
         [Fact]
         public void CreateWithNullContextDoesNotThrow()
         {
+#pragma warning disable 618
             var sut = new InvariantCultureGenerator();
+#pragma warning restore 618
             sut.Create(new object(), null);
         }
 
         [Fact]
         public void CreateWithNonTypeRequestWillReturnNoSpecimen()
         {
+#pragma warning disable 618
             var sut = new InvariantCultureGenerator();
+#pragma warning restore 618
             var actual = sut.Create(new object(), new DelegatingSpecimenContext());
 
             Assert.Equal(new NoSpecimen(), actual);
@@ -44,7 +51,9 @@ namespace Ploeh.AutoFixtureUnitTest
         [Fact]
         public void CreateWithNonCultureInfoTypeWillReturnNoSpecimen()
         {
+#pragma warning disable 618
             var sut = new InvariantCultureGenerator();
+#pragma warning restore 618
             var actual = sut.Create(typeof(object), new DelegatingSpecimenContext());
 
             Assert.Equal(new NoSpecimen(), actual);
@@ -53,7 +62,9 @@ namespace Ploeh.AutoFixtureUnitTest
         [Fact]
         public void CreateWithCultureInfoRequestTypeReturnsInvariantCulture()
         {
+#pragma warning disable 618
             var sut = new InvariantCultureGenerator();
+#pragma warning restore 618
             var actual = sut.Create(typeof(CultureInfo), new DelegatingSpecimenContext());
 
             Assert.Equal(CultureInfo.InvariantCulture, actual);

--- a/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
@@ -14,7 +14,9 @@ namespace Ploeh.AutoFixtureUnitTest
         [Fact]
         public void SutIsSpecimenBuilder()
         {
+#pragma warning disable 618
             var sut = new Utf8EncodingGenerator();
+#pragma warning restore 618
             Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
         }
 
@@ -22,7 +24,9 @@ namespace Ploeh.AutoFixtureUnitTest
         public void CreateWithEncodingRequestWillReturnUtf8Encoding()
         {
             // Arrange
+#pragma warning disable 618
             var sut = new Utf8EncodingGenerator();
+#pragma warning restore 618
 
             // Act
             var result = sut.Create(typeof(Encoding), new DelegatingSpecimenContext());
@@ -35,7 +39,9 @@ namespace Ploeh.AutoFixtureUnitTest
         public void CreateWithNullRequestWillReturnNoSpecimen()
         {
             // Arrange
+#pragma warning disable 618
             var sut = new Utf8EncodingGenerator();
+#pragma warning restore 618
 
             // Act
             var result = sut.Create(null, new DelegatingSpecimenContext());
@@ -48,7 +54,9 @@ namespace Ploeh.AutoFixtureUnitTest
         public void CreateWithNonTypeRequestWillReturnNoSpecimen()
         {
             // Arrange
+#pragma warning disable 618
             var sut = new Utf8EncodingGenerator();
+#pragma warning restore 618
 
             // Act
             var result = sut.Create(new object(), new DelegatingSpecimenContext());


### PR DESCRIPTION
In #490, I mentioned that ```System.Net.IPAddress``` was also a _problematic_ type that AutoFixture wasn't able to create. 

I started out by creating a new type to handle ```IPAddress``` specifically just as ```CulstureInfo``` and ```Encoding``` (#512) were handled, but it very quickly looked like code duplication ([rule of three](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)), I guess).

So I went ahead and created a new generic type that has a constructor taking a default value and the ```Create``` method will always return that default value. I deleted the previous generators and moved relevant tests in the new class' tests.

Open questions:
- Does the ```DefaultValueGenerator``` name sound good? I started out with ```CustomGenerator``` but changed my mind half-way, naming is hard :smile: 
- Should the constructor take a lambda factory instead of a plain value, so that it can return a new instance every time if needed?

CC @tiesmaster 