### PR TITLE
AutoFakeItEasy: Examine created Fake's types instead of using IHideObjectMembers

### DIFF
--- a/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
@@ -56,7 +56,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
         /// The Create method checks whether a request is for an interface or abstract class. If so
         /// it delegates the call to the decorated <see cref="Builder"/>. When the specimen is
         /// returned from the decorated <see cref="ISpecimenBuilder"/> the method checks whether
-        /// the returned instance is a FakeItEasy instance.
+        /// the returned instance is a FakeItEasy Fake instance of the correct type.
         /// </para>
         /// <para>
         /// If all pre- and post-conditions are satisfied, the mock instance is returned; otherwise
@@ -73,16 +73,8 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
 #pragma warning restore 618
             }
 
-            var fake = this.builder.Create(request, context) as FakeItEasy.Configuration.IHideObjectMembers;
-            if (fake == null)
-            {
-#pragma warning disable 618
-                return new NoSpecimen(request);
-#pragma warning restore 618
-            }
-
-            var fakeType = type.GetFakedType();
-            if (fake.GetType().GetFakedType() != fakeType)
+            var fake = this.builder.Create(request, context);
+            if (!type.IsInstanceOfType(fake))
             {
 #pragma warning disable 618
                 return new NoSpecimen(request);

--- a/Src/AutoFakeItEasy/FakeItEasyRelay.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyRelay.cs
@@ -82,11 +82,13 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
 
             var fakeType = typeof(Fake<>).MakeGenericType(type);
 
-            var fake = context.Resolve(fakeType) as FakeItEasy.Configuration.IHideObjectMembers;
-            if (fake == null)
+            var fake = context.Resolve(fakeType);
+            if (!fakeType.IsInstanceOfType(fake))
+            {
 #pragma warning disable 618
                 return new NoSpecimen(request);
 #pragma warning restore 618
+            }
 
             return fake.GetType().GetProperty("FakedObject").GetValue(fake, null);
         }


### PR DESCRIPTION
Relates to #663.

Note that I've only made the change in AutoFakeItEasy (not AutoFakeItEasy2) just so everyone can see the shape of it. I've attempted to follow what seemed to be the coding conventions, especially with the separate ifs.
