### PR TITLE
Introduce Lambda Expression Tree generator

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -100,6 +100,7 @@
     <Compile Include="DomainName.cs" />
     <Compile Include="DomainNameGenerator.cs" />
     <Compile Include="ElementsBuilder.cs" />
+    <Compile Include="LambdaExpressionGenerator.cs" />
     <Compile Include="FixtureRepeater.cs" />
     <Compile Include="InvariantCultureGenerator.cs" />
     <Compile Include="EmailAddressLocalPart.cs" />

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -72,11 +72,11 @@ namespace Ploeh.AutoFixture
                                         this),
                                     new OrRequestSpecification(
                                         new ExactTypeSpecification(
-                                            typeof (Fixture)),
+                                            typeof(Fixture)),
                                         new ExactTypeSpecification(
-                                            typeof (IFixture)),
+                                            typeof(IFixture)),
                                         new ExactTypeSpecification(
-                                            typeof (ISpecimenBuilder)))),
+                                            typeof(ISpecimenBuilder)))),
                                 new StableFiniteSequenceRelay(),
                                 new FilteringSpecimenBuilder(
                                     new Postprocessor(
@@ -108,6 +108,7 @@ namespace Ploeh.AutoFixture
                                 new StringLengthAttributeRelay(),
                                 new RegularExpressionAttributeRelay(),
                                 new EnumGenerator(),
+                                new LambdaExpressionGenerator(),
                                 CreateDefaultValueBuilder(CultureInfo.InvariantCulture),
                                 CreateDefaultValueBuilder(Encoding.UTF8),
                                 CreateDefaultValueBuilder(IPAddress.Loopback))),
@@ -128,7 +129,7 @@ namespace Ploeh.AutoFixture
                         new FilteringSpecimenBuilder(
                             new MutableValueTypeWarningThrower(),
                             new AndRequestSpecification(
-                                new ValueTypeSpecification(), 
+                                new ValueTypeSpecification(),
                                 new NoConstructorsSpecification()))))));
 
             this.UpdateCustomizer();
@@ -416,7 +417,7 @@ namespace Ploeh.AutoFixture
 
         private void UpdateResidueCollector()
         {
-            this.residueCollector = 
+            this.residueCollector =
                 new SpecimenBuilderNodeAdapterCollection(
                     this.graph,
                     n => n is ResidueCollectorNode);

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -41,7 +41,12 @@
             var delegateType = requestType.GetGenericArguments().Single();
             var genericArguments = delegateType.GetGenericArguments().Select(Expression.Parameter).ToList();
 
-            if (delegateType.Name.StartsWith("Action"))
+            if (delegateType == typeof(Action))
+            {
+                return Expression.Lambda(Expression.Empty());
+            }
+
+            if (delegateType.FullName.StartsWith("System.Action`", StringComparison.Ordinal))
             {
                 return Expression.Lambda(Expression.Empty(), genericArguments);
             }

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -1,6 +1,7 @@
 ﻿namespace Ploeh.AutoFixture
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
     using Kernel;
@@ -21,11 +22,17 @@
             }
 
             var genericArguments = requestType
-              .GetGenericArguments().Single()
-              .GetGenericArguments().Single();
+                .GetGenericArguments().Single()
+                .GetGenericArguments().Select(Expression.Parameter).ToList();
 
-            var parameter = Expression.Parameter(genericArguments);
-            var lambdaExpression = Expression.Lambda(parameter);
+            var body = genericArguments.First();
+            var parameters = new List<ParameterExpression>();
+            if (genericArguments.Count > 1)
+            {
+                parameters = genericArguments.Skip(1).ToList();
+            }
+
+            var lambdaExpression = Expression.Lambda(body, parameters);
             return lambdaExpression;
         }
     }

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -21,13 +21,12 @@
                 return new NoSpecimen();
             }
 
-            var genericArguments = requestType
-                .GetGenericArguments().Single()
-                .GetGenericArguments().Select(Expression.Parameter).ToList();
+            var delegateType = requestType.GetGenericArguments().Single();
+            var genericArguments = delegateType.GetGenericArguments().Select(Expression.Parameter).ToList();
 
-            if (!genericArguments.Any())
+            if (delegateType.Name.StartsWith( "Action"))
             {
-                return Expression.Lambda(Expression.Empty());
+                return Expression.Lambda(Expression.Empty(), genericArguments);
             }
 
             var body = genericArguments.Last();

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -5,8 +5,26 @@
     using System.Linq.Expressions;
     using Kernel;
 
+    /// <summary>
+    /// Creates new lambda expressions represented by the <see cref="Expression{TDelegate}"/> type.
+    /// </summary>
+    /// <remarks>
+    /// Specimens are typically either of type <see>
+    ///         <cref>Expression{Func{T}}</cref>
+    ///     </see>
+    ///     or <see cref="Expression{Action}"/>. 
+    /// </remarks>
     public class LambdaExpressionGenerator : ISpecimenBuilder
     {
+        /// <summary>
+        /// Creates a new lambda expression represented by the <see cref="Expression{TDelegate}"/> type.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">Not used.</param>
+        /// <returns>
+        /// A new <see cref="Expression{TDelegate}"/> instance, if <paramref name="request"/> is a request for a
+        /// <see cref="Expression{TDelegate}"/>; otherwise, a <see cref="NoSpecimen"/> instance.
+        /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
             var requestType = request as Type;

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -25,6 +25,11 @@
                 .GetGenericArguments().Single()
                 .GetGenericArguments().Select(Expression.Parameter).ToList();
 
+            if (!genericArguments.Any())
+            {
+                return Expression.Lambda(Expression.Empty());
+            }
+
             var body = genericArguments.Last();
             var parameters = new List<ParameterExpression>();
             if (genericArguments.Count > 1)
@@ -32,8 +37,7 @@
                 parameters = genericArguments.Take(genericArguments.Count - 1).ToList();
             }
 
-            var lambdaExpression = Expression.Lambda(body, parameters);
-            return lambdaExpression;
+            return Expression.Lambda(body, parameters);
         }
     }
 }

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -25,11 +25,11 @@
                 .GetGenericArguments().Single()
                 .GetGenericArguments().Select(Expression.Parameter).ToList();
 
-            var body = genericArguments.First();
+            var body = genericArguments.Last();
             var parameters = new List<ParameterExpression>();
             if (genericArguments.Count > 1)
             {
-                parameters = genericArguments.Skip(1).ToList();
+                parameters = genericArguments.Take(genericArguments.Count - 1).ToList();
             }
 
             var lambdaExpression = Expression.Lambda(body, parameters);

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -56,10 +56,10 @@
                 return Expression.Lambda(Expression.Empty(), genericArguments);
             }
 
-            var body = genericArguments.Last();
-            var parameters = genericArguments.Except(new[] { body });
+            var body = context.Resolve(delegateType.GetGenericArguments().Last());
+            var parameters = genericArguments.Except(new[] { genericArguments.Last() });
 
-            return Expression.Lambda(body, parameters);
+            return Expression.Lambda(Expression.Constant(body), parameters);
         }
     }
 }

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -1,7 +1,6 @@
 ﻿namespace Ploeh.AutoFixture
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
     using Kernel;
@@ -24,17 +23,13 @@
             var delegateType = requestType.GetGenericArguments().Single();
             var genericArguments = delegateType.GetGenericArguments().Select(Expression.Parameter).ToList();
 
-            if (delegateType.Name.StartsWith( "Action"))
+            if (delegateType.Name.StartsWith("Action"))
             {
                 return Expression.Lambda(Expression.Empty(), genericArguments);
             }
 
             var body = genericArguments.Last();
-            var parameters = new List<ParameterExpression>();
-            if (genericArguments.Count > 1)
-            {
-                parameters = genericArguments.Take(genericArguments.Count - 1).ToList();
-            }
+            var parameters = genericArguments.Except(new[] { body });
 
             return Expression.Lambda(body, parameters);
         }

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -1,0 +1,32 @@
+﻿namespace Ploeh.AutoFixture
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using Kernel;
+
+    public class LambdaExpressionGenerator : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            var requestType = request as Type;
+            if (requestType == null)
+            {
+                return new NoSpecimen();
+            }
+
+            if (requestType.BaseType != typeof(LambdaExpression))
+            {
+                return new NoSpecimen();
+            }
+
+            var genericArguments = requestType
+              .GetGenericArguments().Single()
+              .GetGenericArguments().Single();
+
+            var parameter = Expression.Parameter(genericArguments);
+            var lambdaExpression = Expression.Lambda(parameter);
+            return lambdaExpression;
+        }
+    }
+}

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -27,6 +27,11 @@
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             var requestType = request as Type;
             if (requestType == null)
             {

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DomainNameGeneratorTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="ElementsBuilderTest.cs" />
+    <Compile Include="LambdaExpressionGeneratorTest.cs" />
     <Compile Include="FixtureRepeaterTest.cs" />
     <Compile Include="InvariantCultureGeneratorTest.cs" />
     <Compile Include="CreatingAbstractClassWithPublicConstructorTests.cs" />

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5865,14 +5865,19 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void CreateExpression()
+        public void UseActionExpression()
         {
             var fixture = new Fixture();
-            var expected = typeof(Expression<Func<object>>);
+            var actual = fixture.Create<Expression<Action<string, int>>>();
+            Assert.DoesNotThrow(() => actual.Compile()("foo", 42));
+        }
 
-            var actual = fixture.Create<Expression<Func<object>>>().GetType();
-
-            Assert.Equal(expected, actual);
+        [Fact]
+        public void CreateFuncExpression()
+        {
+            var fixture = new Fixture();
+            var actual = fixture.Create<Expression<Func<object>>>();
+            Assert.NotNull(actual.Compile()());
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Net.Mail;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -18,9 +19,6 @@ using Ploeh.AutoFixtureUnitTest.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Extensions;
-using System.Text;
-using System.Globalization;
-using System.Net;
 
 namespace Ploeh.AutoFixtureUnitTest
 {
@@ -1847,7 +1845,7 @@ namespace Ploeh.AutoFixtureUnitTest
             Assert.Equal<int>(expectedRepeatCount, result);
             // Teardown
         }
-            [Fact]
+        [Fact]
         public void RepeatWillPerformActionTheDefaultNumberOfTimes()
         {
             // Fixture setup
@@ -1902,7 +1900,7 @@ namespace Ploeh.AutoFixtureUnitTest
             Assert.Equal<int>(expectedCount, result.Count());
             // Teardown
         }
-        
+
         [Fact]
         public void ReplacingStringMappingWillUseNewStringCreationAlgorithm()
         {
@@ -5791,8 +5789,8 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [InlineData( 1)]
-        [InlineData( 2)]
+        [InlineData(1)]
+        [InlineData(2)]
         [InlineData(10)]
         public void CustomizeBytePropertyReturnsCorrectResult(int expected)
         {
@@ -5806,8 +5804,8 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [InlineData( 1)]
-        [InlineData( 2)]
+        [InlineData(1)]
+        [InlineData(2)]
         [InlineData(10)]
         public void CustomizeByteFieldReturnsCorrectResult(int expected)
         {
@@ -5864,6 +5862,17 @@ namespace Ploeh.AutoFixtureUnitTest
                 in ConcreteType's base class (AbstractType) will cause 
                 a null pointer exception to bubble. 
             */
+        }
+
+        [Fact]
+        public void CreateExpression()
+        {
+            var fixture = new Fixture();
+            var expected = typeof(Expression<Func<object>>);
+
+            var actual = fixture.Create<Expression<Func<object>>>().GetType();
+
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -50,6 +50,7 @@
         }
 
         [Theory]
+        [InlineData(typeof(Expression<Action>))]
         [InlineData(typeof(Expression<Func<object>>))]
         [InlineData(typeof(Expression<Func<object, object>>))]
         [InlineData(typeof(Expression<Func<bool, int>>))]

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -4,6 +4,7 @@
     using System.Linq.Expressions;
     using AutoFixture;
     using AutoFixture.Kernel;
+    using Kernel;
     using Xunit;
     using Xunit.Extensions;
 
@@ -20,9 +21,10 @@
         public void CreateWithNonTypeRequestReturnsNoSpecimen()
         {
             var nonTypeRequest = new object();
+            var dummyContainer = new DelegatingSpecimenContext();
             var sut = new LambdaExpressionGenerator();
 
-            var result = sut.Create(nonTypeRequest, null);
+            var result = sut.Create(nonTypeRequest, dummyContainer);
 
             Assert.IsType<NoSpecimen>(result);
         }
@@ -31,20 +33,30 @@
         public void CreateWithNonLambdaExpressionTypeRequestReturnsNoSpecimen()
         {
             var nonExpressionRequest = typeof(object);
+            var dummyContainer = new DelegatingSpecimenContext();
             var sut = new LambdaExpressionGenerator();
 
-            var result = sut.Create(nonExpressionRequest, null);
+            var result = sut.Create(nonExpressionRequest, dummyContainer);
 
             Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            var expressionRequest = typeof(Expression<Func<object>>);
+            var sut = new LambdaExpressionGenerator();
+            Assert.Throws<ArgumentNullException>(() => sut.Create(expressionRequest, null));
         }
 
         [Fact]
         public void CreateWithLambdaExpressionTypeRequestReturnsCorrectResult()
         {
             var expressionRequest = typeof(Expression<Func<object>>);
+            var dummyContainer = new DelegatingSpecimenContext();
             var sut = new LambdaExpressionGenerator();
 
-            var result = sut.Create(expressionRequest, null);
+            var result = sut.Create(expressionRequest, dummyContainer);
 
             Assert.IsType<Expression<Func<object>>>(result);
         }
@@ -60,9 +72,10 @@
         public void CreateWithExpressionRequestReturnsCorrectResult(Type expected)
         {
             var expressionRequest = expected;
+            var dummyContainer = new DelegatingSpecimenContext();
             var sut = new LambdaExpressionGenerator();
 
-            var result = sut.Create(expressionRequest, null);
+            var result = sut.Create(expressionRequest, dummyContainer);
 
             Assert.IsType(expected, result);
         }

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -72,10 +72,10 @@
         public void CreateWithExpressionRequestReturnsCorrectResult(Type expected)
         {
             var expressionRequest = expected;
-            var dummyContainer = new DelegatingSpecimenContext();
+            var context = new SpecimenContext(new Fixture());
             var sut = new LambdaExpressionGenerator();
 
-            var result = sut.Create(expressionRequest, dummyContainer);
+            var result = sut.Create(expressionRequest, context);
 
             Assert.IsType(expected, result);
         }

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -1,0 +1,65 @@
+﻿namespace Ploeh.AutoFixtureUnitTest
+{
+    using System;
+    using System.Linq.Expressions;
+    using AutoFixture;
+    using AutoFixture.Kernel;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class LambdaExpressionGeneratorTest
+    {
+        [Fact]
+        public void SutIsISpecimenBuilder()
+        {
+            var sut = new LambdaExpressionGenerator();
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void CreateWithNonTypeRequestReturnsNoSpecimen()
+        {
+            var nonTypeRequest = new object();
+            var sut = new LambdaExpressionGenerator();
+
+            var result = sut.Create(nonTypeRequest, null);
+
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void CreateWithNonLambdaExpressionTypeRequestReturnsNoSpecimen()
+        {
+            var nonExpressionRequest = typeof(object);
+            var sut = new LambdaExpressionGenerator();
+
+            var result = sut.Create(nonExpressionRequest, null);
+
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void CreateWithLambdaExpressionTypeRequestReturnsCorrectResult()
+        {
+            var expressionRequest = typeof(Expression<Func<object>>);
+            var sut = new LambdaExpressionGenerator();
+
+            var result = sut.Create(expressionRequest, null);
+
+            Assert.IsType<Expression<Func<object>>>(result);
+        }
+
+        [Theory]
+        [InlineData(typeof(Expression<Func<object>>))]
+        [InlineData(typeof(Expression<Func<object>>))]
+        public void CreateWithExpressionRequestReturnsCorrectResult(Type expected)
+        {
+            var expressionRequest = expected;
+            var sut = new LambdaExpressionGenerator();
+
+            var result = sut.Create(expressionRequest, null);
+
+            Assert.IsType(expected, result);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -51,6 +51,8 @@
 
         [Theory]
         [InlineData(typeof(Expression<Action>))]
+        [InlineData(typeof(Expression<Action<object>>))]
+        [InlineData(typeof(Expression<Action<bool, int>>))]
         [InlineData(typeof(Expression<Func<object>>))]
         [InlineData(typeof(Expression<Func<object, object>>))]
         [InlineData(typeof(Expression<Func<bool, int>>))]

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -52,6 +52,8 @@
         [Theory]
         [InlineData(typeof(Expression<Func<object>>))]
         [InlineData(typeof(Expression<Func<object, object>>))]
+        [InlineData(typeof(Expression<Func<bool, int>>))]
+        [InlineData(typeof(Expression<Func<bool, int, string>>))]
         public void CreateWithExpressionRequestReturnsCorrectResult(Type expected)
         {
             var expressionRequest = expected;

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -51,7 +51,7 @@
 
         [Theory]
         [InlineData(typeof(Expression<Func<object>>))]
-        [InlineData(typeof(Expression<Func<object>>))]
+        [InlineData(typeof(Expression<Func<object, object>>))]
         public void CreateWithExpressionRequestReturnsCorrectResult(Type expected)
         {
             var expressionRequest = expected;


### PR DESCRIPTION
This PR enables AutoFixture to generate expression trees:
```csharp
[Theory, AutoData]
public void GenerateFunc(Expression<Func<bool>> expression)
{
}

[Theory, AutoData]
public void GenerateAction(Expression<Action> expression)
{
}
```