### PR TITLE
Add auto-generated <Service /> item in order to allow VS Test Explorer identify unit tests

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -94,6 +94,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
This PR contains auto-generated code that appears in the `AutoFixture.xUnit.net2.UnitTest.csproj` file every time one runs unit tests using VS Test Explorer. This question is well described on [SO](http://stackoverflow.com/questions/18614342/what-is-service-include-in-a-csproj-file-for).