### PR TITLE
Fix parameter freezing when used in combination with Passive Attributes (#637, xUnit.net2)

### DIFF
--- a/Nuget/Ploeh.AutoFixture.Idioms.nuspec
+++ b/Nuget/Ploeh.AutoFixture.Idioms.nuspec
@@ -8,7 +8,6 @@
         <owners>Mark Seemann</owners>
         <dependencies>
             <dependency id="AutoFixture" version="@build.number@" />
-            <dependency id="Albedo" version="1.0.0" />
         </dependencies>
         <summary>Extension to AutoFixture that contains unit testing idioms.</summary>
         <description>Ubiquitous use of AutoFixture for unit testing has given rise to a number of idiomatic unit tests - unit tests that tend to follow common templates. The AutoFixture Idioms library encapsulates these idioms into reusable classes and methods.</description>

--- a/Nuget/Ploeh.AutoFixture.nuspec
+++ b/Nuget/Ploeh.AutoFixture.nuspec
@@ -6,6 +6,9 @@
         <title>AutoFixture</title>
         <authors>Mark Seemann</authors>
         <owners>Mark Seemann</owners>
+        <dependencies>
+            <dependency id="Albedo" version="1.0.0" />
+        </dependencies>
         <description>AutoFixture makes it easier for developers to do Test-Driven Development by automating non-relevant Test Fixture Setup, allowing the Test Developer to focus on the essentials of each test case.</description>
         <projectUrl>https://github.com/AutoFixture/AutoFixture</projectUrl>
         <licenseUrl>https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt</licenseUrl>

--- a/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
+++ b/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
@@ -57,6 +57,10 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ploeh.Albedo">
+      <HintPath>..\..\Packages\Albedo.1.0.0\lib\net35\Ploeh.Albedo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
@@ -90,7 +94,9 @@
       <Name>AutoFixture</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Src/AutoFixture.NUnit2/packages.config
+++ b/Src/AutoFixture.NUnit2/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Albedo" version="1.0.0" targetFramework="net40" />
+</packages>

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -61,6 +61,10 @@
       <HintPath>..\..\Packages\NUnit.3.0.0\lib\net40\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Ploeh.Albedo">
+      <HintPath>..\..\Packages\Albedo.1.0.0\lib\net35\Ploeh.Albedo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Src/AutoFixture.NUnit3/packages.config
+++ b/Src/AutoFixture.NUnit3/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Albedo" version="1.0.0" targetFramework="net40" />
   <package id="NUnit" version="3.0.0" targetFramework="net40" />
 </packages>

--- a/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
+++ b/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
@@ -73,6 +73,10 @@
     <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ploeh.Albedo">
+      <HintPath>..\..\Packages\Albedo.1.0.0\lib\net35\Ploeh.Albedo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/Src/AutoFixture.xUnit.net/packages.config
+++ b/Src/AutoFixture.xUnit.net/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Albedo" version="1.0.0" targetFramework="net40" />
   <package id="xunit" version="1.8.0.1549" targetFramework="net40" />
   <package id="xunit.extensions" version="1.8.0.1549" targetFramework="net40" />
 </packages>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Ploeh.TestTypeFoundation;
 using Xunit;
@@ -415,6 +416,12 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             FieldHolder<string> p2)
         {
             Assert.NotEqual(p1, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeParameterWithStringLengthConstraint([Frozen][StringLength(3)]string p)
+        {
+            Assert.True(p.Length == 3);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -56,6 +56,11 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ploeh.Albedo, Version=1.0.0.0, Culture=neutral, PublicKeyToken=179ef6dd03497bbd, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\Albedo.1.0.0\lib\net35\Ploeh.Albedo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -110,7 +110,7 @@ namespace Ploeh.AutoFixture.Xunit2
                 .Or(ByParameterName(type, name))
                 .Or(ByFieldName(type, name));
 
-            return new FreezeOnMatchCustomization(type, filter);
+            return new FreezeOnMatchCustomization(parameter, filter);
         }
 
         private static IRequestSpecification ByEqual(object target)

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Ploeh.Albedo;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.Xunit2
@@ -110,7 +111,8 @@ namespace Ploeh.AutoFixture.Xunit2
                 .Or(ByParameterName(type, name))
                 .Or(ByFieldName(type, name));
 
-            return new FreezeOnMatchCustomization(parameter, filter);
+            var reflectionElement = new ParameterInfoElement(parameter);
+            return new FreezeOnMatchCustomization(reflectionElement, filter);
         }
 
         private static IRequestSpecification ByEqual(object target)

--- a/Src/AutoFixture.xUnit.net2/packages.config
+++ b/Src/AutoFixture.xUnit.net2/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Albedo" version="1.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -334,6 +334,7 @@
     <Compile Include="Kernel\ThrowingRecursionGuard.cs" />
     <Compile Include="DefaultRelays.cs" />
     <Compile Include="TracingBehavior.cs" />
+    <Compile Include="TypeElementRelay.cs" />
     <Compile Include="TypeFilter.cs" />
     <Compile Include="TypeGenerator.cs" />
     <Compile Include="UInt16SequenceGenerator.cs" />

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -88,6 +88,10 @@
     <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ploeh.Albedo">
+      <HintPath>..\..\Packages\Albedo.1.0.0\lib\net35\Ploeh.Albedo.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core">
@@ -361,6 +365,9 @@
       <ProductName>Windows Installer 3.1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -203,6 +203,7 @@
     <Compile Include="RandomRangedNumberCustomization.cs" />
     <Compile Include="RandomRangedNumberGenerator.cs" />
     <Compile Include="RangedNumberGenerator.cs" />
+    <Compile Include="ParameterInfoElementRelay.cs" />
     <Compile Include="RegularExpressionGenerator.cs" />
     <Compile Include="ResidueCollectorNode.cs" />
     <Compile Include="SingletonSpecimenBuilderNodeStackAdapterCollection.cs" />

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -121,6 +121,7 @@ namespace Ploeh.AutoFixture
                                 new EnumGenerator(),
                                 new LambdaExpressionGenerator(),
                                 new ParameterInfoElementRelay(),
+                                new TypeElementRelay(),
                                 CreateDefaultValueBuilder(CultureInfo.InvariantCulture),
                                 CreateDefaultValueBuilder(Encoding.UTF8),
                                 CreateDefaultValueBuilder(IPAddress.Loopback))),

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -120,6 +120,7 @@ namespace Ploeh.AutoFixture
                                 new RegularExpressionAttributeRelay(),
                                 new EnumGenerator(),
                                 new LambdaExpressionGenerator(),
+                                new ParameterInfoElementRelay(),
                                 CreateDefaultValueBuilder(CultureInfo.InvariantCulture),
                                 CreateDefaultValueBuilder(Encoding.UTF8),
                                 CreateDefaultValueBuilder(IPAddress.Loopback))),

--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -140,7 +140,8 @@ namespace Ploeh.AutoFixture
         private ISpecimenBuilder FreezeTargetType(IFixture fixture)
         {
             var context = new SpecimenContext(fixture);
-            var specimen = context.Resolve(this.TargetType);
+            var request = (object)this.ParameterInfo ?? this.TargetType;
+            var specimen = context.Resolve(request);
             return new FixedBuilder(specimen);
         }
     }

--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -1,6 +1,5 @@
 using System;
-using System.ComponentModel.DataAnnotations;
-using System.Reflection;
+using Ploeh.Albedo;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture
@@ -68,24 +67,23 @@ namespace Ploeh.AutoFixture
         /// <summary>
         /// Initializes a new instance of the <see cref="FreezeOnMatchCustomization"/> class.
         /// </summary>
-        /// <param name="parameter">
-        /// The <see cref="ParameterInfo"/> used to freeze specimens decorated with advanced
-        /// attributes (e.g. <see cref="StringLengthAttribute"/>).
+        /// <param name="reflectionElement">
+        /// The <see cref="IReflectionElement"/> used to create specimens to freeze.
         /// </param>
         /// <param name="matcher">
         /// The <see cref="IRequestSpecification"/> used to match the requests
         /// that will be satisfied by the frozen specimen.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="parameter"/> or <paramref name="matcher"/> is null.
+        /// <paramref name="reflectionElement"/> or <paramref name="matcher"/> is null.
         /// </exception>
         public FreezeOnMatchCustomization(
-            ParameterInfo parameter,
+            IReflectionElement reflectionElement,
             IRequestSpecification matcher)
         {
-            if (parameter == null)
+            if (reflectionElement == null)
             {
-                throw new ArgumentNullException(nameof(parameter));
+                throw new ArgumentNullException(nameof(reflectionElement));
             }
 
             if (matcher == null)
@@ -93,15 +91,14 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(matcher));
             }
 
-            this.ParameterInfo = parameter;
-            this.TargetType = parameter.ParameterType;
+            this.ReflectionElement = reflectionElement;
             this.Matcher = matcher;
         }
 
         /// <summary>
-        /// The <see cref="ParameterInfo"/> describing the specimen to freeze.
+        /// The <see cref="ReflectionElement"/> describing the specimen to freeze.
         /// </summary>
-        public ParameterInfo ParameterInfo { get; }
+        public IReflectionElement ReflectionElement { get; }
 
         /// <summary>
         /// The <see cref="Type"/> of the frozen specimen.
@@ -140,7 +137,7 @@ namespace Ploeh.AutoFixture
         private ISpecimenBuilder FreezeTargetType(IFixture fixture)
         {
             var context = new SpecimenContext(fixture);
-            var request = (object)this.ParameterInfo ?? this.TargetType;
+            var request = (object)this.ReflectionElement ?? this.TargetType;
             var specimen = context.Resolve(request);
             return new FixedBuilder(specimen);
         }

--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -49,19 +49,9 @@ namespace Ploeh.AutoFixture
         public FreezeOnMatchCustomization(
             Type targetType,
             IRequestSpecification matcher)
+            : this(new TypeElement(targetType), matcher)
         {
-            if (targetType == null)
-            {
-                throw new ArgumentNullException(nameof(targetType));
-            }
-
-            if (matcher == null)
-            {
-                throw new ArgumentNullException(nameof(matcher));
-            }
-
             this.TargetType = targetType;
-            this.Matcher = matcher;
         }
 
         /// <summary>
@@ -137,8 +127,7 @@ namespace Ploeh.AutoFixture
         private ISpecimenBuilder FreezeTargetType(IFixture fixture)
         {
             var context = new SpecimenContext(fixture);
-            var request = (object)this.ReflectionElement ?? this.TargetType;
-            var specimen = context.Resolve(request);
+            var specimen = context.Resolve(this.ReflectionElement);
             return new FixedBuilder(specimen);
         }
     }

--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture
@@ -43,7 +45,7 @@ namespace Ploeh.AutoFixture
         /// that will be satisfied by the frozen specimen.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="targetType"/> or<paramref name="matcher"/> is null.
+        /// <paramref name="targetType"/> or <paramref name="matcher"/> is null.
         /// </exception>
         public FreezeOnMatchCustomization(
             Type targetType,
@@ -62,6 +64,44 @@ namespace Ploeh.AutoFixture
             this.TargetType = targetType;
             this.Matcher = matcher;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FreezeOnMatchCustomization"/> class.
+        /// </summary>
+        /// <param name="parameter">
+        /// The <see cref="ParameterInfo"/> used to freeze specimens decorated with advanced
+        /// attributes (e.g. <see cref="StringLengthAttribute"/>).
+        /// </param>
+        /// <param name="matcher">
+        /// The <see cref="IRequestSpecification"/> used to match the requests
+        /// that will be satisfied by the frozen specimen.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="parameter"/> or <paramref name="matcher"/> is null.
+        /// </exception>
+        public FreezeOnMatchCustomization(
+            ParameterInfo parameter,
+            IRequestSpecification matcher)
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            if (matcher == null)
+            {
+                throw new ArgumentNullException(nameof(matcher));
+            }
+
+            this.ParameterInfo = parameter;
+            this.TargetType = parameter.ParameterType;
+            this.Matcher = matcher;
+        }
+
+        /// <summary>
+        /// The <see cref="ParameterInfo"/> describing the specimen to freeze.
+        /// </summary>
+        public ParameterInfo ParameterInfo { get; }
 
         /// <summary>
         /// The <see cref="Type"/> of the frozen specimen.

--- a/Src/AutoFixture/ParameterInfoElementRelay.cs
+++ b/Src/AutoFixture/ParameterInfoElementRelay.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Reflection;
+using Ploeh.Albedo;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Relays a request for an <see cref="ParameterInfoElement" /> to a request for a
+    /// <see cref="ParameterInfo"/> and returns the result.
+    /// </summary>
+    public class ParameterInfoElementRelay : ISpecimenBuilder
+    {
+        /// <summary>
+        /// Creates a new specimen based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// A specimen resolved from <paramref name="context"/> if possible; otherwise
+        /// a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// If <paramref name="request"/> is a request for an <see cref="ParameterInfoElement"/>,
+        /// <paramref name="context"/> is used to create and return a specimen using request's 
+        /// <see cref="ParameterInfo"/>. If not, the return value is a <see cref="NoSpecimen"/>.
+        /// instance.
+        /// </para>
+        /// </remarks>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var reflectionElement = request as ParameterInfoElement;
+            if (reflectionElement == null)
+            {
+                return new NoSpecimen();
+            }
+
+            return context.Resolve(reflectionElement.ParameterInfo);
+        }
+    }
+}

--- a/Src/AutoFixture/TypeElementRelay.cs
+++ b/Src/AutoFixture/TypeElementRelay.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Reflection;
+using Ploeh.Albedo;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Relays a request for an <see cref="TypeElementRelay " /> to a request for a
+    /// <see cref="Type"/> and returns the result.
+    /// </summary>
+    public class TypeElementRelay : ISpecimenBuilder
+    {
+        /// <summary>
+        /// Creates a new specimen based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// A specimen resolved from <paramref name="context"/> if possible; otherwise
+        /// a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// If <paramref name="request"/> is a request for an <see cref="TypeElement"/>,
+        /// <paramref name="context"/> is used to create and return a specimen using request's 
+        /// <see cref="ParameterInfo"/>. If not, the return value is a <see cref="NoSpecimen"/>.
+        /// instance.
+        /// </para>
+        /// </remarks>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var reflectionElement = request as TypeElement;
+            if (reflectionElement == null)
+            {
+                return new NoSpecimen();
+            }
+
+            return context.Resolve(reflectionElement.Type);
+        }
+    }
+}

--- a/Src/AutoFixture/packages.config
+++ b/Src/AutoFixture/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Albedo" version="1.0.0" targetFramework="net40" />
+</packages>

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -334,6 +334,7 @@
     <Compile Include="TracingBehaviorTest.cs" />
     <Compile Include="TrueComparer.cs" />
     <Compile Include="TypeBasedComparer.cs" />
+    <Compile Include="TypeElementRelayTest.cs" />
     <Compile Include="TypeGeneratorTest.cs" />
     <Compile Include="UInt16SequenceGeneratorTest.cs" />
     <Compile Include="UInt32SequenceGeneratorTest.cs" />

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -192,6 +192,7 @@
     <Compile Include="RandomRangedNumberCustomizationTest.cs" />
     <Compile Include="RandomRangedNumberGeneratorTest.cs" />
     <Compile Include="RangedNumberGeneratorTest.cs" />
+    <Compile Include="ParameterInfoElementRelayTest.cs" />
     <Compile Include="RegularExpressionGeneratorTest.cs" />
     <Compile Include="SpecimenCommandTests.cs" />
     <Compile Include="SpecimenQueryTests.cs" />

--- a/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.AutoFixtureUnitTest.Kernel;
@@ -29,7 +31,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             // Exercise system and verify outcome
             Assert.Throws<ArgumentNullException>(() =>
-                new FreezeOnMatchCustomization(null, new FalseRequestSpecification()));
+                new FreezeOnMatchCustomization((Type)null, new FalseRequestSpecification()));
             // Teardown
         }
 
@@ -75,6 +77,53 @@ namespace Ploeh.AutoFixtureUnitTest
             var sut = new FreezeOnMatchCustomization(typeof(object), matcher);
             // Verify outcome
             Assert.Equal(matcher, sut.Matcher);
+        }
+
+        [Fact]
+        public void InitializeWithNullParameterInfoShouldThrowArgumentNullException()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new FreezeOnMatchCustomization((ParameterInfo)null, new FalseRequestSpecification()));
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithParameterInfoAndNullMatcherShouldThrowArgumentNullException()
+        {
+            // Fixture setup
+            var parameter = typeof(UnguardedMethodHost).GetMethod("ConsumeUnguardedString").GetParameters().First();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new FreezeOnMatchCustomization(parameter, null));
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithParameterInfoAndMatcherShouldSetCorrespondingProperties()
+        {
+            // Fixture setup
+            var parameter = typeof(UnguardedMethodHost).GetMethod("ConsumeUnguardedString").GetParameters().First();
+            var matcher = new TrueRequestSpecification();
+            // Exercise system
+            var sut = new FreezeOnMatchCustomization(parameter, matcher);
+            // Verify outcome
+            Assert.Equal(parameter, sut.ParameterInfo);
+            Assert.Equal(matcher, sut.Matcher);
+        }
+
+        [Fact]
+        public void InitializeWithParameterInfoShouldSetTargetTypeProperty()
+        {
+            // Fixture setup
+            var parameter = typeof(UnguardedMethodHost).GetMethod("ConsumeUnguardedString").GetParameters().First();
+            var matcher = new TrueRequestSpecification();
+            var expected = typeof(string);
+            // Exercise system
+            var sut = new FreezeOnMatchCustomization(parameter, matcher);
+            // Verify outcome
+            Assert.Equal(expected, sut.TargetType);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+using Ploeh.Albedo;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.AutoFixtureUnitTest.Kernel;
@@ -80,50 +79,30 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void InitializeWithNullParameterInfoShouldThrowArgumentNullException()
+        public void InitializeWithNullReflectionElementShouldThrowArgumentNullException()
         {
-            // Fixture setup
-            // Exercise system and verify outcome
             Assert.Throws<ArgumentNullException>(() =>
-                new FreezeOnMatchCustomization((ParameterInfo)null, new FalseRequestSpecification()));
-            // Teardown
+                new FreezeOnMatchCustomization((IReflectionElement)null, new FalseRequestSpecification()));
         }
 
         [Fact]
-        public void InitializeWithParameterInfoAndNullMatcherShouldThrowArgumentNullException()
+        public void InitializeWithReflectionElementAndNullMatcherShouldThrowArgumentNullException()
         {
-            // Fixture setup
-            var parameter = typeof(UnguardedMethodHost).GetMethod("ConsumeUnguardedString").GetParameters().First();
-            // Exercise system and verify outcome
+            var reflectionElement = new NullReflectionElement();
             Assert.Throws<ArgumentNullException>(() =>
-                new FreezeOnMatchCustomization(parameter, null));
-            // Teardown
+                new FreezeOnMatchCustomization(reflectionElement, null));
         }
 
         [Fact]
-        public void InitializeWithParameterInfoAndMatcherShouldSetCorrespondingProperties()
+        public void InitializeWithReflectionElementAndMatcherShouldSetCorrespondingProperties()
         {
-            // Fixture setup
-            var parameter = typeof(UnguardedMethodHost).GetMethod("ConsumeUnguardedString").GetParameters().First();
+            var reflectionElement = new NullReflectionElement();
             var matcher = new TrueRequestSpecification();
-            // Exercise system
-            var sut = new FreezeOnMatchCustomization(parameter, matcher);
-            // Verify outcome
-            Assert.Equal(parameter, sut.ParameterInfo);
+
+            var sut = new FreezeOnMatchCustomization(reflectionElement, matcher);
+
+            Assert.Equal(reflectionElement, sut.ReflectionElement);
             Assert.Equal(matcher, sut.Matcher);
-        }
-
-        [Fact]
-        public void InitializeWithParameterInfoShouldSetTargetTypeProperty()
-        {
-            // Fixture setup
-            var parameter = typeof(UnguardedMethodHost).GetMethod("ConsumeUnguardedString").GetParameters().First();
-            var matcher = new TrueRequestSpecification();
-            var expected = typeof(string);
-            // Exercise system
-            var sut = new FreezeOnMatchCustomization(parameter, matcher);
-            // Verify outcome
-            Assert.Equal(expected, sut.TargetType);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
@@ -106,6 +106,14 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
+        public void InitializeWithTargetTypeShouldSetReflectionElementProperty()
+        {
+            var targetType = typeof(object);
+            var sut = new FreezeOnMatchCustomization(targetType);
+            Assert.IsType<TypeElement>(sut.ReflectionElement);
+        }
+
+        [Fact]
         public void CustomizeWithNullFixtureShouldThrowArgumentNullException()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/ParameterInfoElementRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/ParameterInfoElementRelayTest.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Ploeh.Albedo;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class ParameterInfoElementRelayTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            var sut = new ParameterInfoElementRelay();
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void CreateWithNullRequestThrows()
+        {
+            var context = new DelegatingSpecimenContext();
+            var sut = new ParameterInfoElementRelay();
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(null, context));
+            Assert.Equal("request", ex.ParamName);
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            var request = new object();
+            var sut = new ParameterInfoElementRelay();
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(request, null));
+            Assert.Equal("context", ex.ParamName);
+        }
+
+        [Fact]
+        public void CreateWithNotParameterInfoElementReturnsNoSpecimen()
+        {
+            var request = new object();
+            var context = new DelegatingSpecimenContext();
+            var sut = new ParameterInfoElementRelay();
+
+            var result = sut.Create(request, context);
+
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void CreateWithParameterInfoElementResolvesSpecimen()
+        {
+            var expected = new object();
+            var request = new ParameterInfoElement(
+                typeof(object).GetMethod("Equals", BindingFlags.Instance | BindingFlags.Public)
+                .GetParameters().First());
+            var context = new DelegatingSpecimenContext { OnResolve = r => expected };
+            var sut = new ParameterInfoElementRelay();
+
+            var result = sut.Create(request, context);
+
+            Assert.Same(expected, result);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/TypeElementRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/TypeElementRelayTest.cs
@@ -1,0 +1,64 @@
+using System;
+using Ploeh.Albedo;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class TypeElementRelayTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            var sut = new TypeElementRelay();
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void CreateWithNullRequestThrows()
+        {
+            var context = new DelegatingSpecimenContext();
+            var sut = new TypeElementRelay();
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(null, context));
+            Assert.Equal("request", ex.ParamName);
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            var request = new object();
+            var sut = new TypeElementRelay();
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(request, null));
+            Assert.Equal("context", ex.ParamName);
+        }
+
+        [Fact]
+        public void CreateWithNotTypeElementReturnsNoSpecimen()
+        {
+            var request = new object();
+            var context = new DelegatingSpecimenContext();
+            var sut = new TypeElementRelay();
+
+            var result = sut.Create(request, context);
+
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void CreateWithTypeElementResolvesSpecimen()
+        {
+            var expected = new object();
+            var request = new TypeElement(typeof(object));
+            var context = new DelegatingSpecimenContext { OnResolve = r => expected };
+            var sut = new TypeElementRelay();
+
+            var result = sut.Create(request, context);
+
+            Assert.Same(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #637 for xUnit.net2 Glue Library.