### PR TITLE
Changed the signature of OnCustomize

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
@@ -170,7 +170,12 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             // Fixture setup
             var method = typeof(TypeWithCustomizationAttributes).GetMethod(methodName, new[] { typeof(ConcreteType) });
             var customizationLog = new List<ICustomization>();
-            var fixture = new DelegatingFixture { OnCustomize = c => { customizationLog.Add(c); } };
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = c =>
+            {
+                customizationLog.Add(c);
+                return fixture;
+            };
             var sut = new AutoDataAttribute(fixture);
             // Exercise system
             sut.GetData(method);

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DelegatingFixture.cs
@@ -57,8 +57,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
 
         public IFixture Customize(ICustomization customization)
         {
-            this.OnCustomize(customization);
-            return this;
+            return this.OnCustomize(customization);
         }
 
         public void Customize<T>(Func<Ploeh.AutoFixture.Dsl.ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -103,6 +102,6 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
 
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
 
-        internal Action<ICustomization> OnCustomize { get; set; }
+        internal Func<ICustomization, IFixture> OnCustomize { get; set; }
     }
 }


### PR DESCRIPTION
to match the signature of the method it 'implements'. This will enable
future users to also configure the Test Double to return a particular
IFixture object, if the need should ever arise.