### PR TITLE
Reorder construction attributes so that [Frozen] is always applied last

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Ploeh.TestTypeFoundation;
 using Xunit;
@@ -148,6 +149,24 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             var result = sut.GetData(method);
             // Verify outcome
             Assert.True(new[] { expectedResult }.SequenceEqual(result.Single()));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("CreateWithFrozenAndGreedy")]
+        [InlineData("CreateWithGreedyAndFrozen")]
+        public void GetDataOrdersCustomizationAttributes(string methodName)
+        {
+            // Fixture setup
+            var method = typeof(TypeWithCustomizationAttributes).GetMethod(methodName, new[] { typeof(ConcreteType) });
+            var customizationLog = new List<ICustomization>();
+            var fixture = new DelegatingFixture { OnCustomize = c => { customizationLog.Add(c); } };
+            var sut = new AutoDataAttribute(fixture);
+            // Exercise system
+            sut.GetData(method);
+            // Verify outcome
+            Assert.True(customizationLog[0] is ConstructorCustomization);
+            Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
             // Teardown
         }
     }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
@@ -153,8 +153,18 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Theory]
+        [InlineData("CreateWithFrozenAndFavorArrays")]
+        [InlineData("CreateWithFavorArraysAndFrozen")]
+        [InlineData("CreateWithFrozenAndFavorEnumerables")]
+        [InlineData("CreateWithFavorEnumerablesAndFrozen")]
+        [InlineData("CreateWithFrozenAndFavorLists")]
+        [InlineData("CreateWithFavorListsAndFrozen")]
         [InlineData("CreateWithFrozenAndGreedy")]
         [InlineData("CreateWithGreedyAndFrozen")]
+        [InlineData("CreateWithFrozenAndModest")]
+        [InlineData("CreateWithModestAndFrozen")]
+        [InlineData("CreateWithFrozenAndNoAutoProperties")]
+        [InlineData("CreateWithNoAutoPropertiesAndFrozen")]
         public void GetDataOrdersCustomizationAttributes(string methodName)
         {
             // Fixture setup
@@ -165,7 +175,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             // Exercise system
             sut.GetData(method);
             // Verify outcome
-            Assert.True(customizationLog[0] is ConstructorCustomization);
+            Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
             Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
             // Teardown
         }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -75,6 +75,7 @@
     <Compile Include="InlineAutoDataAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenario.cs" />
+    <Compile Include="TypeWithCustomizationAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture.xUnit.net2\AutoFixture.xUnit.net2.csproj">

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingFixture.cs
@@ -57,7 +57,8 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
 
         public IFixture Customize(ICustomization customization)
         {
-            throw new NotImplementedException();
+            this.OnCustomize(customization);
+            return this;
         }
 
         public void Customize<T>(Func<Ploeh.AutoFixture.Dsl.ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -101,5 +102,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
+
+        internal Action<ICustomization> OnCustomize { get; set; }
     }
 }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/TypeWithCustomizationAttributes.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/TypeWithCustomizationAttributes.cs
@@ -4,11 +4,51 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
 {
     internal class TypeWithCustomizationAttributes
     {
+        public void CreateWithFrozenAndFavorArrays([Frozen, FavorArrays] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorArraysAndFrozen([FavorArrays, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorEnumerables([Frozen, FavorEnumerables] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorEnumerablesAndFrozen([FavorEnumerables, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorLists([Frozen, FavorLists] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorListsAndFrozen([FavorLists, Frozen] ConcreteType sut)
+        {
+        }
+
         public void CreateWithFrozenAndGreedy([Frozen, Greedy] ConcreteType sut)
         {
         }
 
         public void CreateWithGreedyAndFrozen([Greedy, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndModest([Frozen, Modest] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithModestAndFrozen([Modest, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndNoAutoProperties([Frozen, NoAutoProperties] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithNoAutoPropertiesAndFrozen([NoAutoProperties, Frozen] ConcreteType sut)
         {
         }
     }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/TypeWithCustomizationAttributes.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/TypeWithCustomizationAttributes.cs
@@ -1,0 +1,15 @@
+﻿using Ploeh.TestTypeFoundation;
+
+namespace Ploeh.AutoFixture.Xunit2.UnitTest
+{
+    internal class TypeWithCustomizationAttributes
+    {
+        public void CreateWithFrozenAndGreedy([Frozen, Greedy] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithGreedyAndFrozen([Greedy, Frozen] ConcreteType sut)
+        {
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
@@ -109,7 +109,10 @@ namespace Ploeh.AutoFixture.Xunit2
         private void CustomizeFixture(ParameterInfo p)
         {
             var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy).OfType<CustomizeAttribute>();
+            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy)
+                .OfType<CustomizeAttribute>()
+                .OrderBy(x => x, new CustomizeAttributeComparer());
+
             foreach (var ca in customizeAttributes)
             {
                 var c = ca.GetCustomization(p);

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -68,6 +68,7 @@
     <Compile Include="AutoDataAttribute.cs" />
     <Compile Include="CompositeDataAttribute.cs" />
     <Compile Include="CustomizeAttribute.cs" />
+    <Compile Include="CustomizeAttributeComparer.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="FrozenAttribute.cs" />
     <Compile Include="GreedyAttribute.cs" />

--- a/Src/AutoFixture.xUnit.net2/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.xUnit.net2/CustomizeAttributeComparer.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.Xunit2
+{
+    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    {
+        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        {
+            if (x is FrozenAttribute && !(y is FrozenAttribute))
+            {
+                return 1;
+            }
+
+            if (y is FrozenAttribute && !(x is FrozenAttribute))
+            {
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #420 simply moving the `[Frozen]` attribute to the end of the custom attribute list.