### PR TITLE
Fixing InvalidCastException in ConstructorInitializedMemberAssertion

### DIFF
--- a/Src/Idioms/ConstructorInitializedMemberAssertion.cs
+++ b/Src/Idioms/ConstructorInitializedMemberAssertion.cs
@@ -266,7 +266,7 @@ namespace Ploeh.AutoFixture.Idioms
             {
                 //Check for a default value only enum
                 var values = Enum.GetValues(type);
-                return values.Length == 1 && (int)values.GetValue(0) == default(int);
+                return values.Length == 1 && values.GetValue(0).Equals(Activator.CreateInstance(type));
             }
 
             return false;
@@ -303,8 +303,10 @@ namespace Ploeh.AutoFixture.Idioms
                     // Ensure enum isn't getting the default value, otherwise
                     // we won't be able to determine whether initialization
                     // occurred.
-                    if (pi.ParameterType.IsEnum && (int)value == default(int))
+                    if (pi.ParameterType.IsEnum && value.Equals(Activator.CreateInstance(pi.ParameterType)))
+                    {
                         value = this.builder.CreateAnonymous(pi);
+                    }
 
                     return new
                     {

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -476,8 +476,22 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Theory]
-        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestEnum>))]
-        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestIntEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestIntEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestByteEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestByteEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestSByteEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestSByteEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestShortEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestShortEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestUShortEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestUShortEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestUIntEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestUIntEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestLongEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestLongEnum>))]
+        [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestULongEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestULongEnum>))]
         [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestSingleNonDefaultEnum>))]
         [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestSingleNonDefaultEnum>))]
         public void VerifyWellBehavedEnumInitializersDoNotThrow(Type type)
@@ -491,8 +505,22 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Theory]
-        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestEnum>))]
-        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestIntEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestIntEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestByteEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestByteEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestSByteEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestSByteEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestShortEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestShortEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestUShortEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestUShortEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestUIntEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestUIntEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestLongEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestLongEnum>))]
+        [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestULongEnum>))]
+        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestULongEnum>))]
         [InlineData(typeof(ReadOnlyFieldIncorrectlyInitializedViaConstructor<TestSingleNonDefaultEnum>))]
         [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestSingleNonDefaultEnum>))]
         public void VerifyIllBehavedEnumInitializersDoThrow(Type type)
@@ -771,10 +799,19 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             }
         }
 
-        enum TestEnum { none = 0, one, two, three };
+        //All approved enum type variants : https://msdn.microsoft.com/en-us/library/sbbt4032.aspx?f=255&MSPPError=-2147217396
+        enum TestIntEnum { none = 0, one, two, three };
+        enum TestByteEnum : byte { none = 0, one, two, three };
+        enum TestSByteEnum : sbyte { none = 0, one, two, three };
+        enum TestShortEnum : short { none = 0, one, two, three };
+        enum TestUShortEnum : ushort { none = 0, one, two, three };
+        enum TestUIntEnum : uint { none = 0, one, two, three };
+        enum TestLongEnum : long { none = 0, one, two, three };
+        enum TestULongEnum : ulong { none = 0, one, two, three };
 
         enum TestDefaultOnlyEnum { none = 0 };
 
         enum TestSingleNonDefaultEnum { none = 1 };
+
     }
 }


### PR DESCRIPTION
In a previous PR (#516), I incorrectly assumed the value would be castable to int.   As a result, when dealing with enums of type byte an exception would result.

Fix is now type agnostic.