### PR TITLE
 Added example of using OmitOnRecursionBehavior in exception message

### DIFF
--- a/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
@@ -39,6 +39,9 @@ namespace Ploeh.AutoFixture.Kernel
         /// <param name="request">The recursion causing request.</param>
         /// <returns>Nothing. Always throws.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ForEach", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "OfType", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ToList", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ThrowingRecursionBehavior", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "OmitOnRecursionBehavior", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         [Obsolete("This class will be removed in a future version of AutoFixture. Instead, use an instance of RecursionGuard, composed with an instance of ThrowingRecursionHandler.")]

--- a/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
@@ -46,7 +46,13 @@ namespace Ploeh.AutoFixture.Kernel
         {
             throw new ObjectCreationException(string.Format(
                 CultureInfo.InvariantCulture,
-                "AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior.{2}\tPath:{2}{1}",
+                @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
+
+fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
+    .ForEach(b => fixture.Behaviors.Remove(b));
+fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+                " + "{2}\tPath:{2}{1}",
                 this.RecordedRequests.Cast<object>().First().GetType(),
                 this.GetFlattenedRequests(request),
                 Environment.NewLine));

--- a/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
@@ -39,6 +39,9 @@ namespace Ploeh.AutoFixture.Kernel
         /// </para>
         /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "OmitOnRecursionBehavior", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ForEach", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "OfType", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ToList", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ThrowingRecursionBehavior", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         public object HandleRecursiveRequest(
             object request,

--- a/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
@@ -46,7 +46,13 @@ namespace Ploeh.AutoFixture.Kernel
         {
             throw new ObjectCreationException(string.Format(
                 CultureInfo.InvariantCulture,
-                "AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior.{2}\tPath:{2}{1}",
+                @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
+
+fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
+    .ForEach(b => fixture.Behaviors.Remove(b));
+fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+                " + "{2}\tPath:{2}{1}",
                 recordedRequests.Cast<object>().First().GetType(),
                 GetFlattenedRequests(request, recordedRequests),
                 Environment.NewLine));


### PR DESCRIPTION
This pull request fixes #667. It adds a sample usage of OmitOnRecursionBehavior to the exception message. 

Attaching the console output snapshots for reference
**Before fix**
![before fix](https://cloud.githubusercontent.com/assets/951631/16743570/6abdf760-47f0-11e6-89e4-bfc0dbe06d25.png)

**After fix**
![after fix](https://cloud.githubusercontent.com/assets/951631/16743571/6ac4943a-47f0-11e6-9d44-2398ae3db68e.png)

