### PR TITLE
set CodeAnalysisCulture to en-US for AutoFixture.xUnit.net2

### DIFF
--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>ebe64f01</NuGetPackageImportStamp>
+    <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I originally fixed this for all the projects in #200 but I guess AutoFixture.xUnit.net2 was added since then.

Before this fix, the build failed on my machine (which has en-GB set as the OS language) because it detects "favor" as a spelling mistake (the British spelling is "favour").