### PR TITLE
Support netstandard1.X (step 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Packages.dgml
 AutoFixture character.design
 .fake/
 NUnit[23]TestResult.xml
+project.lock.json

--- a/Src/AutoFakeItEasy/FakeItEasyType.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyType.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
 
         internal static Type GetFakedType(this Type type)
         {
-            return type.GetGenericArguments().Single();
+            return type.GetTypeInfo().GetGenericArguments().Single();
         }
     }
 }

--- a/Src/AutoFakeItEasy2.UnitTest/FakeItEasyMethodQueryTest.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/FakeItEasyMethodQueryTest.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         public void SelectMethodsReturnsCorrectNumberOfConstructorsForTypesWithConstructors(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
+            var fakeType = t.GetGenericArguments().Single();
             var expectedCount = fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Length;
             var sut = new FakeItEasyMethodQuery();
             // Exercise system
@@ -64,7 +64,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         public void MethodsDefineCorrectParameters(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
+            var fakeType = t.GetGenericArguments().Single();
             var fakeTypeCtorArgs = from ci in fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                    select ci.GetParameters();
             var sut = new FakeItEasyMethodQuery();
@@ -85,7 +85,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         public void MethodsAreReturnedInCorrectOrder(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
+            var fakeType = t.GetGenericArguments().Single();
             var fakeTypeCtorArgCounts = from ci in fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                         let paramCount = ci.GetParameters().Length
                                         orderby paramCount ascending

--- a/Src/AutoFakeItEasy2.UnitTest/FakeItEasyMethodQueryTest.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/FakeItEasyMethodQueryTest.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         public void SelectMethodsReturnsCorrectNumberOfConstructorsForTypesWithConstructors(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetGenericArguments().Single();
+            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
             var expectedCount = fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Length;
             var sut = new FakeItEasyMethodQuery();
             // Exercise system
@@ -64,7 +64,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         public void MethodsDefineCorrectParameters(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetGenericArguments().Single();
+            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
             var fakeTypeCtorArgs = from ci in fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                    select ci.GetParameters();
             var sut = new FakeItEasyMethodQuery();
@@ -85,7 +85,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         public void MethodsAreReturnedInCorrectOrder(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetGenericArguments().Single();
+            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
             var fakeTypeCtorArgCounts = from ci in fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                         let paramCount = ci.GetParameters().Length
                                         orderby paramCount ascending

--- a/Src/AutoFakeItEasy2/FakeItEasyType.cs
+++ b/Src/AutoFakeItEasy2/FakeItEasyType.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2
 
         internal static Type GetFakedType(this Type type)
         {
-            return type.GetGenericArguments().Single();
+            return type.GetTypeInfo().GetGenericArguments().Single();
         }
     }
 }

--- a/Src/AutoFakeItEasyUnitTest/FakeItEasyMethodQueryTest.cs
+++ b/Src/AutoFakeItEasyUnitTest/FakeItEasyMethodQueryTest.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
         public void SelectMethodsReturnsCorrectNumberOfConstructorsForTypesWithConstructors(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetGenericArguments().Single();
+            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
             var expectedCount = fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Length;
             var sut = new FakeItEasyMethodQuery();
             // Exercise system
@@ -64,7 +64,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
         public void MethodsDefineCorrectParameters(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetGenericArguments().Single();
+            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
             var fakeTypeCtorArgs = from ci in fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                    select ci.GetParameters();
             var sut = new FakeItEasyMethodQuery();
@@ -85,7 +85,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
         public void MethodsAreReturnedInCorrectOrder(Type t)
         {
             // Fixture setup
-            var fakeType = t.GetGenericArguments().Single();
+            var fakeType = t.GetTypeInfo().GetGenericArguments().Single();
             var fakeTypeCtorArgCounts = from ci in fakeType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                         let paramCount = ci.GetParameters().Length
                                         orderby paramCount ascending

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -50,7 +50,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRules>
@@ -61,7 +61,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRules>
@@ -73,7 +73,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Verify|AnyCPU' ">
     <OutputPath>bin\Verify\</OutputPath>
-    <DefineConstants>CODE_ANALYSIS;TRACE</DefineConstants>
+    <DefineConstants>CODE_ANALYSIS;TRACE;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
     <DocumentationFile>bin\Verify\Ploeh.AutoFixture.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -37,7 +37,9 @@ namespace Ploeh.AutoFixture
             yield return new DelegateGenerator();
             yield return new TaskGenerator();
             yield return new IntPtrGuard();
+#if SYSTEM_NET_MAIL
             yield return new MailAddressGenerator();
+#endif
             yield return new EmailAddressLocalPartGenerator();
             yield return new DomainNameGenerator();
         }

--- a/Src/AutoFixture/DictionaryFiller.cs
+++ b/Src/AutoFixture/DictionaryFiller.cs
@@ -53,7 +53,7 @@ namespace Ploeh.AutoFixture
             if (typeArguments.Length != 2)
                 throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 
-            if (!typeof(IDictionary<,>).MakeGenericType(typeArguments).IsAssignableFrom(specimen.GetType()))
+            if (!typeof(IDictionary<,>).MakeGenericType(typeArguments).GetTypeInfo().IsAssignableFrom(specimen.GetType()))
                 throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 
             var filler = (ISpecimenCommand)Activator.CreateInstance(

--- a/Src/AutoFixture/DictionaryFiller.cs
+++ b/Src/AutoFixture/DictionaryFiller.cs
@@ -49,7 +49,7 @@ namespace Ploeh.AutoFixture
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            var typeArguments = specimen.GetType().GetGenericArguments();
+            var typeArguments = specimen.GetType().GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 2)
                 throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -412,7 +412,7 @@ namespace Ploeh.AutoFixture.Dsl
             var m = propertyPicker.GetWritableMember().Member;
             if (m.DeclaringType != typeof(T))
             {
-                m = typeof(T).GetProperty(m.Name) ?? (MemberInfo) typeof(T).GetField(m.Name);
+                m = typeof(T).GetTypeInfo().GetProperty(m.Name) ?? (MemberInfo) typeof(T).GetTypeInfo().GetField(m.Name);
             }
 
             return (NodeComposer<T>)this.ReplaceNodes(

--- a/Src/AutoFixture/FreezingCustomization.cs
+++ b/Src/AutoFixture/FreezingCustomization.cs
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(registeredType));
             }
 
-            if (!registeredType.IsAssignableFrom(targetType))
+            if (!registeredType.GetTypeInfo().IsAssignableFrom(targetType))
             {
                 var message = String.Format(
                     CultureInfo.CurrentCulture,

--- a/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
 
-            return from ci in type.GetConstructors()
+            return from ci in type.GetTypeInfo().GetConstructors()
                    let score = new ArrayParameterScore(ci.GetParameters())
                    orderby score descending
                    select new ConstructorMethod(ci) as IMethod;

--- a/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
+++ b/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
@@ -218,7 +218,7 @@ namespace Ploeh.AutoFixture.Kernel
 
         private IEnumerable<FieldInfo> GetFields(object specimen)
         {
-            return from fi in this.GetSpecimenType(specimen).GetFields(BindingFlags.Public | BindingFlags.Instance)
+            return from fi in this.GetSpecimenType(specimen).GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance)
                    where !fi.IsInitOnly
                    && this.specification.IsSatisfiedBy(fi)
                    select fi;
@@ -226,7 +226,7 @@ namespace Ploeh.AutoFixture.Kernel
 
         private IEnumerable<PropertyInfo> GetProperties(object specimen)
         {
-            return from pi in this.GetSpecimenType(specimen).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            return from pi in this.GetSpecimenType(specimen).GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance)
                    where pi.GetSetMethod() != null
                    && pi.GetIndexParameters().Length == 0
                    && this.specification.IsSatisfiedBy(pi)

--- a/Src/AutoFixture/Kernel/CollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/CollectionRelay.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null) return new NoSpecimen();
-            var typeArguments = type.GetGenericArguments();
+            var typeArguments = type.GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 1) return new NoSpecimen();
             var gtd = type.GetGenericTypeDefinition();
             if (gtd != typeof (ICollection<>)) return new NoSpecimen();

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -35,7 +35,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return new NoSpecimen();
             }
 
-            if (!typeof(Delegate).IsAssignableFrom(delegateType))
+            if (!typeof(Delegate).GetTypeInfo().IsAssignableFrom(delegateType))
             {
                 return new NoSpecimen();
             }

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -40,7 +40,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return new NoSpecimen();
             }
 
-            var delegateMethod = delegateType.GetMethod("Invoke");
+            var delegateMethod = delegateType.GetTypeInfo().GetMethod("Invoke");
             var methodSpecimenParams = DelegateGenerator.CreateMethodSpecimenParameters(delegateMethod);
             var methodSpecimenBody = DelegateGenerator.CreateMethodSpecimenBody(delegateMethod, context);
 

--- a/Src/AutoFixture/Kernel/DictionaryRelay.cs
+++ b/Src/AutoFixture/Kernel/DictionaryRelay.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null) return new NoSpecimen();
-            var typeArguments = type.GetGenericArguments();
+            var typeArguments = type.GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 2) return new NoSpecimen();
             var gtd = type.GetGenericTypeDefinition();
             if (gtd != typeof(IDictionary<,>)) return new NoSpecimen();

--- a/Src/AutoFixture/Kernel/EnumerableFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/EnumerableFavoringConstructorQuery.cs
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            return from ci in type.GetConstructors()
+            return from ci in type.GetTypeInfo().GetConstructors()
                    let score = new ParameterScore(type, typeof(IEnumerable<>), ci.GetParameters())
                    orderby score descending
                    select new ConstructorMethod(ci) as IMethod;

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -41,7 +41,7 @@ namespace Ploeh.AutoFixture.Kernel
             var type = request as Type;
             if (type == null)
                 return new NoSpecimen();
-            var typeArgs = type.GetGenericArguments();
+            var typeArgs = type.GetTypeInfo().GetGenericArguments();
             if (typeArgs.Length != 1)
                 return new NoSpecimen();
             if (type.GetGenericTypeDefinition() != typeof(IEnumerable<>))

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -55,7 +55,7 @@ namespace Ploeh.AutoFixture.Kernel
 
             return typeof (ConvertedEnumerable<>)
                 .MakeGenericType(typeArgs)
-                .GetConstructor(new[] {typeof (IEnumerable<object>)})
+                .GetTypeInfo().GetConstructor(new[] {typeof (IEnumerable<object>)})
                 .Invoke(new[] {enumerable});
         }
 

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (t == null)
                 return new NoSpecimen();
 
-            var typeArguments = t.GetGenericArguments();
+            var typeArguments = t.GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof (IEnumerator<>) != t.GetGenericTypeDefinition())
                 return new NoSpecimen();

--- a/Src/AutoFixture/Kernel/FactoryMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/FactoryMethodQuery.cs
@@ -40,7 +40,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            return from mi in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
+            return from mi in type.GetTypeInfo().GetMethods(BindingFlags.Static | BindingFlags.Public)
                    where mi.ReturnType == type
                    let parameters = mi.GetParameters()
                    where mi.GetParameters().All(p => p.ParameterType != type)

--- a/Src/AutoFixture/Kernel/FieldSpecification.cs
+++ b/Src/AutoFixture/Kernel/FieldSpecification.cs
@@ -120,7 +120,7 @@ namespace Ploeh.AutoFixture.Kernel
                     return true;
                 if (y == null)
                     return false;
-                return y.IsAssignableFrom(x);
+                return y.GetTypeInfo().IsAssignableFrom(x);
             }
 
             public int GetHashCode(Type obj)

--- a/Src/AutoFixture/Kernel/GenericMethod.cs
+++ b/Src/AutoFixture/Kernel/GenericMethod.cs
@@ -75,7 +75,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             return type.HasElementType ?
                 new[] { type.GetElementType() } :
-                type.GetGenericArguments();
+                type.GetTypeInfo().GetGenericArguments();
         }
 
         private static MethodInfo InferMethodInfo(MethodInfo methodInfo, IEnumerable<object> arguments)

--- a/Src/AutoFixture/Kernel/GenericMethod.cs
+++ b/Src/AutoFixture/Kernel/GenericMethod.cs
@@ -93,7 +93,7 @@ namespace Ploeh.AutoFixture.Kernel
                         if (!typeMap.Contains(x))
                             throw new TypeArgumentsCannotBeInferredException(methodInfo);
 
-                        return typeMap[x].Aggregate((t1, t2) => t1.IsAssignableFrom(t2) ? t2 : t1);
+                        return typeMap[x].Aggregate((t1, t2) => t1.GetTypeInfo().IsAssignableFrom(t2) ? t2 : t1);
                     });
 
                 return methodInfo.MakeGenericMethod(actuals.ToArray());

--- a/Src/AutoFixture/Kernel/GreedyConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/GreedyConstructorQuery.cs
@@ -37,7 +37,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            return from ci in type.GetConstructors()
+            return from ci in type.GetTypeInfo().GetConstructors()
                    let parameters = ci.GetParameters()
                    orderby parameters.Length descending
                    select new ConstructorMethod(ci) as IMethod;

--- a/Src/AutoFixture/Kernel/IllegalRequestException.cs
+++ b/Src/AutoFixture/Kernel/IllegalRequestException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if SYSTEM_RUNTIME_SERIALIZATION
 using System.Runtime.Serialization;
+#endif
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -13,7 +15,9 @@ namespace Ploeh.AutoFixture.Kernel
     /// </para>
     /// </remarks>
     /// <seealso cref="IntPtrGuard"/>
+#if SYSTEM_RUNTIME_SERIALIZATION
     [Serializable]
+#endif 
     public class IllegalRequestException : Exception
     {
         /// <summary>
@@ -46,6 +50,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
         }
 
+#if SYSTEM_RUNTIME_SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="IllegalRequestException"/> class.
         /// </summary>
@@ -67,5 +72,6 @@ namespace Ploeh.AutoFixture.Kernel
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
+++ b/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
@@ -74,6 +74,7 @@ namespace Ploeh.AutoFixture.Kernel
         private bool IsInterfaceImplementedByTargetType(object request)
         {
             return this.TargetType
+                       .GetTypeInfo()
                        .GetInterfaces()
                        .Contains((Type)request);
         }

--- a/Src/AutoFixture/Kernel/ListFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ListFavoringConstructorQuery.cs
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            return from ci in type.GetConstructors()
+            return from ci in type.GetTypeInfo().GetConstructors()
                    let score = new ParameterScore(type, typeof(IList<>), ci.GetParameters())
                    orderby score descending
                    select new ConstructorMethod(ci) as IMethod;

--- a/Src/AutoFixture/Kernel/ListRelay.cs
+++ b/Src/AutoFixture/Kernel/ListRelay.cs
@@ -37,7 +37,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (t == null)
                 return new NoSpecimen();
 
-            var typeArguments = t.GetGenericArguments();
+            var typeArguments = t.GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof(IList<>) != t.GetGenericTypeDefinition())
                 return new NoSpecimen();

--- a/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
+++ b/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
@@ -127,8 +127,8 @@ namespace Ploeh.AutoFixture.Kernel
 
         private static bool AreTypesRelated(Type x, Type y)
         {
-            return x.IsAssignableFrom(y)
-                || (y.IsAssignableFrom(x));
+            return x.GetTypeInfo().IsAssignableFrom(y)
+                || (y.GetTypeInfo().IsAssignableFrom(x));
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
@@ -37,7 +37,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
             }
 
-            return from ci in type.GetConstructors()
+            return from ci in type.GetTypeInfo().GetConstructors()
                    let parameters = ci.GetParameters()
                    orderby parameters.Length ascending
                    select new ConstructorMethod(ci) as IMethod;

--- a/Src/AutoFixture/Kernel/NullableEnumRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/NullableEnumRequestSpecification.cs
@@ -25,7 +25,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (requestType == null) return false;
             if (!requestType.IsGenericType()) return false;
             var gtd = requestType.GetGenericTypeDefinition();
-            if (!typeof(Nullable<>).IsAssignableFrom(gtd)) return false;
+            if (!typeof(Nullable<>).GetTypeInfo().IsAssignableFrom(gtd)) return false;
             var ga = requestType.GetGenericArguments();
             return ga.Length == 1 && ga[0].IsEnum();
         }

--- a/Src/AutoFixture/Kernel/NullableEnumRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/NullableEnumRequestSpecification.cs
@@ -26,7 +26,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (!requestType.IsGenericType()) return false;
             var gtd = requestType.GetGenericTypeDefinition();
             if (!typeof(Nullable<>).GetTypeInfo().IsAssignableFrom(gtd)) return false;
-            var ga = requestType.GetGenericArguments();
+            var ga = requestType.GetTypeInfo().GetGenericArguments();
             return ga.Length == 1 && ga[0].IsEnum();
         }
     }

--- a/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
@@ -75,7 +75,7 @@ namespace Ploeh.AutoFixture.Kernel
 
             if (returnValue is OmitSpecimen)
                 return Array.CreateInstance(
-                    pi.ParameterType.GetGenericArguments().Single(),
+                    pi.ParameterType.GetTypeInfo().GetGenericArguments().Single(),
                     0);
 
             return returnValue;

--- a/Src/AutoFixture/Kernel/ParameterScore.cs
+++ b/Src/AutoFixture/Kernel/ParameterScore.cs
@@ -43,7 +43,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (exactMatchScore > 0)
                 return exactMatchScore;
 
-            var genericParameterTypes = parentType.GetGenericArguments();
+            var genericParameterTypes = parentType.GetTypeInfo().GetGenericArguments();
             if (genericParameterTypes.Length != 1)
                 return parameters.Count() * -1;
 
@@ -62,7 +62,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (!p.ParameterType.IsGenericType())
                 return false;
 
-            var genericParameterTypes = p.ParameterType.GetGenericArguments();
+            var genericParameterTypes = p.ParameterType.GetTypeInfo().GetGenericArguments();
             if (genericParameterTypes.Length != 1)
                 return false;
 

--- a/Src/AutoFixture/Kernel/ParameterSpecification.cs
+++ b/Src/AutoFixture/Kernel/ParameterSpecification.cs
@@ -121,7 +121,7 @@ namespace Ploeh.AutoFixture.Kernel
                     return true;
                 if (y == null)
                     return false;
-                return y.IsAssignableFrom(x);
+                return y.GetTypeInfo().IsAssignableFrom(x);
             }
 
             public int GetHashCode(Type obj)

--- a/Src/AutoFixture/Kernel/PropertySpecification.cs
+++ b/Src/AutoFixture/Kernel/PropertySpecification.cs
@@ -122,7 +122,7 @@ namespace Ploeh.AutoFixture.Kernel
                     return true;
                 if (y == null)
                     return false;
-                return y.IsAssignableFrom(x);
+                return y.GetTypeInfo().IsAssignableFrom(x);
             }
 
             public int GetHashCode(Type obj)

--- a/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
@@ -38,7 +38,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (t == null)
                 return new NoSpecimen();
 
-            var typeArguments = t.GetGenericArguments();
+            var typeArguments = t.GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof(IReadOnlyCollection<>) != t.GetGenericTypeDefinition())
                 return new NoSpecimen();

--- a/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -27,8 +28,8 @@ namespace Ploeh.AutoFixture.Kernel
                 return false;
             }
 
-            return type.IsGenericType 
-                && typeof(SortedDictionary<,>) == type.GetGenericTypeDefinition();
+            return type.IsGenericType() 
+                && typeof(SortedDictionary<,>) == type.GetTypeInfo().GetGenericTypeDefinition();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/SortedSetSpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedSetSpecification.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -27,7 +28,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return false;
             }
 
-            return type.IsGenericType && typeof(SortedSet<>) == type.GetGenericTypeDefinition();
+            return type.IsGenericType() && typeof(SortedSet<>) == type.GetTypeInfo().GetGenericTypeDefinition();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -114,7 +114,7 @@ namespace Ploeh.AutoFixture.Kernel
 
         private bool Compare(Type parameterType, Type templateParameterType)
         {
-            if (parameterType.IsAssignableFrom(templateParameterType))
+            if (parameterType.GetTypeInfo().IsAssignableFrom(templateParameterType))
                 return true;
 
             if (parameterType.IsGenericParameter)
@@ -182,8 +182,8 @@ namespace Ploeh.AutoFixture.Kernel
                 var hierarchy = GetHierarchy(templateParameterType).ToList();
                 
                 var matches = methodParameterType.IsClass() ? 
-                    hierarchy.Count(t => t.IsAssignableFrom(methodParameterType)) : 
-                    hierarchy.Count(t => t.GetInterfaces().Any(i => i.IsAssignableFrom(methodParameterType)));
+                    hierarchy.Count(t => t.GetTypeInfo().IsAssignableFrom(methodParameterType)) : 
+                    hierarchy.Count(t => t.GetInterfaces().Any(i => i.GetTypeInfo().IsAssignableFrom(methodParameterType)));
 
                 var score = 50 * -(hierarchy.Count - matches);
 

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -90,7 +90,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
 
-            return from method in type.GetMethods()
+            return from method in type.GetTypeInfo().GetMethods()
                    where method.Name == Template.Name && (Owner != null || method.IsStatic)
                    let methodParameters = method.GetParameters()
                    let templateParameters = Template.GetParameters()

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -134,7 +134,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             return type.HasElementType ?
                 new[] { type.GetElementType() } :
-                type.GetGenericArguments();
+                type.GetTypeInfo().GetGenericArguments();
         }
 
         private class LateBindingParameterScore : IComparable<LateBindingParameterScore>

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -183,7 +183,7 @@ namespace Ploeh.AutoFixture.Kernel
                 
                 var matches = methodParameterType.IsClass() ? 
                     hierarchy.Count(t => t.GetTypeInfo().IsAssignableFrom(methodParameterType)) : 
-                    hierarchy.Count(t => t.GetInterfaces().Any(i => i.GetTypeInfo().IsAssignableFrom(methodParameterType)));
+                    hierarchy.Count(t => t.GetTypeInfo().GetInterfaces().Any(i => i.GetTypeInfo().IsAssignableFrom(methodParameterType)));
 
                 var score = 50 * -(hierarchy.Count - matches);
 
@@ -202,7 +202,7 @@ namespace Ploeh.AutoFixture.Kernel
             private static IEnumerable<Type> GetHierarchy(Type type)
             {
                 if (!type.IsClass())
-                    foreach (var interfaceType in type.GetInterfaces())
+                    foreach (var interfaceType in type.GetTypeInfo().GetInterfaces())
                         yield return interfaceType;
 
                 while (type != null)

--- a/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
+++ b/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
                     GetFriendlyName(methodInfo.ReturnType),
                     methodInfo.DeclaringType.FullName,
                     methodInfo.Name,
-                    string.Join(", ", methodInfo.GetGenericArguments().Select(a => a.ToString())),
+                    string.Join(", ", methodInfo.GetTypeInfo().GetGenericArguments().Select(a => a.ToString())),
                     string.Join(", ", methodInfo.GetParameters().Select(p => GetFriendlyName(p.ParameterType)))
                     ))
         {
@@ -90,7 +90,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return string.Format(CultureInfo.CurrentCulture, 
                     "{0}<{1}>", 
                     type.Name.Split('`')[0], 
-                    string.Join(", ", type.GetGenericArguments().Select(GetFriendlyName)));
+                    string.Join(", ", type.GetTypeInfo().GetGenericArguments().Select(GetFriendlyName)));
 
             return type.Name;
         }

--- a/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
+++ b/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
@@ -72,7 +72,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </param>
         public TypeArgumentsCannotBeInferredException(string message, Exception innerException)
             : base(message, innerException)
-         {
+        {
         }
 
 #if SYSTEM_RUNTIME_SERIALIZATION

--- a/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
+++ b/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture.Kernel
                     GetFriendlyName(methodInfo.ReturnType),
                     methodInfo.DeclaringType.FullName,
                     methodInfo.Name,
-                    string.Join(", ", methodInfo.GetTypeInfo().GetGenericArguments().Select(a => a.ToString())),
+                    string.Join(", ", methodInfo.GetGenericArguments().Select(a => a.ToString())),
                     string.Join(", ", methodInfo.GetParameters().Select(p => GetFriendlyName(p.ParameterType)))
                     ))
         {
@@ -68,7 +68,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </param>
         public TypeArgumentsCannotBeInferredException(string message, Exception innerException)
             : base(message, innerException)
-        {
+         {
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
+++ b/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
@@ -2,7 +2,9 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+#if SYSTEM_RUNTIME_SERIALIZATION
 using System.Runtime.Serialization;
+#endif
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -10,7 +12,9 @@ namespace Ploeh.AutoFixture.Kernel
     /// The exception that is thrown when AutoFixture is unable to infer the type 
     /// parameters of a generic method from its arguments.
     /// </summary>
+#if SYSTEM_RUNTIME_SERIALIZATION
     [Serializable]
+#endif
     public class TypeArgumentsCannotBeInferredException : Exception
     {
         /// <summary>
@@ -71,6 +75,7 @@ namespace Ploeh.AutoFixture.Kernel
          {
         }
 
+#if SYSTEM_RUNTIME_SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="TypeArgumentsCannotBeInferredException"/> class with
         /// serialized data.
@@ -83,6 +88,7 @@ namespace Ploeh.AutoFixture.Kernel
             : base(info, context)
         {
         }
+#endif
 
         private static string GetFriendlyName(Type type)
         {

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -43,8 +43,8 @@
                 return new NoSpecimen();
             }
 
-            var delegateType = requestType.GetGenericArguments().Single();
-            var genericArguments = delegateType.GetGenericArguments().Select(Expression.Parameter).ToList();
+            var delegateType = requestType.GetTypeInfo().GetGenericArguments().Single();
+            var genericArguments = delegateType.GetTypeInfo().GetGenericArguments().Select(Expression.Parameter).ToList();
 
             if (delegateType == typeof(Action))
             {
@@ -56,7 +56,7 @@
                 return Expression.Lambda(Expression.Empty(), genericArguments);
             }
 
-            var body = context.Resolve(delegateType.GetGenericArguments().Last());
+            var body = context.Resolve(delegateType.GetTypeInfo().GetGenericArguments().Last());
             var parameters = genericArguments.Except(new[] { genericArguments.Last() });
 
             return Expression.Lambda(Expression.Constant(body), parameters);

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Reflection;
     using Kernel;
 
     /// <summary>
@@ -38,7 +39,7 @@
                 return new NoSpecimen();
             }
 
-            if (requestType.BaseType != typeof(LambdaExpression))
+            if (requestType.BaseType() != typeof(LambdaExpression))
             {
                 return new NoSpecimen();
             }

--- a/Src/AutoFixture/LazyRelay.cs
+++ b/Src/AutoFixture/LazyRelay.cs
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixture
 
             var builder = (ILazyBuilder)Activator
                 .CreateInstance(typeof(LazyBuilder<>)
-                .MakeGenericType(t.GetGenericArguments()));
+                .MakeGenericType(t.GetTypeInfo().GetGenericArguments()));
             return builder.Create(context);
         }
 

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if SYSTEM_NET_MAIL
+
+using System;
 using System.Globalization;
 using System.Net.Mail;
 using Ploeh.AutoFixture.Kernel;
@@ -59,3 +61,5 @@ namespace Ploeh.AutoFixture
         }
     }       
 }
+
+#endif

--- a/Src/AutoFixture/ObjectCreationException.cs
+++ b/Src/AutoFixture/ObjectCreationException.cs
@@ -1,12 +1,16 @@
 ﻿using System;
+#if SYSTEM_RUNTIME_SERIALIZATION
 using System.Runtime.Serialization;
+#endif
 
 namespace Ploeh.AutoFixture
 {
     /// <summary>
     /// The exception that is thrown when AutoFixture is unable to create an object.
     /// </summary>
+#if SYSTEM_RUNTIME_SERIALIZATION
     [Serializable]
+#endif
     public class ObjectCreationException : Exception
     {
         /// <summary>
@@ -45,6 +49,7 @@ namespace Ploeh.AutoFixture
         {
         }
 
+#if SYSTEM_RUNTIME_SERIALIZATION
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectCreationException"/> class with
         /// serialized data.
@@ -57,5 +62,6 @@ namespace Ploeh.AutoFixture
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
@@ -66,7 +66,7 @@ namespace Ploeh.AutoFixture
 
         private static bool IsNotDateTimeRequest(object request)
         {
-            return !typeof(DateTime).IsAssignableFrom(request as Type);
+            return !typeof(DateTime).GetTypeInfo().IsAssignableFrom(request as Type);
         }
 
         private object CreateRandomDate(ISpecimenContext context)

--- a/Src/AutoFixture/TaskGenerator.cs
+++ b/Src/AutoFixture/TaskGenerator.cs
@@ -63,7 +63,7 @@ namespace Ploeh.AutoFixture
             var taskSourceType = typeof (TaskCompletionSource<>).MakeGenericType(resultType);
             var taskSource = Activator.CreateInstance(taskSourceType);
 
-            taskSourceType.GetMethod("SetResult")
+            taskSourceType.GetTypeInfo().GetMethod("SetResult")
                           .Invoke(taskSource, new[] {result});
 
             var task = taskSourceType.GetTypeInfo().GetProperty("Task")

--- a/Src/AutoFixture/TaskGenerator.cs
+++ b/Src/AutoFixture/TaskGenerator.cs
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixture
 
         private static object CreateGenericTask(Type taskType, ISpecimenContext context)
         {
-            var resultType = taskType.GetGenericArguments().Single();
+            var resultType = taskType.GetTypeInfo().GetGenericArguments().Single();
             var result = context.Resolve(resultType);
             return CreateTask(resultType, result);
         }

--- a/Src/AutoFixture/TaskGenerator.cs
+++ b/Src/AutoFixture/TaskGenerator.cs
@@ -66,7 +66,7 @@ namespace Ploeh.AutoFixture
             taskSourceType.GetMethod("SetResult")
                           .Invoke(taskSource, new[] {result});
 
-            var task = taskSourceType.GetProperty("Task")
+            var task = taskSourceType.GetTypeInfo().GetProperty("Task")
                                      .GetValue(taskSource, null);
 
             return task;

--- a/Src/AutoFixtureUnitTest/Kernel/ConstructorMethodTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ConstructorMethodTest.cs
@@ -87,7 +87,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void InvokeWithSingleParameterReturnsCorrectResult(Type targetType, object parameter)
         {
             // Fixture setup
-            var ctor = targetType.GetConstructor(targetType.GetGenericArguments().ToArray());
+            var ctor = targetType.GetConstructor(targetType.GetTypeInfo().GetGenericArguments().ToArray());
             var sut = new ConstructorMethod(ctor);
             // Exercise system
             var result = sut.Invoke(new[] { parameter });
@@ -103,7 +103,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void InvokeWithTwoParametersReturnsCorrectResult(Type targetType, object parameter1, object parameter2)
         {
             // Fixture setup
-            var ctor = targetType.GetConstructor(targetType.GetGenericArguments().ToArray());
+            var ctor = targetType.GetConstructor(targetType.GetTypeInfo().GetGenericArguments().ToArray());
             var sut = new ConstructorMethod(ctor);
             // Exercise system
             var result = sut.Invoke(new[] { parameter1, parameter2 });

--- a/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
@@ -79,7 +79,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.SelectMethods(type);
             // Verify outcome
-            var genericParameterType = type.GetGenericArguments().Single();
+            var genericParameterType = type.GetTypeInfo().GetGenericArguments().Single();
             Assert.True(result.First().Parameters.Any(p => typeof(IEnumerable<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType)));
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
@@ -79,7 +79,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.SelectMethods(type);
             // Verify outcome
-            var genericParameterType = type.GetTypeInfo().GetGenericArguments().Single();
+            var genericParameterType = type.GetGenericArguments().Single();
             Assert.True(result.First().Parameters.Any(p => typeof(IEnumerable<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType)));
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
@@ -77,7 +77,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.SelectMethods(type);
             // Verify outcome
-            var genericParameterType = type.GetGenericArguments().Single();
+            var genericParameterType = type.GetTypeInfo().GetGenericArguments().Single();
             Assert.True(result.First().Parameters.Any(p => typeof(IList<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType)));
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
@@ -77,7 +77,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.SelectMethods(type);
             // Verify outcome
-            var genericParameterType = type.GetTypeInfo().GetGenericArguments().Single();
+            var genericParameterType = type.GetGenericArguments().Single();
             Assert.True(result.First().Parameters.Any(p => typeof(IList<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType)));
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
@@ -122,7 +122,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var actual = sut.Create(parameterInfo, context);
 
             var expected = Array.CreateInstance(
-                argumentType.GetTypeInfo().GetGenericArguments().Single(),
+                argumentType.GetGenericArguments().Single(),
                 0);
             Assert.Equal(expected, actual);
         }

--- a/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
@@ -122,7 +122,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var actual = sut.Create(parameterInfo, context);
 
             var expected = Array.CreateInstance(
-                argumentType.GetGenericArguments().Single(),
+                argumentType.GetTypeInfo().GetGenericArguments().Single(),
                 0);
             Assert.Equal(expected, actual);
         }

--- a/Src/AutoMoq/MockType.cs
+++ b/Src/AutoMoq/MockType.cs
@@ -71,7 +71,7 @@ namespace Ploeh.AutoFixture.AutoMoq
 
         internal static Type GetMockedType(this Type type)
         {
-            return type.GetGenericArguments().Single();
+            return type.GetTypeInfo().GetGenericArguments().Single();
         }
 
         internal static IReturnsResult<TMock> ReturnsUsingContext<TMock, TResult>(this IReturns<TMock, TResult> setup,

--- a/Src/AutoMoqUnitTest/GreedyMockConstructorQueryTest.cs
+++ b/Src/AutoMoqUnitTest/GreedyMockConstructorQueryTest.cs
@@ -47,7 +47,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         public void SelectMethodsReturnsCorrectNumberOfConstructorsForTypesWithConstructors(Type t)
         {
             // Fixture setup
-            var mockType = t.GetGenericArguments().Single();
+            var mockType = t.GetTypeInfo().GetGenericArguments().Single();
             var expectedCount = mockType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Length;
 
             var sut = new GreedyMockConstructorQuery();
@@ -66,7 +66,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         public void MethodsDefineCorrectParameters(Type t)
         {
             // Fixture setup
-            var mockType = t.GetGenericArguments().Single();
+            var mockType = t.GetTypeInfo().GetGenericArguments().Single();
             var mockTypeCtorArgs = from ci in mockType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                    select ci.GetParameters();
 
@@ -88,7 +88,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         public void MethodsAreReturnedInCorrectOrder(Type t)
         {
             // Fixture setup
-            var mockType = t.GetGenericArguments().Single();
+            var mockType = t.GetTypeInfo().GetGenericArguments().Single();
             var mockTypeCtorArgCounts = from ci in mockType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                         let paramCount = ci.GetParameters().Length
                                         orderby paramCount descending

--- a/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
+++ b/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
@@ -47,7 +47,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         public void SelectMethodsReturnsCorrectNumberOfConstructorsForTypesWithConstructors(Type t)
         {
             // Fixture setup
-            var mockType = t.GetGenericArguments().Single();
+            var mockType = t.GetTypeInfo().GetGenericArguments().Single();
             var expectedCount = mockType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Length;
 
             var sut = new MockConstructorQuery();
@@ -66,7 +66,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         public void MethodsDefineCorrectParameters(Type t)
         {
             // Fixture setup
-            var mockType = t.GetGenericArguments().Single();
+            var mockType = t.GetTypeInfo().GetGenericArguments().Single();
             var mockTypeCtorArgs = from ci in mockType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                    select ci.GetParameters();
 
@@ -89,7 +89,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         public void MethodsAreReturnedInCorrectOrder(Type t)
         {
             // Fixture setup
-            var mockType = t.GetGenericArguments().Single();
+            var mockType = t.GetTypeInfo().GetGenericArguments().Single();
             var mockTypeCtorArgCounts = from ci in mockType.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                                         let paramCount = ci.GetParameters().Length
                                         orderby paramCount ascending

--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -123,7 +123,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
                     return string.Empty;
 
                 return string.Format(CultureInfo.CurrentCulture, "<{0}>",
-                    string.Join(", ", methodInfo.GetGenericArguments().Select(a => a.ToString())));
+                    string.Join(", ", methodInfo.GetTypeInfo().GetGenericArguments().Select(a => a.ToString())));
             }
 
             private static string GetFriendlyName(Type type)
@@ -132,7 +132,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
                     return string.Format(CultureInfo.CurrentCulture,
                         "{0}<{1}>",
                         type.Name.Split('`')[0],
-                        string.Join(", ", type.GetGenericArguments().Select(GetFriendlyName)));
+                        string.Join(", ", type.GetTypeInfo().GetGenericArguments().Select(GetFriendlyName)));
 
                 return type.Name;
             }

--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -123,7 +123,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
                     return string.Empty;
 
                 return string.Format(CultureInfo.CurrentCulture, "<{0}>",
-                    string.Join(", ", methodInfo.GetTypeInfo().GetGenericArguments().Select(a => a.ToString())));
+                    string.Join(", ", methodInfo.GetGenericArguments().Select(a => a.ToString())));
             }
 
             private static string GetFriendlyName(Type type)
@@ -132,7 +132,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
                     return string.Format(CultureInfo.CurrentCulture,
                         "{0}<{1}>",
                         type.Name.Split('`')[0],
-                        string.Join(", ", type.GetTypeInfo().GetGenericArguments().Select(GetFriendlyName)));
+                        string.Join(", ", type.GetGenericArguments().Select(GetFriendlyName)));
 
                 return type.Name;
             }


### PR DESCRIPTION
This begins support for `netstandard` (and coreclr / dotnet core / whatever it's called now) by doing the following:

 * Use the [evolved reflection APIs](https://blogs.msdn.microsoft.com/dotnet/2012/08/28/evolving-the-reflection-api/) (mostly `GetTypeInfo`)
 * Introduces `SYSTEM_NET_MAIL` and `SYSTEM_RUNTIME_SERIALIZATION` defines. `System.Net.Mail` APIs (used by AutoFixture in the `MailAddressGenerator`) are currently only available on the full .net framework (e.g. net45), so we wrap them entirely in an `#if SYSTEM_NET_MAIL` directive. Similarly, serialization (including `SerializableAttribute` and binary remoting serialization) is only available on the full .net framework, so we use `#if SYSTEM_RUNTIME_SERIALIZATION` to allow us to compile on targets that don't have those features.

After these changes, I was able to create a file named `Src\AutoFixture\project.json`:
```json
{
  "version": "1.0.0-*",
  "buildOptions": {
    "debugType": "portable"
  },
  "dependencies": {},
  "frameworks": {
    "net45": {
      "buildOptions": { "define": [ "SYSTEM_NET_MAIL", "SYSTEM_RUNTIME_SERIALIZATION" ] },
      "frameworkAssemblies": {
        "System.ComponentModel.DataAnnotations": ""
      }
    },
    "netstandard1.5": {
      "dependencies": {
        "NETStandard.Library": "1.6.0",
        "System.Threading.Thread": "4.0.0",
        "System.ComponentModel.Annotations": "4.1.0"
      }
    }
  }
}
```

Which allowed me to compile the core AutoFixture library:
![image](https://cloud.githubusercontent.com/assets/570470/16708063/1b332a62-4629-11e6-9d55-121144f7afcf.png)
