### PR TITLE
Fill SortedDictionary when asked from fixture

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -100,6 +100,7 @@
     <Compile Include="DomainName.cs" />
     <Compile Include="DomainNameGenerator.cs" />
     <Compile Include="ElementsBuilder.cs" />
+    <Compile Include="Kernel\SortedDictionarySpecification.cs" />
     <Compile Include="Kernel\SortedSetSpecification.cs" />
     <Compile Include="LambdaExpressionGenerator.cs" />
     <Compile Include="FixtureRepeater.cs" />

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -85,6 +85,12 @@ namespace Ploeh.AutoFixture
                                         new DictionaryFiller()),
                                     new DictionarySpecification()),
                                 new FilteringSpecimenBuilder(
+                                    new Postprocessor(
+                                        new MethodInvoker(
+                                            new ModestConstructorQuery()),
+                                        new DictionaryFiller()),
+                                    new SortedDictionarySpecification()),
+                                new FilteringSpecimenBuilder(
                                     new MethodInvoker(
                                         new EnumerableFavoringConstructorQuery()),
                                     new ObservableCollectionSpecification()),

--- a/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ploeh.AutoFixture.Kernel
+{
+    /// <summary>
+    /// Encapsulates logic that determines whether a request is a request for a
+    /// <see cref="SortedDictionary{TKey, TValue}"/>.
+    /// </summary>
+    public class SortedDictionarySpecification : IRequestSpecification
+    {
+        /// <summary>
+        /// Evaluates a request for a specimen to determine whether it's a request for a
+        /// <see cref="SortedDictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="request">The specimen request.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="request"/> is a request for a
+        /// <see cref="SortedDictionary{TKey, TValue}" />; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool IsSatisfiedBy(object request)
+        {
+            var type = request as Type;
+
+            if (type == null)
+            {
+                return false;
+            }
+
+            return type.IsGenericType 
+                && typeof(SortedDictionary<,>) == type.GetGenericTypeDefinition();
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DomainNameGeneratorTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="ElementsBuilderTest.cs" />
+    <Compile Include="Kernel\SortedDictionarySpecificationTests.cs" />
     <Compile Include="Kernel\SortedSetSpecificationTest.cs" />
     <Compile Include="LambdaExpressionGeneratorTest.cs" />
     <Compile Include="FixtureRepeaterTest.cs" />

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5154,6 +5154,18 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
+        [Fact]
+        public void CreateSortedDictionaryReturnsCorrectResult()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            // Exercise system
+            var result = fixture.Create<SortedDictionary<string,object>>();
+            // Verify outcome
+            Assert.NotEmpty(result);
+            // Teardown
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/Src/AutoFixtureUnitTest/Kernel/SortedDictionarySpecificationTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SortedDictionarySpecificationTests.cs
@@ -1,0 +1,66 @@
+﻿using Ploeh.AutoFixture.Kernel;
+using Ploeh.TestTypeFoundation;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest.Kernel
+{
+    public class SortedDictionarySpecificationTests
+    {
+        [Fact]
+        public void SutIsRequestSpecification()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new SortedDictionarySpecification();
+            // Verify outcome
+            Assert.IsAssignableFrom<IRequestSpecification>(sut);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(Version))]
+        [InlineData(typeof(int?))]
+        [InlineData(typeof(EmptyEnum?))]
+        [InlineData(typeof(object[]))]
+        [InlineData(typeof(string[]))]
+        [InlineData(typeof(int[]))]
+        [InlineData(typeof(Version[]))]
+        [InlineData(typeof(int?[]))]
+        [InlineData(typeof(EmptyEnum?[]))]
+        public void IsSatisfiedByNonSortedSetRequestReturnsCorrectResult(object request)
+        {
+            // Fixture setup.
+            var sut = new SortedDictionarySpecification();
+            // Exercise system
+            var result = sut.IsSatisfiedBy(request);
+            // Verify outcome
+            Assert.False(result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(SortedDictionary<string,int>))]
+        [InlineData(typeof(SortedDictionary<int,string>))]
+        [InlineData(typeof(SortedDictionary<object,object>))]
+        [InlineData(typeof(SortedDictionary<Version, OperatingSystem>))]
+        public void IsSatisfiedBySortedSetRequestReturnsCorrectResult(object request)
+        {
+            // Fixture setup
+            var sut = new SortedDictionarySpecification();
+            // Exercise system
+            var result = sut.IsSatisfiedBy(request);
+            // Verify outcome
+            Assert.True(result);
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes #623. It adds a SortedDictionarySpecification to the Fixture to start filling SortedDictionary requests.