### PR TITLE
Create solution that contains all the projects and build it

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -9,7 +9,7 @@ open System.Text.RegularExpressions
 let releaseFolder = "Release"
 let nunitToolsFolder = "Packages/NUnit.Runners.2.6.2/tools"
 let nuGetOutputFolder = "NuGetPackages"
-let solutionsToBuild = !! "Src/*.sln"
+let solutionsToBuild = !! "Src/All.sln"
 let processorArchitecture = environVar "PROCESSOR_ARCHITECTURE"
 
 type BuildVersionInfo = { assemblyVersion:string; fileVersion:string; infoVersion:string; nugetVersion:string }

--- a/Src/All.sln
+++ b/Src/All.sln
@@ -1,0 +1,273 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture", "AutoFixture\AutoFixture.csproj", "{400AC174-9A4A-4C7D-815B-F2A21130A0D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixtureUnitTest", "AutoFixtureUnitTest\AutoFixtureUnitTest.csproj", "{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixtureDocumentationTest", "AutoFixtureDocumentationTest\AutoFixtureDocumentationTest.csproj", "{53F3A7F8-B4CA-4500-B493-FBE59D2619A7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticComparisonUnitTest", "SemanticComparisonUnitTest\SemanticComparisonUnitTest.csproj", "{E10289EF-D37F-4048-83B4-0A3D0BC29927}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticComparison", "SemanticComparison\SemanticComparison.csproj", "{C5C40C06-264D-4551-AF9E-310BF007F7D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestTypeFoundation", "TestTypeFoundation\TestTypeFoundation.csproj", "{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy", "AutoFakeItEasy\AutoFakeItEasy.csproj", "{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy2", "AutoFakeItEasy2\AutoFakeItEasy2.csproj", "{68A3F347-7D9D-4020-A3D5-F127234DD429}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy2.UnitTest", "AutoFakeItEasy2.UnitTest\AutoFakeItEasy2.UnitTest.csproj", "{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasyUnitTest", "AutoFakeItEasyUnitTest\AutoFakeItEasyUnitTest.csproj", "{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit2", "AutoFixture.NUnit2\AutoFixture.NUnit2.csproj", "{786AFDB3-B705-49DD-A565-34F44A4A2DAD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit2.Addins", "AutoFixture.NUnit2.Addins\AutoFixture.NUnit2.Addins.csproj", "{79D2A714-BEF4-40E2-B1E6-90FEB060093A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit2.Addins.UnitTest", "AutoFixture.NUnit2.Addins.UnitTest\AutoFixture.NUnit2.Addins.UnitTest.csproj", "{690D5964-19D0-4B53-AFF7-3BB721A805BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit2.UnitTest", "AutoFixture.NUnit2.UnitTest\AutoFixture.NUnit2.UnitTest.csproj", "{5CACC229-A5EF-4683-A846-D59230284D66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit3", "AutoFixture.NUnit3\AutoFixture.NUnit3.csproj", "{6539DC8B-7829-478E-A601-7625B0C814E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.NUnit3.UnitTest", "AutoFixture.NUnit3.UnitTest\AutoFixture.NUnit3.UnitTest.csproj", "{1E512431-ADC0-4218-873E-E4DF40C97268}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.xUnit.net", "AutoFixture.xUnit.net\AutoFixture.xUnit.net.csproj", "{266B9F0E-28E5-47CA-9816-ACB6737E7E4D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.xUnit.net.UnitTest", "AutoFixture.xUnit.net.UnitTest\AutoFixture.xUnit.net.UnitTest.csproj", "{14FADDF9-F0D2-4BD4-B285-FDDAB5762CC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.xUnit.net2", "AutoFixture.xUnit.net2\AutoFixture.xUnit.net2.csproj", "{240605C0-84DC-4B01-A79E-1123D20BB25D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.xUnit.net2.UnitTest", "AutoFixture.xUnit.net2.UnitTest\AutoFixture.xUnit.net2.UnitTest.csproj", "{67D81234-8589-4E11-85BC-C0C49399A289}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "AutoFoq", "AutoFoq\AutoFoq.fsproj", "{E2D94FAA-A782-4D17-89A0-0F4B5D3BB021}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "AutoFoqUnitTest", "AutoFoqUnitTest\AutoFoqUnitTest.fsproj", "{11544D61-62C6-4B24-BBD7-8685D7786AE9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMoq", "AutoMoq\AutoMoq.csproj", "{5DCEC2BD-40A3-458A-BEBC-C2FC0D4D451B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMoqUnitTest", "AutoMoqUnitTest\AutoMoqUnitTest.csproj", "{C50B2B1F-AF13-4DAB-8F56-788155017318}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoNSubstitute", "AutoNSubstitute\AutoNSubstitute.csproj", "{189C9474-B406-4356-A367-FBC882E9BA4B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoNSubstituteUnitTest", "AutoNSubstituteUnitTest\AutoNSubstituteUnitTest.csproj", "{B953A044-440C-43C0-B2CC-2585504221A9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRhinoMock", "AutoRhinoMock\AutoRhinoMock.csproj", "{35500763-A1C6-468A-A0F0-7AE737D5CEF0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoRhinoMockUnitTest", "AutoRhinoMockUnitTest\AutoRhinoMockUnitTest.csproj", "{481F0C9E-DA19-4DBD-9D25-EBA1030AAA03}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Idioms", "Idioms\Idioms.csproj", "{35DE0E35-4E3A-46D7-B175-80CA10276BE7}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Idioms.FsCheck", "Idioms.FsCheck\Idioms.FsCheck.fsproj", "{DCAAF1DB-BEA0-4A6F-8F67-A35A9891A7A9}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Idioms.FsCheckUnitTest", "Idioms.FsCheckUnitTest\Idioms.FsCheckUnitTest.fsproj", "{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdiomsUnitTest", "IdiomsUnitTest\IdiomsUnitTest.csproj", "{730E1D38-BA80-48C7-B05C-E2BD29F38851}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Verify|Any CPU = Verify|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{400AC174-9A4A-4C7D-815B-F2A21130A0D1}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{01C86B79-C79F-4EC4-B32E-DA5467DBBD31}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{53F3A7F8-B4CA-4500-B493-FBE59D2619A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53F3A7F8-B4CA-4500-B493-FBE59D2619A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53F3A7F8-B4CA-4500-B493-FBE59D2619A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53F3A7F8-B4CA-4500-B493-FBE59D2619A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53F3A7F8-B4CA-4500-B493-FBE59D2619A7}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{53F3A7F8-B4CA-4500-B493-FBE59D2619A7}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{E10289EF-D37F-4048-83B4-0A3D0BC29927}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E10289EF-D37F-4048-83B4-0A3D0BC29927}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E10289EF-D37F-4048-83B4-0A3D0BC29927}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E10289EF-D37F-4048-83B4-0A3D0BC29927}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E10289EF-D37F-4048-83B4-0A3D0BC29927}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{E10289EF-D37F-4048-83B4-0A3D0BC29927}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{C5C40C06-264D-4551-AF9E-310BF007F7D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5C40C06-264D-4551-AF9E-310BF007F7D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5C40C06-264D-4551-AF9E-310BF007F7D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5C40C06-264D-4551-AF9E-310BF007F7D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5C40C06-264D-4551-AF9E-310BF007F7D1}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{C5C40C06-264D-4551-AF9E-310BF007F7D1}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{68A3F347-7D9D-4020-A3D5-F127234DD429}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68A3F347-7D9D-4020-A3D5-F127234DD429}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68A3F347-7D9D-4020-A3D5-F127234DD429}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68A3F347-7D9D-4020-A3D5-F127234DD429}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68A3F347-7D9D-4020-A3D5-F127234DD429}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{68A3F347-7D9D-4020-A3D5-F127234DD429}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{786AFDB3-B705-49DD-A565-34F44A4A2DAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{786AFDB3-B705-49DD-A565-34F44A4A2DAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{786AFDB3-B705-49DD-A565-34F44A4A2DAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{786AFDB3-B705-49DD-A565-34F44A4A2DAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{786AFDB3-B705-49DD-A565-34F44A4A2DAD}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{786AFDB3-B705-49DD-A565-34F44A4A2DAD}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{79D2A714-BEF4-40E2-B1E6-90FEB060093A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79D2A714-BEF4-40E2-B1E6-90FEB060093A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79D2A714-BEF4-40E2-B1E6-90FEB060093A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79D2A714-BEF4-40E2-B1E6-90FEB060093A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79D2A714-BEF4-40E2-B1E6-90FEB060093A}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{79D2A714-BEF4-40E2-B1E6-90FEB060093A}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{690D5964-19D0-4B53-AFF7-3BB721A805BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{690D5964-19D0-4B53-AFF7-3BB721A805BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{690D5964-19D0-4B53-AFF7-3BB721A805BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{690D5964-19D0-4B53-AFF7-3BB721A805BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{690D5964-19D0-4B53-AFF7-3BB721A805BB}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{690D5964-19D0-4B53-AFF7-3BB721A805BB}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{5CACC229-A5EF-4683-A846-D59230284D66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CACC229-A5EF-4683-A846-D59230284D66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CACC229-A5EF-4683-A846-D59230284D66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CACC229-A5EF-4683-A846-D59230284D66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CACC229-A5EF-4683-A846-D59230284D66}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{5CACC229-A5EF-4683-A846-D59230284D66}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{6539DC8B-7829-478E-A601-7625B0C814E1}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{1E512431-ADC0-4218-873E-E4DF40C97268}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{266B9F0E-28E5-47CA-9816-ACB6737E7E4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{266B9F0E-28E5-47CA-9816-ACB6737E7E4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{266B9F0E-28E5-47CA-9816-ACB6737E7E4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{266B9F0E-28E5-47CA-9816-ACB6737E7E4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{266B9F0E-28E5-47CA-9816-ACB6737E7E4D}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{266B9F0E-28E5-47CA-9816-ACB6737E7E4D}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{14FADDF9-F0D2-4BD4-B285-FDDAB5762CC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14FADDF9-F0D2-4BD4-B285-FDDAB5762CC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14FADDF9-F0D2-4BD4-B285-FDDAB5762CC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14FADDF9-F0D2-4BD4-B285-FDDAB5762CC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14FADDF9-F0D2-4BD4-B285-FDDAB5762CC4}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{14FADDF9-F0D2-4BD4-B285-FDDAB5762CC4}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{240605C0-84DC-4B01-A79E-1123D20BB25D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{240605C0-84DC-4B01-A79E-1123D20BB25D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{240605C0-84DC-4B01-A79E-1123D20BB25D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{240605C0-84DC-4B01-A79E-1123D20BB25D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{240605C0-84DC-4B01-A79E-1123D20BB25D}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{240605C0-84DC-4B01-A79E-1123D20BB25D}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{67D81234-8589-4E11-85BC-C0C49399A289}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67D81234-8589-4E11-85BC-C0C49399A289}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67D81234-8589-4E11-85BC-C0C49399A289}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67D81234-8589-4E11-85BC-C0C49399A289}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67D81234-8589-4E11-85BC-C0C49399A289}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{67D81234-8589-4E11-85BC-C0C49399A289}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{E2D94FAA-A782-4D17-89A0-0F4B5D3BB021}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2D94FAA-A782-4D17-89A0-0F4B5D3BB021}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2D94FAA-A782-4D17-89A0-0F4B5D3BB021}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2D94FAA-A782-4D17-89A0-0F4B5D3BB021}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2D94FAA-A782-4D17-89A0-0F4B5D3BB021}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{E2D94FAA-A782-4D17-89A0-0F4B5D3BB021}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{11544D61-62C6-4B24-BBD7-8685D7786AE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11544D61-62C6-4B24-BBD7-8685D7786AE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11544D61-62C6-4B24-BBD7-8685D7786AE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11544D61-62C6-4B24-BBD7-8685D7786AE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11544D61-62C6-4B24-BBD7-8685D7786AE9}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{11544D61-62C6-4B24-BBD7-8685D7786AE9}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{5DCEC2BD-40A3-458A-BEBC-C2FC0D4D451B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DCEC2BD-40A3-458A-BEBC-C2FC0D4D451B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DCEC2BD-40A3-458A-BEBC-C2FC0D4D451B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DCEC2BD-40A3-458A-BEBC-C2FC0D4D451B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DCEC2BD-40A3-458A-BEBC-C2FC0D4D451B}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{5DCEC2BD-40A3-458A-BEBC-C2FC0D4D451B}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{C50B2B1F-AF13-4DAB-8F56-788155017318}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C50B2B1F-AF13-4DAB-8F56-788155017318}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C50B2B1F-AF13-4DAB-8F56-788155017318}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C50B2B1F-AF13-4DAB-8F56-788155017318}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C50B2B1F-AF13-4DAB-8F56-788155017318}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{C50B2B1F-AF13-4DAB-8F56-788155017318}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{189C9474-B406-4356-A367-FBC882E9BA4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{189C9474-B406-4356-A367-FBC882E9BA4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{189C9474-B406-4356-A367-FBC882E9BA4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{189C9474-B406-4356-A367-FBC882E9BA4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{189C9474-B406-4356-A367-FBC882E9BA4B}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{189C9474-B406-4356-A367-FBC882E9BA4B}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{B953A044-440C-43C0-B2CC-2585504221A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B953A044-440C-43C0-B2CC-2585504221A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B953A044-440C-43C0-B2CC-2585504221A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B953A044-440C-43C0-B2CC-2585504221A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B953A044-440C-43C0-B2CC-2585504221A9}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{B953A044-440C-43C0-B2CC-2585504221A9}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{35500763-A1C6-468A-A0F0-7AE737D5CEF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35500763-A1C6-468A-A0F0-7AE737D5CEF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35500763-A1C6-468A-A0F0-7AE737D5CEF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35500763-A1C6-468A-A0F0-7AE737D5CEF0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35500763-A1C6-468A-A0F0-7AE737D5CEF0}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{35500763-A1C6-468A-A0F0-7AE737D5CEF0}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{481F0C9E-DA19-4DBD-9D25-EBA1030AAA03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{481F0C9E-DA19-4DBD-9D25-EBA1030AAA03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{481F0C9E-DA19-4DBD-9D25-EBA1030AAA03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{481F0C9E-DA19-4DBD-9D25-EBA1030AAA03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{481F0C9E-DA19-4DBD-9D25-EBA1030AAA03}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{481F0C9E-DA19-4DBD-9D25-EBA1030AAA03}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{35DE0E35-4E3A-46D7-B175-80CA10276BE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35DE0E35-4E3A-46D7-B175-80CA10276BE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35DE0E35-4E3A-46D7-B175-80CA10276BE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35DE0E35-4E3A-46D7-B175-80CA10276BE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35DE0E35-4E3A-46D7-B175-80CA10276BE7}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{35DE0E35-4E3A-46D7-B175-80CA10276BE7}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{DCAAF1DB-BEA0-4A6F-8F67-A35A9891A7A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCAAF1DB-BEA0-4A6F-8F67-A35A9891A7A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCAAF1DB-BEA0-4A6F-8F67-A35A9891A7A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCAAF1DB-BEA0-4A6F-8F67-A35A9891A7A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCAAF1DB-BEA0-4A6F-8F67-A35A9891A7A9}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{DCAAF1DB-BEA0-4A6F-8F67-A35A9891A7A9}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Release|Any CPU.Build.0 = Release|Any CPU
+		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{730E1D38-BA80-48C7-B05C-E2BD29F38851}.Verify|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Src/AutoFakeItEasy2.UnitTest/AutoFakeItEasy2.UnitTest.csproj
+++ b/Src/AutoFakeItEasy2.UnitTest/AutoFakeItEasy2.UnitTest.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFakeItEasy2\AutoFakeItEasy2.csproj">
-      <Project>{b6b79e32-ee90-4ae1-bd32-f50b5a0c2b40}</Project>
+      <Project>{68A3F347-7D9D-4020-A3D5-F127234DD429}</Project>
       <Name>AutoFakeItEasy2</Name>
     </ProjectReference>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj">

--- a/Src/AutoFakeItEasy2/AutoFakeItEasy2.csproj
+++ b/Src/AutoFakeItEasy2/AutoFakeItEasy2.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{B6B79E32-EE90-4AE1-BD32-F50B5A0C2B40}</ProjectGuid>
+    <ProjectGuid>{68A3F347-7D9D-4020-A3D5-F127234DD429}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy2</RootNamespace>

--- a/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
+++ b/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}</ProjectGuid>
+    <ProjectGuid>{E5CAB3E1-10DD-4081-A5FF-ED8A11F3C2CB}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>


### PR DESCRIPTION
Before we built AutoFixture project multiple times as a part of the different solutions. It significantly slowed downs the build process (e.g. because code analysis was run for the AutoFixture project for a few times).

I've created a solution `All.sln` that contains all the projects we have. The benefits are following:
- it takes about half of time to build the project (e.g. 4 min 19 secs compared to average 7 min 30 secs)[https://ci.appveyor.com/project/AutoFixture/autofixture/history]
- it allows to reduce the AppVeyor [build log](https://ci.appveyor.com/project/AutoFixture/autofixture/build/1.0.95) size, so browser lags significantly less when a build is opened (3143 lines compared to 6776 lines).
- you have ability to load all the projects simultaneously and perform some code analysis on the whole codebase (e.g. check usages of the particular API).

~~The only thing I'm not confident in is the solution name. Do you like `AutoFixture.AllProjects` name or the `AutoFixture.All` name looks nicer?~~
Solution name was updated to `All.sln`.