### PR TITLE
NUnit3: change the way test name is created so that it doesn't change between discovery and execution

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -62,8 +62,12 @@
     <Compile Include="NoAutoPropertiesAttributeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenario.cs" />
+    <Compile Include="TestNameStrategiesFixture.cs" />
+    <Compile Include="TestNameStrategiesTest.cs" />
     <Compile Include="ThrowingStubFixture.cs" />
     <Compile Include="TypeWithCustomizationAttributes.cs" />
+    <Compile Include="FixedNameTestMethodBuilderTest.cs" />
+    <Compile Include="VolatileNameTestMethodBuilderTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture.NUnit3\AutoFixture.NUnit3.csproj">

--- a/Src/AutoFixture.NUnit3.UnitTest/FixedNameTestMethodBuilderTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/FixedNameTestMethodBuilderTest.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+
+namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    public class FixedNameTestMethodBuilderTest
+    {
+        [Test]
+        public void FixedNameTestMethodBuilderIsResilientToFactoryException()
+        {
+            // Fixture setup
+            var dummyMethod = new MethodWrapper(typeof(TestNameStrategiesFixture), nameof(TestNameStrategiesFixture.FixedNameDecoratedMethod));
+            var sut = new FixedNameTestMethodBuilder();
+            // Exercise system
+            var testMethod = sut.Build(dummyMethod, null, () => throw new Exception(), 0);
+            // Verify outcome
+            Assert.That(testMethod.Name, Is.EqualTo(nameof(TestNameStrategiesFixture.FixedNameDecoratedMethod)));
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
@@ -378,7 +378,7 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
 
         [Theory, AutoData]
         public void NoAutoPropertiesAttributeLeavesPropertiesUnset(
-            [NoAutoProperties]PropertyHolder<object> ph1, 
+            [NoAutoProperties]PropertyHolder<object> ph1,
             [NoAutoProperties]PropertyHolder<string> ph2,
             [NoAutoProperties]PropertyHolder<int> ph3
             )

--- a/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesFixture.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesFixture.cs
@@ -1,0 +1,68 @@
+﻿namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    public class TestNameStrategiesFixture
+    {
+        private static IFixture CreateFixtureWithInjectedValues()
+        {
+            var result = new Fixture();
+            // Make so that fixed values will be returned
+            result.Inject(42);
+            result.Inject("foo");
+            return result;
+        }
+
+        public class AutoDataFixedNameAttribute : AutoDataAttribute
+        {
+            public AutoDataFixedNameAttribute()
+            {
+                TestMethodBuilder = new FixedNameTestMethodBuilder();
+            }
+        }
+
+        public class AutoDataVolatileNameAttribute : AutoDataAttribute
+        {
+            public AutoDataVolatileNameAttribute() : base(CreateFixtureWithInjectedValues())
+            {
+                TestMethodBuilder = new VolatileNameTestMethodBuilder();
+            }
+        }
+
+        public class InlineAutoDataFixedNameAttribute : InlineAutoDataAttribute
+        {
+            public InlineAutoDataFixedNameAttribute(params object[] arguments) 
+                : base(arguments)
+            {
+                TestMethodBuilder = new FixedNameTestMethodBuilder();
+            }
+        }
+
+        public class InlineAutoDataVolatileNameAttribute : InlineAutoDataAttribute
+        {
+            public InlineAutoDataVolatileNameAttribute(params object[] arguments) 
+                : base(CreateFixtureWithInjectedValues(), arguments)
+            {
+                TestMethodBuilder = new VolatileNameTestMethodBuilder();
+            }
+        }
+
+        [AutoDataFixedName]
+        public void FixedNameDecoratedMethod(int expectedNumber, MyClass sut)
+        {
+        }
+
+        [AutoDataVolatileName]
+        public void VolatileNameDecoratedMethod(int expectedNumber, string value)
+        {
+        }
+
+        [InlineAutoDataFixedName("alpha", "beta")]
+        public void InlineFixedNameDecoratedMethod(string p1, string p2, string p3)
+        {
+        }
+
+        [InlineAutoDataVolatileNameAttribute("alpha", "beta")]
+        public void InlineVolatileNameDecoratedMethod(string p1, string p2, string p3)
+        {
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesTest.cs
@@ -1,0 +1,139 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+using System.Linq;
+using static Ploeh.AutoFixture.NUnit3.UnitTest.TestNameStrategiesFixture;
+
+namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    public class TestNameStrategiesTest
+    {
+        [Test]
+        public void AutoDataAttributeUsesRealValueByDefault()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new AutoDataAttribute();
+            // Verify outcome
+            Assert.That(sut.TestMethodBuilder,
+                Is.TypeOf<VolatileNameTestMethodBuilder>());
+            // Teardown
+        }
+
+        [Test]
+        public void InlineAutoDataAttributeUsesRealValueByDefault()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new InlineAutoDataAttribute();
+            // Verify outcome
+            Assert.That(sut.TestMethodBuilder,
+                Is.TypeOf<VolatileNameTestMethodBuilder>());
+            // Teardown
+        }
+
+        [Test]
+        public void AutoDataUsesFixedValuesForTestName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<AutoDataFixedNameAttribute>(nameof(TestNameStrategiesFixture.FixedNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.Name,
+                Is.EqualTo(@"FixedNameDecoratedMethod(auto<Int32>,auto<MyClass>)"));
+            // Teardown
+        }
+
+        [Test]
+        public void AutoDataFixedNameUsesFixedValuesForTestFullName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<AutoDataFixedNameAttribute>(nameof(TestNameStrategiesFixture.FixedNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.FullName,
+                Is.EqualTo(@"Ploeh.AutoFixture.NUnit3.UnitTest.TestNameStrategiesFixture.FixedNameDecoratedMethod(auto<Int32>,auto<MyClass>)"));
+            // Teardown
+        }
+
+        [Test]
+        public void AutoDataVolatileNameUsesRealValuesForTestName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<AutoDataVolatileNameAttribute>(nameof(TestNameStrategiesFixture.VolatileNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.Name,
+                Is.EqualTo(@"VolatileNameDecoratedMethod(42,""foo"")"));
+            // Teardown
+        }
+
+        [Test]
+        public void AutoDataVolatileNameUsesRealValuesForTestFullName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<AutoDataVolatileNameAttribute>(nameof(TestNameStrategiesFixture.VolatileNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.FullName,
+                Is.EqualTo(@"Ploeh.AutoFixture.NUnit3.UnitTest.TestNameStrategiesFixture.VolatileNameDecoratedMethod(42,""foo"")"));
+            // Teardown
+        }
+
+        [Test]
+        public void InlineAutoDataUsesFixedValuesForTestName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<InlineAutoDataFixedNameAttribute>(nameof(TestNameStrategiesFixture.InlineFixedNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.Name,
+                Is.EqualTo(@"InlineFixedNameDecoratedMethod(""alpha"",""beta"",auto<String>)"));
+            // Teardown
+        }
+
+        [Test]
+        public void InlineAutoDataFixedNameUsesFixedValuesForTestFullName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<InlineAutoDataFixedNameAttribute>(nameof(TestNameStrategiesFixture.InlineFixedNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.FullName,
+                Is.EqualTo(@"Ploeh.AutoFixture.NUnit3.UnitTest.TestNameStrategiesFixture.InlineFixedNameDecoratedMethod(""alpha"",""beta"",auto<String>)"));
+            // Teardown
+        }
+
+        [Test]
+        public void InlineAutoDataVolatileNameUsesRealValuesForTestName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<InlineAutoDataVolatileNameAttribute>(nameof(TestNameStrategiesFixture.InlineVolatileNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.Name,
+                Is.EqualTo(@"InlineVolatileNameDecoratedMethod(""alpha"",""beta"",""foo"")"));
+            // Teardown
+        }
+
+        [Test]
+        public void InlineAutoDataVolatileNameUsesRealValuesForFullName()
+        {
+            // Fixture setup
+            // Exercise system
+            var testMethod = GetTestMethod<InlineAutoDataVolatileNameAttribute>(nameof(TestNameStrategiesFixture.InlineVolatileNameDecoratedMethod));
+            // Verify outcome
+            Assert.That(testMethod.FullName,
+                Is.EqualTo(@"Ploeh.AutoFixture.NUnit3.UnitTest.TestNameStrategiesFixture.InlineVolatileNameDecoratedMethod(""alpha"",""beta"",""foo"")"));
+            // Teardown
+        }
+
+        private static TestMethod GetTestMethod<TAttribute>(string testName) where TAttribute : Attribute, NUnit.Framework.Interfaces.ITestBuilder
+        {
+            var method = new MethodWrapper(typeof(TestNameStrategiesFixture), testName);
+            var inlineAttribute = (TAttribute)Attribute.GetCustomAttribute(method.MethodInfo, typeof(TAttribute));
+            var testMethod = inlineAttribute.BuildFrom(method, null).Single();
+            return testMethod;
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/VolatileNameTestMethodBuilderTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/VolatileNameTestMethodBuilderTest.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+
+namespace Ploeh.AutoFixture.NUnit3.UnitTest
+{
+    public class VolatileNameTestMethodBuilderTest
+    {
+        [Test]
+        public void VolatileNameTestMethodBuilderIsResilientToFactoryException()
+        {
+            // Fixture setup
+            var anyMethod = new MethodWrapper(typeof(TestNameStrategiesFixture), nameof(TestNameStrategiesFixture.VolatileNameDecoratedMethod));
+            var sut = new VolatileNameTestMethodBuilder();
+            // Exercise system
+            var testMethod = sut.Build(anyMethod, null, () => throw new Exception(), 0);
+            // Verify outcome
+            Assert.That(testMethod.Name, Is.EqualTo(nameof(TestNameStrategiesFixture.VolatileNameDecoratedMethod)));
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -5,6 +5,7 @@ using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
 using Ploeh.AutoFixture.Kernel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Ploeh.AutoFixture.NUnit3
 {
@@ -12,11 +13,22 @@ namespace Ploeh.AutoFixture.NUnit3
     /// This attribute uses AutoFixture to generate values for unit test parameters. 
     /// This implementation is based on TestCaseAttribute of NUnit3
     /// </summary>
+    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", 
+        Justification = "This attribute is the root of a potential attribute hierarchy.")]
     [AttributeUsage(AttributeTargets.Method)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class AutoDataAttribute : Attribute, ITestBuilder
     {
         private readonly IFixture _fixture;
+
+        private ITestMethodBuilder _testMethodBuilder = new VolatileNameTestMethodBuilder();
+        /// <summary>
+        /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.
+        /// </summary>
+        public ITestMethodBuilder TestMethodBuilder
+        {
+            get => _testMethodBuilder;
+            set => _testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         /// <summary>
         /// Construct a <see cref="AutoDataAttribute"/>
@@ -49,31 +61,14 @@ namespace Ploeh.AutoFixture.NUnit3
         /// <returns>One or more TestMethods</returns>
         public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
-            var test = new NUnitTestCaseBuilder().BuildTestMethod(method, suite, this.GetParametersForMethod(method));
+            var test = this.TestMethodBuilder.Build(method, suite, () => GetParameterValues(method).ToArray(), 0);
 
             yield return test;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "This method is always expected to return an instance of the TestCaseParameters class.")]
-        private TestCaseParameters GetParametersForMethod(IMethodInfo method)
+        private IEnumerable<object> GetParameterValues(IMethodInfo method)
         {
-            try
-            {
-                var parameters = method.GetParameters();
-
-                var parameterValues = this.GetParameterValues(parameters);
-
-                return new TestCaseParameters(parameterValues.ToArray());
-            }
-            catch (Exception ex)
-            {
-                return new TestCaseParameters(ex);
-            }
-        }
-
-        private IEnumerable<object> GetParameterValues(IEnumerable<IParameterInfo> parameters)
-        {
-            return parameters.Select(Resolve);
+            return method.GetParameters().Select(Resolve);
         }
 
         private object Resolve(IParameterInfo parameterInfo)

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -71,6 +71,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FixedNameTestMethodBuilder.cs" />
     <Compile Include="InlineAutoDataAttribute.cs" />
     <Compile Include="AutoDataAttribute.cs" />
     <Compile Include="CustomizeAttribute.cs" />
@@ -84,6 +85,8 @@
     <Compile Include="ModestAttribute.cs" />
     <Compile Include="NoAutoPropertiesAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VolatileNameTestMethodBuilder.cs" />
+    <Compile Include="ITestMethodBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj">

--- a/Src/AutoFixture.NUnit3/FixedNameTestMethodBuilder.cs
+++ b/Src/AutoFixture.NUnit3/FixedNameTestMethodBuilder.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Ploeh.AutoFixture.NUnit3
+{
+    /// <summary>
+    /// Builder that generates <see cref="TestMethod"/> with fixed names.
+    /// This might be needed by some test runners to correctly identify tests between the discovery and execution
+    /// (e.g. Nunit test adaptor for Visual Studio, NCrunch).
+    /// </summary>
+    public class FixedNameTestMethodBuilder : ITestMethodBuilder
+    {
+        /// <inheritdoc />
+        public virtual TestMethod Build(IMethodInfo method, Test suite, Func<object[]> argsFactory, int autoDataStartIndex)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (argsFactory == null)
+            {
+                throw new ArgumentNullException(nameof(argsFactory));
+            }
+
+            return new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForMethod(method, argsFactory, autoDataStartIndex));
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+            Justification = "This method is always expected to return an instance of the TestCaseParameters class.")]
+        private static TestCaseParameters GetParametersForMethod(IMethodInfo method, Func<object[]> argFactory, int autoDataStartIndex)
+        {
+            try
+            {
+                var parameterValues = argFactory();
+                return GetParametersForMethod(method, parameterValues.ToArray(), autoDataStartIndex);
+            }
+            catch (Exception ex)
+            {
+                return new TestCaseParameters(ex);
+            }
+        }
+
+        private static TestCaseParameters GetParametersForMethod(IMethodInfo method, object[] args, int autoDataStartIndex)
+        {
+            var result = new TestCaseParameters(args);
+
+            EnsureOriginalArgumentsArrayIsNotShared(result);
+
+            var methodParameters = method.GetParameters();
+            for (int i = autoDataStartIndex; i < result.OriginalArguments.Length; i++)
+            {
+                result.OriginalArguments[i] = new TypeNameRenderer(methodParameters[i].ParameterType);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Before NUnit 3.5 the Arguments and OriginalArguments properties are referencing the same array, so
+        /// we cannot safely update the OriginalArguments without touching the Arguments value.
+        /// This method fixes that by making the OriginalArguments array a standalone copy.
+        /// <para>
+        /// When running in NUnit3.5 and later the method is supposed to do nothing.
+        /// </para>
+        /// </summary>
+        private static void EnsureOriginalArgumentsArrayIsNotShared(TestCaseParameters parameters)
+        {
+            if (ReferenceEquals(parameters.Arguments, parameters.OriginalArguments))
+            {
+                var clonedArguments = new object[parameters.OriginalArguments.Length];
+                Array.Copy(parameters.OriginalArguments, clonedArguments, parameters.OriginalArguments.Length);
+                
+                // Unfortunately the property has a private setter, so can be updated via reflection only.
+                // Should use the type where the property is declared as otherwise the private setter is not available.
+                var property = typeof(TestParameters).GetProperty(nameof(TestCaseParameters.OriginalArguments));
+                property.SetValue(parameters, clonedArguments, null);
+            }
+        }
+
+        private class TypeNameRenderer
+        {
+            public Type Type { get; }
+
+            public TypeNameRenderer(Type type)
+            {
+                this.Type = type ?? throw new ArgumentNullException(nameof(type));
+            }
+
+            public override string ToString()
+            {
+                return "auto<" + this.Type.Name + ">";
+            }
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/ITestMethodBuilder.cs
+++ b/Src/AutoFixture.NUnit3/ITestMethodBuilder.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using System;
+
+namespace Ploeh.AutoFixture.NUnit3
+{
+    /// <summary>
+    /// Utility used to create a <see cref="TestMethod"/> instance.
+    /// </summary>
+    public interface ITestMethodBuilder
+    {
+        /// <summary>
+        /// Builds a <see cref="TestCaseParameters"/> from a method and the argument values.
+        /// </summary>
+        /// <param name="method">The <see cref="IMethodInfo"/> for which tests are to be constructed.</param>
+        /// <param name="suite">The suite to which the tests will be added.</param>
+        /// <param name="argsFactory">The argument values generated for the test case.</param>
+        /// <param name="autoDataStartIndex">Index at which the automatically generated values start.</param>
+        TestMethod Build(IMethodInfo method, Test suite, Func<object[]> argsFactory, int autoDataStartIndex);
+    }
+}

--- a/Src/AutoFixture.NUnit3/VolatileNameTestMethodBuilder.cs
+++ b/Src/AutoFixture.NUnit3/VolatileNameTestMethodBuilder.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework.Internal.Builders;
+
+namespace Ploeh.AutoFixture.NUnit3
+{
+    /// Creates <see cref="TestMethod"/> instances with name that includes actual argument values.
+    /// Name is volatile and varies on the argument values.
+    public class VolatileNameTestMethodBuilder : ITestMethodBuilder
+    {
+        /// <inheritdoc />
+        public TestMethod Build(IMethodInfo method, Test suite, Func<object[]> argsFactory, int autoDataStartIndex)
+        {
+            if (method == null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (argsFactory == null)
+            {
+                throw new ArgumentNullException(nameof(argsFactory));
+            }
+
+            return new NUnitTestCaseBuilder().BuildTestMethod(method, suite, GetParametersForMethod(argsFactory));
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", 
+            Justification = "This method is always expected to return an instance of the TestCaseParameters class.")]
+        private static TestCaseParameters GetParametersForMethod(Func<object[]> argsFactory)
+        {
+            try
+            {
+                var parameterValues = argsFactory.Invoke();
+                return GetParametersForMethod(parameterValues.ToArray());
+            }
+            catch (Exception ex)
+            {
+                return new TestCaseParameters(ex);
+            }
+        }
+
+        private static TestCaseParameters GetParametersForMethod(object[] args)
+        {
+            return new TestCaseParameters(args);
+        }
+    }
+}


### PR DESCRIPTION
There are some problems when using the test explorer for running tests that use the AutoData / InlineAutoData attributes. When the parameter values are converted as string for generating the test name, the name contains the value that will change each time AutoFixture is requested to produce a value. In Visual Studio there are two distinct steps: discovery and execution. Because of the test name that changes constantly the test framework will fail at running/debuggin the test. Here are the steps to reproduce:
1. Create an empty C# project and add the Autofixture.NUnit3 and NUnit3TestAdapter packages
2. Declare one simple method: `[Test, AutoData]
   public void SomeMethod(string unfixedArgumentProducedByTheGreatAutofixture) { }`
3. Go to the Test Explorer, it displays one test SomeMethod("<some value that constantly change from one discovery / execution to another>")
4. Try to Run/Debug -> doesn't work

This can be reproduced with any primitive type, string, or types/structs whose ToString() method shows the property values that have been created by AutoFixture (Version, Guid, StringBuider...).

Even if there was no such error, I don't think there is real value to display values that constantly change. The only benefit would be _if_ a test randomly fails because of a particular value but that's very unlikely in general. This PR make it so that:
- AutoData: the test name and full test name will display respectively **SomeMethod(auto<string>)** and **NameSpace.SomeMethod(auto<string>)**
- InlineAutoData: the test name and full test name will display respectively **SomeMethod("fixed value 1", "fixed value 2"..., auto<string>, auto<MyClass>)** and **NameSpace.SomeMethod("fixed value 1", "fixed value 2"..., auto<string>, auto<MyClass>)**
