### PR TITLE
Calculate build version based on repo status

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -76,7 +76,10 @@ let build target configuration =
         | "" -> []
         | x  -> [ "AssemblyOriginatorKeyFile", FullName x ]
 
-    let properties = [ "Configuration", configuration ] @ keyFile
+    let properties = keyFile @ [ "Configuration", configuration
+                                 "AssemblyVersion", buildVersion.assemblyVersion
+                                 "FileVersion", buildVersion.fileVersion
+                                 "InformationalVersion", buildVersion.infoVersion ]
 
     solutionsToBuild
     |> MSBuild "" target properties

--- a/Build.fsx
+++ b/Build.fsx
@@ -55,6 +55,20 @@ let buildVersion = match getBuildParamOrDefault "BuildVersion" "git" with
 
 
 
+Target "PatchAssemblyVersions" (fun _ ->
+    printfn 
+        "Patching assembly versions. Assembly version: %s, File version: %s, Informational version: %s" 
+        buildVersion.assemblyVersion
+        buildVersion.fileVersion
+        buildVersion.infoVersion
+
+    let filesToPatch = !! "Src/*/Properties/AssemblyInfo.*"
+    ReplaceAssemblyInfoVersionsBulk filesToPatch 
+                                    (fun f -> { f with AssemblyVersion              = buildVersion.assemblyVersion
+                                                       AssemblyFileVersion          = buildVersion.fileVersion
+                                                       AssemblyInformationalVersion = buildVersion.infoVersion })
+)
+
 let build target configuration =
     let keyFile =
         match getBuildParam "signkey" with
@@ -191,8 +205,9 @@ Target "CompleteBuild" (fun _ -> ())
 "CleanReleaseFolder" ==> "Verify"
 "CleanAll"           ==> "Verify"
 
-"Verify"    ==> "Build"
-"BuildOnly" ==> "Build"
+"Verify"                ==> "Build"
+"PatchAssemblyVersions" ==> "Build"
+"BuildOnly"             ==> "Build"
 
 "Build"    ==> "Test"
 "TestOnly" ==> "Test"

--- a/Build.fsx
+++ b/Build.fsx
@@ -3,6 +3,7 @@
 open Fake
 open Fake.Testing
 open System
+open System.Diagnostics;
 open System.Text.RegularExpressions
 
 let releaseFolder = "Release"
@@ -184,10 +185,7 @@ Target "CleanNuGetPackages" (fun _ ->
 )
 
 Target "NuGetPack" (fun _ ->
-    let version = "Src/AutoFixture/bin/Release/Ploeh.AutoFixture.dll"
-                  |> GetAssemblyVersion
-                  |> (fun v -> sprintf "%i.%i.%i" v.Major v.Minor v.Build)
-
+    let version = buildVersion.nugetVersion
     let nuSpecFiles = !! "NuGet/*.nuspec"
 
     nuSpecFiles

--- a/Build.fsx
+++ b/Build.fsx
@@ -3,12 +3,57 @@
 open Fake
 open Fake.Testing
 open System
+open System.Text.RegularExpressions
 
 let releaseFolder = "Release"
 let nunitToolsFolder = "Packages/NUnit.Runners.2.6.2/tools"
 let nuGetOutputFolder = "NuGetPackages"
 let solutionsToBuild = !! "Src/*.sln"
 let processorArchitecture = environVar "PROCESSOR_ARCHITECTURE"
+
+type BuildVersionInfo = { assemblyVersion:string; fileVersion:string; infoVersion:string; nugetVersion:string }
+let calculateVersionFromGit buildNumber =
+    // Example of output for a release tag: v3.50.2-288-g64fd5c5b, for a prerelease tag: v3.50.2-alpha1-288-g64fd5c5b
+    let desc = Git.CommandHelper.runSimpleGitCommand "" "describe --tags --long --match=v*"
+
+    let result = Regex.Match(desc,
+                             @"^v(?<maj>\d+)\.(?<min>\d+)\.(?<rev>\d+)(?<pre>-\w+\d*)?-(?<num>\d+)-g(?<sha>[a-z0-9]+)$",
+                             RegexOptions.IgnoreCase)
+                      .Groups
+    let getMatch (name:string) = result.[name].Value
+
+    let major, minor, revision, preReleaseSuffix, commitsNum, sha =
+        getMatch "maj" |> int, getMatch "min" |> int, getMatch "rev" |> int, getMatch "pre", getMatch "num" |> int, getMatch "sha"
+
+    
+    let assemblyVersion = sprintf "%d.%d.%d.0" major minor revision
+    let fileVersion = sprintf "%d.%d.%d.%d" major minor revision buildNumber
+    
+    // If number of commits since last tag is greater than zero, we append another identifier with number of commits.
+    // The produced version is larger than the last tag version.
+    // If we are on a tag, we use version specified modification.
+    // Examples of output: 3.50.2.1, 3.50.2.215, 3.50.1-rc1.3, 3.50.1-rc3.35
+    let nugetVersion = match commitsNum with
+                       | 0 -> sprintf "%d.%d.%d%s" major minor revision preReleaseSuffix
+                       | _ -> sprintf "%d.%d.%d%s.%d" major minor revision preReleaseSuffix commitsNum
+
+    let infoVersion = match commitsNum with
+                      | 0 -> nugetVersion
+                      | _ -> sprintf "%s-%s" nugetVersion sha
+
+    { assemblyVersion=assemblyVersion; fileVersion=fileVersion; infoVersion=infoVersion; nugetVersion=nugetVersion }
+
+// Calculate version that should be used for the build. Define globally as data might be required by multiple targets.
+// Please never name the build parameter with version as "Version" - it might be consumed by the MSBuild, override 
+// the defined properties and break some tasks (e.g. NuGet restore).
+let buildVersion = match getBuildParamOrDefault "BuildVersion" "git" with
+                   | "git"       -> calculateVersionFromGit (getBuildParamOrDefault "BuildNumber" "0" |> int)
+                   | assemblyVer -> { assemblyVersion = assemblyVer
+                                      fileVersion = getBuildParamOrDefault "BuildFileVersion" assemblyVer
+                                      infoVersion = getBuildParamOrDefault "BuildInfoVersion" assemblyVer
+                                      nugetVersion = getBuildParamOrDefault "BuildNugetVersion" assemblyVer }
+
+
 
 let build target configuration =
     let keyFile =

--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ AutoFixture is available via NuGet:
 
 AutoFixture follows [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html).
 
+## Build
+
+AutoFixture uses [FAKE](http://fsharp.github.io/FAKE/) as a build engine. If you would like to build the AutoFixture locally, run the `Build.cmd` file and wait for the result.
+
+The repository state (the last tag name and number of commits since the last tag) is used to determine the build version. If you would like to override the auto-generated AutoFixture version, pass the `BuildVersion` parameter to the `Build.cmd` file. For example:
+```
+Build.cmd BuildVersion=3.52.0
+```
+
+Refer to the [Build.fsx](Build.fsx) file to get information about all the supported build keys.
+
 ## Documentation ##
 
 * [CheatSheet](https://github.com/AutoFixture/AutoFixture/wiki/Cheat-Sheet)

--- a/Src/AutoFakeItEasy/Properties/AssemblyInfo.cs
+++ b/Src/AutoFakeItEasy/Properties/AssemblyInfo.cs
@@ -33,8 +33,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoFakeItEasy2.UnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFakeItEasy2.UnitTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFakeItEasy2/Properties/AssemblyInfo.cs
+++ b/Src/AutoFakeItEasy2/Properties/AssemblyInfo.cs
@@ -33,8 +33,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoFakeItEasyUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFakeItEasyUnitTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixture.NUnit2.Addins.UnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.NUnit2.Addins.UnitTest/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixture.NUnit2.Addins/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.NUnit2.Addins/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixture.NUnit2.UnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
-
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixture.NUnit2/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.NUnit2/Properties/AssemblyInfo.cs
@@ -34,8 +34,9 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoFixture.NUnit3.UnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixture.NUnit3/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.NUnit3/Properties/AssemblyInfo.cs
@@ -34,8 +34,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoFixture.xUnit.net.UnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixture.xUnit.net/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.xUnit.net/Properties/AssemblyInfo.cs
@@ -33,7 +33,8 @@ using System;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixture.xUnit.net2/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.xUnit.net2/Properties/AssemblyInfo.cs
@@ -33,7 +33,8 @@ using System;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]

--- a/Src/AutoFixture/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture/Properties/AssemblyInfo.cs
@@ -33,8 +33,9 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoFixtureDocumentationTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixtureDocumentationTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFixtureUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixtureUnitTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -14,6 +14,7 @@
     <Name>AutoFoq</Name>
     <SignAssembly>false</SignAssembly>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <NoWarn>2003</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Src/AutoFoq/Properties/AssemblyInfo.fs
+++ b/Src/AutoFoq/Properties/AssemblyInfo.fs
@@ -35,8 +35,9 @@ open System.Runtime.InteropServices
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[<assembly: AssemblyVersion("3.50.2.0")>]
-[<assembly: AssemblyFileVersion("3.50.2.0")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+[<assembly: AssemblyInformationalVersion("1.0.0.0")>]
 
 [<assembly: CLSCompliant(true)>]
 [<assembly: NeutralResourcesLanguage("en")>]

--- a/Src/AutoFoqUnitTest/Properties/AssemblyInfo.fs
+++ b/Src/AutoFoqUnitTest/Properties/AssemblyInfo.fs
@@ -33,7 +33,8 @@ open System.Runtime.InteropServices
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[<assembly: AssemblyVersion("3.50.2.0")>]
-[<assembly: AssemblyFileVersion("3.50.2.0")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+[<assembly: AssemblyInformationalVersion("1.0.0.0")>]
 
 ()

--- a/Src/AutoMoq/Properties/AssemblyInfo.cs
+++ b/Src/AutoMoq/Properties/AssemblyInfo.cs
@@ -33,7 +33,8 @@ using System;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]

--- a/Src/AutoMoqUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoMoqUnitTest/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoNSubstitute/Properties/AssemblyInfo.cs
+++ b/Src/AutoNSubstitute/Properties/AssemblyInfo.cs
@@ -33,8 +33,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoNSubstituteUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoNSubstituteUnitTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/AutoRhinoMock/Properties/AssemblyInfo.cs
+++ b/Src/AutoRhinoMock/Properties/AssemblyInfo.cs
@@ -33,8 +33,9 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/Src/AutoRhinoMockUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoRhinoMockUnitTest/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/Idioms.FsCheck/Properties/AssemblyInfo.fs
+++ b/Src/Idioms.FsCheck/Properties/AssemblyInfo.fs
@@ -35,8 +35,9 @@ open System.Runtime.InteropServices
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[<assembly: AssemblyVersion("3.50.2.0")>]
-[<assembly: AssemblyFileVersion("3.50.2.0")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+[<assembly: AssemblyInformationalVersion("1.0.0.0")>]
 
 
 [<assembly: CLSCompliant(true)>]

--- a/Src/Idioms/Properties/AssemblyInfo.cs
+++ b/Src/Idioms/Properties/AssemblyInfo.cs
@@ -34,8 +34,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/IdiomsUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/IdiomsUnitTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/SemanticComparison/Properties/AssemblyInfo.cs
+++ b/Src/SemanticComparison/Properties/AssemblyInfo.cs
@@ -34,8 +34,9 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/Src/SemanticComparisonUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/SemanticComparisonUnitTest/Properties/AssemblyInfo.cs
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Src/TestTypeFoundation/Properties/AssemblyInfo.cs
+++ b/Src/TestTypeFoundation/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.50.2.0")]
-[assembly: AssemblyFileVersion("3.50.2.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]


### PR DESCRIPTION
This PR is intended to simplify the release management of the project. I've implemented version calculation based on the state of the repository. Last tag and number of commits since last tag is used to determine the current version.

## Main changes:

- [x] Add code to calculate current version using the [git describe](https://git-scm.com/docs/git-describe) command output as a base.
- [x] Add build target to automatically patch all the `AssemblyInfo.[cs,fs]` files before the build.
- [x] Use the [AssemblyInformationalVersion](https://msdn.microsoft.com/en-us/library/system.reflection.assemblyinformationalversionattribute(v=vs.110).aspx) attribute to store the NuGet version of the particular DLL file. As a part of this change I've modified all the `AssemblyInfo` files to reset default version to `1.0.0.0` and to add the missing attribute (to be able to update it's value during the build).

## Version resolve logic
As it was stated above, the `git describe` command output is used to calculate current version. The logic depends on the last/current tag name, whether it's a release or a pre-release tag and number of commits since last tag. The result is following:

| Repo state            | Calculated version | Explanation |
--------------------- | --------------------| ---------------- |
| on tag `v3.52.0` | `3.52.0` | If we are on a tag, we use it's version without any changes. |
| on tag `v3.52.0-beta2` | `3.52.0-beta2` | If we are on a tag, we use it's version without any changes. |
| 15 commits since tag `v3.52.2` | `3.52.3-pre0015` |  We patch version to have a new version that is larger than `3.52.2`. We know nothing about changes, so we speculatively increase the `revision` number. We also add a `-preXXXX` pre-release suffix to both indicate that this version is a pre-release and to distinguish between different commits on the same branch. Number padding is required because nuget doesn't support SemVer 2.0 and uses lexical comparison for numbers. |
| 15 commits since tag `v3.52.2-beta2` | `3.52.2-beta2-build0015` | We simply append the `-buildXXXX` suffix to produce a version that is larger than `3.52.2-beta2`. NuGet uses the lexical comparison for the pre-release part, so the produced version is larger. |

Pay attention that I intentionally use the different suffixes in last 2 examples. That is because versions have completely different semantics:
- the version `3.52.3` was never released before, so we use the `-pre` suffix.
- the version `3.52.0-beta2` was already released and current version it's just something that contains more changes. Therefore, I use the `-build` suffix.

If you feel this logic too much confusing, let's find the better approach.

__Note!__ Versions from the last 2 table rows are never supposed to be published to the release (nuget.org) feed. They could be potentially published to the pre-release feed.

Also I know about the [GitVersion](https://github.com/GitTools/GitVersion) tool, however didn't use it intentionally. That is because it [doesn't work well](https://github.com/AutoFixture/AutoFixture/pull/749#issuecomment-293077239) with pre-release tags ending with numbers (e.g. `-rc1`, `-beta2`, etc) while I want to have such a possibility for such versions.