### PR TITLE
Fix one customization could affect other customizations

### DIFF
--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -212,8 +212,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> Do(Action<T> action)
         {
-            var graphWithoutSeedIgnoringRelay =
-                this.WithoutSeedIgnoringRelay();
+            var graphWithoutSeedIgnoringRelay = WithoutSeedIgnoringRelay(this);
 
             var container = FindContainer(graphWithoutSeedIgnoringRelay);
             var autoPropertiesNode = FindAutoPropertiesNode(container);
@@ -229,19 +228,6 @@ namespace Ploeh.AutoFixture.Dsl
             return (NodeComposer<T>)graphWithDoNode.ReplaceNodes(
                 with: n => n.Compose(n.Concat(new [] { new SeedIgnoringRelay() })),
                 when: filter.Equals);
-        }
-
-        private static ISpecimenBuilderNode FindAutoPropertiesNode(
-            ISpecimenBuilderNode graph)
-        {
-            return graph.FindFirstNodeOrDefault(IsAutoPropertyNode);
-        }
-
-        private static bool IsAutoPropertyNode(ISpecimenBuilderNode n)
-        {
-            var postprocessor = n as Postprocessor<T>;
-            return postprocessor != null
-                && postprocessor.Command is AutoPropertiesCommand<T>;
         }
 
         private static NodeComposer<T> WithDoNode(
@@ -269,16 +255,22 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> OmitAutoProperties()
         {
-            var targetToRemove = FindAutoPropertiesNode(this);
+            var autoPropertiesNode = FindAutoPropertiesNode(this);
 
-            if (targetToRemove == null)
+            if (autoPropertiesNode == null)
                 return this;
 
-            var p = this.Parents(targetToRemove.Equals).First();
-
-            return (NodeComposer<T>)this.ReplaceNodes(
-                with: targetToRemove.Concat(p.Where(b => targetToRemove != b)),
-                when: p.Equals);
+            // We disable postprocessor rather than delete it.
+            // The reason is that it's the only holder of which properties/fields should not be populated.
+            // If user later decide to enable properties population, we'll need this information 
+            // (e.g. if user does smth like fixture.Build().Without(x => x.P).OmitAutoProperties().WithAutoProperties()
+            // the information from "Without" should not be missed)
+            return (NodeComposer<T>) this.ReplaceNodes(
+                with: n => new Postprocessor<T>(
+                    autoPropertiesNode.Builder,
+                    autoPropertiesNode.Command,
+                    new FalseRequestSpecification()),
+                when: autoPropertiesNode.Equals);
         }
 
         /// <summary>
@@ -332,8 +324,8 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
-            var graphWithoutSeedIgnoringRelay =
-                this.WithoutSeedIgnoringRelay();
+            var graphWithAutoPropertiesNode = this.GetGraphWithAutoPropertiesNode();
+            var graphWithoutSeedIgnoringRelay = WithoutSeedIgnoringRelay(graphWithAutoPropertiesNode);
 
             var container = FindContainer(graphWithoutSeedIgnoringRelay);
          
@@ -349,17 +341,8 @@ namespace Ploeh.AutoFixture.Dsl
                     }),
                 when: container.Equals);
 
-            return (NodeComposer<T>)graphWithProperty.ReplaceNodes(
-                with: n => n.Compose(
-                    new []
-                    {
-                        new Omitter(
-                            new EqualRequestSpecification(
-                                propertyPicker.GetWritableMember().Member,
-                                new MemberInfoEqualityComparer()))
-                    }
-                    .Concat(n)),
-                when: n => n is NodeComposer<T>);
+            var member = propertyPicker.GetWritableMember().Member;
+            return (NodeComposer<T>) ExcludeMemberFromAutoProperties(member, graphWithProperty);
         }
 
         /// <summary>
@@ -371,21 +354,15 @@ namespace Ploeh.AutoFixture.Dsl
         /// </returns>
         public IPostprocessComposer<T> WithAutoProperties()
         {
-            var g = this.WithoutSeedIgnoringRelay();
+            var g = GetGraphWithAutoPropertiesNode();
+            var autoProperties = FindAutoPropertiesNode(g);
 
-            var filter = FindContainer(g);
-
-            return (NodeComposer<T>)g.ReplaceNodes(
-                with: n => ((FilteringSpecimenBuilder)n).Compose(
-                    new ISpecimenBuilder[]
-                    {
-                        new Postprocessor<T>(
-                            CompositeSpecimenBuilder.ComposeIfMultiple(n),
-                            new AutoPropertiesCommand<T>(),
-                            CreateSpecification()),
-                        new SeedIgnoringRelay()
-                    }),
-                when: filter.Equals);
+            return (NodeComposer<T>) g.ReplaceNodes(
+                with: n => new Postprocessor<T>(
+                    autoProperties.Builder,
+                    autoProperties.Command,
+                    new TrueRequestSpecification()),
+                when: autoProperties.Equals);
         }
 
         /// <summary>
@@ -411,16 +388,8 @@ namespace Ploeh.AutoFixture.Dsl
                 m = typeof(T).GetTypeInfo().GetProperty(m.Name) ?? (MemberInfo) typeof(T).GetTypeInfo().GetField(m.Name);
             }
 
-            return (NodeComposer<T>)this.ReplaceNodes(
-                with: n => n.Compose(
-                    new[]
-                    {
-                        new Omitter(
-                            new EqualRequestSpecification(
-                                m,
-                                new MemberInfoEqualityComparer()))
-                    }.Concat(n)),
-                when: n => n is NodeComposer<T>);
+            var graphWithAutoPropertiesNode = GetGraphWithAutoPropertiesNode();
+            return (NodeComposer<T>) ExcludeMemberFromAutoProperties(m, graphWithAutoPropertiesNode);
         }
 
         /// <summary>
@@ -522,9 +491,81 @@ namespace Ploeh.AutoFixture.Dsl
         /// <seealso cref="NodeComposer{T}(ISpecimenBuilder)" />
         public ISpecimenBuilder Builder { get; }
 
-        private ISpecimenBuilderNode WithoutSeedIgnoringRelay()
+        /// <summary>
+        /// Looks for the AutoProperties postprocessor in the current graph.
+        /// If postprocessor is missing, it's created in inactive state.
+        /// </summary>
+        private NodeComposer<T> GetGraphWithAutoPropertiesNode()
         {
-            var g = this.ReplaceNodes(
+            var existingNode = FindAutoPropertiesNode(this);
+            if(existingNode != null) return this;
+            
+            var g = WithoutSeedIgnoringRelay(this);
+            var filter = FindContainer(g);
+
+            //Create AutoProperties node in inactive state
+            return (NodeComposer<T>)g.ReplaceNodes(
+                with: n => n.Compose(
+                    new ISpecimenBuilder[]
+                    {
+                        new Postprocessor<T>(
+                            CompositeSpecimenBuilder.ComposeIfMultiple(n),
+                            new AutoPropertiesCommand<T>(),
+                            new FalseRequestSpecification()),
+                        new SeedIgnoringRelay()
+                    }),
+                when: filter.Equals);
+        }
+
+        private static Postprocessor<T> FindAutoPropertiesNode(ISpecimenBuilderNode graph)
+        {
+            return (Postprocessor<T>) graph
+                .FindFirstNodeOrDefault(n => n is Postprocessor<T> postprocessor &&
+                                             postprocessor.Command is AutoPropertiesCommand<T>);
+        }
+        
+        /// <summary>
+        /// Adjusts the AutoProperties postprocessor and changes rule to avoid the specified member population.
+        /// If AutoProperties node is missing, nothing is done. 
+        /// </summary>
+        private static ISpecimenBuilderNode ExcludeMemberFromAutoProperties(MemberInfo member, 
+            ISpecimenBuilderNode graph)
+        {
+            var autoPropertiesNode = FindAutoPropertiesNode(graph);
+            if (autoPropertiesNode == null) return graph;
+
+            var currentSpecification = ((AutoPropertiesCommand<T>) autoPropertiesNode.Command).Specification;
+            var newRule = new InverseRequestSpecification(
+                new EqualRequestSpecification(
+                    member,
+                    new MemberInfoEqualityComparer()));
+
+            // Try to make specification list flat if possible
+            IRequestSpecification specification;
+            if (currentSpecification is TrueRequestSpecification)
+            {
+                specification = newRule;
+            }
+            else if (currentSpecification is AndRequestSpecification andSpec)
+            {
+                specification = new AndRequestSpecification(andSpec.Specifications.Concat(new[] {newRule}));
+            }
+            else
+            {
+                specification = new AndRequestSpecification(currentSpecification, newRule);
+            }
+
+            return graph.ReplaceNodes(
+                with: _ => new Postprocessor<T>(
+                    autoPropertiesNode.Builder,
+                    new AutoPropertiesCommand<T>(specification),
+                    autoPropertiesNode.Specification),
+                when: autoPropertiesNode.Equals);
+        }
+        
+        private static ISpecimenBuilderNode WithoutSeedIgnoringRelay(ISpecimenBuilderNode graph)
+        {
+            var g = graph.ReplaceNodes(
                 with: n => CompositeSpecimenBuilder.UnwrapIfSingle(
                     n.Compose(n.Where(b => !(b is SeedIgnoringRelay)))),
                 when: n => n.OfType<SeedIgnoringRelay>().Any());

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -382,14 +382,10 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> Without<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker)
         {
-            var m = propertyPicker.GetWritableMember().Member;
-            if (m.DeclaringType != typeof(T))
-            {
-                m = typeof(T).GetTypeInfo().GetProperty(m.Name) ?? (MemberInfo) typeof(T).GetTypeInfo().GetField(m.Name);
-            }
-
+            var member = propertyPicker.GetWritableMember().Member;
             var graphWithAutoPropertiesNode = GetGraphWithAutoPropertiesNode();
-            return (NodeComposer<T>) ExcludeMemberFromAutoProperties(m, graphWithAutoPropertiesNode);
+
+            return (NodeComposer<T>) ExcludeMemberFromAutoProperties(member, graphWithAutoPropertiesNode);
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
+++ b/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
@@ -103,7 +103,10 @@ namespace Ploeh.AutoFixture.Kernel
     public class AutoPropertiesCommand<T> : ISpecifiedSpecimenCommand<T>, ISpecimenCommand
 #pragma warning restore 618
     {
-        private readonly IRequestSpecification specification;
+        /// <summary>
+        /// Specification that filters properties and files that should be populated.
+        /// </summary>
+        public IRequestSpecification Specification { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoPropertiesCommand{T}"/> class.
@@ -133,7 +136,7 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(specification));
             }
 
-            this.specification = specification;
+            this.Specification = specification;
         }
 
         /// <summary>
@@ -220,7 +223,7 @@ namespace Ploeh.AutoFixture.Kernel
         {
             return from fi in this.GetSpecimenType(specimen).GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance)
                    where !fi.IsInitOnly
-                   && this.specification.IsSatisfiedBy(fi)
+                   && this.Specification.IsSatisfiedBy(fi)
                    select fi;
         }
 
@@ -229,7 +232,7 @@ namespace Ploeh.AutoFixture.Kernel
             return from pi in this.GetSpecimenType(specimen).GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance)
                    where pi.GetSetMethod() != null
                    && pi.GetIndexParameters().Length == 0
-                   && this.specification.IsSatisfiedBy(pi)
+                   && this.Specification.IsSatisfiedBy(pi)
                    select pi;
         }
 

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -350,9 +350,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
                                     new SeedRequestSpecification(
                                         typeof(Version)))),
                             new AutoPropertiesCommand<Version>(),
-                            new OrRequestSpecification(
-                                new SeedRequestSpecification(typeof(Version)),
-                                new ExactTypeSpecification(typeof(Version)))),
+                            new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
                         new SeedRequestSpecification(typeof(Version)),
@@ -386,7 +384,22 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             // Exercise system
             var actual = sut.WithAutoProperties().OmitAutoProperties();
             // Verify outcome
-            var expected = sut;
+            var expected = new NodeComposer<Version>(
+                new FilteringSpecimenBuilder(
+                    new CompositeSpecimenBuilder(
+                        new Postprocessor<Version>(
+                            new NoSpecimenOutputGuard(
+                                new MethodInvoker(
+                                    new ModestConstructorQuery()),
+                                new InverseRequestSpecification(
+                                    new SeedRequestSpecification(
+                                        typeof(Version)))),
+                            new AutoPropertiesCommand<Version>(),
+                            new FalseRequestSpecification()),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(Version)),
+                        new ExactTypeSpecification(typeof(Version)))));
 
             var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
@@ -438,13 +451,9 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             var actual = sut.With(x => x.Property, value);
             // Verify outcome
             var expected = new NodeComposer<PropertyHolder<string>>(
-                new CompositeSpecimenBuilder(
-                    new Omitter(
-                        new EqualRequestSpecification(
-                            pi,
-                            new MemberInfoEqualityComparer())),
-                    new FilteringSpecimenBuilder(
-                        new CompositeSpecimenBuilder(
+                new FilteringSpecimenBuilder(
+                    new CompositeSpecimenBuilder(
+                        new Postprocessor<PropertyHolder<string>>(
                             new Postprocessor<PropertyHolder<string>>(
                                 new NoSpecimenOutputGuard(
                                     new MethodInvoker(
@@ -452,14 +461,21 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
                                     new InverseRequestSpecification(
                                         new SeedRequestSpecification(
                                             typeof(PropertyHolder<string>)))),
-                                new BindingCommand<PropertyHolder<string>, string>(x => x.Property, value),
-                                new OrRequestSpecification(
-                                    new SeedRequestSpecification(typeof(PropertyHolder<string>)),
-                                    new ExactTypeSpecification(typeof(PropertyHolder<string>)))),
-                            new SeedIgnoringRelay()),
-                        new OrRequestSpecification(
-                            new SeedRequestSpecification(typeof(PropertyHolder<string>)),
-                            new ExactTypeSpecification(typeof(PropertyHolder<string>))))));
+                                new AutoPropertiesCommand<PropertyHolder<string>>(
+                                    new InverseRequestSpecification(
+                                        new EqualRequestSpecification(
+                                            pi,
+                                            new MemberInfoEqualityComparer()))),
+                                new FalseRequestSpecification()
+                            ),
+                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, value),
+                            new OrRequestSpecification(
+                                new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                                new ExactTypeSpecification(typeof(PropertyHolder<string>)))),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                        new ExactTypeSpecification(typeof(PropertyHolder<string>)))));
 
             var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
@@ -486,38 +502,40 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
                 .With(x => x.Property2, value2);
             // Verify outcome
             var expected = new NodeComposer<DoublePropertyHolder<string, int>>(
-                new CompositeSpecimenBuilder(
-                    new Omitter(
-                        new EqualRequestSpecification(
-                            pi2,
-                            new MemberInfoEqualityComparer())),
+                new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Omitter(
-                            new EqualRequestSpecification(
-                                pi1,
-                                new MemberInfoEqualityComparer())),
-                        new FilteringSpecimenBuilder(
-                            new CompositeSpecimenBuilder(
+                        new Postprocessor<DoublePropertyHolder<string, int>>(
+                            new Postprocessor<DoublePropertyHolder<string, int>>(
                                 new Postprocessor<DoublePropertyHolder<string, int>>(
-                                    new Postprocessor<DoublePropertyHolder<string, int>>(
-                                        new NoSpecimenOutputGuard(
-                                            new MethodInvoker(
-                                                new ModestConstructorQuery()),
+                                    new NoSpecimenOutputGuard(
+                                        new MethodInvoker(
+                                            new ModestConstructorQuery()),
+                                        new InverseRequestSpecification(
+                                            new SeedRequestSpecification(
+                                                typeof(DoublePropertyHolder<string, int>)))),
+                                    new AutoPropertiesCommand<DoublePropertyHolder<string, int>>(
+                                        new AndRequestSpecification(
                                             new InverseRequestSpecification(
-                                                new SeedRequestSpecification(
-                                                    typeof(DoublePropertyHolder<string, int>)))),
-                                        new BindingCommand<DoublePropertyHolder<string, int>, string>(x => x.Property1, value1),
-                                        new OrRequestSpecification(
-                                            new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
-                                            new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))),
-                                    new BindingCommand<DoublePropertyHolder<string, int>, int>(x => x.Property2, value2),
-                                    new OrRequestSpecification(
-                                        new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
-                                        new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))),
-                                new SeedIgnoringRelay()),
+                                                new EqualRequestSpecification(
+                                                    pi1,
+                                                    new MemberInfoEqualityComparer())),
+                                            new InverseRequestSpecification(
+                                                new EqualRequestSpecification(
+                                                    pi2,
+                                                    new MemberInfoEqualityComparer())))),
+                                    new FalseRequestSpecification()),
+                                new BindingCommand<DoublePropertyHolder<string, int>, string>(x => x.Property1, value1),
+                                new OrRequestSpecification(
+                                    new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
+                                    new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))),
+                            new BindingCommand<DoublePropertyHolder<string, int>, int>(x => x.Property2, value2),
                             new OrRequestSpecification(
                                 new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
-                                new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))))));
+                                new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
+                        new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))));
 
             var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
@@ -534,24 +552,26 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             var actual = sut.Without(x => x.Field);
             // Verify outcome
             var expected = new NodeComposer<FieldHolder<short>>(
-                new CompositeSpecimenBuilder(
-                    new Omitter(
-                        new EqualRequestSpecification(
-                            fi,
-                            new MemberInfoEqualityComparer())),
-                    new FilteringSpecimenBuilder(
-                        new CompositeSpecimenBuilder(
+                new FilteringSpecimenBuilder(
+                    new CompositeSpecimenBuilder(
+                        new Postprocessor<FieldHolder<short>>(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
                                 new InverseRequestSpecification(
                                     new SeedRequestSpecification(
                                         typeof(FieldHolder<short>)))),
-                            new SeedIgnoringRelay()),
-                        new OrRequestSpecification(
-                            new SeedRequestSpecification(typeof(FieldHolder<short>)),
-                            new ExactTypeSpecification(typeof(FieldHolder<short>))))));
-
+                            new AutoPropertiesCommand<FieldHolder<short>>(
+                                new InverseRequestSpecification(
+                                    new EqualRequestSpecification(
+                                        fi,
+                                        new MemberInfoEqualityComparer()))),
+                            new FalseRequestSpecification()),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(FieldHolder<short>)),
+                        new ExactTypeSpecification(typeof(FieldHolder<short>)))));
+            
             var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
             // Teardown
@@ -577,9 +597,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
                                     new SeedRequestSpecification(
                                         typeof(Version)))),
                             new AutoPropertiesCommand<Version>(),
-                            new OrRequestSpecification(
-                                new SeedRequestSpecification(typeof(Version)),
-                                new ExactTypeSpecification(typeof(Version)))),
+                            new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
                         new SeedRequestSpecification(typeof(Version)),
@@ -613,7 +631,22 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             // Exercise system
             var actual = sut.WithAutoProperties(true).WithAutoProperties(false);
             // Verify outcome
-            var expected = sut;
+            var expected = new NodeComposer<Version>(
+                new FilteringSpecimenBuilder(
+                    new CompositeSpecimenBuilder(
+                        new Postprocessor<Version>(
+                            new NoSpecimenOutputGuard(
+                                new MethodInvoker(
+                                    new ModestConstructorQuery()),
+                                new InverseRequestSpecification(
+                                    new SeedRequestSpecification(
+                                        typeof(Version)))),
+                            new AutoPropertiesCommand<Version>(),
+                            new FalseRequestSpecification()),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(Version)),
+                        new ExactTypeSpecification(typeof(Version)))));
 
             var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
@@ -640,9 +673,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
                                     new SeedRequestSpecification(
                                         typeof(PropertyHolder<string>)))),
                             new AutoPropertiesCommand<PropertyHolder<string>>(),
-                            new OrRequestSpecification(
-                                new SeedRequestSpecification(typeof(PropertyHolder<string>)),
-                                new ExactTypeSpecification(typeof(PropertyHolder<string>)))),
+                            new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
                         new SeedRequestSpecification(typeof(PropertyHolder<string>)),
@@ -675,9 +706,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
                                             typeof(PropertyHolder<int>)))),
                                 new ActionSpecimenCommand<PropertyHolder<int>>(a)),
                             new AutoPropertiesCommand<PropertyHolder<int>>(),
-                            new OrRequestSpecification(
-                                new SeedRequestSpecification(typeof(PropertyHolder<int>)),
-                                new ExactTypeSpecification(typeof(PropertyHolder<int>)))),
+                            new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
                         new SeedRequestSpecification(typeof(PropertyHolder<int>)),

--- a/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
@@ -21,48 +21,36 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
         public bool Equals(ISpecimenBuilder x, ISpecimenBuilder y)
         {
-            var fx = x as FilteringSpecimenBuilder;
-            var fy = y as FilteringSpecimenBuilder;
-            if (fx != null &&
-                fy != null &&
+            if (x is FilteringSpecimenBuilder fx &&
+                y is FilteringSpecimenBuilder fy &&
                 this.specificationComparer.Equals(fx.Specification, fy.Specification))
                 return true;
 
             if (x is CompositeSpecimenBuilder && y is CompositeSpecimenBuilder)
                 return true;
 
-            var gx = x as NoSpecimenOutputGuard;
-            var gy = y as NoSpecimenOutputGuard;
-            if (gx != null &&
-                gy != null &&
+            if (x is NoSpecimenOutputGuard gx &&
+                y is NoSpecimenOutputGuard gy &&
                 this.specificationComparer.Equals(gx.Specification, gy.Specification))
                 return true;
 
-            var sirx = x as SeedIgnoringRelay;
-            var siry = y as SeedIgnoringRelay;
-            if (sirx != null && siry != null)
+            if (x is SeedIgnoringRelay && y is SeedIgnoringRelay)
             {
                 return true;
             }
 
-            var mix = x as MethodInvoker;
-            var miy = y as MethodInvoker;
-            if (mix != null &&
-                miy != null &&
+            if (x is MethodInvoker mix &&
+                y is MethodInvoker miy &&
                 this.queryComparer.Equals(mix.Query, miy.Query))
                 return true;
 
-            var omx = x as Omitter;
-            var omy = y as Omitter;
-            if (omx != null &&
-                omy != null &&
+            if (x is Omitter omx &&
+                y is Omitter omy &&
                 this.specificationComparer.Equals(omx.Specification, omy.Specification))
                 return true;
 
-            var dx = x as DelegatingSpecimenBuilder;
-            var dy = y as DelegatingSpecimenBuilder;
-            if (dx != null &&
-                dy != null &&
+            if (x is DelegatingSpecimenBuilder dx &&
+                y is DelegatingSpecimenBuilder dy &&
                 object.Equals(dx.OnCreate, dy.OnCreate))
                 return true;
 
@@ -88,45 +76,31 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             public bool Equals(IRequestSpecification x, IRequestSpecification y)
             {
-                var invx = x as InverseRequestSpecification;
-                var invy = y as InverseRequestSpecification;
-                if (invx != null &&
-                    invy != null &&
+                if (x is InverseRequestSpecification invx &&
+                    y is InverseRequestSpecification invy &&
                     this.Equals(invx.Specification, invy.Specification))
                     return true;
 
-                var ox = x as OrRequestSpecification;
-                var oy = y as OrRequestSpecification;
-                if (ox != null &&
-                    oy != null &&
+                if (x is OrRequestSpecification ox &&
+                    y is OrRequestSpecification oy &&
                     ox.Specifications.SequenceEqual(oy.Specifications, this))
                     return true;
 
-                var sx = x as SeedRequestSpecification;
-                var sy = y as SeedRequestSpecification;
-                if (sx != null && sy != null)
-                {
-                    if (sx.TargetType == sy.TargetType)
-                        return true;
-                }
-
-                var ex = x as ExactTypeSpecification;
-                var ey = y as ExactTypeSpecification;
-                if (ex != null && ey != null)
-                {
-                    if (ex.TargetType == ey.TargetType)
-                        return true;
-                }
-
-                var tx = x as TrueRequestSpecification;
-                var ty = x as TrueRequestSpecification;
-                if (tx != null && ty != null)
+                if (x is SeedRequestSpecification sx &&
+                    y is SeedRequestSpecification sy &&
+                    sx.TargetType == sy.TargetType)
                     return true;
 
-                var eqx = x as EqualRequestSpecification;
-                var eqy = y as EqualRequestSpecification;
-                if (eqx != null &&
-                    eqy != null &&
+                if (x is ExactTypeSpecification ex && 
+                    y is ExactTypeSpecification ey &&
+                    ex.TargetType == ey.TargetType)
+                    return true;
+                
+                if (x is TrueRequestSpecification && y is TrueRequestSpecification)
+                    return true;
+
+                if (x is EqualRequestSpecification eqx &&
+                    y is EqualRequestSpecification eqy &&
                     object.Equals(eqx.Target, eqy.Target) &&
                     this.comparerComparer.Equals(eqx.Comparer, eqy.Comparer))
                     return true;
@@ -143,10 +117,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             {
                 public bool Equals(IEqualityComparer x, IEqualityComparer y)
                 {
-                    var micx = x as MemberInfoEqualityComparer;
-                    var micy = y as MemberInfoEqualityComparer;
-                    if (micx != null &&
-                        micy != null)
+                    if (x is MemberInfoEqualityComparer &&
+                        y is MemberInfoEqualityComparer)
                         return true;
 
                     return EqualityComparer<IEqualityComparer>.Default.Equals(x, y);
@@ -163,10 +135,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             public bool Equals(IMethodQuery x, IMethodQuery y)
             {
-                var mqx = x as ModestConstructorQuery;
-                var mqy = y as ModestConstructorQuery;
-                if (mqx != null &&
-                    mqy != null)
+                if (x is ModestConstructorQuery &&
+                    y is ModestConstructorQuery)
                     return true;
 
                 return EqualityComparer<IMethodQuery>.Default.Equals(x, y);
@@ -200,9 +170,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                 if (!t.IsGenericType)
                     return new object();
 
-                Type equatableType;
-                if (equatables.TryGetValue(t.GetGenericTypeDefinition(),
-                    out equatableType))
+                if (equatables.TryGetValue(t.GetGenericTypeDefinition(), out Type equatableType))
                 {
                     var typeArguments = t.GetGenericArguments();
                     return equatableType.MakeGenericType(typeArguments)
@@ -226,7 +194,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             protected override bool EqualsInstance(Postprocessor<T> other)
             {
-                return this.Item.Command.GetType().Equals(other.Command.GetType())
+                return this.Item.Command.GetType() == other.Command.GetType()
                     && this.specificationComparer.Equals(this.Item.Specification, other.Specification);                
             }
         }
@@ -347,8 +315,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             public override bool Equals(object obj)
             {
-                var other = obj as T;
-                if (other != null)
+                if (obj is T other)
                     return this.Equals(other);
                 return base.Equals(obj);
             }

--- a/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
@@ -86,6 +86,11 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                     ox.Specifications.SequenceEqual(oy.Specifications, this))
                     return true;
 
+                if (x is AndRequestSpecification ax &&
+                    y is AndRequestSpecification ay &&
+                    ax.Specifications.SequenceEqual(ay.Specifications, this))
+                    return true;
+
                 if (x is SeedRequestSpecification sx &&
                     y is SeedRequestSpecification sy &&
                     sx.TargetType == sy.TargetType)
@@ -97,6 +102,9 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                     return true;
                 
                 if (x is TrueRequestSpecification && y is TrueRequestSpecification)
+                    return true;
+
+                if (x is FalseRequestSpecification && y is FalseRequestSpecification)
                     return true;
 
                 if (x is EqualRequestSpecification eqx &&

--- a/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
@@ -194,8 +194,19 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
 
             protected override bool EqualsInstance(Postprocessor<T> other)
             {
-                return this.Item.Command.GetType() == other.Command.GetType()
+                return CommandsAreEqual(this.Item.Command, other.Command)
                     && this.specificationComparer.Equals(this.Item.Specification, other.Specification);                
+            }
+
+            private bool CommandsAreEqual(ISpecimenCommand x, ISpecimenCommand y)
+            {
+                if (x is AutoPropertiesCommand<T> apx &&
+                    y is AutoPropertiesCommand<T> apy)
+                {
+                    return this.specificationComparer.Equals(apx.Specification, apy.Specification);
+                }
+
+                return x.GetType() == y.GetType();
             }
         }
 


### PR DESCRIPTION
This fixes #321, fixes #531 and fixes #772.
Currently when we customize any property (e.g. using `.Without(x => x.Prop)` or `.With(x => x.Prop, value)`), we add a global `Omitter` for that property. This leads to the issue if property belongs to the parent class, so when an instance of sibling type is created that property is not filled.

I reworked the way, so that we don't create a global `Omitter` more. Rather, we customize a local AutoProperties PostProcessor and exclude a particular field/property from there. As result, customization is local to our graph and never interfere with other customizations (and the `Build()` graph).

There are modified tests because they assert the particular graph of nodes that was modified (in fact, they are structural tests). No behavioral tests failed.

----
Some internal changes
- I configure the `AutoProperties` command's specification to set the list of members that should not be filled.
- I create the `AutoProperties` postprocessor when it's needed for the first time to store information about skipped properties. If autoproperties are not enabled, the postprocessor is present in tree, but it's in disabled state (via `postProcessor.Specification == FalseRequestSpecification`).
- When we call the `OmitAutoProperties()` I don't remove the `AutoProperties` postprocessor more. Rather, I disable it via specification. See reason in code comments.

P.S. I decided to use `v4` as a base because I change the customization graph. If you feel that this is not a breaking change, I could rebase my PR on top of master for the quicker delivery 😉 