### PR TITLE
Introduce MinLength attribute support

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Ploeh.TestTypeFoundation;
 using Xunit;
@@ -415,6 +416,13 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             FieldHolder<string> p2)
         {
             Assert.NotEqual(p1, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void LongStringLengthConstraint([MinLength(50)]string p)
+        {
+            const int expectedLongString = 50;
+            Assert.True(p.Length == expectedLongString);
         }
     }
 }

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -98,6 +98,7 @@
   <ItemGroup>
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
+    <Compile Include="DataAnnotations\MinLengthAttributeRelay.cs" />
     <Compile Include="DomainName.cs" />
     <Compile Include="DomainNameGenerator.cs" />
     <Compile Include="ElementsBuilder.cs" />

--- a/Src/AutoFixture/DataAnnotations/MinLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/MinLengthAttributeRelay.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.DataAnnotations
+{
+    /// <summary>
+    /// Relays a request for a constrained string to a <see cref="ConstrainedStringRequest"/>.
+    /// </summary>
+    public class MinLengthAttributeRelay : ISpecimenBuilder
+    {
+        /// <summary>
+        /// Creates a new specimen based on a specified length of characters that are allowed.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A container that can be used to create other specimens.</param>
+        /// <returns>
+        /// A specimen created from a <see cref="ConstrainedStringRequest"/> encapsulating the 
+        /// minimum and the maximum of the requested number, if possible; otherwise,
+        /// a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request == null)
+            {
+                return new NoSpecimen();
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var customAttributeProvider = request as ICustomAttributeProvider;
+            if (customAttributeProvider == null)
+            {
+                return new NoSpecimen();
+            }
+
+            var minLengthAttribute = customAttributeProvider.GetCustomAttributes(typeof(MinLengthAttribute), inherit: true).Cast<MinLengthAttribute>().SingleOrDefault();
+            if (minLengthAttribute == null)
+            {
+                return new NoSpecimen();
+            }
+
+            return context.Resolve(new ConstrainedStringRequest(minLengthAttribute.Length, minLengthAttribute.Length));
+        }
+    }
+}

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -123,6 +123,7 @@ namespace Ploeh.AutoFixture
                                     new NullableEnumRequestSpecification()),
                                 new RangeAttributeRelay(),
                                 new StringLengthAttributeRelay(),
+                                new MinLengthAttributeRelay(),
                                 new RegularExpressionAttributeRelay(),
                                 new EnumGenerator(),
                                 new LambdaExpressionGenerator(),

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -95,6 +95,7 @@
     <Compile Include="AbstractRecursionIssue\ItemBase.cs" />
     <Compile Include="AbstractRecursionIssue\ItemLocation.cs" />
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
+    <Compile Include="DataAnnotations\MinLengthAttributeRelayTest.cs" />
     <Compile Include="DomainNameGeneratorTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="ElementsBuilderTest.cs" />

--- a/Src/AutoFixtureUnitTest/DataAnnotations/MinLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/MinLengthAttributeRelayTest.cs
@@ -92,7 +92,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
             // Fixture setup
             var minLengthAttribute = new MinLengthAttribute(length);
             var providedAttribute = new ProvidedAttribute(minLengthAttribute, true);
-            ICustomAttributeProvider request = new FakeCustomAttributeProvider(providedAttribute);
+            ICustomAttributeProvider request = new FakeMemberInfo(providedAttribute);
             var expectedRequest = new ConstrainedStringRequest(minLengthAttribute.Length, minLengthAttribute.Length);
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext

--- a/Src/AutoFixtureUnitTest/DataAnnotations/MinLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/MinLengthAttributeRelayTest.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Ploeh.AutoFixture.DataAnnotations;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
+{
+    public class MinLengthAttributeRelayTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new MinLengthAttributeRelay();
+            // Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullRequestReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new MinLengthAttributeRelay();
+            // Exercise system
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(null, dummyContext);
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(), result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            // Fixture setup
+            var sut = new MinLengthAttributeRelay();
+            var dummyRequest = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(dummyRequest, null));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithAnonymousRequestReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new MinLengthAttributeRelay();
+            var dummyRequest = new object();
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = sut.Create(dummyRequest, dummyContainer);
+            // Verify outcome
+            var expectedResult = new NoSpecimen();
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(Version))]
+        public void CreateWithNonConstrainedStringRequestReturnsCorrectResult(object request)
+        {
+            // Fixture setup
+            var sut = new MinLengthAttributeRelay();
+            // Exercise system
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(request, dummyContext);
+            // Verify outcome
+            var expectedResult = new NoSpecimen();
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void CreateWithConstrainedStringRequestReturnsCorrectResult(int length)
+        {
+            // Fixture setup
+            var minLengthAttribute = new MinLengthAttribute(length);
+            var providedAttribute = new ProvidedAttribute(minLengthAttribute, true);
+            ICustomAttributeProvider request = new FakeCustomAttributeProvider(providedAttribute);
+            var expectedRequest = new ConstrainedStringRequest(minLengthAttribute.Length, minLengthAttribute.Length);
+            var expectedResult = new object();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+            };
+            var sut = new MinLengthAttributeRelay();
+            // Exercise system
+            var result = sut.Create(request, context);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
Closes #678 for v4 (which is based on .NET4.5).
