### PR TITLE
Refactored collections to support derived collection types

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <Compile Include="AutoPropertiesTarget.cs" />
     <Compile Include="BehaviorRoot.cs" />
+    <Compile Include="CollectionFillerCommand.cs" />
     <Compile Include="DomainName.cs" />
     <Compile Include="DomainNameGenerator.cs" />
     <Compile Include="ElementsBuilder.cs" />

--- a/Src/AutoFixture/CollectionFillerCommand.cs
+++ b/Src/AutoFixture/CollectionFillerCommand.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Ploeh.AutoFixture.Kernel;
+using System.Linq;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Contains methods for populating collections with specimens.
+    /// </summary>
+    public class CollectionFillerCommand : ISpecimenCommand
+    {
+        /// <summary>
+        /// Adds many items to a collection.
+        /// </summary>
+        /// <param name="specimen">The collection to which items should be added.</param>
+        /// <param name="context">The context which can be used to resolve other specimens.</param>
+        /// <remarks>
+        /// <para>
+        /// This method mainly exists to support AutoFixture's infrastructure code (particularly
+        /// <see cref="MultipleCustomization" /> and is not intended for use in user code.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="specimen"/> is not an instance of <see cref="ICollection{T}" />.
+        /// </exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use the instance method Execute instead.")]
+        public static void AddMany(object specimen, ISpecimenContext context)
+        {
+            new CollectionFillerCommand().Execute(specimen, context);
+        }
+
+        /// <summary>
+        /// Adds many items to a collection.
+        /// </summary>
+        /// <param name="specimen">The collection to which items should be added.</param>
+        /// <param name="context">The context which can be used to resolve other specimens.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="specimen"/> is not an instance of <see cref="ICollection{T}" />.
+        /// </exception>
+        public void Execute(object specimen, ISpecimenContext context)
+        {
+            if (specimen == null)
+                throw new ArgumentNullException(nameof(specimen));
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            var typeArguments = GetInheritedCollectionGenericArguments(specimen.GetType());
+            if (typeArguments.Length != 1)
+                throw new ArgumentException("The specimen must be an instance of ICollection<T>.", nameof(specimen));
+
+            if (!typeof(ICollection<>).MakeGenericType(typeArguments).IsAssignableFrom(specimen.GetType()))
+                throw new ArgumentException("The specimen must be an instance of ICollection<T>.", nameof(specimen));
+
+            var filler = (ISpecimenCommand)Activator.CreateInstance(
+                typeof(Filler<>).MakeGenericType(typeArguments));
+            filler.Execute(specimen, context);
+        }
+
+        private static Type[] GetInheritedCollectionGenericArguments(Type type)
+        {
+            var collectionInterfaces =
+                from i in type.GetInterfaces()
+                where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICollection<>)
+                select i;
+
+            var collectionInterface = collectionInterfaces.FirstOrDefault();
+            return collectionInterface == null 
+                ? new Type[0] 
+                : collectionInterface.GetGenericArguments();
+        }
+
+        private class Filler<TValue> : ISpecimenCommand
+        {
+            public void Execute(object specimen, ISpecimenContext context)
+            {
+                Fill((ICollection<TValue>)specimen, context);
+            }
+
+            private static void Fill(
+                ICollection<TValue> collection,
+                ISpecimenContext context)
+            {
+                foreach (var kvp in GetValues(context))
+                    collection.Add(kvp);
+            }
+
+            private static IEnumerable<TValue> GetValues(
+                ISpecimenContext context)
+            {
+                return
+                    ((IEnumerable)context.Resolve(
+                        new MultipleRequest(typeof(TValue))))
+                    .Cast<TValue>();
+            }
+        }
+    }
+}

--- a/Src/AutoFixture/DictionaryFiller.cs
+++ b/Src/AutoFixture/DictionaryFiller.cs
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixture
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            var typeArguments = specimen.GetType().GetGenericArguments();
+            var typeArguments = GetInheritedDictionaryGenericArguments(specimen.GetType());
             if (typeArguments.Length != 2)
                 throw new ArgumentException("The specimen must be an instance of IDictionary<TKey, TValue>.", nameof(specimen));
 
@@ -58,6 +58,19 @@ namespace Ploeh.AutoFixture
             var filler = (ISpecimenCommand)Activator.CreateInstance(
                 typeof(Filler<,>).MakeGenericType(typeArguments));
             filler.Execute(specimen, context);
+        }
+
+        private static Type[] GetInheritedDictionaryGenericArguments(Type type)
+        {
+            var dictionaryInterfaces =
+                from i in type.GetInterfaces()
+                where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                select i;
+
+            var dictionaryInterface = dictionaryInterfaces.FirstOrDefault();
+            return dictionaryInterface == null
+                ? new Type[0]
+                : dictionaryInterface.GetGenericArguments();
         }
 
         private class Filler<TKey, TValue> : ISpecimenCommand

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -89,34 +89,8 @@ namespace Ploeh.AutoFixture
                                     new Postprocessor(
                                         new MethodInvoker(
                                             new ModestConstructorQuery()),
-                                        new DictionaryFiller()),
-                                    new SortedDictionarySpecification()),
-                                new FilteringSpecimenBuilder(
-                                    new Postprocessor(
-                                        new MethodInvoker(
-                                            new ModestConstructorQuery()),
-                                        new DictionaryFiller()),
-                                    new SortedListSpecification()),
-                                new FilteringSpecimenBuilder(
-                                    new MethodInvoker(
-                                        new EnumerableFavoringConstructorQuery()),
-                                    new ObservableCollectionSpecification()),
-                                new FilteringSpecimenBuilder(
-                                    new MethodInvoker(
-                                        new ListFavoringConstructorQuery()),
+                                        new CollectionFillerCommand()),
                                     new CollectionSpecification()),
-                                new FilteringSpecimenBuilder(
-                                    new MethodInvoker(
-                                        new EnumerableFavoringConstructorQuery()),
-                                    new HashSetSpecification()),
-                                new FilteringSpecimenBuilder(
-                                    new MethodInvoker(
-                                        new EnumerableFavoringConstructorQuery()),
-                                    new SortedSetSpecification()),
-                                new FilteringSpecimenBuilder(
-                                    new MethodInvoker(
-                                        new EnumerableFavoringConstructorQuery()),
-                                    new ListSpecification()),
                                 new FilteringSpecimenBuilder(
                                     new MethodInvoker(
                                         new ModestConstructorQuery()),

--- a/Src/AutoFixture/Kernel/CollectionSpecification.cs
+++ b/Src/AutoFixture/Kernel/CollectionSpecification.cs
@@ -1,22 +1,24 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Ploeh.AutoFixture.Kernel
 {
     /// <summary>
-    /// Encapsulates logic that determines whether a request is a request for a
-    /// <see cref="Collection{T}"/>.
+    /// Encapsulates logic that determines whether a request is a request for an
+    /// <see cref="ICollection{T}"/>.
     /// </summary>
     public class CollectionSpecification : IRequestSpecification
     {
         /// <summary>
-        /// Evaluates a request for a specimen to determine whether it's a request for a
-        /// <see cref="Collection{T}"/>.
+        /// Evaluates a request for a specimen to determine whether it's a request for an
+        /// <see cref="ICollection{T}"/>.
         /// </summary>
         /// <param name="request">The specimen request.</param>
         /// <returns>
-        /// <see langword="true"/> if <paramref name="request"/> is a request for a
-        /// <see cref="Collection{T}" />; otherwise, <see langword="false"/>.
+        /// <see langword="true"/> if <paramref name="request"/> is a request for an
+        /// <see cref="ICollection{T}" />; otherwise, <see langword="false"/>.
         /// </returns>
         public bool IsSatisfiedBy(object request)
         {
@@ -26,8 +28,47 @@ namespace Ploeh.AutoFixture.Kernel
                 return false;
             }
 
-            return type.IsGenericType
-                && typeof(Collection<>) == type.GetGenericTypeDefinition();
+            // Do not allow interfaces, abstract classes, or other types that cannot be constructed
+            if (!type.GetConstructors().Any())
+            {
+                return false;
+            }
+
+            // Arrays are read-only and cannot be filled
+            if (type.IsArray)
+            {
+                return false;
+            }
+
+            // Read-only collections cannot be filled
+            if (IsReadOnlyCollection(type))
+            {
+                return false;
+            }
+
+            var collectionInterfaces =
+                from i in type.GetInterfaces()
+                where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICollection<>)
+                select i;
+
+            return collectionInterfaces.Any();
+        }
+
+        private static bool IsReadOnlyCollection(Type type)
+        {
+            // TODO: After updating to .Net 4.5, simply check for inheriting from interface IReadOnlyDictionary<,>
+
+            if (type == typeof(object))
+            {
+                return false;
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ReadOnlyCollection<>))
+            {
+                return true;
+            }
+
+            return IsReadOnlyCollection(type.BaseType);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/DictionarySpecification.cs
+++ b/Src/AutoFixture/Kernel/DictionarySpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -15,7 +16,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <param name="request">The specimen request.</param>
         /// <returns>
         /// <see langword="true"/> if <paramref name="request"/> is a request for a
-        /// <see cref="Dictionary{TKey, TValue}" />; otherwise, <see langword="false"/>.
+        /// <see cref="IDictionary{TKey, TValue}" />; otherwise, <see langword="false"/>.
         /// </returns>
         public bool IsSatisfiedBy(object request)
         {
@@ -25,8 +26,19 @@ namespace Ploeh.AutoFixture.Kernel
                 return false;
             }
 
-            return type.IsGenericType
-                && typeof(Dictionary<,>) == type.GetGenericTypeDefinition();
+            if (!type.GetConstructors().Any())
+            {
+                return false;
+            }
+
+            // TODO: After updating to .Net 4.5, check for IReadOnlyDictionary<,>
+
+            var dictionaryInterfaces =
+                from i in type.GetInterfaces()
+                where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                select i;
+
+            return dictionaryInterfaces.Any();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/HashSetSpecification.cs
+++ b/Src/AutoFixture/Kernel/HashSetSpecification.cs
@@ -7,6 +7,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// Encapsulates logic that determines whether a request is a request for a
     /// <see cref="HashSet{T}"/>.
     /// </summary>
+    [Obsolete("Please move over to using CollectionSpecification as that class now generically handles the HashSet functionality.")]
     public class HashSetSpecification : IRequestSpecification
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/ListSpecification.cs
+++ b/Src/AutoFixture/Kernel/ListSpecification.cs
@@ -7,6 +7,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// Encapsulates logic that determines whether a request is a request for a
     /// <see cref="List{T}"/>.
     /// </summary>
+    [Obsolete("Please move over to using CollectionSpecification as that class now generically handles the List functionality.")]
     public class ListSpecification : IRequestSpecification
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/ObservableCollectionSpecification.cs
+++ b/Src/AutoFixture/Kernel/ObservableCollectionSpecification.cs
@@ -7,6 +7,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// Encapsulates logic that determines whether a request is a request for a
     /// <see cref="ObservableCollection{T}"/>.
     /// </summary>
+    [Obsolete("Please move over to using CollectionSpecification as that class now generically handles the ObservableCollection functionality.")]
     public class ObservableCollectionSpecification : IRequestSpecification
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
@@ -7,6 +7,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// Encapsulates logic that determines whether a request is a request for a
     /// <see cref="SortedDictionary{TKey, TValue}"/>.
     /// </summary>
+    [Obsolete("Please move over to using DictionarySpecification as that class now generically handles the SortedDictionary functionality.")]
     public class SortedDictionarySpecification : IRequestSpecification
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/SortedListSpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedListSpecification.cs
@@ -7,6 +7,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// Encapsulates logic that determines whether a request is a request for a
     /// <see cref="SortedList{TKey,TValue}"/>.
     /// </summary>
+    [Obsolete("Please move over to using DictionarySpecification as that class now generically handles the SortedList functionality.")]
     public class SortedListSpecification : IRequestSpecification
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/SortedSetSpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedSetSpecification.cs
@@ -7,6 +7,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// Encapsulates logic that determines whether a request is a request for a
     /// <see cref="SortedSet{T}"/>.
     /// </summary>
+    [Obsolete("Please move over to using CollectionSpecification as that class now generically handles the SortedSet functionality.")]
     public class SortedSetSpecification : IRequestSpecification
     {
         /// <summary>

--- a/Src/AutoFixture/MultipleCustomization.cs
+++ b/Src/AutoFixture/MultipleCustomization.cs
@@ -58,19 +58,11 @@ namespace Ploeh.AutoFixture
                     new DictionarySpecification()));
             fixture.Customizations.Add(
                 new FilteringSpecimenBuilder(
-                    new MethodInvoker(
-                        new ListFavoringConstructorQuery()),
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()),
+                        new CollectionFillerCommand()),
                     new CollectionSpecification()));
-            fixture.Customizations.Add(
-                new FilteringSpecimenBuilder(
-                    new MethodInvoker(
-                        new EnumerableFavoringConstructorQuery()),
-                    new HashSetSpecification()));
-            fixture.Customizations.Add(
-                new FilteringSpecimenBuilder(
-                    new MethodInvoker(
-                        new EnumerableFavoringConstructorQuery()),
-                    new ListSpecification()));
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AbstractRecursionIssue\ItemBase.cs" />
     <Compile Include="AbstractRecursionIssue\ItemLocation.cs" />
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
+    <Compile Include="CollectionFillerCommandTest.cs" />
     <Compile Include="DomainNameGeneratorTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="ElementsBuilderTest.cs" />

--- a/Src/AutoFixtureUnitTest/CollectionFillerCommandTest.cs
+++ b/Src/AutoFixtureUnitTest/CollectionFillerCommandTest.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class CollectionFillerCommandTest
+    {
+#pragma warning disable 618
+        [Fact]
+        public void AddManyToNullSpecimenThrows()
+        {
+            // Fixture setup
+            var dummyContext = new DelegatingSpecimenContext();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CollectionFillerCommand.AddMany(null, dummyContext));
+            // Teardown
+        }
+
+        [Fact]
+        public void AddManyWithNullContextThrows()
+        {
+            // Fixture setup
+            var dummyCollection = new List<object>();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CollectionFillerCommand.AddMany(dummyCollection, null));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        public void AddManyToNonCollectionThrows(object specimen)
+        {
+            // Fixture setup
+            var dummyContext = new DelegatingSpecimenContext();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentException>(() =>
+                CollectionFillerCommand.AddMany(specimen, dummyContext));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(List<int>))]
+        [InlineData(typeof(HashSet<int>))]
+        [InlineData(typeof(ObservableCollection<int>))]
+        [InlineData(typeof(SortedSet<int>))]
+        [InlineData(typeof(LinkedList<int>))]
+        [InlineData(typeof(DerivedCollection))]
+        public void AddManyFillsCollection(Type collectionType)
+        {
+            // Fixture setup
+            var collection = (ICollection<int>)Activator.CreateInstance(collectionType);
+
+            var expectedRequest = new MultipleRequest(typeof(int));
+            var expectedResult = Enumerable.Range(1, 3);
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)expectedResult : new NoSpecimen(r) };
+            // Exercise system
+            CollectionFillerCommand.AddMany(collection, context);
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(collection));
+            // Teardown
+        }
+#pragma warning restore 618
+
+        [Fact]
+        public void SutIsSpecimenCommand()
+        {
+            var sut = new CollectionFillerCommand();
+            Assert.IsAssignableFrom<ISpecimenCommand>(sut);
+        }
+
+        [Fact]
+        public void ExecuteNullSpecimenThrows()
+        {
+            var sut = new CollectionFillerCommand();
+            var dummyContext = new DelegatingSpecimenContext();
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Execute(null, dummyContext));
+        }
+
+        [Fact]
+        public void ExecuteNullContextThrows()
+        {
+            var sut = new CollectionFillerCommand();
+            var dummyCollection = new List<object>();
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Execute(dummyCollection, null));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        public void ExecuteNonCollectionThrows(object specimen)
+        {
+            // Fixture setup
+            var sut = new CollectionFillerCommand();
+            var dummyContext = new DelegatingSpecimenContext();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentException>(() =>
+                sut.Execute(specimen, dummyContext));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(List<int>))]
+        [InlineData(typeof(HashSet<int>))]
+        [InlineData(typeof(ObservableCollection<int>))]
+        [InlineData(typeof(SortedSet<int>))]
+        [InlineData(typeof(LinkedList<int>))]
+        [InlineData(typeof(DerivedCollection))]
+        public void ExecuteFillsCollection(Type collectionType)
+        {
+            // Fixture setup
+            var collection = (ICollection<int>)Activator.CreateInstance(collectionType);
+
+            var expectedRequest = new MultipleRequest(typeof(int));
+            var expectedResult = Enumerable.Range(1, 3);
+#pragma warning disable 618
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)expectedResult : new NoSpecimen(r) };
+#pragma warning restore 618
+
+            var sut = new CollectionFillerCommand();
+            // Exercise system
+            sut.Execute(collection, context);
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(collection));
+            // Teardown
+        }
+
+        [Fact]
+        public void DoesNotThrowWithDuplicateEntries()
+        {
+            // Fixture setup
+            var collection = new List<int>();
+
+            var request = new MultipleRequest(typeof(int));
+            var sequence = Enumerable.Repeat(0, 3);
+#pragma warning disable 618
+            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? (object)sequence : new NoSpecimen(r) };
+#pragma warning restore 618
+
+            var sut = new CollectionFillerCommand();
+            // Exercise system & Verify outcome
+            Assert.DoesNotThrow(() => sut.Execute(collection, context));
+            // Teardown
+        }
+
+        private class DerivedCollection : Collection<int>
+        { }
+    }
+}

--- a/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
+++ b/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Ploeh.AutoFixture;
@@ -52,11 +53,16 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact]
-        public void AddManyFillsDictionary()
+        [Theory]
+        [InlineData(typeof(Dictionary<int, string>))]
+        [InlineData(typeof(SortedDictionary<int, string>))]
+        [InlineData(typeof(SortedList<int, string>))]
+        [InlineData(typeof(ConcurrentDictionary<int, string>))]
+        [InlineData(typeof(DerivedDictionary))]
+        public void AddManyFillsDictionary(Type dictionaryType)
         {
             // Fixture setup
-            var dictionary = new Dictionary<int, string>();
+            var dictionary = (IDictionary<int, string>)Activator.CreateInstance(dictionaryType);
 
             var expectedRequest = new MultipleRequest(typeof(KeyValuePair<int, string>));
             var expectedResult = Enumerable.Range(1, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
@@ -113,11 +119,16 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact]
-        public void ExecuteFillsDictionary()
+        [Theory]
+        [InlineData(typeof(Dictionary<int, string>))]
+        [InlineData(typeof(SortedDictionary<int, string>))]
+        [InlineData(typeof(SortedList<int, string>))]
+        [InlineData(typeof(ConcurrentDictionary<int, string>))]
+        [InlineData(typeof(DerivedDictionary))]
+        public void ExecuteFillsDictionary(Type dictionaryType)
         {
             // Fixture setup
-            var dictionary = new Dictionary<int, string>();
+            var dictionary = (IDictionary<int, string>)Activator.CreateInstance(dictionaryType);
 
             var expectedRequest = new MultipleRequest(typeof(KeyValuePair<int, string>));
             var expectedResult = Enumerable.Range(1, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
@@ -150,5 +161,8 @@ namespace Ploeh.AutoFixtureUnitTest
             Assert.DoesNotThrow(() => sut.Execute(dictionary, context));
             // Teardown
         }
+
+        private class DerivedDictionary : Dictionary<int, string>
+        { }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4936,7 +4936,13 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var sut = new Fixture();
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new MethodInvoker(new EnumerableFavoringConstructorQuery()), new ListSpecification()));
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()),
+                        new CollectionFillerCommand()),
+                    new CollectionSpecification()));
             sut.ResidueCollectors.Add(new EnumerableRelay());
             // Exercise system
             var result = sut.Create<List<string>>();
@@ -4950,7 +4956,13 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var sut = new Fixture();
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new MethodInvoker(new EnumerableFavoringConstructorQuery()), new HashSetSpecification()));
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()),
+                        new CollectionFillerCommand()),
+                    new CollectionSpecification()));
             sut.ResidueCollectors.Add(new EnumerableRelay());
             // Exercise system
             var result = sut.Create<HashSet<float>>();
@@ -4964,7 +4976,13 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var sut = new Fixture();
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new MethodInvoker(new EnumerableFavoringConstructorQuery()), new ListSpecification()));
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()),
+                        new CollectionFillerCommand()),
+                    new CollectionSpecification()));
             sut.ResidueCollectors.Add(new EnumerableRelay());
             sut.ResidueCollectors.Add(new ListRelay());
             // Exercise system
@@ -4979,7 +4997,13 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var sut = new Fixture();
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new MethodInvoker(new EnumerableFavoringConstructorQuery()), new ListSpecification()));
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()),
+                        new CollectionFillerCommand()),
+                    new CollectionSpecification()));
             sut.ResidueCollectors.Add(new EnumerableRelay());
             sut.ResidueCollectors.Add(new CollectionRelay());
             // Exercise system
@@ -4994,8 +5018,13 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var sut = new Fixture();
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new MethodInvoker(new EnumerableFavoringConstructorQuery()), new ListSpecification()));
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new MethodInvoker(new ListFavoringConstructorQuery()), new CollectionSpecification()));
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()),
+                        new CollectionFillerCommand()),
+                    new CollectionSpecification()));
             sut.ResidueCollectors.Add(new EnumerableRelay());
             sut.ResidueCollectors.Add(new ListRelay());
             // Exercise system
@@ -5010,7 +5039,13 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var sut = new Fixture();
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new Postprocessor(new MethodInvoker(new ModestConstructorQuery()), new DictionaryFiller()), new DictionarySpecification()));
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()), 
+                        new DictionaryFiller()), 
+                    new DictionarySpecification()));
             // Exercise system
             var result = sut.Create<Dictionary<int, string>>();
             // Verify outcome
@@ -5023,7 +5058,13 @@ namespace Ploeh.AutoFixtureUnitTest
         {
             // Fixture setup
             var sut = new Fixture();
-            sut.Customizations.Add(new FilteringSpecimenBuilder(new Postprocessor(new MethodInvoker(new ModestConstructorQuery()), new DictionaryFiller()), new DictionarySpecification()));
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new Postprocessor(
+                        new MethodInvoker(
+                            new ModestConstructorQuery()),
+                        new DictionaryFiller()),
+                    new DictionarySpecification()));
             sut.ResidueCollectors.Add(new DictionaryRelay());
             // Exercise system
             var result = sut.Create<IDictionary<TimeSpan, Version>>();
@@ -5218,22 +5259,19 @@ namespace Ploeh.AutoFixtureUnitTest
                 relayType.Name + " not found.");
         }
 
-        [Theory]
-        [InlineData(typeof(ListSpecification), typeof(EnumerableFavoringConstructorQuery))]
-        [InlineData(typeof(HashSetSpecification), typeof(EnumerableFavoringConstructorQuery))]
-        [InlineData(typeof(CollectionSpecification), typeof(ListFavoringConstructorQuery))]
-        [InlineData(typeof(ObservableCollectionSpecification), typeof(EnumerableFavoringConstructorQuery))]
-        public void CustomizationsContainBuilderForProperConcreteMultipleTypeByDefault(
-            Type specificationType,
-            Type queryType)
+        [Fact]
+        public void CustomizationsContainBuilderForConcreteCollectionTypeByDefault()
         {
             var sut = new Fixture();
             Assert.True(sut.Customizations
                 .OfType<FilteringSpecimenBuilder>()
-                .Where(b => specificationType.IsAssignableFrom(b.Specification.GetType()))
-                .Where(b => typeof(MethodInvoker).IsAssignableFrom(b.Builder.GetType()))
-                .Select(b => (MethodInvoker)b.Builder)
-                .Where(i => queryType.IsAssignableFrom(i.Query.GetType()))
+                .Where(b => typeof(CollectionSpecification).IsAssignableFrom(b.Specification.GetType()))
+                .Where(b => typeof(Postprocessor).IsAssignableFrom(b.Builder.GetType()))
+                .Select(b => (Postprocessor)b.Builder)
+                .Where(p => p.Command is CollectionFillerCommand)
+                .Where(p => typeof(MethodInvoker).IsAssignableFrom(p.Builder.GetType()))
+                .Select(p => (MethodInvoker)p.Builder)
+                .Where(i => typeof(ModestConstructorQuery).IsAssignableFrom(i.Query.GetType()))
                 .Any());
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/CollectionSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CollectionSpecificationTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
@@ -31,6 +32,11 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         [InlineData(typeof(string[]))]
         [InlineData(typeof(int[]))]
         [InlineData(typeof(Version[]))]
+        [InlineData(typeof(IEnumerable<Version>))]
+        [InlineData(typeof(ICollection<Version>))]
+        [InlineData(typeof(IList<Version>))]
+        [InlineData(typeof(ReadOnlyCollection<object>))]
+        [InlineData(typeof(PrivateConstructorCollection))]
         public void IsSatisfiedByNonCollectionRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
@@ -47,6 +53,27 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         [InlineData(typeof(Collection<string>))]
         [InlineData(typeof(Collection<int>))]
         [InlineData(typeof(Collection<Version>))]
+        [InlineData(typeof(HashSet<object>))]
+        [InlineData(typeof(HashSet<string>))]
+        [InlineData(typeof(HashSet<int>))]
+        [InlineData(typeof(HashSet<Version>))]
+        [InlineData(typeof(List<object>))]
+        [InlineData(typeof(List<string>))]
+        [InlineData(typeof(List<int>))]
+        [InlineData(typeof(List<Version>))]
+        [InlineData(typeof(ObservableCollection<object>))]
+        [InlineData(typeof(ObservableCollection<string>))]
+        [InlineData(typeof(ObservableCollection<int>))]
+        [InlineData(typeof(ObservableCollection<Version>))]
+        [InlineData(typeof(SortedSet<object>))]
+        [InlineData(typeof(SortedSet<string>))]
+        [InlineData(typeof(SortedSet<int>))]
+        [InlineData(typeof(SortedSet<Version>))]
+        [InlineData(typeof(LinkedList<object>))]
+        [InlineData(typeof(LinkedList<string>))]
+        [InlineData(typeof(LinkedList<int>))]
+        [InlineData(typeof(LinkedList<Version>))]
+        [InlineData(typeof(DerivedCollection))]
         public void IsSatisfiedByCollectionRequestReturnsCorrectResult(Type request)
         {
             // Fixture setup
@@ -56,6 +83,14 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Verify outcome
             Assert.True(result);
             // Teardown
+        }
+
+        private class DerivedCollection : Collection<object>
+        { }
+
+        private class PrivateConstructorCollection : Collection<object>
+        {
+            private PrivateConstructorCollection() { }
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/DictionarySpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DictionarySpecificationTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
@@ -31,6 +32,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         [InlineData(typeof(string[]))]
         [InlineData(typeof(int[]))]
         [InlineData(typeof(Version[]))]
+        [InlineData(typeof(IDictionary<object, object>))]
+        [InlineData(typeof(IEnumerable<KeyValuePair<object, object>>))]
+        [InlineData(typeof(PrivateConstructorDictionary))]
         public void IsSatisfiedByNonDictionaryRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
@@ -47,6 +51,19 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         [InlineData(typeof(Dictionary<int, string>))]
         [InlineData(typeof(Dictionary<string, int>))]
         [InlineData(typeof(Dictionary<Version, OperatingSystem>))]
+        [InlineData(typeof(SortedDictionary<object, object>))]
+        [InlineData(typeof(SortedDictionary<int, string>))]
+        [InlineData(typeof(SortedDictionary<string, int>))]
+        [InlineData(typeof(SortedDictionary<Version, OperatingSystem>))]
+        [InlineData(typeof(SortedList<object, object>))]
+        [InlineData(typeof(SortedList<int, string>))]
+        [InlineData(typeof(SortedList<string, int>))]
+        [InlineData(typeof(SortedList<Version, OperatingSystem>))]
+        [InlineData(typeof(ConcurrentDictionary<object, object>))]
+        [InlineData(typeof(ConcurrentDictionary<int, string>))]
+        [InlineData(typeof(ConcurrentDictionary<string, int>))]
+        [InlineData(typeof(ConcurrentDictionary<Version, OperatingSystem>))]
+        [InlineData(typeof(DerivedDictionary))]
         public void IsSatisfiedByDictionaryRequestReturnsCorrectResult(Type request)
         {
             // Fixture setup
@@ -56,6 +73,15 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Verify outcome
             Assert.True(result);
             // Teardown
+        }
+
+        private class DerivedDictionary : Dictionary<object, object>
+        { }
+
+        private class PrivateConstructorDictionary : Dictionary<object, object>
+        {
+            private PrivateConstructorDictionary()
+            { }
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/HashSetSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/HashSetSpecificationTest.cs
@@ -13,7 +13,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
+#pragma warning disable 618
             var sut = new HashSetSpecification();
+#pragma warning restore 618
             // Verify outcome
             Assert.IsAssignableFrom<IRequestSpecification>(sut);
             // Teardown
@@ -34,7 +36,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByNonHashSetRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new HashSetSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome
@@ -50,7 +54,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByCollectionRequestReturnsCorrectResult(Type request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new HashSetSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/Kernel/ListSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListSpecificationTest.cs
@@ -13,7 +13,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
+#pragma warning disable 618
             var sut = new ListSpecification();
+#pragma warning restore 618
             // Verify outcome
             Assert.IsAssignableFrom<IRequestSpecification>(sut);
             // Teardown
@@ -34,7 +36,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByNonEnumerableRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new ListSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome
@@ -50,7 +54,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByEnumerableRequestReturnsCorrectResult(Type request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new ListSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/Kernel/ObservableCollectionSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ObservableCollectionSpecificationTest.cs
@@ -14,7 +14,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
+#pragma warning disable 618
             var sut = new ObservableCollectionSpecification();
+#pragma warning restore 618
             // Verify outcome
             Assert.IsAssignableFrom<IRequestSpecification>(sut);
             // Teardown
@@ -35,7 +37,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByNonEnumerableRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new ObservableCollectionSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome
@@ -51,7 +55,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByEnumerableNonObservableRequestReturnsCorrectResult(Type request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new ObservableCollectionSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome
@@ -67,7 +73,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByEnumerableRequestReturnsCorrectResult(Type request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new ObservableCollectionSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/Kernel/SortedDictionarySpecificationTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SortedDictionarySpecificationTests.cs
@@ -14,7 +14,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
+#pragma warning disable 618
             var sut = new SortedDictionarySpecification();
+#pragma warning restore 618
             // Verify outcome
             Assert.IsAssignableFrom<IRequestSpecification>(sut);
             // Teardown
@@ -39,7 +41,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByNonSortedSetRequestReturnsCorrectResult(object request)
         {
             // Fixture setup.
+#pragma warning disable 618
             var sut = new SortedDictionarySpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome
@@ -55,7 +59,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedBySortedSetRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new SortedDictionarySpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/Kernel/SortedListSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SortedListSpecificationTest.cs
@@ -14,7 +14,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
+#pragma warning disable 618
             var sut = new SortedListSpecification();
+#pragma warning restore 618
             // Verify outcome
             Assert.IsAssignableFrom<IRequestSpecification>(sut);
             // Teardown
@@ -36,7 +38,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedBySortedListRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new SortedListSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome
@@ -65,7 +69,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByNonSortedListRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new SortedListSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/Kernel/SortedSetSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SortedSetSpecificationTest.cs
@@ -14,7 +14,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
+#pragma warning disable 618
             var sut = new SortedSetSpecification();
+#pragma warning restore 618
             // Verify outcome
             Assert.IsAssignableFrom<IRequestSpecification>(sut);
             // Teardown
@@ -39,7 +41,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedByNonSortedSetRequestReturnsCorrectResult(object request)
         {
             // Fixture setup.
+#pragma warning disable 618
             var sut = new SortedSetSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome
@@ -63,7 +67,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void IsSatisfiedBySortedSetRequestReturnsCorrectResult(object request)
         {
             // Fixture setup
+#pragma warning disable 618
             var sut = new SortedSetSpecification();
+#pragma warning restore 618
             // Exercise system
             var result = sut.IsSatisfiedBy(request);
             // Verify outcome

--- a/Src/AutoFixtureUnitTest/MultipleCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/MultipleCustomizationTest.cs
@@ -50,11 +50,8 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Theory]
-        [InlineData(typeof(ListSpecification), typeof(EnumerableFavoringConstructorQuery))]
-        [InlineData(typeof(HashSetSpecification), typeof(EnumerableFavoringConstructorQuery))]
-        [InlineData(typeof(CollectionSpecification), typeof(ListFavoringConstructorQuery))]
-        public void CustomizeAddsBuilderForProperConcreteMultipleType(Type specificationType, Type queryType)
+        [Fact]
+        public void CustomizeAddsBuilderForConcreteCollectionType()
         {
             // Fixture setup
             var sut = new MultipleCustomization();
@@ -64,10 +61,13 @@ namespace Ploeh.AutoFixtureUnitTest
             // Verify outcome
             Assert.True(fixture.Customizations
                 .OfType<FilteringSpecimenBuilder>()
-                .Where(b => specificationType.IsAssignableFrom(b.Specification.GetType()))
-                .Where(b => typeof(MethodInvoker).IsAssignableFrom(b.Builder.GetType()))
-                .Select(b => (MethodInvoker)b.Builder)
-                .Where(i => queryType.IsAssignableFrom(i.Query.GetType()))
+                .Where(b => typeof(CollectionSpecification).IsAssignableFrom(b.Specification.GetType()))
+                .Where(b => typeof(Postprocessor).IsAssignableFrom(b.Builder.GetType()))
+                .Select(b => (Postprocessor)b.Builder)
+                .Where(p => p.Command is CollectionFillerCommand)
+                .Where(p => typeof(MethodInvoker).IsAssignableFrom(p.Builder.GetType()))
+                .Select(p => (MethodInvoker)p.Builder)
+                .Where(i => typeof(ModestConstructorQuery).IsAssignableFrom(i.Query.GetType()))
                 .Any());
             // Teardown
         }


### PR DESCRIPTION
Closes #700 

I implemented this change as a replacement for the multiple implementations of collection types to a single implementation that is more generic as it works for all derived collection types. Alternatively, I may have been able to add some generic relays, but I felt this was a better solution. I'm happy to take critical feedback.