### PR TITLE
Fix wrong sample code in exception message of kernel type.

### DIFF
--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -153,7 +153,7 @@ namespace Ploeh.AutoFixture.Kernel
             "use Moq, you can customize AutoFixture like this:" +
             "{1}" +
             "{1}" +
-            "fixture.Customizations.Add(new AutoMoqCustomization());" +
+            "fixture.Customize(new AutoMoqCustomization());" +
             "{1}" +
             "{1}" +
             "See http://blog.ploeh.dk/2010/08/19/AutoFixtureasanauto-mockingcontainer " +


### PR DESCRIPTION
When I was going through TDD, and AutoFixture, with a new collegae, I noticed that the exception message of the `TerminatingWithPathSpecimenBuilder` is wrong. This PR fixes that.

I didn't put in a separate issue, since it's this minor. If that's not ok, I can always create one, if you want.