### PR TITLE
Handle enum types with no values

### DIFF
--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -96,11 +96,14 @@ namespace Ploeh.AutoFixture
 
             public IEnumerator GetEnumerator()
             {
-                while (true)
+                if (this.values.Any())
                 {
-                    foreach (var obj in this.values)
+                    while (true)
                     {
-                        yield return obj;
+                        foreach (var obj in this.values)
+                        {
+                            yield return obj;
+                        }
                     }
                 }
             }

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Ploeh.AutoFixture.Kernel;
 
@@ -84,6 +85,7 @@ namespace Ploeh.AutoFixture
         {
             private readonly IEnumerable<object> values;
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
             internal RoundRobinEnumEnumerable(Type enumType)
             {
                 if (enumType == null)
@@ -92,18 +94,25 @@ namespace Ploeh.AutoFixture
                 }
 
                 this.values = Enum.GetValues(enumType).Cast<object>();
+
+                if (!this.values.Any())
+                {
+                    throw new ObjectCreationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "AutoFixture was unable to create a value for {0} since it is an enum containing no values. " +
+                            "Please add at least one value to the enum.",
+                            enumType.FullName));
+                }
             }
 
             public IEnumerator GetEnumerator()
             {
-                if (this.values.Any())
+                while (true)
                 {
-                    while (true)
+                    foreach (var obj in this.values)
                     {
-                        foreach (var obj in this.values)
-                        {
-                            yield return obj;
-                        }
+                        yield return obj;
                     }
                 }
             }

--- a/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
@@ -110,5 +110,18 @@ namespace Ploeh.AutoFixtureUnitTest
             Assert.Equal(expectedResult, result);
             // Teardown
         }
+
+        [Fact]
+        public void RequestForEnumWithNoValuesReturnsNull()
+        {
+            // Fixture setup
+            var sut = new EnumGenerator();
+            // Exercise system
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(typeof (EmptyEnum), dummyContext);
+            // Verify outcome
+            Assert.Null(result);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
@@ -112,15 +112,13 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void RequestForEnumWithNoValuesReturnsNull()
+        public void RequestForEnumWithNoValuesThrowsObjectCreationException()
         {
             // Fixture setup
             var sut = new EnumGenerator();
-            // Exercise system
+            // Exercise system and Verify outcome
             var dummyContext = new DelegatingSpecimenContext();
-            var result = sut.Create(typeof (EmptyEnum), dummyContext);
-            // Verify outcome
-            Assert.Null(result);
+            Assert.Throws<ObjectCreationException>(() => sut.Create(typeof (EmptyEnum), dummyContext));
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5846,5 +5846,16 @@ namespace Ploeh.AutoFixtureUnitTest
 
             Assert.Equal(expected, actual.Field);
         }
+
+        [Fact]
+        public void CreatingInstanceOfTypeContainingEmptyEnumFieldGetsFieldInitializedToZero()
+        {
+            var fixture = new Fixture();
+
+            var actual = fixture.Create<TypeWithEmptyEnumField>();
+
+            Assert.Equal(0, (int)actual.EmptyEnumField);
+            Assert.Equal(0, (int)actual.EmptyEnumProperty);
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5848,14 +5848,11 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void CreatingInstanceOfTypeContainingEmptyEnumFieldGetsFieldInitializedToZero()
+        public void CreatingInstanceOfTypeContainingEmptyEnumFieldThrowsObjectCreationException()
         {
             var fixture = new Fixture();
-
-            var actual = fixture.Create<TypeWithEmptyEnumField>();
-
-            Assert.Equal(0, (int)actual.EmptyEnumField);
-            Assert.Equal(0, (int)actual.EmptyEnumProperty);
+            
+            Assert.Throws<ObjectCreationException>(() => fixture.Create<TypeWithEmptyEnumField>());
         }
     }
 }

--- a/Src/TestTypeFoundation/EmptyEnum.cs
+++ b/Src/TestTypeFoundation/EmptyEnum.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.TestTypeFoundation
+{
+    public enum EmptyEnum
+    {
+        //this must not contain any values
+    }
+}

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -83,6 +83,7 @@
     <Compile Include="DoubleFieldHolder.cs" />
     <Compile Include="DoubleParameterType.cs" />
     <Compile Include="DoublePropertyHolder.cs" />
+    <Compile Include="EmptyEnum.cs" />
     <Compile Include="EqualityResponder.cs" />
     <Compile Include="FieldHolder.cs" />
     <Compile Include="GenericType.cs" />
@@ -110,6 +111,7 @@
     <Compile Include="TriplePropertyHolder.cs" />
     <Compile Include="TriState.cs" />
     <Compile Include="TypeWithConcreteParameterMethod.cs" />
+    <Compile Include="TypeWithEmptyEnumField.cs" />
     <Compile Include="TypeWithFactoryMethod.cs" />
     <Compile Include="TypeWithIndexer.cs" />
     <Compile Include="TypeWithOverloadedMembers.cs" />

--- a/Src/TestTypeFoundation/TypeWithEmptyEnumField.cs
+++ b/Src/TestTypeFoundation/TypeWithEmptyEnumField.cs
@@ -1,0 +1,9 @@
+﻿namespace Ploeh.TestTypeFoundation
+{
+    public class TypeWithEmptyEnumField
+    {
+        public EmptyEnum EmptyEnumField;
+
+        public EmptyEnum EmptyEnumProperty { get; set; }
+    }
+}


### PR DESCRIPTION
fixes #594 
This stops fixture creation hanging when a type contains a field with an empty enum - field values are initialised to 0 (zero) which appears to be in line with the C# language specification