### PR TITLE
Support fake classes (not just interfaces) when using FakeItEasy 2.0

### DIFF
--- a/Src/All.sln
+++ b/Src/All.sln
@@ -67,6 +67,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Idioms.FsCheckUnitTest", "I
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdiomsUnitTest", "IdiomsUnitTest\IdiomsUnitTest.csproj", "{730E1D38-BA80-48C7-B05C-E2BD29F38851}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy.FakeItEasy2UnitTest", "AutoFakeItEasy.FakeItEasy2UnitTest\AutoFakeItEasy.FakeItEasy2UnitTest.csproj", "{7F957CC0-79C3-48A1-9A3E-47BED7539248}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -266,6 +268,12 @@ Global
 		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Release|Any CPU.Build.0 = Release|Any CPU
 		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Verify|Any CPU.ActiveCfg = Release|Any CPU
 		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7F957CC0-79C3-48A1-9A3E-47BED7539248}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
+    <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.FakeItEasy2UnitTest</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
+    <TargetFrameworkProfile />
+    <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core">
+      <HintPath>..\..\Packages\Castle.Core.2.5.2\lib\NET35\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\..\Packages\FakeItEasy.2.0.0\lib\net40\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="xunit">
+      <HintPath>..\..\Packages\xunit.1.8.0.1549\lib\xunit.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.extensions">
+      <HintPath>..\..\Packages\xunit.extensions.1.8.0.1549\lib\xunit.extensions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\AutoFakeItEasyUnitTest\AutoFakeItEasyCustomizationTest.cs">
+      <Link>AutoFakeItEasyCustomizationTest.cs</Link>
+    </Compile>
+    <Compile Include="..\AutoFakeItEasyUnitTest\DependencyConstraints.cs">
+      <Link>DependencyConstraints.cs</Link>
+    </Compile>
+    <Compile Include="..\AutoFakeItEasyUnitTest\FakeItEasyBuilderTest.cs">
+      <Link>FakeItEasyBuilderTest.cs</Link>
+    </Compile>
+    <Compile Include="..\AutoFakeItEasyUnitTest\FakeItEasyMethodQueryTest.cs">
+      <Link>FakeItEasyMethodQueryTest.cs</Link>
+    </Compile>
+    <Compile Include="..\AutoFakeItEasyUnitTest\FakeItEasyRelayTest.cs">
+      <Link>FakeItEasyRelayTest.cs</Link>
+    </Compile>
+    <Compile Include="..\AutoFakeItEasyUnitTest\FixtureIntegrationTest.cs">
+      <Link>FixtureIntegrationTest.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AutoFakeItEasy\AutoFakeItEasy.csproj">
+      <Project>{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}</Project>
+      <Name>AutoFakeItEasy</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj">
+      <Project>{400AC174-9A4A-4C7D-815B-F2A21130A0D1}</Project>
+      <Name>AutoFixture</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj">
+      <Project>{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}</Project>
+      <Name>TestTypeFoundation</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AutoFakeItEasy.FakeItEasy2.UnitTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Ploeh")]
+[assembly: AssemblyProduct("AutoFixture")]
+[assembly: AssemblyCopyright("Copyright © Ploeh 2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e5b03a34-7cea-4bcc-9123-e12349fc932b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("3.50.2.0")]
+[assembly: AssemblyFileVersion("3.50.2.0")]

--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/app.config
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FakeItEasy" publicKeyToken="eff28e2146d5fd2c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/packages.config
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="2.5.2" targetFramework="net40" />
+  <package id="FakeItEasy" version="2.0.0" targetFramework="net40" />
+  <package id="xunit" version="1.8.0.1549" targetFramework="net40" />
+  <package id="xunit.extensions" version="1.8.0.1549" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net40" />
+</packages>

--- a/Src/AutoFakeItEasy.sln
+++ b/Src/AutoFakeItEasy.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy", "AutoFakeI
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasyUnitTest", "AutoFakeItEasyUnitTest\AutoFakeItEasyUnitTest.csproj", "{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy.FakeItEasy2UnitTest", "AutoFakeItEasy.FakeItEasy2UnitTest\AutoFakeItEasy.FakeItEasy2UnitTest.csproj", "{7F957CC0-79C3-48A1-9A3E-47BED7539248}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +50,12 @@ Global
 		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Verify|Any CPU.ActiveCfg = Release|Any CPU
 		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
@@ -74,8 +74,46 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
 
             public object Invoke(IEnumerable<object> parameters)
             {
-                return new Fake<T>(
-                    b => b.WithArgumentsForConstructor(parameters));
+                var genericFakeType = typeof (Fake<>).MakeGenericType(typeof (T));
+
+                foreach (var constructor in genericFakeType.GetConstructors())
+                {
+                    var constructorParameterInfos = constructor.GetParameters();
+                    if (constructorParameterInfos.Length != 1)
+                    {
+                        continue;
+                    }
+
+                    var parameterType = constructorParameterInfos[0].ParameterType;
+                    if (!parameterType.IsGenericType ||
+                        parameterType.GetGenericTypeDefinition() != typeof (Action<>))
+                    {
+                        continue;
+                    }
+
+                    // The parameter is an action of type
+                    // Action<IFakeOptionsBuilder<T>> (FakeItEasy 1.x) or
+                    // Action<IFakeOptions<T>> (FakeItEasy 2.0+).
+                    // Each of the options-type interfaces contains a WithArgumentsForConstructor method
+                    // that we'll use to pass arguments to the fake object's constructor.
+                    var fakeOptionsType = parameterType.GetGenericArguments()[0];
+
+                    var withArgumentsForConstructorMethod = fakeOptionsType.GetMethod(
+                        "WithArgumentsForConstructor",
+                        new[] {typeof (object[])});
+
+                    if (withArgumentsForConstructorMethod == null)
+                    {
+                        continue;
+                    }
+
+                    Action<object> addConstructorArgumentsToOptionsAction =
+                        options => withArgumentsForConstructorMethod.Invoke(options, new object[] {parameters});
+
+                    return constructor.Invoke(new object[] {addConstructorArgumentsToOptionsAction});
+                }
+
+                return null;
             }
         }
     }

--- a/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
+++ b/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
@@ -73,6 +73,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/AutoFakeItEasyUnitTest/app.config
+++ b/Src/AutoFakeItEasyUnitTest/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FakeItEasy" publicKeyToken="eff28e2146d5fd2c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.7.4257.42" newVersion="1.7.4257.42" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Fixes #693.

Resorting to finding the `Fake<T>` constructor by reflection and invoking that one, so we don't rely on it having the same interface as in FakeItEasy 1.0.

The first step was to add a test project for AutoFakeItEasy that targeted FakeItEasy 2.0. I opted to use FakeItEasy 2.2.0 with the tests because that's the version that #693 was reported against, and in this case it seemed that testing for a newer version was a good choice, in contrast to AutoFixture's policy of having the framework depend on the lowest possible version of a library.

Of course if you hate this whole approach to testing FakeItEasy 2.0 integration, or the library version I chose, or anything, I'm happy to make any changes.

The actual fix seems to be functional, but is not optimized. If you like, I could attempt to do so, by caching found constructors, creating  delegates to invoke, or something similar.
Of course, such optimizations could be introduced in later issues/PRs as well…
