### PR TITLE
Relaxed version requirements for AutoFakeItEasy

### DIFF
--- a/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
+++ b/Nuget/Ploeh.AutoFixture.AutoFakeItEasy.nuspec
@@ -8,7 +8,7 @@
         <owners>Nikos Baxevanis</owners>
         <dependencies>
             <dependency id="AutoFixture" version="@build.number@" />
-            <dependency id="FakeItEasy" version="[1.7,2)" />
+            <dependency id="FakeItEasy" version="1.7" />
         </dependencies>
         <summary>Turns AutoFixture into an Auto-Mocking Container based on FakeItEasy.</summary>
         <description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by FakeItEasy. To use it, add the AutoFakeItEasyCustomization to your Fixture instance. Read more at http://autofixture.codeplex.com/</description>


### PR DESCRIPTION
With the new implementation that doesn't rely on IHideObjectMembers, there
seems to be no reason to restrict users to FakeItEasy 1.x.

I've tried to create a local build based off this pull request, and then created a test project that uses these packages:

```
Id                                  Versions
--                                  --------
AutoFixture                         {3.49.0}
AutoFixture.AutoFakeItEasy          {3.49.0}
FakeItEasy                          {2.1.0} 
xunit                               {2.1.0} 
xunit.abstractions                  {2.0.0} 
xunit.assert                        {2.1.0} 
xunit.core                          {2.1.0} 
xunit.extensibility.core            {2.1.0} 
xunit.extensibility.execution       {2.1.0} 
```

(Do not that the two AutoFixture packages are my special builds, so not the official 3.49.0 packages.)

Then I wrote this test:

```C#
public class Class1
{
    [Fact]
    public void Test()
    {
        var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization());
        var foo = fixture.Create<IFoo>();
        Assert.NotNull(foo);
    }
}
```

With this binding redirect, the test passes:

```XML
<configuration>
  <runtime>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="FakeItEasy" publicKeyToken="eff28e2146d5fd2c" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
      </dependentAssembly>
    </assemblyBinding>
  </runtime>
</configuration>
```

If I remove the binding redirect, the test fails as expected, because it can't locate FakeItEasy version 1.7.4257.42.

ping, @blairconrad, @adamralph 