### PR TITLE
Corrected typo in ObjectCreationException error message

### DIFF
--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -124,7 +124,7 @@ namespace Ploeh.AutoFixture.Kernel
                     "that class, but you can help AutoFixture figure it out." +
                     "{1}" +
                     "{1}" +
-                    "If you have a concrete class deriving from the abstract" +
+                    "If you have a concrete class deriving from the abstract " +
                     "class, you can map the abstract class to that derived " + 
                     "class:" +
                     typeMappingOptionsHelp +


### PR DESCRIPTION
On receiving an ObjectCreationException the exception message includes the following text: "if you have a concrete class deriving from the abstractclass". There should be a space between "abstract" and "class". This has been added.