### PR TITLE
Fix code analysis configuration for NUnit3 (#598) 

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
@@ -43,6 +43,19 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
                 Is.EqualTo(ExceptionHelper.BuildMessage(new ThrowingStubFixture.DummyException())));
         }
 
+        [Test]
+        public void InitializedWithArgumentsHasCorrectArguments()
+        {
+            // Fixture setup
+            var expectedArguments = new object[] { };
+            var sut = new InlineAutoDataAttribute(expectedArguments);
+            // Exercise system
+            var result = sut.Arguments;
+            // Verify outcome
+            Assert.AreSame(expectedArguments, result);
+            // Teardown
+        }
+
         /// <summary>
         /// This is used in BuildFromYieldsParameterValues for building a unit test method
         /// </summary>

--- a/Src/AutoFixture.NUnit3.sln
+++ b/Src/AutoFixture.NUnit3.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture", "AutoFixture\AutoFixture.csproj", "{400AC174-9A4A-4C7D-815B-F2A21130A0D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixtureUnitTest", "AutoFixtureUnitTest\AutoFixtureUnitTest.csproj", "{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit3", "AutoFixture.NUnit3\AutoFixture.NUnit3.csproj", "{6539DC8B-7829-478E-A601-7625B0C814E1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit3.UnitTest", "AutoFixture.NUnit3.UnitTest\AutoFixture.NUnit3.UnitTest.csproj", "{1E512431-ADC0-4218-873E-E4DF40C97268}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture", "AutoFixture\AutoFixture.csproj", "{400AC174-9A4A-4C7D-815B-F2A21130A0D1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestTypeFoundation", "TestTypeFoundation\TestTypeFoundation.csproj", "{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}"
 EndProject
@@ -16,24 +18,30 @@ Global
 		Verify|Any CPU = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6539DC8B-7829-478E-A601-7625B0C814E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6539DC8B-7829-478E-A601-7625B0C814E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6539DC8B-7829-478E-A601-7625B0C814E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6539DC8B-7829-478E-A601-7625B0C814E1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6539DC8B-7829-478E-A601-7625B0C814E1}.Verify|Any CPU.ActiveCfg = Release|Any CPU
-		{6539DC8B-7829-478E-A601-7625B0C814E1}.Verify|Any CPU.Build.0 = Release|Any CPU
-		{1E512431-ADC0-4218-873E-E4DF40C97268}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1E512431-ADC0-4218-873E-E4DF40C97268}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1E512431-ADC0-4218-873E-E4DF40C97268}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1E512431-ADC0-4218-873E-E4DF40C97268}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1E512431-ADC0-4218-873E-E4DF40C97268}.Verify|Any CPU.ActiveCfg = Release|Any CPU
-		{1E512431-ADC0-4218-873E-E4DF40C97268}.Verify|Any CPU.Build.0 = Release|Any CPU
 		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Verify|Any CPU.Build.0 = Release|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -13,6 +13,7 @@ namespace Ploeh.AutoFixture.NUnit3
     /// This implementation is based on TestCaseAttribute of NUnit3
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
+    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class AutoDataAttribute : Attribute, ITestBuilder
     {
         private readonly IFixture _fixture;
@@ -91,5 +92,5 @@ namespace Ploeh.AutoFixture.NUnit3
                 this._fixture.Customize(customization);
             }
         }
-    } 
+    }
 }

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -13,7 +13,7 @@ namespace Ploeh.AutoFixture.NUnit3
     /// This implementation is based on TestCaseAttribute of NUnit3
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class AutoDataAttribute : Attribute, ITestBuilder
     {
         private readonly IFixture _fixture;
@@ -54,6 +54,7 @@ namespace Ploeh.AutoFixture.NUnit3
             yield return test;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "This method is always expected to return an instance of the TestCaseParameters class.")]
         private TestCaseParameters GetParametersForMethod(IMethodInfo method)
         {
             try

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -89,6 +89,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Src/AutoFixture.NUnit3/CodeAnalysisDictionary.xml
+++ b/Src/AutoFixture.NUnit3/CodeAnalysisDictionary.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Dictionary>
+    <Words>
+        <Unrecognized>
+        </Unrecognized>
+        <Recognized>
+            <Word>ploeh</Word>
+            <Word>xunit</Word>
+            <Word>enumerables</Word>
+        </Recognized>
+        <Deprecated>
+        </Deprecated>
+    </Words>
+    <Acronyms>
+        <CasingExceptions>
+        </CasingExceptions>
+    </Acronyms>
+</Dictionary>

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -14,6 +14,7 @@ namespace Ploeh.AutoFixture.NUnit3
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     [CLSCompliant(false)]
+    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         private readonly object[] _existingParameterValues;
@@ -113,5 +114,5 @@ namespace Ploeh.AutoFixture.NUnit3
                 this._fixture.Customize(customization);
             }
         }
-    } 
+    }
 }

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -14,7 +14,7 @@ namespace Ploeh.AutoFixture.NUnit3
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     [CLSCompliant(false)]
-    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         private readonly object[] _existingParameterValues;
@@ -63,6 +63,7 @@ namespace Ploeh.AutoFixture.NUnit3
             yield return test;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "This method is always expected to return an instance of the TestCaseParameters class.")]
         private TestCaseParameters GetParametersForMethod(IMethodInfo method)
         {
             try

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -50,6 +50,14 @@ namespace Ploeh.AutoFixture.NUnit3
         }
 
         /// <summary>
+        /// Gets the parameter values for the test method.
+        /// </summary>
+        public IEnumerable<object> Arguments
+        {
+            get { return this._existingParameterValues; }
+        }
+
+        /// <summary>
         ///     Construct one or more TestMethods from a given MethodInfo,
         ///     using available parameter data.
         /// </summary>


### PR DESCRIPTION
Addresses issue #598 for NUnit3 Glue Library.

When I fixed the code analysis configuration I got the following errors:
```
  1) Building S:\autofixture\Src\AutoFixture.NUnit3.sln failed with exitcode 1.
  2) CA1704: (-1,0): Microsoft.Naming : Correct the spelling of 'Ploeh' in namespace name 'Ploeh.AutoFixture.NUnit3'.
  3) CA1704: (-1,0): Microsoft.Naming : Correct the spelling of 'Ploeh' in assembly name 'Ploeh.AutoFixture.NUnit3.dll'.
  4) CA1813: (-1,0): Microsoft.Performance : Seal 'AutoDataAttribute', if possible.
  5) CA1822: S:\autofixture\Src\AutoFixture.NUnit3\AutoDataAttribute.cs(82,0): Microsoft.Performance : The 'this' parameter (or 'Me' in Visual Basic) of 'AutoDataAttribute.CustomizeFixtureByParameter(IFixture, IParameterInfo)' is never used. Mark the member as static (or Shared in Visual Basic) or use 'this'/'Me' in the method body or at least one property accessor, if appropriate.
  6) CA1031: S:\autofixture\Src\AutoFixture.NUnit3\AutoDataAttribute.cs(63,0): Microsoft.Design : Modify 'AutoDataAttribute.GetParametersForMethod(IMethodInfo)' to catch a more specific exception than 'Exception' or rethrow the exception.
  7) CA1704: (-1,0): Microsoft.Naming : Correct the spelling of 'Enumerables' in type name 'FavorEnumerablesAttribute'.
```

I suppressed the error `CA1031: Do not catch general exception types` in the `AutoDataAttribute.GetParametersForMethod()` method. AFAICS it's by design, but we'd better ask @hackle to confirm this.