### PR TITLE
Reorder construction attributes so that [Frozen] is always applied last (NUnit3)

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoDataAttributeTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Ploeh.TestTypeFoundation;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -80,6 +82,38 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
 
             Assert.That(testMethod.Properties.Get(PropertyNames.SkipReason),
                 Is.EqualTo(ExceptionHelper.BuildMessage(new ThrowingStubFixture.DummyException())));
+        }
+
+        [TestCase("CreateWithFrozenAndFavorArrays")]
+        [TestCase("CreateWithFavorArraysAndFrozen")]
+        [TestCase("CreateWithFrozenAndFavorEnumerables")]
+        [TestCase("CreateWithFavorEnumerablesAndFrozen")]
+        [TestCase("CreateWithFrozenAndFavorLists")]
+        [TestCase("CreateWithFavorListsAndFrozen")]
+        [TestCase("CreateWithFrozenAndGreedy")]
+        [TestCase("CreateWithGreedyAndFrozen")]
+        [TestCase("CreateWithFrozenAndModest")]
+        [TestCase("CreateWithModestAndFrozen")]
+        [TestCase("CreateWithFrozenAndNoAutoProperties")]
+        [TestCase("CreateWithNoAutoPropertiesAndFrozen")]
+        public void GetDataOrdersCustomizationAttributes(string methodName)
+        {
+            // Fixture setup
+            var method = new MethodWrapper(typeof(TypeWithCustomizationAttributes), methodName);
+            var customizationLog = new List<ICustomization>();
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = c =>
+            {
+                customizationLog.Add(c);
+                return fixture;
+            };
+            var sut = new AutoDataAttributeStub(fixture);
+            // Exercise system
+            sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
+            // Verify outcome
+            Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
+            Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
+            // Teardown
         }
     }
 }

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -50,6 +50,7 @@
     <Compile Include="CustomizeAttributeTest.cs" />
     <Compile Include="DelegatingCustomization.cs" />
     <Compile Include="DelegatingCustomizeAttribute.cs" />
+    <Compile Include="DelegatingFixture.cs" />
     <Compile Include="FavorArraysAttributeTest.cs" />
     <Compile Include="FavorEnumerablesAttributeTest.cs" />
     <Compile Include="FavorListsAttributeTest.cs" />
@@ -62,6 +63,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenario.cs" />
     <Compile Include="ThrowingStubFixture.cs" />
+    <Compile Include="TypeWithCustomizationAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture.NUnit3\AutoFixture.NUnit3.csproj">

--- a/Src/AutoFixture.NUnit3.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/DelegatingFixture.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    internal class DelegatingFixture : IFixture
+    {
+        private readonly List<ISpecimenBuilder> customizations;
+        private readonly List<ISpecimenBuilder> residueCollectors;
+
+        public DelegatingFixture()
+        {
+            this.customizations = new List<ISpecimenBuilder>();
+            this.residueCollectors = new List<ISpecimenBuilder>();
+            this.OnCreate = (r, s) => new object();
+        }
+
+        public IList<ISpecimenBuilderTransformation> Behaviors
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IList<ISpecimenBuilder> Customizations
+        {
+            get { return this.customizations; }
+        }
+
+        public bool OmitAutoProperties { get; set; }
+
+        public int RepeatCount { get; set; }
+
+        public IList<ISpecimenBuilder> ResidueCollectors
+        {
+            get { return this.residueCollectors; }
+        }
+
+        public void AddManyTo<T>(ICollection<T> collection, Func<T> creator)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddManyTo<T>(ICollection<T> collection)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddManyTo<T>(ICollection<T> collection, int repeatCount)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Ploeh.AutoFixture.Dsl.ICustomizationComposer<T> Build<T>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IFixture Customize(ICustomization customization)
+        {
+            return this.OnCustomize(customization);
+        }
+
+        public void Customize<T>(Func<Ploeh.AutoFixture.Dsl.ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Inject<T>(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Register<T>(Func<T> creator)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Register<TInput, T>(Func<TInput, T> creator)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Register<TInput1, TInput2, T>(Func<TInput1, TInput2, T> creator)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Register<TInput1, TInput2, TInput3, T>(Func<TInput1, TInput2, TInput3, T> creator)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Register<TInput1, TInput2, TInput3, TInput4, T>(Func<TInput1, TInput2, TInput3, TInput4, T> creator)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            return this.OnCreate(request, context);
+        }
+
+        internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
+
+        internal Func<ICustomization, IFixture> OnCustomize { get; set; }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/TypeWithCustomizationAttributes.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TypeWithCustomizationAttributes.cs
@@ -1,0 +1,55 @@
+﻿using Ploeh.TestTypeFoundation;
+
+namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    internal class TypeWithCustomizationAttributes
+    {
+        public void CreateWithFrozenAndFavorArrays([Frozen, FavorArrays] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorArraysAndFrozen([FavorArrays, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorEnumerables([Frozen, FavorEnumerables] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorEnumerablesAndFrozen([FavorEnumerables, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndFavorLists([Frozen, FavorLists] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFavorListsAndFrozen([FavorLists, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndGreedy([Frozen, Greedy] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithGreedyAndFrozen([Greedy, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndModest([Frozen, Modest] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithModestAndFrozen([Modest, Frozen] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithFrozenAndNoAutoProperties([Frozen, NoAutoProperties] ConcreteType sut)
+        {
+        }
+
+        public void CreateWithNoAutoPropertiesAndFrozen([NoAutoProperties, Frozen] ConcreteType sut)
+        {
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -86,7 +86,9 @@ namespace Ploeh.AutoFixture.NUnit3
 
         private void CustomizeFixtureByParameter(IParameterInfo parameter)
         {
-            var customizeAttributes = parameter.GetCustomAttributes<CustomizeAttribute>(false);
+            var customizeAttributes = parameter.GetCustomAttributes<CustomizeAttribute>(false)
+                .OrderBy(x => x, new CustomizeAttributeComparer());
+
             foreach (var ca in customizeAttributes)
             {
                 var customization = ca.GetCustomization(parameter.ParameterInfo);

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -71,6 +71,7 @@
     <Compile Include="InlineAutoDataAttribute.cs" />
     <Compile Include="AutoDataAttribute.cs" />
     <Compile Include="CustomizeAttribute.cs" />
+    <Compile Include="CustomizeAttributeComparer.cs" />
     <Compile Include="FavorArraysAttribute.cs" />
     <Compile Include="FavorEnumerablesAttribute.cs" />
     <Compile Include="FavorListsAttribute.cs" />

--- a/Src/AutoFixture.NUnit3/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.NUnit3/CustomizeAttributeComparer.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.NUnit3
+{
+    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    {
+        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        {
+            var xfrozen = x is FrozenAttribute;
+            var yfrozen = y is FrozenAttribute;
+
+            if (xfrozen && !yfrozen)
+            {
+                return 1;
+            }
+
+            if (yfrozen && !xfrozen)
+            {
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #420 for NUnit3 Glue Library.

Question: I noticed that the `AutoDataAttribute(IFixture fixture)` constructor is *protected* in the [NUnit3](https://github.com/AutoFixture/AutoFixture/blob/master/Src/AutoFixture.NUnit3/AutoDataAttribute.cs#L33) library but it's public in all the [other](https://github.com/AutoFixture/AutoFixture/blob/master/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs#L59) [Glue](https://github.com/AutoFixture/AutoFixture/blob/master/Src/AutoFixture.NUnit2/AutoDataAttribute.cs#L56) [Libraries](https://github.com/AutoFixture/AutoFixture/blob/master/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs#L56). Is there any reason for this?