### PR TITLE
C# 6: getter-only properties (pt. 1)

### DIFF
--- a/Src/AutoFixture/DataAnnotations/MinimizationOperations.cs
+++ b/Src/AutoFixture/DataAnnotations/MinimizationOperations.cs
@@ -539,24 +539,15 @@ namespace Ploeh.AutoFixture.DataAnnotations
 
         private sealed class IntPair
         {
-            private readonly int n1;
-            private readonly int n2;
-
             internal IntPair(int n1, int n2)
             {
-                this.n1 = n1;
-                this.n2 = n2;
+                this.N1 = n1;
+                this.N2 = n2;
             }
 
-            internal int N1
-            {
-                get { return n1; }
-            }
+            internal int N1 { get; }
 
-            internal int N2
-            {
-                get { return n2; }
-            }
+            internal int N2 { get; }
         }
 
         #endregion

--- a/Src/AutoFixture/DataAnnotations/State.cs
+++ b/Src/AutoFixture/DataAnnotations/State.cs
@@ -43,7 +43,6 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// </summary>
     internal sealed class State : IEquatable<State>, IComparable<State>
     {
-        private readonly int id;
         private static int nextId;
 
         /// <summary>
@@ -53,16 +52,13 @@ namespace Ploeh.AutoFixture.DataAnnotations
         internal State()
         {
             this.ResetTransitions();
-            id = Interlocked.Increment(ref nextId);
+            Id = Interlocked.Increment(ref nextId);
         }
 
         /// <summary>
         /// Gets the id.
         /// </summary>
-        internal int Id
-        {
-            get { return this.id; }
-        }
+        internal int Id { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this State is Accept.
@@ -149,7 +145,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         {
             unchecked
             {
-                int result = id;
+                int result = Id;
                 result = (result * 397) ^ Accept.GetHashCode();
                 result = (result * 397) ^ Number;
                 return result;
@@ -176,7 +172,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 return true;
             }
 
-            return other.id == id 
+            return other.Id == Id 
                 && other.Accept.Equals(Accept)
                 && other.Number == Number;
         }

--- a/Src/AutoFixture/DataAnnotations/Transition.cs
+++ b/Src/AutoFixture/DataAnnotations/Transition.cs
@@ -45,10 +45,6 @@ namespace Ploeh.AutoFixture.DataAnnotations
     ///</summary>
     internal sealed class Transition : IEquatable<Transition>
     {
-        private readonly char max;
-        private readonly char min;
-        private readonly State to;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Transition"/> class.
         /// (Constructs a new singleton interval transition).
@@ -57,8 +53,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// <param name="to">The destination state.</param>
         internal Transition(char c, State to)
         {
-            this.min = this.max = c;
-            this.to = to;
+            this.Min = this.Max = c;
+            this.To = to;
         }
 
         /// <summary>
@@ -77,34 +73,25 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 min = t;
             }
 
-            this.min = min;
-            this.max = max;
-            this.to = to;
+            this.Min = min;
+            this.Max = max;
+            this.To = to;
         }
 
         /// <summary>
         /// Gets the minimum of this transition interval.
         /// </summary>
-        internal char Min
-        {
-            get { return this.min; }
-        }
+        internal char Min { get; }
 
         /// <summary>
         /// Gets the maximum of this transition interval.
         /// </summary>
-        internal char Max
-        {
-            get { return this.max; }
-        }
+        internal char Max { get; }
 
         /// <summary>
         /// Gets the destination of this transition.
         /// </summary>
-        internal State To
-        {
-            get { return this.to; }
-        }
+        internal State To { get; }
 
         /// <summary>
         /// Implements the operator ==.
@@ -141,14 +128,14 @@ namespace Ploeh.AutoFixture.DataAnnotations
         public override string ToString()
         {
             var sb = new StringBuilder();
-            Transition.AppendCharString(min, sb);
-            if (min != max)
+            Transition.AppendCharString(Min, sb);
+            if (Min != Max)
             {
                 sb.Append("-");
-                Transition.AppendCharString(max, sb);
+                Transition.AppendCharString(Max, sb);
             }
 
-            sb.Append(" -> ").Append(to.Number);
+            sb.Append(" -> ").Append(To.Number);
             return sb.ToString();
         }
 
@@ -198,9 +185,9 @@ namespace Ploeh.AutoFixture.DataAnnotations
         {
             unchecked
             {
-                int result = min.GetHashCode();
-                result = (result*397) ^ max.GetHashCode();
-                result = (result*397) ^ (to != null ? to.GetHashCode() : 0);
+                int result = Min.GetHashCode();
+                result = (result*397) ^ Max.GetHashCode();
+                result = (result*397) ^ (To != null ? To.GetHashCode() : 0);
                 return result;
             }
         }
@@ -225,9 +212,9 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 return true;
             }
 
-            return other.min == min
-                   && other.max == max
-                   && object.Equals(other.to, to);
+            return other.Min == Min
+                   && other.Max == Max
+                   && object.Equals(other.To, To);
         }
 
         private static void AppendCharString(char c, StringBuilder sb)

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -24,8 +24,6 @@ namespace Ploeh.AutoFixture.Dsl
         ICustomizationComposer<T>,
         ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilderNode node;
-
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="CompositeNodeComposer{T}" /> class.
@@ -42,7 +40,7 @@ namespace Ploeh.AutoFixture.Dsl
             if (node == null)
                 throw new ArgumentNullException(nameof(node));
 
-            this.node = node;
+            this.Node = node;
         }
 
         /// <summary>
@@ -426,7 +424,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.node.Create(request, context);
+            return this.Node.Create(request, context);
         }
 
         /// <summary>
@@ -438,7 +436,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.node;
+            yield return this.Node;
         }
 
         /// <summary>
@@ -456,9 +454,6 @@ namespace Ploeh.AutoFixture.Dsl
         /// <summary>Gets the encapsulated node.</summary>
         /// <value>The encapsulated node.</value>
         /// <seealso cref="CompositeNodeComposer{T}(ISpecimenBuilderNode)" />
-        public ISpecimenBuilderNode Node
-        {
-            get { return this.node; }
-        }
+        public ISpecimenBuilderNode Node { get; }
     }
 }

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -12,8 +12,6 @@ namespace Ploeh.AutoFixture.Dsl
     /// <typeparam name="T">The type of specimen to customize.</typeparam>
     public class CompositePostprocessComposer<T> : IPostprocessComposer<T>
     {
-        private readonly IEnumerable<IPostprocessComposer<T>> composers;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositePostprocessComposer&lt;T&gt;"/>
         /// class with a sequence of <see cref="IPostprocessComposer{T}"/> instances.
@@ -36,16 +34,13 @@ namespace Ploeh.AutoFixture.Dsl
                 throw new ArgumentNullException(nameof(composers));
             }
 
-            this.composers = composers;
+            this.Composers = composers;
         }
 
         /// <summary>
         /// Gets the aggregated composers.
         /// </summary>
-        public IEnumerable<IPostprocessComposer<T>> Composers
-        {
-            get { return this.composers; }
-        }
+        public IEnumerable<IPostprocessComposer<T>> Composers { get; }
 
         /// <summary>
         /// Performs the specified action on a specimen.
@@ -57,7 +52,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> Do(Action<T> action)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.Do(action));
         }
 
@@ -70,7 +65,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> OmitAutoProperties()
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.OmitAutoProperties());
         }
 
@@ -89,7 +84,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.With(propertyPicker));
         }
 
@@ -112,7 +107,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.With(propertyPicker, value));
         }
 
@@ -125,7 +120,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> WithAutoProperties()
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.WithAutoProperties());
         }
 
@@ -143,7 +138,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
-            return new CompositePostprocessComposer<T>(from c in this.composers
+            return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.Without(propertyPicker));
         }
 
@@ -167,7 +162,7 @@ namespace Ploeh.AutoFixture.Dsl
         public object Create(object request, ISpecimenContext context)
         {
             return new CompositeSpecimenBuilder(
-                this.composers.Cast<ISpecimenBuilder>())
+                this.Composers.Cast<ISpecimenBuilder>())
                 .Create(
                     request,
                     context);

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -16,8 +16,6 @@ namespace Ploeh.AutoFixture.Dsl
         ICustomizationComposer<T>,
         ISpecimenBuilderNode
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NodeComposer{T}" />
         /// class.
@@ -35,7 +33,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// <seealso cref="Builder" />
         public NodeComposer(ISpecimenBuilder builder)
         {
-            this.builder = builder;
+            this.Builder = builder;
         }
 
         /// <summary>
@@ -493,7 +491,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            return this.builder.Create(request, context);
+            return this.Builder.Create(request, context);
         }
 
         /// <summary>
@@ -505,7 +503,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.builder;
+            yield return this.Builder;
         }
 
         /// <summary>
@@ -523,10 +521,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// <summary>Gets the encapsulated builder.</summary>
         /// <value>The encapsulated builder.</value>
         /// <seealso cref="NodeComposer{T}(ISpecimenBuilder)" />
-        public ISpecimenBuilder Builder
-        {
-            get { return this.builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         private ISpecimenBuilderNode WithoutSeedIgnoringRelay()
         {


### PR DESCRIPTION
This PR converts getter-only properties with readonly backing-fields to C# 6's auto-implemented getter-only properties.

Before:
```charp
private readonly ISpecimenBuilderNode node;	

public ISpecimenBuilderNode Node
{		
    get { return this.node; }		
}
```

After:
```charp	
public ISpecimenBuilderNode Node { get; }
```

Functionally, they are equivalent, as the auto-implemented getter-only property also receives a `readonly` backing field under the hood ([description on the Roslyn wiki](https://github.com/dotnet/roslyn/wiki/New-Language-Features-in-C%23-6#getter-only-auto-properties)).

Is this something you'd be in favor of? If so, I'd be happy to also convert all other such properties.