### PR TITLE
Reorder construction attributes so that [Frozen] is always applied last (xUnit.net)

### DIFF
--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoDataAttributeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Ploeh.TestTypeFoundation;
 using Xunit;
@@ -158,6 +159,39 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             var result = sut.GetData(method, parameterTypes);
             // Verify outcome
             Assert.True(new[] { expectedResult }.SequenceEqual(result.Single()));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("CreateWithFrozenAndFavorArrays")]
+        [InlineData("CreateWithFavorArraysAndFrozen")]
+        [InlineData("CreateWithFrozenAndFavorEnumerables")]
+        [InlineData("CreateWithFavorEnumerablesAndFrozen")]
+        [InlineData("CreateWithFrozenAndFavorLists")]
+        [InlineData("CreateWithFavorListsAndFrozen")]
+        [InlineData("CreateWithFrozenAndGreedy")]
+        [InlineData("CreateWithGreedyAndFrozen")]
+        [InlineData("CreateWithFrozenAndModest")]
+        [InlineData("CreateWithModestAndFrozen")]
+        [InlineData("CreateWithFrozenAndNoAutoProperties")]
+        [InlineData("CreateWithNoAutoPropertiesAndFrozen")]
+        public void GetDataOrdersCustomizationAttributes(string methodName)
+        {
+            // Fixture setup
+            var method = typeof(TypeWithCustomizationAttributes).GetMethod(methodName, new[] { typeof(ConcreteType) });
+
+            var parameters = method.GetParameters();
+            var parameterTypes = (from pi in parameters
+                                  select pi.ParameterType).ToArray();
+
+            var customizationLog = new List<ICustomization>();
+            var fixture = new DelegatingFixture { OnCustomize = c => { customizationLog.Add(c); } };
+            var sut = new AutoDataAttribute(fixture);
+            // Exercise system
+            sut.GetData(method, parameterTypes);
+            // Verify outcome
+            Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
+            Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
             // Teardown
         }
     }

--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoDataAttributeTest.cs
@@ -185,7 +185,12 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
                                   select pi.ParameterType).ToArray();
 
             var customizationLog = new List<ICustomization>();
-            var fixture = new DelegatingFixture { OnCustomize = c => { customizationLog.Add(c); } };
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = c =>
+            {
+                customizationLog.Add(c);
+                return fixture;
+            };
             var sut = new AutoDataAttribute(fixture);
             // Exercise system
             sut.GetData(method, parameterTypes);

--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
@@ -90,6 +90,7 @@
     <Compile Include="NoAutoPropertiesAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenario.cs" />
+    <Compile Include="TypeWithCustomizationAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture.xUnit.net\AutoFixture.xUnit.net.csproj">

--- a/Src/AutoFixture.xUnit.net.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/DelegatingFixture.cs
@@ -57,7 +57,8 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         public IFixture Customize(ICustomization customization)
         {
-            throw new NotImplementedException();
+            this.OnCustomize(customization);
+            return this;
         }
 
         public void Customize<T>(Func<Ploeh.AutoFixture.Dsl.ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -101,5 +102,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         }
 
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
+
+        internal Action<ICustomization> OnCustomize { get; set; }
     }
 }

--- a/Src/AutoFixture.xUnit.net.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/DelegatingFixture.cs
@@ -57,8 +57,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         public IFixture Customize(ICustomization customization)
         {
-            this.OnCustomize(customization);
-            return this;
+            return this.OnCustomize(customization);
         }
 
         public void Customize<T>(Func<Ploeh.AutoFixture.Dsl.ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -103,6 +102,6 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
 
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
 
-        internal Action<ICustomization> OnCustomize { get; set; }
+        internal Func<ICustomization, IFixture> OnCustomize { get; set; }
     }
 }

--- a/Src/AutoFixture.xUnit.net.UnitTest/TypeWithCustomizationAttributes.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/TypeWithCustomizationAttributes.cs
@@ -1,0 +1,55 @@
+﻿using Ploeh.TestTypeFoundation;
+
+namespace Ploeh.AutoFixture.Xunit.UnitTest
+{
+    internal class TypeWithCustomizationAttributes
+    {
+        public void CreateWithFrozenAndFavorArrays([Frozen, FavorArrays] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorArraysAndFrozen([FavorArrays, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorEnumerables([Frozen, FavorEnumerables] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorEnumerablesAndFrozen([FavorEnumerables, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorLists([Frozen, FavorLists] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorListsAndFrozen([FavorLists, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndGreedy([Frozen, Greedy] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithGreedyAndFrozen([Greedy, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndModest([Frozen, Modest] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithModestAndFrozen([Modest, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndNoAutoProperties([Frozen, NoAutoProperties] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithNoAutoPropertiesAndFrozen([NoAutoProperties, Frozen] ConcreteType sut)
+        {
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
@@ -107,7 +107,10 @@ namespace Ploeh.AutoFixture.Xunit
         private void CustomizeFixture(ParameterInfo p)
         {
             var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy).OfType<CustomizeAttribute>();
+            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy)
+                .OfType<CustomizeAttribute>()
+                .OrderBy(x => x, new CustomizeAttributeComparer());
+
             foreach (var ca in customizeAttributes)
             {
                 var c = ca.GetCustomization(p);

--- a/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
+++ b/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
@@ -88,6 +88,7 @@
     <Compile Include="AutoDataAttribute.cs" />
     <Compile Include="CompositeDataAttribute.cs" />
     <Compile Include="CustomizeAttribute.cs" />
+    <Compile Include="CustomizeAttributeComparer.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="FavorArraysAttribute.cs" />
     <Compile Include="FavorEnumerablesAttribute.cs" />

--- a/Src/AutoFixture.xUnit.net/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.xUnit.net/CustomizeAttributeComparer.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.Xunit
+{
+    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    {
+        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        {
+            if (x is FrozenAttribute && !(y is FrozenAttribute))
+            {
+                return 1;
+            }
+
+            if (y is FrozenAttribute && !(x is FrozenAttribute))
+            {
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/Src/AutoFixture.xUnit.net/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.xUnit.net/CustomizeAttributeComparer.cs
@@ -6,12 +6,15 @@ namespace Ploeh.AutoFixture.Xunit
     {
         public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
         {
-            if (x is FrozenAttribute && !(y is FrozenAttribute))
+            var xfrozen = x is FrozenAttribute;
+            var yfrozen = y is FrozenAttribute;
+
+            if (xfrozen && !yfrozen)
             {
                 return 1;
             }
 
-            if (y is FrozenAttribute && !(x is FrozenAttribute))
+            if (yfrozen && !xfrozen)
             {
                 return -1;
             }


### PR DESCRIPTION
Fixes issue #420 for [xUnit.net](https://www.nuget.org/packages/AutoFixture.Xunit) glue library.