### PR TITLE
Support for .NET Standard

### DIFF
--- a/Src/AutoFixture.sln
+++ b/Src/AutoFixture.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture", "AutoFixture\AutoFixture.csproj", "{400AC174-9A4A-4C7D-815B-F2A21130A0D1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixtureUnitTest", "AutoFixtureUnitTest\AutoFixtureUnitTest.csproj", "{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}"

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -1,80 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{400AC174-9A4A-4C7D-815B-F2A21130A0D1}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Ploeh.AutoFixture</RootNamespace>
-    <AssemblyName>Ploeh.AutoFixture</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
-    <SccProjectName>
-    </SccProjectName>
-    <SccLocalPath>
-    </SccLocalPath>
-    <SccAuxPath>
-    </SccAuxPath>
-    <SccProvider>
-    </SccProvider>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
+    <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRules>
-    </CodeAnalysisRules>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NET45;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
     <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRules>
-    </CodeAnalysisRules>
-    <RunCodeAnalysis>false</RunCodeAnalysis>
-    <DocumentationFile>bin\Release\Ploeh.AutoFixture.xml</DocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Verify|AnyCPU' ">
-    <OutputPath>bin\Verify\</OutputPath>
-    <DefineConstants>CODE_ANALYSIS;TRACE;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
-    <DocumentationFile>bin\Verify\Ploeh.AutoFixture.xml</DocumentationFile>
+  <PropertyGroup Condition=" '$(Configuration)|$(TargetFramework)|$(Platform)' == 'Verify|net45|AnyCPU' ">
+    <OutputPath>bin\Verify\net45</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;TRACE;NET45;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
+    <DocumentationFile>bin\Verify\net45\Ploeh.AutoFixture.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -88,290 +31,30 @@
     <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NET45;SYSTEM_NET_MAIL;SYSTEM_RUNTIME_SERIALIZATION</DefineConstants>
+    <CodeAnalysisRuleSet>..\AutoFixture.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.5|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD;NETSTANDARD1_5</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.5|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NETSTANDARD;NETSTANDARD1_5</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AutoPropertiesTarget.cs" />
-    <Compile Include="BehaviorRoot.cs" />
-    <Compile Include="DomainName.cs" />
-    <Compile Include="DomainNameGenerator.cs" />
-    <Compile Include="ElementsBuilder.cs" />
-    <Compile Include="Kernel\SortedDictionarySpecification.cs" />
-    <Compile Include="Kernel\SortedListSpecification.cs" />
-    <Compile Include="Kernel\SortedSetSpecification.cs" />
-    <Compile Include="LambdaExpressionGenerator.cs" />
-    <Compile Include="FixtureRepeater.cs" />
-    <Compile Include="InvariantCultureGenerator.cs" />
-    <Compile Include="EmailAddressLocalPart.cs" />
-    <Compile Include="EmailAddressLocalPartGenerator.cs" />
-    <Compile Include="Kernel\CompositeSpecimenCommand.cs" />
-    <Compile Include="Kernel\Criterion.cs" />
-    <Compile Include="Kernel\EnumeratorRelay.cs" />
-    <Compile Include="Kernel\FieldTypeAndNameCriterion.cs" />
-    <Compile Include="Kernel\GenericMethod.cs" />
-    <Compile Include="Kernel\IMethodFactory.cs" />
-    <Compile Include="Kernel\MissingParametersSupplyingMethodFactory.cs" />
-    <Compile Include="Kernel\ParameterTypeAndNameCriterion.cs" />
-    <Compile Include="Kernel\PropertyTypeAndNameCriterion.cs" />
-    <Compile Include="Kernel\TemplateMethodQuery.cs" />
-    <Compile Include="Kernel\MissingParametersSupplyingMethod.cs" />
-    <Compile Include="Kernel\MissingParametersSupplyingStaticMethodFactory.cs" />
-    <Compile Include="Kernel\TypeArgumentsCannotBeInferredException.cs" />
-    <Compile Include="Kernel\TypeEnvy.cs" />
-    <Compile Include="LazyRelay.cs" />
-    <Compile Include="FreezeOnMatchCustomization.cs" />
-    <Compile Include="Kernel\ImplementedInterfaceSpecification.cs" />
-    <Compile Include="NoDataAnnotationsCustomization.cs" />
-    <Compile Include="Kernel\IRecursionHandler.cs" />
-    <Compile Include="Kernel\MultidimensionalArrayRelay.cs" />
-    <Compile Include="Kernel\OmitArrayParameterRequestRelay.cs" />
-    <Compile Include="Kernel\OmitEnumerableParameterRequestRelay.cs" />
-    <Compile Include="Kernel\ReadOnlyCollectionRelay.cs" />
-    <Compile Include="Kernel\TerminatingWithPathSpecimenBuilder.cs" />
-    <Compile Include="Kernel\ObservableCollectionSpecification.cs" />
-    <Compile Include="Kernel\PropertySpecification.cs" />
-    <Compile Include="Kernel\DirectBaseTypeSpecification.cs" />
-    <Compile Include="Kernel\ParameterSpecification.cs" />
-    <Compile Include="Kernel\FieldSpecification.cs" />
-    <Compile Include="MapCreateManyToEnumerable.cs" />
-    <Compile Include="Kernel\MultipleToEnumerableRelay.cs" />
-    <Compile Include="Kernel\NoConstructorsSpecification.cs" />
-    <Compile Include="Kernel\NullRecursionHandler.cs" />
-    <Compile Include="Kernel\OmitOnRecursionHandler.cs" />
-    <Compile Include="Kernel\ThrowingRecursionHandler.cs" />
-    <Compile Include="Kernel\ValueTypeSpecification.cs" />
-    <Compile Include="Kernel\MutableValueTypeWarningThrower.cs" />
-    <Compile Include="NoAutoPropertiesCustomization.cs" />
-    <Compile Include="RandomBooleanSequenceGenerator.cs" />
-    <Compile Include="CharSequenceGenerator.cs" />
-    <Compile Include="CollectionFiller.cs" />
-    <Compile Include="CompositeCustomization.cs" />
-    <Compile Include="ConstrainedStringGenerator.cs" />
-    <Compile Include="CurrentDateTimeCustomization.cs" />
-    <Compile Include="CurrentDateTimeGenerator.cs" />
-    <Compile Include="CustomizationNode.cs" />
-    <Compile Include="DataAnnotations\Automaton.cs" />
-    <Compile Include="DataAnnotations\BasicAutomata.cs" />
-    <Compile Include="DataAnnotations\BasicOperations.cs" />
-    <Compile Include="DataAnnotations\LinkedListExtensions.cs" />
-    <Compile Include="DataAnnotations\ListEqualityComparer.cs" />
-    <Compile Include="DataAnnotations\MinimizationOperations.cs" />
-    <Compile Include="DataAnnotations\RangeAttributeRelay.cs" />
-    <Compile Include="DataAnnotations\RegExp.cs" />
-    <Compile Include="DataAnnotations\RegExpMatchingOptions.cs" />
-    <Compile Include="DataAnnotations\RegExpSyntaxOptions.cs" />
-    <Compile Include="DataAnnotations\RegularExpressionAttributeRelay.cs" />
-    <Compile Include="DataAnnotations\SpecialOperations.cs" />
-    <Compile Include="DataAnnotations\State.cs" />
-    <Compile Include="DataAnnotations\StateEqualityComparer.cs" />
-    <Compile Include="DataAnnotations\StatePair.cs" />
-    <Compile Include="DataAnnotations\StringLengthAttributeRelay.cs" />
-    <Compile Include="DataAnnotations\Transition.cs" />
-    <Compile Include="DataAnnotations\TransitionComparer.cs" />
-    <Compile Include="DataAnnotations\Xeger.cs" />
-    <Compile Include="DateTimeGenerator.cs" />
-    <Compile Include="Dsl\NodeComposer.cs" />
-    <Compile Include="EnumerableList.cs" />
-    <Compile Include="Generator.cs" />
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="Dsl\CompositeNodeComposer.cs" />
-    <Compile Include="IncrementingDateTimeCustomization.cs" />
-    <Compile Include="Kernel\AbstractTypeSpecification.cs" />
-    <Compile Include="Kernel\ActionSpecimenCommand.cs" />
-    <Compile Include="Kernel\ConstrainedStringRequest.cs" />
-    <Compile Include="Kernel\EqualRequestSpecification.cs" />
-    <Compile Include="Kernel\ISpecimenCommand.cs" />
-    <Compile Include="Kernel\OmitOnRecursionGuard.cs" />
-    <Compile Include="Kernel\ISpecimenBuilderNode.cs" />
-    <Compile Include="Kernel\OmitSpecimen.cs" />
-    <Compile Include="Kernel\Omitter.cs" />
-    <Compile Include="Kernel\RangedNumberRequest.cs" />
-    <Compile Include="Kernel\RegularExpressionRequest.cs" />
-    <Compile Include="Kernel\SpecimenBuilderNodeFactory.cs" />
-    <Compile Include="Kernel\TypeRelay.cs" />
-    <Compile Include="OmitOnRecursionBehavior.cs" />
-    <Compile Include="RandomCharSequenceGenerator.cs" />
-    <Compile Include="RandomDateTimeSequenceGenerator.cs" />
-    <Compile Include="RandomBooleanSequenceCustomization.cs" />
-    <Compile Include="RandomNumericSequenceCustomization.cs" />
-    <Compile Include="RandomNumericSequenceGenerator.cs" />
-    <Compile Include="RandomRangedNumberCustomization.cs" />
-    <Compile Include="RandomRangedNumberGenerator.cs" />
-    <Compile Include="RangedNumberGenerator.cs" />
-    <Compile Include="RegularExpressionGenerator.cs" />
-    <Compile Include="ResidueCollectorNode.cs" />
-    <Compile Include="SingletonSpecimenBuilderNodeStackAdapterCollection.cs" />
-    <Compile Include="Kernel\SpecimenBuilderNode.cs" />
-    <Compile Include="SpecimenBuilderNodeAdapterCollection.cs" />
-    <Compile Include="SpecimenBuilderNodeEventArgs.cs" />
-    <Compile Include="SpecimenCommand.cs" />
-    <Compile Include="SpecimenQuery.cs" />
-    <Compile Include="StrictlyMonotonicallyIncreasingDateTimeGenerator.cs" />
-    <Compile Include="DefaultPrimitiveBuilders.cs" />
-    <Compile Include="DictionaryFiller.cs" />
-    <Compile Include="DisposableTrackingCustomization.cs" />
-    <Compile Include="Dsl\CompositePostprocessComposer.cs" />
-    <Compile Include="Dsl\IFactoryComposer.cs" />
-    <Compile Include="Dsl\IPostprocessComposer.cs" />
-    <Compile Include="DefaultEngineParts.cs" />
-    <Compile Include="EnumGenerator.cs" />
-    <Compile Include="FixtureFreezer.cs" />
-    <Compile Include="FixtureRegistrar.cs" />
-    <Compile Include="FreezingCustomization.cs" />
-    <Compile Include="ConstructorCustomization.cs" />
-    <Compile Include="ICustomization.cs" />
-    <Compile Include="IFixture.cs" />
-    <Compile Include="Kernel\ArrayFavoringConstructorQuery.cs" />
-    <Compile Include="Kernel\ArrayRelay.cs" />
-    <Compile Include="Kernel\CollectionRelay.cs" />
-    <Compile Include="Kernel\CollectionSpecification.cs" />
-    <Compile Include="Kernel\CompositeConstructorQuery.cs" />
-    <Compile Include="Kernel\CompositeMethodQuery.cs" />
-    <Compile Include="Kernel\ConstructorMethod.cs" />
-    <Compile Include="Kernel\DelegateGenerator.cs" />
-    <Compile Include="Kernel\DictionaryRelay.cs" />
-    <Compile Include="Kernel\DictionarySpecification.cs" />
-    <Compile Include="Kernel\DisposableTracker.cs" />
-    <Compile Include="Kernel\DisposableTrackingBehavior.cs" />
-    <Compile Include="Kernel\EnumerableRelay.cs" />
-    <Compile Include="Kernel\IMethodQuery.cs" />
-    <Compile Include="Kernel\InstanceMethod.cs" />
-    <Compile Include="Kernel\MethodInvoker.cs" />
-    <Compile Include="Kernel\StaticMethod.cs" />
-    <Compile Include="Kernel\HashSetSpecification.cs" />
-    <Compile Include="Kernel\FactoryMethodQuery.cs" />
-    <Compile Include="Kernel\ListFavoringConstructorQuery.cs" />
-    <Compile Include="Kernel\ListRelay.cs" />
-    <Compile Include="Kernel\ListSpecification.cs" />
-    <Compile Include="Kernel\FixedBuilder.cs" />
-    <Compile Include="Kernel\GreedyConstructorQuery.cs" />
-    <Compile Include="Kernel\IConstructorQuery.cs" />
-    <Compile Include="Kernel\IllegalRequestException.cs" />
-    <Compile Include="Kernel\IMethod.cs" />
-    <Compile Include="Kernel\IntPtrGuard.cs" />
-    <Compile Include="Dsl\ICustomizationComposer.cs" />
-    <Compile Include="Dsl\NullComposer.cs" />
-    <Compile Include="Kernel\AndRequestSpecification.cs" />
-    <Compile Include="Kernel\AnyTypeSpecification.cs" />
-    <Compile Include="Kernel\AutoPropertiesCommand.cs" />
-    <Compile Include="Kernel\ExpressionReflector.cs" />
-    <Compile Include="Kernel\FalseRequestSpecification.cs" />
-    <Compile Include="Kernel\FieldRequestRelay.cs" />
-    <Compile Include="Kernel\FilteringSpecimenBuilder.cs" />
-    <Compile Include="Kernel\InverseRequestSpecification.cs" />
-    <Compile Include="Kernel\IRequestSpecification.cs" />
-    <Compile Include="Kernel\ISpecifiedSpecimenCommand.cs" />
-    <Compile Include="Kernel\FiniteSequenceRequest.cs" />
-    <Compile Include="Kernel\FiniteSequenceRelay.cs" />
-    <Compile Include="Kernel\ISpecimenBuilderTransformation.cs" />
-    <Compile Include="Kernel\MultipleRequest.cs" />
-    <Compile Include="Kernel\MultipleRelay.cs" />
-    <Compile Include="Kernel\MemberInfoEqualityComparer.cs" />
-    <Compile Include="Kernel\ModestConstructorQuery.cs" />
-    <Compile Include="Kernel\NoSpecimenOutputGuard.cs" />
-    <Compile Include="Kernel\EnumerableFavoringConstructorQuery.cs" />
-    <Compile Include="Kernel\NullableEnumRequestSpecification.cs" />
-    <Compile Include="Kernel\ParameterScore.cs" />
-    <Compile Include="Kernel\StableFiniteSequenceRelay.cs" />
-    <Compile Include="MultipleCustomization.cs" />
-    <Compile Include="NullRecursionBehavior.cs" />
-    <Compile Include="Kernel\SeedRequestSpecification.cs" />
-    <Compile Include="Kernel\SpecifiedNullCommand.cs" />
-    <Compile Include="Kernel\OrRequestSpecification.cs" />
-    <Compile Include="Kernel\Postprocessor.cs" />
-    <Compile Include="Kernel\BindingCommand.cs" />
-    <Compile Include="Kernel\PropertyRequestRelay.cs" />
-    <Compile Include="Kernel\SeededFactory.cs" />
-    <Compile Include="Kernel\SpecimenFactory.cs" />
-    <Compile Include="Kernel\TerminatingSpecimenBuilder.cs" />
-    <Compile Include="StableFiniteSequenceCustomization.cs" />
-    <Compile Include="NumericSequenceGenerator.cs" />
-    <Compile Include="NumericSequencePerTypeCustomization.cs" />
-    <Compile Include="SupportMutableValueTypesCustomization.cs" />
-    <Compile Include="MutableValueTypeGenerator.cs" />
-    <Compile Include="TaskGenerator.cs" />
-    <Compile Include="ThrowingRecursionBehavior.cs" />
-    <Compile Include="Kernel\TraceWriter.cs" />
-    <Compile Include="GuidGenerator.cs" />
-    <Compile Include="Kernel\CompositeSpecimenBuilder.cs" />
-    <Compile Include="Kernel\SpecimenContext.cs" />
-    <Compile Include="Kernel\ISpecimenBuilder.cs" />
-    <Compile Include="Kernel\ISpecimenContext.cs" />
-    <Compile Include="Kernel\ConstructorInvoker.cs" />
-    <Compile Include="Kernel\NoSpecimen.cs" />
-    <Compile Include="Kernel\ParameterRequestRelay.cs" />
-    <Compile Include="Kernel\TracingBuilder.cs" />
-    <Compile Include="Kernel\SpecimenCreatedEventArgs.cs" />
-    <Compile Include="Kernel\RequestTraceEventArgs.cs" />
-    <Compile Include="StringSeedRelay.cs" />
-    <Compile Include="Kernel\TrueRequestSpecification.cs" />
-    <Compile Include="Kernel\ExactTypeSpecification.cs" />
-    <Compile Include="Kernel\UnspecifiedSpecimenCommand.cs" />
-    <Compile Include="Kernel\SeedIgnoringRelay.cs" />
-    <Compile Include="BooleanSwitch.cs" />
-    <Compile Include="ByteSequenceGenerator.cs" />
-    <Compile Include="DecimalSequenceGenerator.cs" />
-    <Compile Include="DoubleSequenceGenerator.cs" />
-    <Compile Include="Fixture.cs" />
-    <Compile Include="Int16SequenceGenerator.cs" />
-    <Compile Include="Int32SequenceGenerator.cs" />
-    <Compile Include="Int64SequenceGenerator.cs" />
-    <Compile Include="Kernel\NullRecursionGuard.cs" />
-    <Compile Include="ObjectCreationException.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Kernel\RecursionGuard.cs" />
-    <Compile Include="SByteSequenceGenerator.cs" />
-    <Compile Include="Kernel\SeededRequest.cs" />
-    <Compile Include="SingleSequenceGenerator.cs" />
-    <Compile Include="SpecimenFactory.cs" />
-    <Compile Include="StringGenerator.cs" />
-    <Compile Include="Kernel\ThrowingRecursionGuard.cs" />
-    <Compile Include="DefaultRelays.cs" />
-    <Compile Include="TracingBehavior.cs" />
-    <Compile Include="TypeFilter.cs" />
-    <Compile Include="TypeGenerator.cs" />
-    <Compile Include="UInt16SequenceGenerator.cs" />
-    <Compile Include="UInt32SequenceGenerator.cs" />
-    <Compile Include="UInt64SequenceGenerator.cs" />
-    <Compile Include="UriGenerator.cs" />
-    <Compile Include="UriScheme.cs" />
-    <Compile Include="UriSchemeGenerator.cs" />
-    <Compile Include="MailAddressGenerator.cs" />
-    <Compile Include="Utf8EncodingGenerator.cs" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
+    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml">
       <SubType>Designer</SubType>
     </CodeAnalysisDictionary>
   </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Src/AutoFixture/Kernel/SortedListSpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedListSpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -26,7 +27,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return false;
             }
             
-            return type.IsGenericType && typeof(SortedList<,>) == type.GetGenericTypeDefinition();
+            return type.IsGenericType() && typeof(SortedList<,>) == type.GetGenericTypeDefinition();
         }
     }
 }


### PR DESCRIPTION
The target of this PR is to enable the basic usage of AutoFixture in .NET Standard projects, as discussed in the issue #404.
To allow this, I converted the AutoFixture.csproj file to the new .NET Standard class library template.
This introduces few breaking changes:
* Visual Studio 2015 and below are not supported.
* MSBuild 15 is required
* .NET Core SDK 1.0.0 is required

These breaking changes are likely to break the current CI setup.
Few suggested changes:
* Update FAKE to latest version to support MSBuild 15 https://github.com/fsharp/FAKE/issues/1442
* Change AppVeyor build settings to use Visual Studio 2017 image https://github.com/appveyor/ci/issues/1179

Additional notes:
All tests in the Src/AutoFixture.sln solution are correctly ran to completion but are executed only in .NET Framework mode.
I was thinking about converting the test projects as well, but then we would have lost the possibility to test with SYSTEM_NET_EMAIL and SYSTEM_RUNTIME_SERIALIZATION variables set.