### PR TITLE
Add auto deployment for the vNext branch

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -18,8 +18,9 @@ let signKeyPath = FullName "Src/AutoFixture.snk"
 let solutionsToBuild = !! "Src/All.sln"
 let bakFileExt = ".orig"
 
-type BuildVersionInfo = { assemblyVersion:string; fileVersion:string; infoVersion:string; nugetVersion:string }
-let calculateVersionFromGit buildNumber =
+type BuildVersionCalculationSource = { major: int; minor: int; revision: int; preSuffix: string; 
+                                       commitsNum: int; sha: string; buildNumber: int }
+let getVersionSourceFromGit buildNumber =
     // Example of output for a release tag: v3.50.2-288-g64fd5c5b, for a prerelease tag: v3.50.2-alpha1-288-g64fd5c5b
     let desc = Git.CommandHelper.runSimpleGitCommand "" "describe --tags --long --match=v*"
 
@@ -27,18 +28,31 @@ let calculateVersionFromGit buildNumber =
                              @"^v(?<maj>\d+)\.(?<min>\d+)\.(?<rev>\d+)(?<pre>-\w+\d*)?-(?<num>\d+)-g(?<sha>[a-z0-9]+)$",
                              RegexOptions.IgnoreCase)
                       .Groups
+
     let getMatch (name:string) = result.[name].Value
 
-    let major, minor, revision, preReleaseSuffix, commitsNum, sha =
-        getMatch "maj" |> int, getMatch "min" |> int, getMatch "rev" |> int, getMatch "pre", getMatch "num" |> int, getMatch "sha"
+    { major = getMatch "maj" |> int
+      minor = getMatch "min" |> int
+      revision = getMatch "rev" |> int
+      preSuffix = getMatch "pre"
+      commitsNum = getMatch "num" |> int
+      sha = getMatch "sha"
+      buildNumber = buildNumber
+    }
 
-    
+type BuildVersionInfo = { assemblyVersion:string; fileVersion:string; infoVersion:string; nugetVersion:string; 
+                          source: Option<BuildVersionCalculationSource> }
+let calculateVersion source =
+    let s = source
+    let (major, minor, revision, preReleaseSuffix, commitsNum, sha, buildNumber) =
+        (s.major, s.minor, s.revision, s.preSuffix, s.commitsNum, s.sha, s.buildNumber)
+
     let assemblyVersion = sprintf "%d.%d.0.0" major minor
     let fileVersion = sprintf "%d.%d.%d.%d" major minor revision buildNumber
     
     // If number of commits since last tag is greater than zero, we append another identifier with number of commits.
     // The produced version is larger than the last tag version.
-    // If we are on a tag, we use version specified modification.
+    // If we are on a tag, we use version without modification.
     // Examples of output: 3.50.2.1, 3.50.2.215, 3.50.1-rc1.3, 3.50.1-rc3.35
     let nugetVersion = match commitsNum with
                        | 0 -> sprintf "%d.%d.%d%s" major minor revision preReleaseSuffix
@@ -48,17 +62,23 @@ let calculateVersionFromGit buildNumber =
                       | 0 -> nugetVersion
                       | _ -> sprintf "%s-%s" nugetVersion sha
 
-    { assemblyVersion=assemblyVersion; fileVersion=fileVersion; infoVersion=infoVersion; nugetVersion=nugetVersion }
+    { assemblyVersion=assemblyVersion; fileVersion=fileVersion; infoVersion=infoVersion; nugetVersion=nugetVersion; 
+      source = Some source }
 
 // Calculate version that should be used for the build. Define globally as data might be required by multiple targets.
 // Please never name the build parameter with version as "Version" - it might be consumed by the MSBuild, override 
 // the defined properties and break some tasks (e.g. NuGet restore).
-let buildVersion = match getBuildParamOrDefault "BuildVersion" "git" with
-                   | "git"       -> calculateVersionFromGit (getBuildParamOrDefault "BuildNumber" "0" |> int)
-                   | assemblyVer -> { assemblyVersion = assemblyVer
-                                      fileVersion = getBuildParamOrDefault "BuildFileVersion" assemblyVer
-                                      infoVersion = getBuildParamOrDefault "BuildInfoVersion" assemblyVer
-                                      nugetVersion = getBuildParamOrDefault "BuildNugetVersion" assemblyVer }
+let mutable buildVersion = match getBuildParamOrDefault "BuildVersion" "git" with
+                           | "git"       -> getBuildParamOrDefault "BuildNumber" "0"
+                                            |> int
+                                            |> getVersionSourceFromGit
+                                            |> calculateVersion
+
+                           | assemblyVer -> { assemblyVersion = assemblyVer
+                                              fileVersion = getBuildParamOrDefault "BuildFileVersion" assemblyVer
+                                              infoVersion = getBuildParamOrDefault "BuildInfoVersion" assemblyVer
+                                              nugetVersion = getBuildParamOrDefault "BuildNugetVersion" assemblyVer
+                                              source = None }
 
 let addBakExt path = sprintf "%s%s" path bakFileExt
 

--- a/Build.fsx
+++ b/Build.fsx
@@ -340,16 +340,19 @@ Target "PublishNuGetAll" DoNothing
 type AppVeyorEnvironment with
     static member IsPullRequest = isNotNullOrEmpty AppVeyorEnvironment.PullRequestNumber
 
-type AppVeyorTrigger = SemVerTag | CustomTag | PR | Unknown
+type AppVeyorTrigger = SemVerTag | CustomTag | PR | VNextBranch | Unknown
 let anAppVeyorTrigger =
     let tag = if AppVeyorEnvironment.RepoTag then Some AppVeyorEnvironment.RepoTagName else None
     let isPR = AppVeyorEnvironment.IsPullRequest
+    let branch = if isNotNullOrEmpty AppVeyorEnvironment.RepoBranch then Some AppVeyorEnvironment.RepoBranch else None
 
-    match tag, isPR with
-    | Some t, _ when "v\d+.*" >** t -> SemVerTag
-    | Some _, _                     -> CustomTag
-    | _, true                       -> PR
-    | _                             -> Unknown
+    match tag, isPR, branch with
+    | Some t, _, _ when "v\d+.*" >** t -> SemVerTag
+    | Some _, _, _                     -> CustomTag
+    | _, true, _                       -> PR
+    // Branch name should be checked after the PR flag, because for PR it's set to the upstream branch name.
+    | _, _, Some br when "v\d+" >** br -> VNextBranch
+    | _                                -> Unknown
 
 // Print state info at the very beginning
 if buildServer = BuildServer.AppVeyor 
@@ -360,14 +363,24 @@ if buildServer = BuildServer.AppVeyor
               AppVeyorEnvironment.RepoBranch
               anAppVeyorTrigger
 
+Target "AppVeyor_SetVNextVersion" (fun _ ->
+    // vNext branch has the following name: "vX", where X is the next version
+    AppVeyorEnvironment.RepoBranch.Substring(1) 
+    |> int
+    |> setVNextBranchVersion
+)
+
 Target "AppVeyor" (fun _ ->
     //Artifacts might be deployable, so we update build version to find them later by file version
     if not AppVeyorEnvironment.IsPullRequest then UpdateBuildVersion buildVersion.fileVersion
 )
 
+"AppVeyor_SetVNextVersion" =?> ("PatchAssemblyVersions", anAppVeyorTrigger = VNextBranch)
+
 // Add logic to resolve action based on current trigger info
 dependency "AppVeyor" <| match anAppVeyorTrigger with
                          | SemVerTag                -> "PublishNuGetPublic"
+                         | VNextBranch              -> "PublishNuGetPrivate"
                          | PR | CustomTag | Unknown -> "CompleteBuild"
 
 


### PR DESCRIPTION
This PR enables push to the [private feed](https://www.myget.org/F/autofixture) on any commit to the vNext branch (`v4` in our case).

## Version calculation
The version calculation logic was updated to the following one:
1. Extract `vNext` major version from the `vNext` branch name (e.g. `4` for the `v4`).
1. Calculate version using the current [tag based logic](https://github.com/AutoFixture/AutoFixture/pull/753). Compare version's major number to `vNext` major version. If they are the same, use this version (e.g. use result if it's `v4.0.0-beta1.25` for `v4` branch).
1. If previous version is not applicable, generate version based on `vNext` major version and number of commits since the last release before the `vNext` fork. The generated version has the `-alpha` pre-release suffix.  For instance, for the graph below
```
| * vNext commit 6
| * merge master to vNext
 /|
/ |
* | master commit
* | master commit
* | master commit
| * vNext commit 5
| * vNext commit 4 (tagged as v4.0.0-beta1)
| * vNext commit 3
| * merge master to vNext
 /|
/ |
| * vNext commit
* | master commit (tagged as v3.50.2)
| * vNext commit 1
* | master commit
| /
|/
* master commit (tagged as v3.50.1)
* master commit
```
result would be:
- `vNext commit 1` - `v4.0.0-alpha.1`
- `vNext commit 2` - `v4.0.0-alpha.2`
- `vNext commit 3` - `v4.0.0-alpha.4`
- `vNext commit 4` - `v4.0.0-beta1`
- `vNext commit 5` - `v4.0.0-beta1.1`
- `vNext commit 6` - `v4.0.0-beta1.3`

## vNext branch configuration (updated)
No need to configure the vNext branch somehow - simply create a branch with the `vX` name, where X is the number and builds will be automatically pushed to the MyGet feed.