### PR TITLE
Add fill sorted set to fixture customizations.

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -100,6 +100,7 @@
     <Compile Include="DomainName.cs" />
     <Compile Include="DomainNameGenerator.cs" />
     <Compile Include="ElementsBuilder.cs" />
+    <Compile Include="Kernel\SortedSetSpecification.cs" />
     <Compile Include="LambdaExpressionGenerator.cs" />
     <Compile Include="FixtureRepeater.cs" />
     <Compile Include="InvariantCultureGenerator.cs" />

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -99,6 +99,10 @@ namespace Ploeh.AutoFixture
                                 new FilteringSpecimenBuilder(
                                     new MethodInvoker(
                                         new EnumerableFavoringConstructorQuery()),
+                                    new SortedSetSpecification()),
+                                new FilteringSpecimenBuilder(
+                                    new MethodInvoker(
+                                        new EnumerableFavoringConstructorQuery()),
                                     new ListSpecification()),
                                 new FilteringSpecimenBuilder(
                                     new MethodInvoker(

--- a/Src/AutoFixture/Kernel/SortedSetSpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedSetSpecification.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Encapsulates logic that determines whether a request is a request for a
+    /// <see cref="SortedSet{T}"/>.
+    /// </summary>
+    public class SortedSetSpecification : IRequestSpecification
+    {
+        /// <summary>
+        /// Evaluates a request for a specimen to determine whether it's a request for a
+        /// <see cref="SortedSet{T}"/>.
+        /// </summary>
+        /// <param name="request">The specimen request.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="request"/> is a request for a
+        /// <see cref="SortedSet{T}" />; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool IsSatisfiedBy(object request)
+        {
+            var type = request as Type;
+
+            if (type == null)
+            {
+                return false;
+            }
+
+            return type.IsGenericType && typeof(SortedSet<>) == type.GetGenericTypeDefinition();
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DomainNameGeneratorTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="ElementsBuilderTest.cs" />
+    <Compile Include="Kernel\SortedSetSpecificationTest.cs" />
     <Compile Include="LambdaExpressionGeneratorTest.cs" />
     <Compile Include="FixtureRepeaterTest.cs" />
     <Compile Include="InvariantCultureGeneratorTest.cs" />

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5130,6 +5130,30 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
+        [Fact]
+        public void CreateHashSetReturnsCorrectResult()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            // Exercise system
+            var result = fixture.Create<HashSet<string>>();
+            // Verify outcome
+            Assert.NotEmpty(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateSortedSetReturnsCorrectResult()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            // Exercise system
+            var result = fixture.Create<SortedSet<string>>();
+            // Verify outcome
+            Assert.NotEmpty(result);
+            // Teardown
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/Src/AutoFixtureUnitTest/Kernel/SortedSetSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SortedSetSpecificationTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest.Kernel
+{
+    public class SortedSetSpecificationTest
+    {
+        [Fact]
+        public void SutIsRequestSpecification()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new SortedSetSpecification();
+            // Verify outcome
+            Assert.IsAssignableFrom<IRequestSpecification>(sut);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(Version))]
+        [InlineData(typeof(int?))]
+        [InlineData(typeof(EmptyEnum?))]
+        [InlineData(typeof(object[]))]
+        [InlineData(typeof(string[]))]
+        [InlineData(typeof(int[]))]
+        [InlineData(typeof(Version[]))]
+        [InlineData(typeof(int?[]))]
+        [InlineData(typeof(EmptyEnum?[]))]
+        public void IsSatisfiedByNonSortedSetRequestReturnsCorrectResult(object request)
+        {
+            // Fixture setup.
+            var sut = new SortedSetSpecification();
+            // Exercise system
+            var result = sut.IsSatisfiedBy(request);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(SortedSet<string>))]
+        [InlineData(typeof(SortedSet<int>))]
+        [InlineData(typeof(SortedSet<object>))]
+        [InlineData(typeof(SortedSet<Version>))]
+        [InlineData(typeof(SortedSet<int?>))]
+        [InlineData(typeof(SortedSet<EmptyEnum?>))]
+        [InlineData(typeof(SortedSet<string[]>))]
+        [InlineData(typeof(SortedSet<int[]>))]
+        [InlineData(typeof(SortedSet<object[]>))]
+        [InlineData(typeof(SortedSet<Version[]>))]
+        [InlineData(typeof(SortedSet<int?[]>))]
+        [InlineData(typeof(SortedSet<EmptyEnum?[]>))]
+        public void IsSatisfiedBySortedSetRequestReturnsCorrectResult(object request)
+        {
+            // Fixture setup
+            var sut = new SortedSetSpecification();
+            // Exercise system
+            var result = sut.IsSatisfiedBy(request);
+            // Verify outcome
+            Assert.True(result);
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
This pull request addresses issue #624 with the option to fill sorted sets. A new customization has been added to the Fixture class that uses the new SortedSetSpecification to start filling sorted set instances. 