### PR TITLE
Removed SemanticComparison.ruleset item from the project file

### DIFF
--- a/Src/SemanticComparison/SemanticComparison.csproj
+++ b/Src/SemanticComparison/SemanticComparison.csproj
@@ -111,9 +111,6 @@
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="SemanticComparison.ruleset" />
-  </ItemGroup>
-  <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
       <Visible>False</Visible>
       <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>


### PR DESCRIPTION
This Pull Request removes the `SemanticComparison.ruleset` item from the project file, since the actual file doesn't exist, as reported in #651.