### PR TITLE
Separate NUnit test results 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Packages.dgml
 *_mm_cache.bin
 AutoFixture character.design
 .fake/
+NUnit[23]TestResult.xml

--- a/Build.fsx
+++ b/Build.fsx
@@ -50,21 +50,19 @@ Target "TestOnly" (fun _ ->
     let nunit2TestAssemblies = !! (sprintf "Src/AutoFixture.NUnit2.*Test/bin/%s/*Test.dll" configuration)
 
     nunit2TestAssemblies
-    |> NUnit (fun p -> { p with StopOnError = false })
+    |> NUnit (fun p -> { p with StopOnError = false
+                                OutputFile = "NUnit2TestResult.xml" })
 
     let nunit3TestAssemblies = !! (sprintf "Src/AutoFixture.NUnit3.UnitTest/bin/%s/Ploeh.AutoFixture.NUnit3.UnitTest.dll" configuration)
 
     nunit3TestAssemblies
-    |> NUnit3 (fun p -> { p with StopOnError = false })
+    |> NUnit3 (fun p -> { p with StopOnError = false
+                                 ResultSpecs = ["NUnit3TestResult.xml;format=nunit2"] })
 )
 
 Target "BuildAndTestOnly" (fun _ -> ())
 Target "Build" (fun _ -> ())
 Target "Test"  (fun _ -> ())
-
-Target "DeleteTestResultFiles" (fun _ ->
-    DeleteFile "TestResult.xml"
-)
 
 Target "CopyToReleaseFolder" (fun _ ->
     let buildOutput = [
@@ -155,14 +153,12 @@ Target "CompleteBuild" (fun _ -> ())
 
 "BuildOnly" ==> "BuildAndTestOnly"
 "TestOnly"  ==> "BuildAndTestOnly"
-      
-"Test" ==> "DeleteTestResultFiles"
+
 "Test" ==> "CopyToReleaseFolder"
 
 "CleanNuGetPackages"  ==> "NuGetPack"
 "CopyToReleaseFolder" ==> "NuGetPack"
 
-"NuGetPack"              ==> "CompleteBuild"
-"DeleteTestResultFiles"  ==> "CompleteBuild"
+"NuGetPack" ==> "CompleteBuild"
 
 RunTargetOrDefault "CompleteBuild"


### PR DESCRIPTION
This PR makes the NUnit 2 test runner output its results to `NUnit2TestResult.xml`, whereas the NUnit 3 test runner outputs its results to `NUnit3TestResult.xml`, in NUnit 2 format. 

It also adds those two NUnit result files to the `.gitignore` file and removes the build step that removed the test runner results.