### PR TITLE
[ON HOLD] C# 6: nameof (part 1)

### DIFF
--- a/Src/AutoFixture/AutoPropertiesTarget.cs
+++ b/Src/AutoFixture/AutoPropertiesTarget.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture
         public AutoPropertiesTarget(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/BehaviorRoot.cs
+++ b/Src/AutoFixture/BehaviorRoot.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture
         public BehaviorRoot(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/CollectionFiller.cs
+++ b/Src/AutoFixture/CollectionFiller.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.AddManyTo(collection, fixture.Create<T>);
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             collection.AddMany(fixture.Create<T>, repeatCount);
@@ -97,7 +97,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             collection.AddMany(creator, fixture.RepeatCount);

--- a/Src/AutoFixture/CompositeCustomization.cs
+++ b/Src/AutoFixture/CompositeCustomization.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture
         {
             if (customizations == null)
             {
-                throw new ArgumentNullException("customizations");
+                throw new ArgumentNullException(nameof(customizations));
             }
 
             this.customizations = customizations;

--- a/Src/AutoFixture/ConstrainedStringGenerator.cs
+++ b/Src/AutoFixture/ConstrainedStringGenerator.cs
@@ -26,7 +26,7 @@ namespace Ploeh.AutoFixture
 
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             var constrain = request as ConstrainedStringRequest;

--- a/Src/AutoFixture/ConstructorCustomization.cs
+++ b/Src/AutoFixture/ConstructorCustomization.cs
@@ -26,11 +26,11 @@ namespace Ploeh.AutoFixture
         {
             if (targetType == null)
             {
-                throw new ArgumentNullException("targetType");
+                throw new ArgumentNullException(nameof(targetType));
             }
             if (query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             this.targetType = targetType;
@@ -63,7 +63,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             var factory = new MethodInvoker(this.Query);

--- a/Src/AutoFixture/CurrentDateTimeCustomization.cs
+++ b/Src/AutoFixture/CurrentDateTimeCustomization.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixture
         {
             if (fixture == null)
             {
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
             }
 
             fixture.Customizations.Add(new CurrentDateTimeGenerator());

--- a/Src/AutoFixture/CustomizationNode.cs
+++ b/Src/AutoFixture/CustomizationNode.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture
         public CustomizationNode(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
             this.builder = builder;
         }

--- a/Src/AutoFixture/DefaultEngineParts.cs
+++ b/Src/AutoFixture/DefaultEngineParts.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture
         {
             if (primitiveBuilders == null)
             {
-                throw new ArgumentNullException("primitiveBuilders");
+                throw new ArgumentNullException(nameof(primitiveBuilders));
             }
 
             this.primitiveBuilders = primitiveBuilders;

--- a/Src/AutoFixture/DictionaryFiller.cs
+++ b/Src/AutoFixture/DictionaryFiller.cs
@@ -44,16 +44,16 @@ namespace Ploeh.AutoFixture
         public void Execute(object specimen, ISpecimenContext context)
         {
             if (specimen == null)
-                throw new ArgumentNullException("specimen");
+                throw new ArgumentNullException(nameof(specimen));
             if (context == null)
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
 
             var typeArguments = specimen.GetType().GetGenericArguments();
             if (typeArguments.Length != 2)
-                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", "specimen");
+                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 
             if (!typeof(IDictionary<,>).MakeGenericType(typeArguments).IsAssignableFrom(specimen.GetType()))
-                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", "specimen");
+                throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 
             var filler = (ISpecimenCommand)Activator.CreateInstance(
                 typeof(Filler<,>).MakeGenericType(typeArguments));


### PR DESCRIPTION
Now that #500 is fixed by #523, we are ready to use C# 6 features. This PR is part 1 of a series of PR's to use C# 6 features in the existing code base.

This PR is parts of a series that converts parameter string names to `nameof` calls. There are 161 modified files in total. As I remember, having multiple small PR's was the preferred method, so that is what I'll do. The only question I have is: how many modified files should each PR contain? For the moment, I have opted for 10 modified files, would that suffice or is too much or too little?