### PR TITLE
Deprecated all public types in AutoFakeItEasy2.

### DIFF
--- a/Src/AutoFakeItEasy2.UnitTest/AutoFakeItEasyCustomizationTest.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/AutoFakeItEasyCustomizationTest.cs
@@ -5,6 +5,7 @@ using FakeItEasy;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
 
+#pragma warning disable 618
 namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
 {
     public class AutoFakeItEasyCustomizationTest
@@ -101,3 +102,4 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         }
     }
 }
+#pragma warning restore 618

--- a/Src/AutoFakeItEasy2.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/DependencyConstraints.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using Xunit.Extensions;
 
+#pragma warning disable 618
 namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
 {
   public class DependencyConstraints
@@ -37,3 +38,4 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         }
     }
 }
+#pragma warning restore 618

--- a/Src/AutoFakeItEasy2.UnitTest/FakeItEasyBuilderTest.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/FakeItEasyBuilderTest.cs
@@ -5,6 +5,7 @@ using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Extensions;
 
+#pragma warning disable 618
 namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
 {
   public class FakeItEasyBuilderTest
@@ -140,3 +141,4 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         }
     }
 }
+#pragma warning restore 618

--- a/Src/AutoFakeItEasy2.UnitTest/FakeItEasyMethodQueryTest.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/FakeItEasyMethodQueryTest.cs
@@ -7,6 +7,7 @@ using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Extensions;
 
+#pragma warning disable 618
 namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
 {
   public class FakeItEasyMethodQueryTest
@@ -101,3 +102,4 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         }
     }
 }
+#pragma warning restore 618

--- a/Src/AutoFakeItEasy2.UnitTest/FakeItEasyRelayTest.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/FakeItEasyRelayTest.cs
@@ -5,6 +5,7 @@ using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Extensions;
 
+#pragma warning disable 618
 namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
 {
   public class FakeItEasyRelayTest
@@ -177,3 +178,4 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         }
     }
 }
+#pragma warning restore 618

--- a/Src/AutoFakeItEasy2.UnitTest/FixtureIntegrationTest.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/FixtureIntegrationTest.cs
@@ -5,6 +5,7 @@ using FakeItEasy;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 
+#pragma warning disable 618
 namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
 {
   public class FixtureIntegrationTest
@@ -121,3 +122,4 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2.UnitTest
         }
     }
 }
+#pragma warning restore 618

--- a/Src/AutoFakeItEasy2/AutoFakeItEasyCustomization.cs
+++ b/Src/AutoFakeItEasy2/AutoFakeItEasyCustomization.cs
@@ -6,6 +6,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2
     /// <summary>
     /// Enables auto-mocking with FakeItEasy.
     /// </summary>
+    [Obsolete("The AutoFakeItEasy2 package has been retired; use the AutoFakeItEasy (without the trailing \"2\") package instead. Details: it's turned out that it's possible to enable AutoFakeItEasy to also work with FakeItEasy 2. From version 3.49.1, you should be able to use AutoFakeItEasy with FakeItEasy 2 by adding an assembly binding redirect. This enables us, the maintainers of AutoFixture, to maintain only one code base for FakeItEasy, instead of two. If this causes problems, please create an issue at https://github.com/AutoFixture/AutoFixture/issues. We apologise for any inconvenience this may cause.")]
     public class AutoFakeItEasyCustomization : ICustomization
     {
         private readonly ISpecimenBuilder relay;

--- a/Src/AutoFakeItEasy2/FakeItEasyBuilder.cs
+++ b/Src/AutoFakeItEasy2/FakeItEasyBuilder.cs
@@ -7,6 +7,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2
     /// Provides pre- and post-condition checks for requests for fake instances.
     /// </summary>
     /// <seealso cref="Create(object, ISpecimenContext)" />
+    [Obsolete("The AutoFakeItEasy2 package has been retired; use the AutoFakeItEasy (without the trailing \"2\") package instead. Details: it's turned out that it's possible to enable AutoFakeItEasy to also work with FakeItEasy 2. From version 3.49.1, you should be able to use AutoFakeItEasy with FakeItEasy 2 by adding an assembly binding redirect. This enables us, the maintainers of AutoFixture, to maintain only one code base for FakeItEasy, instead of two. If this causes problems, please create an issue at https://github.com/AutoFixture/AutoFixture/issues. We apologise for any inconvenience this may cause.")]
     public class FakeItEasyBuilder : ISpecimenBuilder
     {
         private readonly ISpecimenBuilder builder;

--- a/Src/AutoFakeItEasy2/FakeItEasyMethodQuery.cs
+++ b/Src/AutoFakeItEasy2/FakeItEasyMethodQuery.cs
@@ -10,6 +10,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2
     /// <summary>
     /// Selects appropriate methods to create <see cref="FakeItEasy.Fake{T}"/> instances.
     /// </summary>
+    [Obsolete("The AutoFakeItEasy2 package has been retired; use the AutoFakeItEasy (without the trailing \"2\") package instead. Details: it's turned out that it's possible to enable AutoFakeItEasy to also work with FakeItEasy 2. From version 3.49.1, you should be able to use AutoFakeItEasy with FakeItEasy 2 by adding an assembly binding redirect. This enables us, the maintainers of AutoFixture, to maintain only one code base for FakeItEasy, instead of two. If this causes problems, please create an issue at https://github.com/AutoFixture/AutoFixture/issues. We apologise for any inconvenience this may cause.")]
     public class FakeItEasyMethodQuery : IMethodQuery
     {
         /// <summary>

--- a/Src/AutoFakeItEasy2/FakeItEasyRelay.cs
+++ b/Src/AutoFakeItEasy2/FakeItEasyRelay.cs
@@ -8,6 +8,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2
     /// Relays a request for an interface or an abstract class to a request for a
     /// <see cref="Fake{T}"/> of that class.
     /// </summary>
+    [Obsolete("The AutoFakeItEasy2 package has been retired; use the AutoFakeItEasy (without the trailing \"2\") package instead. Details: it's turned out that it's possible to enable AutoFakeItEasy to also work with FakeItEasy 2. From version 3.49.1, you should be able to use AutoFakeItEasy with FakeItEasy 2 by adding an assembly binding redirect. This enables us, the maintainers of AutoFixture, to maintain only one code base for FakeItEasy, instead of two. If this causes problems, please create an issue at https://github.com/AutoFixture/AutoFixture/issues. We apologise for any inconvenience this may cause.")]
     public class FakeItEasyRelay : ISpecimenBuilder
     {
         private readonly IRequestSpecification fakeableSpecification;


### PR DESCRIPTION
It's turned out that the AutoFakeItEasy package can support both
FakeItEasy 1 and 2, so there's no reason to maintain two almost identical
packages.

See the discussion at https://github.com/AutoFixture/AutoFixture/pull/672
for more details.