### PR TITLE
Fix: NPE is thrown when without is called on a base class's field.

### DIFF
--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using Ploeh.AutoFixture.Kernel;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Ploeh.AutoFixture.Dsl
 {
@@ -410,7 +411,9 @@ namespace Ploeh.AutoFixture.Dsl
         {
             var m = propertyPicker.GetWritableMember().Member;
             if (m.ReflectedType != typeof(T))
-                m = typeof(T).GetProperty(m.Name);
+            {
+                m = typeof(T).GetProperty(m.Name) ?? (MemberInfo) typeof(T).GetField(m.Name);
+            }
 
             return (NodeComposer<T>)this.ReplaceNodes(
                 with: n => n.Compose(

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5846,5 +5846,25 @@ namespace Ploeh.AutoFixtureUnitTest
 
             Assert.Equal(expected, actual.Field);
         }
+
+
+        /// <summary>
+        /// This test reproduces the issue as reported in pull request:
+        /// https://github.com/AutoFixture/AutoFixture/pull/604
+        /// </summary>
+        [Fact]
+        public void WithoutOnFieldInBaseClassThrowsNullPointerException()
+        {
+            Fixture f = new Fixture();
+            f.Build<ConcreteType>().Without(x => x.Field1).Create();
+
+            /*
+                Success when no ArgumentNullException is thrown:
+
+                When reported, the call to Without on Field1 residing 
+                in ConcreteType's base class (AbstractType) will cause 
+                a null pointer exception to bubble. 
+            */
+        }
     }
 }

--- a/Src/TestTypeFoundation/AbstractType.cs
+++ b/Src/TestTypeFoundation/AbstractType.cs
@@ -13,5 +13,7 @@
         public object Property3 { get; set; }
 
         public virtual object Property4 { get; set; }
+
+        public object Field1;
     }
 }


### PR DESCRIPTION
I'm not sure if this is desired behavior, but it looks like an exception is raised by `EqualRequestSpecification` when using `Without` on a field that exists in a class's base class. 

Here's the simplified example demonstrating this behavior:

```
public class CoolPerson : CoolPersonality
{            
}
```
```
public class CoolPersonality
{
    public bool IsCool = true;
}
```
```
[Fact]
public void ThrowsNullPointerException_WhenWithoutIsCalledOnABaseClassesField()
{
    Fixture f = new Fixture();
    Assert.Throws<ArgumentNullException>(() => f.Build<CoolPerson>().Without(x => x.IsCool).Create());
}
```

Since the `NodeComposer` doesn't check that the reflected type could potentially be a field, null is passed down the line to `EqualRequestSpecification` where a NPE is raised. 

This was discovered when I was trying to 'mock out' a statically assigned field in a base class to see if AutoFixture + Moq could help me out. 

Sorry for the lack of tests but since I don't understand the architecture of Autofixture that well, it was hard for me to gauge how this change would impact other classes. 

I just wanted to quickly put up this merge request so that I wouldn't forget about it; I'll try to write some tests this weekend!