### PR TITLE
Ignore Rider temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Packages.dgml
 AutoFixture character.design
 .fake/
 NUnit[23]TestResult.xml
+.idea/


### PR DESCRIPTION
Ignore the [Rider IDE](https://www.jetbrains.com/rider/) temp files.