### PR TITLE
Reorder construction attributes so that [Frozen] is always applied last (NUnit2)

### DIFF
--- a/Src/AutoFixture.NUnit2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoDataAttributeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Ploeh.AutoFixture.NUnit2.Addins;
 using NUnit.Framework;
@@ -138,7 +139,7 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             // Fixture setup
             var method = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) });
             var parameters = method.GetParameters();
-            
+
             var expectedResult = new object();
             var builder = new DelegatingSpecimenBuilder
             {
@@ -156,6 +157,38 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             var result = sut.GetData(method);
             // Verify outcome
             Assert.True(new[] { expectedResult }.SequenceEqual(result.Single()));
+            // Teardown
+        }
+
+        [TestCase("CreateWithFrozenAndFavorArrays")]
+        [TestCase("CreateWithFavorArraysAndFrozen")]
+        [TestCase("CreateWithFrozenAndFavorEnumerables")]
+        [TestCase("CreateWithFavorEnumerablesAndFrozen")]
+        [TestCase("CreateWithFrozenAndFavorLists")]
+        [TestCase("CreateWithFavorListsAndFrozen")]
+        [TestCase("CreateWithFrozenAndGreedy")]
+        [TestCase("CreateWithGreedyAndFrozen")]
+        [TestCase("CreateWithFrozenAndModest")]
+        [TestCase("CreateWithModestAndFrozen")]
+        [TestCase("CreateWithFrozenAndNoAutoProperties")]
+        [TestCase("CreateWithNoAutoPropertiesAndFrozen")]
+        public void GetDataOrdersCustomizationAttributes(string methodName)
+        {
+            // Fixture setup
+            var method = typeof(TypeWithCustomizationAttributes).GetMethod(methodName, new[] { typeof(ConcreteType) });
+            var customizationLog = new List<ICustomization>();
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = c =>
+            {
+                customizationLog.Add(c);
+                return fixture;
+            };
+            var sut = new AutoDataAttribute(fixture);
+            // Exercise system
+            sut.GetData(method);
+            // Verify outcome
+            Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
+            Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
             // Teardown
         }
     }

--- a/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <CodeAnalysisCulture>en-US</CodeAnalysisCulture> 
+    <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,6 +70,7 @@
     <Compile Include="NoAutoPropertiesAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenario.cs" />
+    <Compile Include="TypeWithCustomizationAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture.NUnit2.Addins\AutoFixture.NUnit2.Addins.csproj">

--- a/Src/AutoFixture.NUnit2.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/DelegatingFixture.cs
@@ -57,7 +57,7 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
 
         public IFixture Customize(ICustomization customization)
         {
-            throw new NotImplementedException();
+            return this.OnCustomize(customization);
         }
 
         public void Customize<T>(Func<Ploeh.AutoFixture.Dsl.ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -101,5 +101,7 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         }
 
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
+
+        internal Func<ICustomization, IFixture> OnCustomize { get; set; }
     }
 }

--- a/Src/AutoFixture.NUnit2.UnitTest/TypeWithCustomizationAttributes.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/TypeWithCustomizationAttributes.cs
@@ -1,0 +1,55 @@
+﻿using Ploeh.TestTypeFoundation;
+
+namespace Ploeh.AutoFixture.NUnit2.UnitTest
+{
+    internal class TypeWithCustomizationAttributes
+    {
+        public void CreateWithFrozenAndFavorArrays([Frozen, FavorArrays] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorArraysAndFrozen([FavorArrays, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorEnumerables([Frozen, FavorEnumerables] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorEnumerablesAndFrozen([FavorEnumerables, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorLists([Frozen, FavorLists] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorListsAndFrozen([FavorLists, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndGreedy([Frozen, Greedy] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithGreedyAndFrozen([Greedy, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndModest([Frozen, Modest] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithModestAndFrozen([Modest, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndNoAutoProperties([Frozen, NoAutoProperties] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithNoAutoPropertiesAndFrozen([NoAutoProperties, Frozen] ConcreteType sut)
+        {
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
@@ -106,7 +106,10 @@ namespace Ploeh.AutoFixture.NUnit2
         private void CustomizeFixture(ParameterInfo p)
         {
             var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy).OfType<CustomizeAttribute>();
+            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy)
+                .OfType<CustomizeAttribute>()
+                .OrderBy(x => x, new CustomizeAttributeComparer());
+
             foreach (var ca in customizeAttributes)
             {
                 var c = ca.GetCustomization(p);

--- a/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
+++ b/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoDataAttribute.cs" />
+    <Compile Include="CustomizeAttributeComparer.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Matching.cs" />
     <Compile Include="ModestAttribute.cs" />

--- a/Src/AutoFixture.NUnit2/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.NUnit2/CustomizeAttributeComparer.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.NUnit2
+{
+    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    {
+        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        {
+            var xfrozen = x is FrozenAttribute;
+            var yfrozen = y is FrozenAttribute;
+
+            if (xfrozen && !yfrozen)
+            {
+                return 1;
+            }
+
+            if (yfrozen && !xfrozen)
+            {
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #420 for NUnit2 Glue Library.