### PR TITLE
No autoproperty attribute

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -57,6 +57,7 @@
     <Compile Include="ModestAttributeTest.cs" />
     <Compile Include="InlineAutoDataAttributeTest.cs" />
     <Compile Include="MyClass.cs" />
+    <Compile Include="NoAutoPropertiesAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenario.cs" />
     <Compile Include="ThrowingStubFixture.cs" />

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DependencyConstraints.cs" />
     <Compile Include="InlineAutoDataAttributeStub.cs" />
     <Compile Include="AutoDataAttributeStub.cs" />
     <Compile Include="AutoDataAttributeTest.cs" />

--- a/Src/AutoFixture.NUnit3.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/DependencyConstraints.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+using System.Linq;
+
+namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    public class DependencyConstraints
+    {
+        [InlineAutoData("FakeItEasy")]
+        [InlineAutoData("Foq")]
+        [InlineAutoData("FsCheck")]
+        [InlineAutoData("Moq")]
+        [InlineAutoData("NSubstitute")]
+        [InlineAutoData("Rhino.Mocks")]
+        [InlineAutoData("Unquote")]
+        [InlineAutoData("xunit")]
+        [InlineAutoData("xunit.extensions")]
+        public void AutoFixtureNUnit3DoesNotReference(string assemblyName)
+        {
+            // Fixture setup
+            // Exercise system
+            var references = typeof(AutoDataAttribute).Assembly.GetReferencedAssemblies();
+            // Verify outcome
+            Assert.False(references.Any(an => an.Name == assemblyName));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineAutoData("FakeItEasy")]
+        [InlineAutoData("Foq")]
+        [InlineAutoData("FsCheck")]
+        [InlineAutoData("Moq")]
+        [InlineAutoData("NSubstitute")]
+        [InlineAutoData("Rhino.Mocks")]
+        [InlineAutoData("Unquote")]
+        [InlineAutoData("xunit")]
+        [InlineAutoData("xunit.extensions")]
+        public void AutoFixtureNUnit3UnitTestsDoNotReference(string assemblyName)
+        {
+            // Fixture setup
+            // Exercise system
+            var references = this.GetType().Assembly.GetReferencedAssemblies();
+            // Verify outcome
+            Assert.False(references.Any(an => an.Name == assemblyName));
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/NoAutoPropertiesAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/NoAutoPropertiesAttributeTest.cs
@@ -1,0 +1,46 @@
+﻿using NUnit.Framework;
+using Ploeh.TestTypeFoundation;
+using System;
+using System.Linq;
+
+namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    [TestFixture]
+    public class NoAutoPropertiesAttributeTest
+    {
+        [Test]
+        public void SutIsAttribute()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new NoAutoPropertiesAttribute();
+            // Verify outcome
+            Assert.IsInstanceOf<CustomizeAttribute>(sut);
+        }
+
+        [Test]
+        public void GetCustomizationFromNullParameterThrows()
+        {
+            // Fixture setup
+            var sut = new NoAutoPropertiesAttribute();
+            // Exercise system and verify the outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.GetCustomization(null));
+        }
+
+        [Test]
+        public void GetCustomizationReturnsTheCorrectResult()
+        {
+            // Fixture setup
+            var sut = new NoAutoPropertiesAttribute();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                .GetParameters()
+                .Single();
+            // Exercise system
+            var result = sut.GetCustomization(parameter);
+            // Verify the outcome
+            Assert.IsAssignableFrom<NoAutoPropertiesCustomization>(result);
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
@@ -375,5 +375,17 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
         {
             Assert.That(p3, Is.EqualTo(p4));
         }
+
+        [Theory, AutoData]
+        public void NoAutoPropertiesAttributeLeavesPropertiesUnset(
+            [NoAutoProperties]PropertyHolder<object> ph1, 
+            [NoAutoProperties]PropertyHolder<string> ph2,
+            [NoAutoProperties]PropertyHolder<int> ph3
+            )
+        {
+            Assert.That(ph1.Property, Is.EqualTo(default(object)));
+            Assert.That(ph2.Property, Is.EqualTo(default(string)));
+            Assert.That(ph3.Property, Is.EqualTo(default(int)));
+        }
     }
 }

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -78,6 +78,7 @@
     <Compile Include="GreedyAttribute.cs" />
     <Compile Include="Matching.cs" />
     <Compile Include="ModestAttribute.cs" />
+    <Compile Include="NoAutoPropertiesAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFixture.NUnit3/NoAutoPropertiesAttribute.cs
+++ b/Src/AutoFixture.NUnit3/NoAutoPropertiesAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Reflection;
+
+namespace Ploeh.AutoFixture.NUnit3
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// TestCase to indicate that the parameter value should not have properties auto populated
+    /// when the <see cref="IFixture"/> creates an instance of that type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class NoAutoPropertiesAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Gets a customization that stops auto population of properties for the type of the parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns>
+        /// A customization that stops auto population of the <see cref="Type"/> of the parameter.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="parameter"/> is null.
+        /// </exception>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException("parameter");
+            }
+
+            var targetType = parameter.ParameterType;
+            return new NoAutoPropertiesCustomization(targetType);
+        }
+    }
+}


### PR DESCRIPTION
This is a simple port over from AutoFixture.Xnunit2 of NoAutoPropertiesAttribute along with

1. with an extra test in Scenario
2. with DependencyConstraints

AFAIK this should be the last pull request to complete parity with other glue libraries.