### PR TITLE
Ignore abstract methods in GuardClauseAssertion

### DIFF
--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -120,7 +120,8 @@ namespace Ploeh.AutoFixture.Idioms
             if (methodInfo.IsEqualsMethod() ||
                 methodInfo.IsGetHashCodeMethod() ||
                 methodInfo.IsToString() ||
-                methodInfo.IsGetType())
+                methodInfo.IsGetType() ||
+                methodInfo.IsAbstract)
                 return;
 
             methodInfo = this.ResolveUnclosedGenericType(methodInfo);

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -1773,5 +1773,19 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
                     throw new ArgumentNullException("arg1");
             }
         }
+
+        [Fact]
+        public void VerifyOnAbstractMethodDoesNotThrow()
+        {
+            var method = typeof(AbstractTypeWithAbstractMethod)
+                .GetMethod("Method");
+            var sut = new GuardClauseAssertion(new Fixture());
+            sut.Verify(method);
+        }
+
+        private abstract class AbstractTypeWithAbstractMethod
+        {
+            public abstract void Method(object arg);
+        }
     }
 }


### PR DESCRIPTION
Fixes #715.
