### PR TITLE
Woodburysoft/722 range attribute on enum throws exception

### DIFF
--- a/Src/AutoFixture.sln
+++ b/Src/AutoFixture.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture", "AutoFixture\AutoFixture.csproj", "{400AC174-9A4A-4C7D-815B-F2A21130A0D1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixtureUnitTest", "AutoFixtureUnitTest\AutoFixtureUnitTest.csproj", "{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}"

--- a/Src/AutoFixture.sln
+++ b/Src/AutoFixture.sln
@@ -13,8 +13,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticComparison", "Seman
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestTypeFoundation", "TestTypeFoundation\TestTypeFoundation.csproj", "{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApplication1", "ConsoleApplication1\ConsoleApplication1.csproj", "{01705506-1218-4A0B-8BE2-F311BE2DB9C4}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,12 +56,6 @@ Global
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.ActiveCfg = Release|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.Build.0 = Release|Any CPU
-		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Verify|Any CPU.ActiveCfg = Release|Any CPU
-		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Verify|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFixture.sln
+++ b/Src/AutoFixture.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture", "AutoFixture\AutoFixture.csproj", "{400AC174-9A4A-4C7D-815B-F2A21130A0D1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixtureUnitTest", "AutoFixtureUnitTest\AutoFixtureUnitTest.csproj", "{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}"
@@ -14,6 +12,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticComparison", "SemanticComparison\SemanticComparison.csproj", "{C5C40C06-264D-4551-AF9E-310BF007F7D1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestTypeFoundation", "TestTypeFoundation\TestTypeFoundation.csproj", "{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApplication1", "ConsoleApplication1\ConsoleApplication1.csproj", "{01705506-1218-4A0B-8BE2-F311BE2DB9C4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -58,6 +58,12 @@ Global
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.ActiveCfg = Release|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{01705506-1218-4A0B-8BE2-F311BE2DB9C4}.Verify|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -81,11 +81,21 @@ namespace Ploeh.AutoFixture.DataAnnotations
                 conversionType = underlyingType;
             }
 
-            return new RangedNumberRequest(
-                conversionType,
-                Convert.ChangeType(rangeAttribute.Minimum, conversionType, CultureInfo.CurrentCulture),
-                Convert.ChangeType(rangeAttribute.Maximum, conversionType, CultureInfo.CurrentCulture)
-                );
+            object minimum;
+            object maximum;
+
+            if (conversionType.IsEnum)
+            {
+                minimum = Enum.Parse(conversionType, rangeAttribute.Minimum.ToString());
+                maximum = Enum.Parse(conversionType, rangeAttribute.Maximum.ToString());
+            }
+            else
+            {
+                minimum = Convert.ChangeType(rangeAttribute.Minimum, conversionType, CultureInfo.CurrentCulture);
+                maximum = Convert.ChangeType(rangeAttribute.Maximum, conversionType, CultureInfo.CurrentCulture);
+            }
+
+            return new RangedNumberRequest(conversionType, minimum, maximum);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/RangedNumberRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedNumberRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -34,6 +35,21 @@ namespace Ploeh.AutoFixture.Kernel
             if (((IComparable)minimum).CompareTo((IComparable)maximum) >= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be lower than Maximum.");
+            }
+
+            if (operandType.IsEnum)
+            {
+                if ((int)minimum < Enum.GetValues(operandType).Cast<int>().Min() 
+                    || (int)minimum > Enum.GetValues(operandType).Cast<int>().Max())
+                {
+                    throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be within the range of enum values.");
+                }
+
+                if ((int)maximum < Enum.GetValues(operandType).Cast<int>().Min() 
+                    || (int)maximum > Enum.GetValues(operandType).Cast<int>().Max())
+                {
+                    throw new ArgumentOutOfRangeException(nameof(maximum), "Maximum must be within the range of enum values.");
+                }                
             }
 
             this.OperandType = operandType;

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -84,7 +84,7 @@ namespace Ploeh.AutoFixture
                     object target;
                     if (range.OperandType == typeof(byte) &&
                         Convert.ToInt32(
-                            this.rangedValue,
+                            this.rangedValue, 
                             CultureInfo.CurrentCulture) > byte.MaxValue ||
                         range.OperandType == typeof(short) &&
                         Convert.ToInt32(
@@ -124,12 +124,12 @@ namespace Ploeh.AutoFixture
                                     range.OperandType,
                                     CultureInfo.CurrentCulture)),
                             range.OperandType,
-                            CultureInfo.CurrentCulture);                    
+                            CultureInfo.CurrentCulture);
 
                     if (maximum.CompareTo(this.rangedValue) < 0)
                     {
                         this.rangedValue = Convert.ChangeType(
-                            maximum,
+                            maximum, 
                             range.OperandType,
                             CultureInfo.CurrentCulture);
                     }
@@ -208,7 +208,6 @@ namespace Ploeh.AutoFixture
                 case TypeCode.Single:
                     return (float)a + (float)b;
                 
-
                 default:
                     throw new InvalidOperationException("The underlying type code of the specified types is not supported.");
             }

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -103,10 +103,10 @@ namespace Ploeh.AutoFixture
                 {
                     this.rangedValue =
                         Enum.Parse(
-                            range.OperandType,
+                            range.OperandType,                            
                             RangedNumberGenerator.Add(this.rangedValue, Enum.Parse(range.OperandType, "1")).ToString());
 
-                    if (maximum.CompareTo((int)this.rangedValue) < 0)
+                    if (((int)maximum).CompareTo((int)this.rangedValue) < 0)
                     {
                         this.rangedValue = Enum.Parse(
                             range.OperandType,

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -165,16 +165,9 @@ namespace Ploeh.AutoFixture
                     }
                 }
 
-                if (range.OperandType.IsEnum)
-                {
-                    this.rangedValue = range.OperandType.IsEnum
-                        ? Enum.Parse(range.OperandType, rangedValue.ToString())
-                        : Convert.ChangeType(rangedValue, range.OperandType, CultureInfo.CurrentCulture);
-                }
-                else
-                {
-                    this.rangedValue = Convert.ChangeType(this.rangedValue, range.OperandType, CultureInfo.CurrentCulture);
-                }                
+                this.rangedValue = range.OperandType.IsEnum
+                    ? Enum.Parse(range.OperandType, rangedValue.ToString())
+                    : Convert.ChangeType(rangedValue, range.OperandType, CultureInfo.CurrentCulture);                                
             }
         }
 

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -207,7 +207,7 @@ namespace Ploeh.AutoFixture
 
                 case TypeCode.Single:
                     return (float)a + (float)b;
-                
+
                 default:
                     throw new InvalidOperationException("The underlying type code of the specified types is not supported.");
             }

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -113,7 +113,8 @@ namespace Ploeh.AutoFixture
                             maximum.ToString());
                     }
                 }
-                else if (this.rangedValue != null && !range.OperandType.IsEnum && (minimum.CompareTo(this.rangedValue) <= 0 && maximum.CompareTo(this.rangedValue) > 0))
+                else if (this.rangedValue != null && !range.OperandType.IsEnum 
+                    && minimum.CompareTo(this.rangedValue) <= 0 && maximum.CompareTo(this.rangedValue) > 0)
                 {                 
                     this.rangedValue =
                         Convert.ChangeType(

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AbstractRecursionIssue\ItemBase.cs" />
     <Compile Include="AbstractRecursionIssue\ItemLocation.cs" />
     <Compile Include="AbstractRecursionIssue\Repro.cs" />
+    <Compile Include="DataAnnotations\RangeValidatedEnum.cs" />
     <Compile Include="DomainNameGeneratorTest.cs" />
     <Compile Include="DomainNameTest.cs" />
     <Compile Include="ElementsBuilderTest.cs" />

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
@@ -86,7 +86,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
 #pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
-        }                
+        }
 
         [Theory]
         [InlineData(typeof(int), 10, 20)]
@@ -96,7 +96,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         [InlineData(typeof(double), 10, 20)]
         [InlineData(typeof(double), -2, -1)]
         [InlineData(typeof(long), 10, 20)]
-        [InlineData(typeof(long), -2, -1)]        
+        [InlineData(typeof(long), -2, -1)]
         public void CreateWithRangeAttributeRequestReturnsCorrectResult(Type type, object minimum, object maximum)
         {
             // Fixture setup
@@ -174,12 +174,12 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         [InlineData("NullableTypeProperty", -2, -1)]
         public void CreateWithPropertyDecoratedWithRangeAttributeReturnsCorrectResult(
             string name,
-            object attributeMinimum,
+            object attributeMinimum, 
             object attributeMaximum)
         {
             // Fixture setup
             var request = typeof(RangeValidatedType).GetProperty(name);
-            Type target = Nullable.GetUnderlyingType(request.PropertyType)
+            Type target = Nullable.GetUnderlyingType(request.PropertyType) 
                 ?? request.PropertyType;
 
             var expectedRequest = new RangedNumberRequest(

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
@@ -86,7 +86,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
 #pragma warning restore 618
             Assert.Equal(expectedResult, result);
             // Teardown
-        }
+        }                
 
         [Theory]
         [InlineData(typeof(int), 10, 20)]
@@ -96,7 +96,7 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         [InlineData(typeof(double), 10, 20)]
         [InlineData(typeof(double), -2, -1)]
         [InlineData(typeof(long), 10, 20)]
-        [InlineData(typeof(long), -2, -1)]
+        [InlineData(typeof(long), -2, -1)]        
         public void CreateWithRangeAttributeRequestReturnsCorrectResult(Type type, object minimum, object maximum)
         {
             // Fixture setup
@@ -125,6 +125,37 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         }
 
         [Theory]
+        [InlineData(1, 3)]
+        [InlineData(1, 2)]
+        [InlineData(2, 3)]
+        public void CreateWithEnumRangeAttributeRequestReturnsCorrectResult(object minimum, object maximum)
+        {
+            // Fixture setup
+            var rangeAttribute = new RangeAttribute(typeof(RangeValidatedEnum), minimum.ToString(), maximum.ToString());
+            var providedAttribute = new ProvidedAttribute(rangeAttribute, true);
+            ICustomAttributeProvider request = new FakeCustomAttributeProvider(providedAttribute);
+            Type conversionType = rangeAttribute.OperandType;
+            var expectedRequest = new RangedNumberRequest(
+                conversionType,
+                Enum.Parse(conversionType, rangeAttribute.Minimum.ToString()),
+                Enum.Parse(conversionType, rangeAttribute.Maximum.ToString())
+                );
+            var expectedResult = new object();
+            var context = new DelegatingSpecimenContext
+            {
+#pragma warning disable 618
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
+            };
+            var sut = new RangeAttributeRelay();
+            // Exercise system
+            var result = sut.Create(request, context);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }        
+
+        [Theory]
         [InlineData("Property", 10, 20)]
         [InlineData("Property", -2, -1)]
         [InlineData("Property", "10.1", "20.2")]
@@ -143,12 +174,12 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         [InlineData("NullableTypeProperty", -2, -1)]
         public void CreateWithPropertyDecoratedWithRangeAttributeReturnsCorrectResult(
             string name,
-            object attributeMinimum, 
+            object attributeMinimum,
             object attributeMaximum)
         {
             // Fixture setup
             var request = typeof(RangeValidatedType).GetProperty(name);
-            Type target = Nullable.GetUnderlyingType(request.PropertyType) 
+            Type target = Nullable.GetUnderlyingType(request.PropertyType)
                 ?? request.PropertyType;
 
             var expectedRequest = new RangedNumberRequest(
@@ -156,7 +187,51 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
                 Convert.ChangeType(RangeValidatedType.Minimum, target, CultureInfo.CurrentCulture),
                 Convert.ChangeType(RangeValidatedType.Maximum, target, CultureInfo.CurrentCulture)
                 );
-           
+
+            var expectedResult = new object();
+            var context = new DelegatingSpecimenContext
+            {
+#pragma warning disable 618
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
+            };
+            var sut = new RangeAttributeRelay();
+            // Exercise system
+            var result = sut.Create(request, context);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("EnumProperty", 1, 2)]
+        [InlineData("EnumProperty", 1, 3)]
+        [InlineData("EnumProperty", 2, 3)]
+        [InlineData("EnumProperty", "1", "2")]
+        [InlineData("EnumProperty", "1", "3")]
+        [InlineData("EnumProperty", "2", "3")]
+        [InlineData("NullableTypeEnumProperty", 1, 2)]
+        [InlineData("NullableTypeEnumProperty", 1, 3)]
+        [InlineData("NullableTypeEnumProperty", 2, 3)]
+        [InlineData("NullableTypeEnumProperty", "1", "2")]
+        [InlineData("NullableTypeEnumProperty", "1", "3")]
+        [InlineData("NullableTypeEnumProperty", "2", "3")]        
+        public void CreateWithEnumPropertyDecoratedWithRangeAttributeReturnsCorrectResult(
+            string name,
+            object attributeMinimum,
+            object attributeMaximum)
+        {
+            // Fixture setup
+            var request = typeof(RangeValidatedType).GetProperty(name);
+            Type target = Nullable.GetUnderlyingType(request.PropertyType)
+                ?? request.PropertyType;
+
+            var expectedRequest = new RangedNumberRequest(
+                target,                
+                Enum.Parse(target, RangeValidatedType.EnumMinimum.ToString()),
+                Enum.Parse(target, RangeValidatedType.EnumMaximum.ToString())
+                );
+
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
@@ -203,6 +278,50 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
                 target,
                 Convert.ChangeType(RangeValidatedType.Minimum, target, CultureInfo.CurrentCulture),
                 Convert.ChangeType(RangeValidatedType.Maximum, target, CultureInfo.CurrentCulture)
+                );
+
+            var expectedResult = new object();
+            var context = new DelegatingSpecimenContext
+            {
+#pragma warning disable 618
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen(r)
+#pragma warning restore 618
+            };
+            var sut = new RangeAttributeRelay();
+            // Exercise system
+            var result = sut.Create(request, context);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("EnumField", 1, 2)]
+        [InlineData("EnumField", 1, 3)]
+        [InlineData("EnumField", 2, 3)]
+        [InlineData("EnumField", "1", "2")]
+        [InlineData("EnumField", "1", "3")]
+        [InlineData("EnumField", "2", "3")]
+        [InlineData("NullableTypeEnumField", 1, 2)]
+        [InlineData("NullableTypeEnumField", 1, 3)]
+        [InlineData("NullableTypeEnumField", 2, 3)]
+        [InlineData("NullableTypeEnumField", "1", "2")]
+        [InlineData("NullableTypeEnumField", "1", "3")]
+        [InlineData("NullableTypeEnumField", "2", "3")]
+        public void CreateWithEnumFieldDecoratedWithRangeAttributeReturnsCorrectResult(
+            string name,
+            object attributeMinimum,
+            object attributeMaximum)
+        {
+            // Fixture setup
+            var request = typeof(RangeValidatedType).GetField(name);
+            Type target = Nullable.GetUnderlyingType(request.FieldType)
+                ?? request.FieldType;
+
+            var expectedRequest = new RangedNumberRequest(
+                target,
+                Enum.Parse(target, RangeValidatedType.EnumMinimum.ToString()),
+                Enum.Parse(target, RangeValidatedType.EnumMaximum.ToString())
                 );
 
             var expectedResult = new object();

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedEnum.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedEnum.cs
@@ -1,0 +1,9 @@
+﻿namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
+{
+    public enum RangeValidatedEnum
+    {
+        First = 1,
+        Second = 2,
+        Third = 3
+    }
+}

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedType.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedType.cs
@@ -13,8 +13,14 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         public const string StringMinimum = "10.1";
         public const string StringMaximum = "20.2";
 
+        public const int EnumMinimum = 1;
+        public const int EnumMaximum = 3;
+
         [Range(Minimum, Maximum)]
         public decimal Field;
+
+        [Range(EnumMinimum, EnumMaximum)]
+        public RangeValidatedEnum EnumField;
 
         [Range(Minimum, Maximum)]
         public decimal Property { get; set; }
@@ -52,6 +58,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         [Range(Minimum, Maximum)]
         public decimal? NullableTypeField;
 
+        [Range(EnumMinimum, EnumMaximum)]
+        public RangeValidatedEnum? NullableTypeEnumField;
+
         [Range(Minimum, Maximum)]
         public decimal? NullableTypeProperty { get; set; }
 
@@ -66,5 +75,11 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
 
         [Range(Minimum, float.MaxValue)]
         public float PropertyWithMaximumFloatMaxValue { get; set; }
+
+        [Range(EnumMinimum, EnumMaximum)]
+        public RangeValidatedEnum EnumProperty { get; set; }
+
+        [Range(EnumMinimum, EnumMaximum)]
+        public RangeValidatedEnum? NullableTypeEnumProperty { get; set; }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.DataAnnotations;
 using Xunit;
 using Xunit.Extensions;
 
@@ -126,7 +127,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             // Exercise system and verify outcome
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new RangedNumberRequest(typeof(OneTwoThreeEnum), minimum, maximum));
+                new RangedNumberRequest(typeof(RangeValidatedEnum), minimum, maximum));
             // Teardown
         }
 
@@ -139,7 +140,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Fixture setup
             // Exercise system and verify outcome
             Assert.DoesNotThrow(() =>
-                new RangedNumberRequest(typeof(OneTwoThreeEnum), minimum, maximum));
+                new RangedNumberRequest(typeof(RangeValidatedEnum), minimum, maximum));
             // Teardown
         }
 
@@ -317,13 +318,6 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Verify outcome
             Assert.Equal(expectedHashCode, result);
             // Teardown
-        }
-
-        private enum OneTwoThreeEnum
-        {
-            First = 1,
-            Second = 2,
-            Third = 3
-        }
+        }        
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
@@ -114,6 +114,33 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             Assert.DoesNotThrow(() =>
                 new RangedNumberRequest(type, minimum, maximum));
             // Teardown
+        }        
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(1, 1)]
+        [InlineData(-1, 0)]
+        [InlineData(4, 5)]
+        public void CreateWithOutOfRangeEnumValuesWillThrow(object minimum, object maximum)
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new RangedNumberRequest(typeof(OneTwoThreeEnum), minimum, maximum));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(1, 3)]
+        [InlineData(1, 2)]
+        [InlineData(2, 3)]        
+        public void CreateWithInRangeEnumValuesDoesNotThrow(object minimum, object maximum)
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.DoesNotThrow(() =>
+                new RangedNumberRequest(typeof(OneTwoThreeEnum), minimum, maximum));
+            // Teardown
         }
 
         [Fact]
@@ -290,6 +317,13 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Verify outcome
             Assert.Equal(expectedHashCode, result);
             // Teardown
+        }
+
+        private enum OneTwoThreeEnum
+        {
+            First = 1,
+            Second = 2,
+            Third = 3
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
@@ -318,6 +318,6 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Verify outcome
             Assert.Equal(expectedHashCode, result);
             // Teardown
-        }        
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/LoopTest.cs
+++ b/Src/AutoFixtureUnitTest/LoopTest.cs
@@ -15,7 +15,18 @@ namespace Ploeh.AutoFixtureUnitTest
 
         public void Execute(int loopCount)
         {
-            Execute(loopCount, (TResult)Convert.ChangeType(loopCount, typeof(TResult)));
+            TResult expectedResult;
+
+            if (typeof(TResult).IsEnum)
+            {
+                expectedResult = (TResult)Enum.Parse(typeof(TResult), loopCount.ToString());
+            }
+            else
+            {
+                expectedResult = (TResult)Convert.ChangeType(loopCount, typeof(TResult));
+            }            
+
+            Execute(loopCount, expectedResult);
         }
 
         public void Execute(int loopCount, TResult expectedResult)

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -107,7 +107,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system and verify outcome
             loopTest.Execute(loopCount);
             // Teardown
-        }        
+        }
 
         [Theory]
         [InlineData(10.1, 20.2)]

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.DataAnnotations;
 using Ploeh.AutoFixtureUnitTest.Kernel;
 using Xunit;
 using Xunit.Extensions;
@@ -106,7 +107,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system and verify outcome
             loopTest.Execute(loopCount);
             // Teardown
-        }
+        }        
 
         [Theory]
         [InlineData(10.1, 20.2)]
@@ -519,6 +520,14 @@ namespace Ploeh.AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue: new object(),
 #pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(ushort), 10, 20)));
+#pragma warning restore 618
+
+                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 1, expectedResult: RangeValidatedEnum.First);
+                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 2, expectedResult: RangeValidatedEnum.Second);
+                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 3, expectedResult: RangeValidatedEnum.Third);
+                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: new object(),
+#pragma warning disable 618
+                    expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(RangeValidatedEnum), 1, 3)));
 #pragma warning restore 618
             }
 

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -522,9 +522,12 @@ namespace Ploeh.AutoFixtureUnitTest
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(ushort), 10, 20)));
 #pragma warning restore 618
 
-                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 1, expectedResult: RangeValidatedEnum.First);
-                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 2, expectedResult: RangeValidatedEnum.Second);
-                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 3, expectedResult: RangeValidatedEnum.Third);
+                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 1, 
+                    expectedResult: RangeValidatedEnum.First);
+                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 2, 
+                    expectedResult: RangeValidatedEnum.Second);
+                yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: 3, 
+                    expectedResult: RangeValidatedEnum.Third);
                 yield return CreateTestCase(operandType: typeof(RangeValidatedEnum), minimum: 1, maximum: 3, contextValue: new object(),
 #pragma warning disable 618
                     expectedResult: new NoSpecimen(new RangedNumberRequest(typeof(RangeValidatedEnum), 1, 3)));


### PR DESCRIPTION
This is intended to fix the bug raised here https://github.com/AutoFixture/AutoFixture/issues/722. 

My original intention was to create a new Range attribute that took 2 Enum values but when I tried this I had a warning that the project was no longer CLI compliant because Enum was exposed and so I changed course. The solution implemented here uses the standard Range attribute and simply detects if the underlying type is an enum and behaves accordingly. I have added new unit tests where I felt it appropiate.

This is my first pull request to an open source project and while I've read the guidelines and hopefully followed them all I expect there might be some things I've missed.