### PR TITLE
Suppress the 'CA1506:AvoidExcessiveClassCoupling' code analysis error

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -13,6 +13,7 @@ namespace Ploeh.AutoFixture
     /// <summary>
     /// Provides anonymous object creation services.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Fixture is coupled to many other types, because it embodies rules for creating various well-known types from the base class library.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main purpose of Fixture isn't to be a collection of anything. That it implements IEnumerable is just a coincidental side effect of how graphs are implemented in AutoFixture. Besides, fixing this CA error would be a breaking change.")]
     public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
     {


### PR DESCRIPTION
Suppresses the 'CA1506:AvoidExcessiveClassCoupling' code analysis error on the class level.

The code analysis does not report any errors in the current product state but referencing
any new class in `Fixture` leads to the following error:
```
  1) Building C:\projects\autofixture\Src\AutoFakeItEasy.sln failed with exitcode 1.
  2) CA1506: (-1,0): Microsoft.Maintainability : 'Fixture' is coupled with 81 different
types from 15 different namespaces. Rewrite or refactor this class's methods to
decrease its class coupling, or consider moving some of the class's methods to some
of the other types it is tightly coupled with. A class coupling above 95 indicates poor
maintainability, a class coupling between 95 and 80 indicates moderate
maintainability, and a class coupling below 80 indicates good maintainability.
```

This PR is required for #665 and #679.
