### PR TITLE
Improve exception handling by showing full request path on failure

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -65,7 +65,7 @@ namespace Ploeh.AutoFixture
 
             this.graph =
                 new BehaviorRoot(
-                    new TerminatingWithPathSpecimenBuilder(new TracingBuilder(new CompositeSpecimenBuilder(
+                    new TerminatingWithPathSpecimenBuilder(new CompositeSpecimenBuilder(
                         new CustomizationNode(
                             new CompositeSpecimenBuilder(
                                 new FilteringSpecimenBuilder(
@@ -147,7 +147,7 @@ namespace Ploeh.AutoFixture
                             new MutableValueTypeWarningThrower(),
                             new AndRequestSpecification(
                                 new ValueTypeSpecification(),
-                                new NoConstructorsSpecification()))))));
+                                new NoConstructorsSpecification())))));
 
             this.UpdateCustomizer();
             this.UpdateResidueCollector();

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 
 namespace Ploeh.AutoFixture.Kernel
@@ -14,7 +13,7 @@ namespace Ploeh.AutoFixture.Kernel
     /// when <see cref="NoSpecimen"/> is detected, throws an <see cref="ObjectCreationException"/>, which
     /// includes a description of the request path.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix",
+    [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix",
         Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
     {
@@ -27,44 +26,23 @@ namespace Ploeh.AutoFixture.Kernel
         }
 
         /// <summary>
-        /// Creates a new <see cref="TerminatingWithPathSpecimenBuilder"/> using the
-        /// supplied <see cref="TracingBuilder"/> to track specimen requests.
+        /// Creates a new <see cref="TerminatingWithPathSpecimenBuilder"/> instance.
         /// </summary>
-        /// <param name="tracer"></param>
-        public TerminatingWithPathSpecimenBuilder(TracingBuilder tracer)
+        /// <param name="builder">The specimen builder which creation requests are redirected to.</param>
+        public TerminatingWithPathSpecimenBuilder(ISpecimenBuilder builder)
         {
-            if (tracer == null)
-                throw new ArgumentNullException(nameof(tracer));
-
-            this.Tracer = tracer;
-            this.Tracer.SpecimenRequested += OnSpecimenRequested;
-            this.Tracer.SpecimenCreated += OnSpecimenCreated;
-        }
-
-        private void OnSpecimenCreated(object sender, SpecimenCreatedEventArgs e)
-        {
-            // Keep the final NoSpecimen in the list, even though we're about to throw
-            if (!(e.Specimen is NoSpecimen))
-                GetPathForCurrentThread().Pop();
-        }
-
-        private void OnSpecimenRequested(object sender, RequestTraceEventArgs e)
-        {
-            GetPathForCurrentThread().Push(e.Request);
+            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
         }
 
         /// <summary>
-        /// Gets the <see cref="TracingBuilder"/> decorated by this instance.
+        /// Gets the <see cref="ISpecimenBuilder"/> decorated by this instance.
         /// </summary>
-        public TracingBuilder Tracer { get; }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>
         /// Gets the observed specimen requests, in the order they were requested.
         /// </summary>
-        public IEnumerable<object> SpecimenRequests
-        {
-            get { return this.GetPathForCurrentThread().Reverse(); }
-        }
+        public IEnumerable<object> SpecimenRequests => this.GetPathForCurrentThread().Reverse();
 
         /// <summary>
         /// Creates a new specimen based on a request by delegating to its decorated builder.
@@ -72,15 +50,16 @@ namespace Ploeh.AutoFixture.Kernel
         /// <param name="request">The request that describes what to create.</param>
         /// <param name="context">A context that can be used to create other specimens.</param>
         /// <returns>
-        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// The requested specimen if possible; otherwise a creation exception is thrown.
         /// </returns>
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         public object Create(object request, ISpecimenContext context)
         {
-            var result = this.Tracer.Create(request, context);
-            if (result is NoSpecimen)
+            this.GetPathForCurrentThread().Push(request);
+            try
             {
-                try
+                var result = this.Builder.Create(request, context);
+                if (result is NoSpecimen)
                 {
                     throw new ObjectCreationException(string.Format(
                         CultureInfo.CurrentCulture,
@@ -89,14 +68,15 @@ namespace Ploeh.AutoFixture.Kernel
                         Environment.NewLine,
                         BuildRequestPathText(this.SpecimenRequests)));
                 }
-                finally
-                {
-                    this.GetPathForCurrentThread().Clear();
-                }
-            }
-            return result;
-        }
 
+                return result;
+            }
+            finally
+            {
+                this.GetPathForCurrentThread().Pop();
+            }
+        }
+       
         private static string BuildCoreMessageTemplate(object request)
         {
             var t = request as Type;
@@ -176,8 +156,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public virtual ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
-            var builder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-            return new TerminatingWithPathSpecimenBuilder(new TracingBuilder(builder));
+            return new TerminatingWithPathSpecimenBuilder(CompositeSpecimenBuilder.ComposeIfMultiple(builders));
         }
 
         /// <summary>
@@ -189,12 +168,9 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            yield return this.Tracer.Builder;
+            yield return this.Builder;
         }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Contact/Parsing/ContactTest.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/Parsing/ContactTest.cs
@@ -16,7 +16,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Contact.Parsing
             // Fixture setup
             Fixture fixture = new Fixture();
             // Exercise system and verify outcome
-            Assert.Throws<TargetInvocationException>(() =>
+            Assert.Throws<ObjectCreationException>(() =>
                 fixture.Create<Contact>());
             // Teardown
         }

--- a/Src/AutoFixtureDocumentationTest/Simple/DocumentationExample.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/DocumentationExample.cs
@@ -338,7 +338,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
             var fixture = new Fixture();
             fixture.Customizations.Add(new NumericSequenceGenerator());
             // Exercise system and verify outcome
-            Assert.Throws<TargetInvocationException>(()=>
+            Assert.Throws<ObjectCreationException>(()=>
                 fixture.Create<Filter>());
             // Teardown
         }
@@ -391,7 +391,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
             // Fixture setup
             var fixture = new Fixture();
             // Exercise system and verify outcome
-            Assert.Throws<TargetInvocationException>(() =>
+            Assert.Throws<ObjectCreationException>(() =>
                 fixture.Create<SomeImp>());
             // Teardown
         }

--- a/Src/AutoFixtureDocumentationTest/Simple/MyViewModelTest.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/MyViewModelTest.cs
@@ -46,7 +46,7 @@ namespace Ploeh.AutoFixtureDocumentationTest.Simple
             var fixture = new Fixture();
             // Exercise system
             // Verify outcome (expected exception)
-            Assert.Throws<TargetInvocationException>(() =>
+            Assert.Throws<ObjectCreationException>(() =>
                 fixture.Create<MyViewModel>());
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4854,8 +4854,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system and verify outcome
-            Assert.Throws<IllegalRequestException>(() =>
+           var creationEx = Assert.Throws<ObjectCreationException>(() =>
                 sut.Create<IntPtr>());
+            Assert.IsAssignableFrom<IllegalRequestException>(creationEx.InnerException);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Reflection.Emit;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
@@ -18,7 +16,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
-            var sut = new TerminatingWithPathSpecimenBuilder(new DelegatingTracingBuilder());
+            var sut = new TerminatingWithPathSpecimenBuilder(new DelegatingSpecimenBuilder());
             // Verify outcome
             Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
             // Teardown
@@ -29,7 +27,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             // Exercise system
-            var sut = new TerminatingWithPathSpecimenBuilder(new DelegatingTracingBuilder());
+            var sut = new TerminatingWithPathSpecimenBuilder(new DelegatingSpecimenBuilder());
             // Verify outcome
             Assert.IsAssignableFrom<ISpecimenBuilderNode>(sut);
             // Teardown
@@ -46,14 +44,14 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void TracerIsCorrect()
+        public void SpecimenBuilderIsCorrect()
         {
             // Fixture setup
-            var expected = new DelegatingTracingBuilder();
+            var expected = new DelegatingSpecimenBuilder();
             // Exercise system
             var sut = new TerminatingWithPathSpecimenBuilder(expected);
             // Verify outcome
-            Assert.Same(expected, sut.Tracer);
+            Assert.Same(expected, sut.Builder);
             // Teardown
         }
 
@@ -62,8 +60,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var expected = new DelegatingSpecimenBuilder();
-            var tracer = new DelegatingTracingBuilder(expected);
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var sut = new TerminatingWithPathSpecimenBuilder(expected);
             // Exercise system
             // Verify outcome
             Assert.Equal(expected, sut.Single());
@@ -75,8 +72,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void ComposeReturnsCorrectResult()
         {
             // Fixture setup
-            var tracer = new DelegatingTracingBuilder();
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var builder = new DelegatingSpecimenBuilder();
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
             // Exercise system
             var expectedBuilders = new[]
             {
@@ -87,7 +84,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var actual = sut.Compose(expectedBuilders);
             // Verify outcome
             var tw = Assert.IsAssignableFrom<TerminatingWithPathSpecimenBuilder>(actual);
-            var composite = Assert.IsAssignableFrom<CompositeSpecimenBuilder>(tw.Tracer.Builder);
+            var composite = Assert.IsAssignableFrom<CompositeSpecimenBuilder>(tw.Builder);
             Assert.True(expectedBuilders.SequenceEqual(composite));
             // Teardown
         }
@@ -96,14 +93,14 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void ComposeSingleItemReturnsCorrectResult()
         {
             // Fixture setup
-            var tracer = new DelegatingTracingBuilder();
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var builder = new DelegatingSpecimenBuilder();
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
             // Exercise system
             var expected = new DelegatingSpecimenBuilder();
             var actual = sut.Compose(new[] { expected });
             // Verify outcome
             var tw = Assert.IsAssignableFrom<TerminatingWithPathSpecimenBuilder>(actual);
-            Assert.Equal(expected, tw.Tracer.Builder);
+            Assert.Equal(expected, tw.Builder);
             // Teardown
         }
 
@@ -112,10 +109,10 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var expectedSpecimen = new object();
-            var stubBuilder = new TracingBuilder(new DelegatingSpecimenBuilder
+            var stubBuilder = new DelegatingSpecimenBuilder
             {
                 OnCreate = (r, c) => expectedSpecimen
-            });
+            };
 
             var sut = new TerminatingWithPathSpecimenBuilder(stubBuilder);
             // Exercise system
@@ -135,10 +132,10 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var expectedContainer = new DelegatingSpecimenContext();
 
             var verified = false;
-            var mockBuilder = new TracingBuilder(new DelegatingSpecimenBuilder
+            var mockBuilder = new DelegatingSpecimenBuilder
             {
                 OnCreate = (r, c) => verified = expectedRequest == r && expectedContainer == c
-            });
+            };
 
             var sut = new TerminatingWithPathSpecimenBuilder(mockBuilder);
             // Exercise system
@@ -152,8 +149,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void SpecimenRequestsWillInitiallyBeEmpty()
         {
             // Fixture setup
-            var tracer = new DelegatingTracingBuilder();
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var builder = new DelegatingSpecimenBuilder();
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
             // Exercise system and verify outcome
             Assert.Empty(sut.SpecimenRequests);
             // Teardown
@@ -163,14 +160,35 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void SpecimenRequestsRaisedFromTracerAreRecordedCorrectly()
         {
             // Fixture setup
-            var tracer = new DelegatingTracingBuilder();
-            var specimens = new[] { new object(), new object(), new object() };
-            var requestEvents = specimens.Select((o, i) => new RequestTraceEventArgs(o, i)).ToList();
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var requests = new[] { new object(), new object(), new object() };
+            var requestQueue = new Queue<object>(requests);
+            var firstRequest = requestQueue.Dequeue();
+
+            object[] capturedRequests = null;
+            TerminatingWithPathSpecimenBuilder sut = null;
+            
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) =>
+                {
+                    if(requestQueue.Count > 0) 
+                        return c.Resolve(requestQueue.Dequeue());
+                    
+                    capturedRequests = sut.SpecimenRequests.ToArray();
+                    return new object();
+                }
+            };
+            
+            sut = new TerminatingWithPathSpecimenBuilder(builder);
+            // Cause sut to be executed recursively for multiple times.
+            var context = new SpecimenContext(sut);
+            
             // Exercise system
-            requestEvents.ForEach(tracer.RaiseSpecimenRequested);
+            sut.Create(firstRequest, context);
+            
             // Verify outcome
-            Assert.True(specimens.SequenceEqual(sut.SpecimenRequests));
+            Assert.NotNull(capturedRequests);
+            Assert.Equal(requests, capturedRequests);
             // Teardown
         }
 
@@ -178,16 +196,24 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void SpecimenRequestsAreEmptyWhenAllThatWereRequestedAreCreated()
         {
             // Fixture setup
-            var tracer = new DelegatingTracingBuilder();
-            var specimens = new[] { new object(), new object(), new object() };
-            var requestEvents = specimens.Select(
-                (o, i) => new RequestTraceEventArgs(o, i)).ToList();
-            var createdEvents = specimens.Reverse().Select(
-                (o, i) => new SpecimenCreatedEventArgs(o, null, i)).ToList();
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var requests = new[] {new object(), new object(), new object()};
+            var requestQueue = new Queue<object>(requests);
+            var firstRequest = requestQueue.Dequeue();
+
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => requestQueue.Count > 0
+                    ? c.Resolve(requestQueue.Dequeue())
+                    : new object()
+            };
+
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
+            // Cause sut to be executed recursively for multiple times.
+            var context = new SpecimenContext(sut);
+
             // Exercise system
-            requestEvents.ForEach(tracer.RaiseSpecimenRequested);
-            createdEvents.ForEach(tracer.RaiseSpecimenCreated);
+            sut.Create(firstRequest, context);
+
             // Verify outcome
             Assert.Empty(sut.SpecimenRequests);
             // Teardown
@@ -200,18 +226,18 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var requests = new[] {new object(), new object(), new object() };
             var requestQueue = new Queue<object>(requests);
             var firstRequest = requestQueue.Dequeue();
-            var tracer = new DelegatingTracingBuilder(new DelegatingSpecimenBuilder
+            var builder = new DelegatingSpecimenBuilder
             {
                 OnCreate = (r, c) => requestQueue.Count > 0
                     ? c.Resolve(requestQueue.Dequeue())
                     : new NoSpecimen()
-            });
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            };
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
+            // Cause sut to be executed recursively for multiple times.
             var container = new SpecimenContext(sut);
 
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() =>
-                sut.Create(firstRequest, container));
+            Assert.Throws<ObjectCreationException>(() => sut.Create(firstRequest, container));
 
             Assert.Empty(sut.SpecimenRequests);
         }
@@ -221,13 +247,13 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         {
             // Fixture setup
             var requests = new[] {new object(), new object(), new object()};
-            var tracer = new DelegatingTracingBuilder(new DelegatingSpecimenBuilder
+            var builder = new DelegatingSpecimenBuilder
             {
                 // Returns NoSpecimen only on the last specimen request
-                OnCreate = (r, c) => (r == requests[2]) ? new NoSpecimen() : new object(),
-            });
+                OnCreate = (r, c) => r == requests[2] ? new NoSpecimen() : new object()
+            };
 
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
             var container = new SpecimenContext(sut);
             // Exercise system and verify outcome
             Assert.DoesNotThrow(() => sut.Create(requests[0], container));
@@ -243,13 +269,11 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             object request,
             string requestType)
         {
-            var tracer =
-                new DelegatingTracingBuilder(
-                    new DelegatingSpecimenBuilder
-                    {
-                        OnCreate = (r, c) => new NoSpecimen()
-                    });
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => new NoSpecimen()
+            };
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
 
             var context = new SpecimenContext(sut);
             var e = Assert.Throws<ObjectCreationException>(
@@ -273,14 +297,14 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void CreateOnMultipleThreadsConcurrentlyWorks()
         {
             // Fixture setup
-            var tracer = new DelegatingTracingBuilder(new DelegatingSpecimenBuilder
+            var builder = new DelegatingSpecimenBuilder
             {
                 OnCreate = (r, c) => 99
-            });
-            var sut = new TerminatingWithPathSpecimenBuilder(tracer);
-            var dummyContext = new DelegatingSpecimenContext()
+            };
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
+            var dummyContext = new DelegatingSpecimenContext
             {
-                OnResolve = (r) => 99
+                OnResolve = r => 99
             };
             // Exercise system
             int[] specimens = Enumerable.Range(0, 1000)
@@ -294,6 +318,5 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             Assert.True(specimens.All(s => s == 99));
             // Teardown
         }
-
     }
 }


### PR DESCRIPTION
This PR fixes #694 and closes #771.

I improved the `TerminatingWithPathSpecimenBuilder` so that it shows the request path when creation failed with exception, similar to the situations when we were unable to create a result (i.e. `NoSpecimen` was returned).

To better understand the changes see the following sample.

<details><summary>Code (click to expand)</summary><p>

```
public class EntryPoint
{
    public SomeSubComponent SubComponentHolder { get; set; }
}

public class SomeSubComponent
{
    public BrokenComponent BrokenHolder { get; set; }
}

public class BrokenComponent
{
    public int BrokenProperty
    {
        get => 42;
        set => throw new InvalidOperationException("Value should be equal 42");
    }
}
```
</p></details>
<details><summary>Exception before (click to expand)</summary><p>

```
System.Reflection.TargetInvocationException
Exception has been thrown by the target of an invocation.
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, Object[] index)
   at Ploeh.AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.PropertyRequestRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.PropertyRequestRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.SpecimenFactory.Create[T](ISpecimenContext context, T seed)
   at Ploeh.AutoFixture.SpecimenFactory.Create[T](ISpecimenContext context)
   at Ploeh.AutoFixture.SpecimenFactory.Create[T](ISpecimenBuilder builder)
   at Ploeh.AutoFixtureUnitTest.Kernel.TerminatingWithPathSpecimenBuilderTest.LogTest()

System.InvalidOperationException
Value should be equal 42
   at Ploeh.AutoFixtureUnitTest.Kernel.BrokenComponent.set_BrokenProperty(Int32 value)
```

</p></details>
<details><summary>Exception after (click to expand)</summary><p>

```
Ploeh.AutoFixture.ObjectCreationException
AutoFixture was unable to create an instance from Ploeh.AutoFixtureUnitTest.Kernel.BrokenComponent because creation unexpectedly failed with exception. Please refer to the inner exception to investigate the root cause of the failure.

Request path:
	  Ploeh.AutoFixtureUnitTest.Kernel.EntryPoint --> 
	   Ploeh.AutoFixtureUnitTest.Kernel.SomeSubComponent SubComponentHolder --> 
	    Ploeh.AutoFixtureUnitTest.Kernel.SomeSubComponent --> 
	     Ploeh.AutoFixtureUnitTest.Kernel.BrokenComponent BrokenHolder --> 
	      Ploeh.AutoFixtureUnitTest.Kernel.BrokenComponent


   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.PropertyRequestRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.PropertyRequestRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at Ploeh.AutoFixture.SpecimenFactory.Create[T](ISpecimenContext context, T seed)
   at Ploeh.AutoFixture.SpecimenFactory.Create[T](ISpecimenContext context)
   at Ploeh.AutoFixture.SpecimenFactory.Create[T](ISpecimenBuilder builder)
   at Ploeh.AutoFixtureUnitTest.Kernel.TerminatingWithPathSpecimenBuilderTest.LogTest()

System.Reflection.TargetInvocationException
Exception has been thrown by the target of an invocation.
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, Object[] index)
   at Ploeh.AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at Ploeh.AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)

System.InvalidOperationException
Value should be equal 42
   at Ploeh.AutoFixtureUnitTest.Kernel.BrokenComponent.set_BrokenProperty(Int32 value)
```
</p></details>
<p></p>

As you can see, previously it was impossible to understand how we reached the particular error, while now it's clear and we see the full request chain.

Additionally, I've refactored the implementation to avoid usage of `TracingBuilder` as it was agreed in #771. Given that it changed the design, tests were adjusted appropriately.

@adamchester Explicitly inviting you here as you created the `TerminatingWithPathSpecimenBuilder`.