### PR TITLE
Idioms: Verify methods with deferred execution

### DIFF
--- a/Src/Idioms/MethodInvokeCommand.cs
+++ b/Src/Idioms/MethodInvokeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Globalization;
 using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
@@ -80,7 +81,8 @@ namespace Ploeh.AutoFixture.Idioms
         /// </remarks>
         public void Execute(object value)
         {
-            this.method.Invoke(this.expansion.Expand(value));
+            var result = this.method.Invoke(this.expansion.Expand(value)) as IEnumerable;
+            result?.GetEnumerator().MoveNext();
         }
 
         /// <summary>

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -485,12 +485,11 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             }
         }
 
-        [Theory]
-        [InlineData(typeof(ClassWithDeferredGuidGuardReturningEnumerator))]
-        public void VerifyMethodWithDeferredGuardThrowsExceptionWithExtraHelpfulMessage(
-            Type type)
+        [Fact]
+        public void VerifyMethodWithDeferredGuardThrowsExceptionWithExtraHelpfulMessage()
         {
             // Fixture setup
+            var type = typeof (ClassWithDeferredGuidGuardReturningEnumerator);
             var sut = new GuardClauseAssertion(new Fixture());
             var method = type.GetMethod("GetValues");
             // Exercise system and verify outcome

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -446,7 +446,6 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         [Theory]
         [InlineData(typeof(ClassWithDeferredNullGuard))]
         [InlineData(typeof(ClassWithDeferredGuidGuard))]
-        [InlineData(typeof(ClassWithDeferredGuidGuardReturningEnumerator))]
         public void VerifyMethodWithDeferredGuardDoesNotThrow(
             Type type)
         {
@@ -484,6 +483,21 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
                 yield return someGuid;
                 yield return someGuid;
             }
+        }
+
+        [Theory]
+        [InlineData(typeof(ClassWithDeferredGuidGuardReturningEnumerator))]
+        public void VerifyMethodWithDeferredGuardThrowsExceptionWithExtraHelpfulMessage(
+            Type type)
+        {
+            // Fixture setup
+            var sut = new GuardClauseAssertion(new Fixture());
+            var method = type.GetMethod("GetValues");
+            // Exercise system and verify outcome
+            var e =
+                Assert.Throws<GuardClauseException>(() => sut.Verify(method));
+            Assert.Contains("deferred", e.Message);
+            // Teardown
         }
 
         private class ClassWithDeferredGuidGuardReturningEnumerator
@@ -654,7 +668,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         {
             public Dictionary<string, string> GetValues(string someString)
             {
-                return new Dictionary<string, string> 
+                return new Dictionary<string, string>
                 {
                     { "uniqueKey1", someString },
                     { "uniqueKey2", someString }
@@ -990,7 +1004,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
                     mockVerification = true;
                 }
             };
-            
+
             var sut = new GuardClauseAssertion(fixture, behaviorExpectation);
             var methodInfo = typeof(DynamicInstanceTestConstraint<>).GetMethod("Method");
             // Exercise system
@@ -1096,7 +1110,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
 
                 return System.Threading.Tasks.Task.Factory.StartNew(() => obj.ToString());
             }
-            
+
             public System.Threading.Tasks.Task TaskWithCorrectGuardClause(object obj)
             {
                 if (obj == null)
@@ -1698,7 +1712,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             public void Method<T2>(ref T2 argument) where T2 : class
             {
             }
-            
+
             public void Method(ref T1 argument1, int argument2)
             {
             }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -447,16 +447,14 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         [InlineData(typeof(ClassWithDeferredNullGuard))]
         [InlineData(typeof(ClassWithDeferredGuidGuard))]
         [InlineData(typeof(ClassWithDeferredGuidGuardReturningEnumerator))]
-        public void VerifyMethodWithDeferredGuardThrowsExceptionWithExtraHelpfulMessage(
+        public void VerifyMethodWithDeferredGuardDoesNotThrow(
             Type type)
         {
             // Fixture setup
             var sut = new GuardClauseAssertion(new Fixture());
             var method = type.GetMethod("GetValues");
             // Exercise system and verify outcome
-            var e =
-                Assert.Throws<GuardClauseException>(() => sut.Verify(method));
-            Assert.Contains("deferred", e.Message);
+            Assert.DoesNotThrow(() => sut.Verify(method));
             // Teardown
         }
 

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -475,7 +475,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         {
             public IEnumerable<Guid> GetValues(Guid someGuid)
             {
-                if (someGuid == null)
+                if (someGuid == Guid.Empty)
                     throw new ArgumentException(
                         "Guid.Empty not allowed.",
                         "someGuid");
@@ -490,7 +490,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         {
             public IEnumerator<Guid> GetValues(Guid someGuid)
             {
-                if (someGuid == null)
+                if (someGuid == Guid.Empty)
                     throw new ArgumentException(
                         "Guid.Empty not allowed.",
                         "someGuid");


### PR DESCRIPTION
Closes #717.

There are three test cases in the [GuardClassAssertionTest](https://github.com/AutoFixture/AutoFixture/blob/ab829640ed8e02776e4f4730d0e72ab3cc382339/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs#L450) checking that AF throws an exception with message saying that it was unable to verify the guard:
```csharp
[InlineData(typeof(ClassWithDeferredNullGuard))]
[InlineData(typeof(ClassWithDeferredGuidGuard))]
[InlineData(typeof(ClassWithDeferredGuidGuardReturningEnumerator))]
public void VerifyMethodWithDeferredGuardThrowsExceptionWithExtraHelpfulMessage(...)
```

This PR _enables_ guard clause verification for the first two cases.