### PR TITLE
Fixed the case of various package dependencies

### DIFF
--- a/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
@@ -7,7 +7,7 @@
         <authors>Nikos Baxevanis</authors>
         <owners>Nikos Baxevanis</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
+            <dependency id="AutoFixture" version="@build.number@" />
             <dependency id="FakeItEasy" version="[1.7,2)" />
         </dependencies>
         <summary>Turns AutoFixture into an Auto-Mocking Container based on FakeItEasy.</summary>

--- a/Nuget/Ploeh.AutoFixture.AutoFoq.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoFoq.nuspec
@@ -7,8 +7,8 @@
         <authors>Nikos Baxevanis</authors>
         <owners>Nikos Baxevanis</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
-            <dependency id="foq" version="1.5.1" />
+            <dependency id="AutoFixture" version="@build.number@" />
+            <dependency id="Foq" version="1.5.1" />
         </dependencies>
         <summary>Turns AutoFixture into an Auto-Mocking Container based on Foq.</summary>
         <description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by Foq. To use it, add the AutoFoqCustomization to your Fixture instance. Read more at http://github.com/autofixture/autofixture/</description>

--- a/Nuget/Ploeh.AutoFixture.AutoNSubstitute.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoNSubstitute.nuspec
@@ -7,7 +7,7 @@
         <authors>Daniel Hilgarth</authors>
         <owners>Daniel Hilgarth, Mark Seemann</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
+            <dependency id="AutoFixture" version="@build.number@" />
             <dependency id="NSubstitute" version="1.5.0" />
         </dependencies>
         <summary>Turns AutoFixture into an Auto-Mocking Container based on NSubstitute.</summary>

--- a/Nuget/Ploeh.AutoFixture.AutoRhinoMock.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoRhinoMock.nuspec
@@ -7,7 +7,7 @@
         <authors>Mark Seemann</authors>
         <owners>Mark Seemann</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
+            <dependency id="AutoFixture" version="@build.number@" />
             <dependency id="RhinoMocks" version="3.6" />
         </dependencies>
         <summary>Turns AutoFixture into an Auto-Mocking Container based on Rhino Mocks.</summary>

--- a/Nuget/Ploeh.AutoFixture.Idioms.FsCheck.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Idioms.FsCheck.nuspec
@@ -7,8 +7,8 @@
         <authors>Nikos Baxevanis</authors>
         <owners>Nikos Baxevanis</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
-            <dependency id="autofixture.idioms" version="@build.number@" />
+            <dependency id="AutoFixture" version="@build.number@" />
+            <dependency id="AutoFixture.Idioms" version="@build.number@" />
             <dependency id="FsCheck" version="0.9.2" />
         </dependencies>
         <summary>Extension to AutoFixture that contains unit testing idioms that use FsCheck.</summary>

--- a/Nuget/Ploeh.AutoFixture.Idioms.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Idioms.nuspec
@@ -7,7 +7,7 @@
         <authors>Mark Seemann</authors>
         <owners>Mark Seemann</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
+            <dependency id="AutoFixture" version="@build.number@" />
             <dependency id="Albedo" version="1.0.1" />
         </dependencies>
         <summary>Extension to AutoFixture that contains unit testing idioms.</summary>

--- a/Nuget/Ploeh.AutoFixture.NUnit2.nuspec
+++ b/Nuget/Ploeh.AutoFixture.NUnit2.nuspec
@@ -7,8 +7,8 @@
         <authors>Gert Jansen van Rensburg</authors>
         <owners>Gert Jansen van Rensburg</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
-            <dependency id="nunit" version="2.6.2" />
+            <dependency id="AutoFixture" version="@build.number@" />
+            <dependency id="NUnit" version="2.6.2" />
         </dependencies>
         <summary>Extension to AutoFixture that integrates it with NUnit.</summary>
         <description>By leveraging the some features of NUnit, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</description>

--- a/Nuget/Ploeh.AutoFixture.NUnit3.nuspec
+++ b/Nuget/Ploeh.AutoFixture.NUnit3.nuspec
@@ -7,8 +7,8 @@
         <authors>Hackle Wayne, AutoFixture</authors>
         <owners>AutoFixture</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
-            <dependency id="nunit" version="3.0.1" />
+            <dependency id="AutoFixture" version="@build.number@" />
+            <dependency id="NUnit" version="3.0.1" />
         </dependencies>
         <summary>Extension to AutoFixture that integrates it with NUnit3.</summary>
         <description>By leveraging some features of NUnit3, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</description>

--- a/Nuget/Ploeh.AutoFixture.Xunit.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Xunit.nuspec
@@ -7,7 +7,7 @@
         <authors>Mark Seemann</authors>
         <owners>Mark Seemann</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
+            <dependency id="AutoFixture" version="@build.number@" />
             <dependency id="xunit.extensions" version="[1.8.0.1549,2.0.0)" />
         </dependencies>
         <summary>Extension to AutoFixture that integrates it with xUnit.net.</summary>

--- a/Nuget/Ploeh.AutoFixture.Xunit2.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Xunit2.nuspec
@@ -7,7 +7,7 @@
         <authors>Mark Seemann</authors>
         <owners>Mark Seemann</owners>
         <dependencies>
-            <dependency id="autofixture" version="@build.number@" />
+            <dependency id="AutoFixture" version="@build.number@" />
             <dependency id="xunit.core" version="[2,3)" />
         </dependencies>
         <summary>Extension to AutoFixture that integrates it with xUnit.net v2.</summary>


### PR DESCRIPTION
It seems the latest NuGet client used by the erstwhile dnu CLI and now dotnet CLI has become case sensitive. Several packages had lower case dependencies, most notably the packages referencing AutoFixture.

I found when I experienced the same problem as #642.