### PR TITLE
constrain FakeItEasy version to less than 2.0

### DIFF
--- a/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
@@ -8,7 +8,7 @@
         <owners>Nikos Baxevanis</owners>
         <dependencies>
             <dependency id="autofixture" version="@build.number@" />
-            <dependency id="FakeItEasy" version="1.7" />
+            <dependency id="FakeItEasy" version="[1.7,2)" />
         </dependencies>
         <summary>Turns AutoFixture into an Auto-Mocking Container based on FakeItEasy.</summary>
         <description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by FakeItEasy. To use it, add the AutoFakeItEasyCustomization to your Fixture instance. Read more at http://autofixture.codeplex.com/</description>


### PR DESCRIPTION
FakeItEasy 2.0 (as the version implies) has breaking changes.

Unfortunately, the current version of AutoFixture.AutoFakeItEasy is incompatible with FakeItEasy 2.0 because of these two lines of code

* https://github.com/AutoFixture/AutoFixture/blob/98d7b4d00ba05e406796e32b560b5975f1f9af78/Src/AutoFakeItEasy/FakeItEasyBuilder.cs#L76
* https://github.com/AutoFixture/AutoFixture/blob/98d7b4d00ba05e406796e32b560b5975f1f9af78/Src/AutoFakeItEasy/FakeItEasyRelay.cs#L85

This is because `FakeItEasy.Configuration.IHideObjectMembers` has been renamed to `FakeItEasy.IHideObjectMembers`.

This is, of course, easily fixed, but I believe the best course of action, given that the FakeItEasy 2.0 release is imminent, is to, as soon as possible, release a patch of AutoFixture.AutoFakeItEasy which restricts the FakeItEasy dependency to less than 2.0.

After FakeItEasy 2.0 is released, a version of AutoFixture.AutoFakeItEasy may be released with those two lines of code fixed, and with the FakeItEasy dependency restricted to greater than 2.0. (If you are following SemVer then I guess this would also imply a major version bump of AutoFixture.AutoFakeItEasy since the upgrade would force a major upgrade of FakeItEasy.)