### PR TITLE
Excludestaticpropertiesconstructorinitializedmemberassertion

### DIFF
--- a/Src/Idioms/ConstructorInitializedMemberAssertion.cs
+++ b/Src/Idioms/ConstructorInitializedMemberAssertion.cs
@@ -401,7 +401,9 @@ namespace Ploeh.AutoFixture.Idioms
             if (memberAsFieldInfo != null)
             {
                 bool isReadOnly = memberAsFieldInfo.Attributes.HasFlag(FieldAttributes.InitOnly);
-                return isReadOnly;
+                bool isStatic = memberAsFieldInfo.Attributes.HasFlag(FieldAttributes.Static);
+
+                return isReadOnly && !isStatic;
             }
 
             return false;

--- a/Src/Idioms/ConstructorInitializedMemberAssertion.cs
+++ b/Src/Idioms/ConstructorInitializedMemberAssertion.cs
@@ -391,7 +391,10 @@ namespace Ploeh.AutoFixture.Idioms
                 bool isReadOnly = memberAsPropertyInfo.CanRead &&
                     (setterMethod == null || setterMethod.IsPrivate || setterMethod.IsFamilyOrAssembly || setterMethod.IsFamilyAndAssembly);
 
-                return isReadOnly;
+                MethodInfo getterMethod = memberAsPropertyInfo.GetGetMethod();
+                bool isStatic = getterMethod.IsStatic;
+
+                return isReadOnly && !isStatic;
             }
 
             var memberAsFieldInfo = member as FieldInfo;

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -469,6 +469,18 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
+        public void VerifyTypeWithPublicStaticReadOnlyPropertyAndNoMatchingGuardedConstuctorArgumentDoesNotThrow()
+        {
+            // Fixture setup
+            var dummyComposer = new Fixture();
+            var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
+            var typeToVerify = typeof(GuardedConstructorHostHoldingStaticReadOnlyProperty<ComplexType, int>);
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            // Teardown
+        }
+
+        [Fact]
         public void VerifyTypeWithReadOnlyPropertyAndIllBehavedConstructorThrows()
         {
             // Fixture setup

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -433,6 +433,30 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
+        public void VerifyTypeWithPublicStaticPropertyAndNoMatchingConstructorArgumentDoesNotThrow()
+        {
+            // Fixture setup
+            var dummyComposer = new Fixture();
+            var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
+            var typeToVerify = typeof(StaticPropertyHolder<ComplexType>);
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            // Teardown
+        }
+
+        [Fact]
+        public void VerifyWithPublicStaticFieldAndNoMatchingConstructorArgumentDoesNotThrow()
+        {
+            // Fixture setup
+            var dummyComposer = new Fixture();
+            var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
+            var typeToVerify = typeof(StaticFieldHolder<ComplexType>);
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            // Teardown
+        }
+
+        [Fact]
         public void VerifyTypeWithReadOnlyPropertyAndIllBehavedConstructorThrows()
         {
             // Fixture setup

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -445,12 +445,24 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
-        public void VerifyWithPublicStaticFieldAndNoMatchingConstructorArgumentDoesNotThrow()
+        public void VerifyTypeWithPublicStaticFieldAndNoMatchingConstructorArgumentDoesNotThrow()
         {
             // Fixture setup
             var dummyComposer = new Fixture();
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var typeToVerify = typeof(StaticFieldHolder<ComplexType>);
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            // Teardown
+        }
+
+        [Fact]
+        public void VerifyTypeWithPublicStaticReadOnlyFieldAndNoMatchingGuardedConstuctorArgumentDoesNotThrow()
+        {
+            // Fixture setup
+            var dummyComposer = new Fixture();
+            var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
+            var typeToVerify = typeof(GuardedConstructorHostHoldingStaticReadOnlyField<ComplexType, int>);
             // Exercise system and verify outcome
             Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
             // Teardown

--- a/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyField.cs
+++ b/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyField.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Ploeh.TestTypeFoundation
+{
+    public class GuardedConstructorHostHoldingStaticReadOnlyField<TItem, TStaticField> where TItem : class
+    {
+        public static readonly TStaticField Field = default(TStaticField);
+
+        public GuardedConstructorHostHoldingStaticReadOnlyField(TItem item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            this.Item = item;
+        }
+
+        public TItem Item { get; private set; }
+    }
+}

--- a/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyProperty.cs
+++ b/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyProperty.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Ploeh.TestTypeFoundation
+{
+    public class GuardedConstructorHostHoldingStaticReadOnlyProperty<TItem, TStaticProperty> where TItem : class
+    {
+        static GuardedConstructorHostHoldingStaticReadOnlyProperty()
+        {
+            Property = default(TStaticProperty);
+        }
+
+        public GuardedConstructorHostHoldingStaticReadOnlyProperty(TItem item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            this.Item = item;
+        }
+
+        public static TStaticProperty Property { get;private set;}
+
+        public TItem Item { get; private set; }
+    }
+}

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -104,6 +104,7 @@
     <Compile Include="ReadOnlyFieldHolder.cs" />
     <Compile Include="ReadOnlyPropertyHolder.cs" />
     <Compile Include="SingleParameterType.cs" />
+    <Compile Include="GuardedConstructorHostHoldingStaticReadOnlyField.cs" />
     <Compile Include="StaticFieldHolder.cs" />
     <Compile Include="StaticPropertyHolder.cs" />
     <Compile Include="MutableValueType.cs" />

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -88,6 +88,7 @@
     <Compile Include="FieldHolder.cs" />
     <Compile Include="GenericType.cs" />
     <Compile Include="GuardedConstructorHost.cs" />
+    <Compile Include="GuardedConstructorHostHoldingStaticReadOnlyProperty.cs" />
     <Compile Include="GuardedStaticMethodOnStaticTypeHost.cs" />
     <Compile Include="IInterface.cs" />
     <Compile Include="IllBehavedPropertyHolder.cs" />


### PR DESCRIPTION
Fixes issue #656.

* Static properties are now excluded from ConstructorInitializedMemberAssertion
* Static fields are also excluded from ConstructorInitializedMemberAssertion
* Extended the TestTypeFoundation to have types that have those traits
