### PR TITLE
AutoMoq: Fixes mocking get-only interface properties with recent Moq version.

### DIFF
--- a/Src/AutoMoq/AutoConfiguredMoqCustomization.cs
+++ b/Src/AutoMoq/AutoConfiguredMoqCustomization.cs
@@ -58,8 +58,8 @@ namespace Ploeh.AutoFixture.AutoMoq
                                 new MethodInvoker(
                                     new MockConstructorQuery())),
                     command: new CompositeSpecimenCommand(
-                                new MockVirtualMethodsCommand(),
                                 new StubPropertiesCommand(),
+                                new MockVirtualMethodsCommand(),
                                 new AutoMockPropertiesCommand())));
 
             fixture.ResidueCollectors.Add(Relay);

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -88,6 +88,7 @@
     <Compile Include="StubPropertiesCommandTest.cs" />
     <Compile Include="TestTypes\IDerivedInterface.cs" />
     <Compile Include="TestTypes\IInterfaceWithGenericMethod.cs" />
+    <Compile Include="TestTypes\IInterfaceWithGetOnlyProperty.cs" />
     <Compile Include="TestTypes\IInterfaceWithIndexer.cs" />
     <Compile Include="TestTypes\IInterfaceWithMethod.cs" />
     <Compile Include="TestTypes\IInterfaceWithMethodWithOutParameterOfReferenceType.cs" />

--- a/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
@@ -76,6 +76,19 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         }
 
         [Fact]
+        public void GetOnlyPropertiesReturnValueFromFixture()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());
+            var frozenString = fixture.Freeze<string>();
+            // Exercise system
+            var result = fixture.Create<IInterfaceWithGetOnlyProperty>();
+            // Verify outcome
+            Assert.Same(frozenString, result.GetOnlyProperty);
+            // Teardown
+        }
+
+        [Fact]
         public void IndexersReturnValueFromFixture()
         {
             // Fixture setup
@@ -97,6 +110,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             var result = fixture.Create<Mock<TypeWithVirtualMembers>>();
             // Verify outcome
+            Assert.Equal(frozenString, result.Object.VirtualGetOnlyProperty);
             Assert.Equal(frozenString, result.Object.VirtualMethod());
             Assert.Equal(frozenString, result.Object.VirtualProperty);
             // Teardown

--- a/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
@@ -129,13 +129,30 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Fixture setup
             var fixture = new Fixture();
             var frozenString = fixture.Freeze<string>();
-            var mock = new Mock<IInterfaceWithProperty>();
+            var mock = new Mock<IInterfaceWithGetOnlyProperty>();
 
             var sut = new MockVirtualMethodsCommand();
             // Exercise system
             sut.Execute(mock, new SpecimenContext(fixture));
             // Verify outcome
-            var result = mock.Object.Property;
+            var result = mock.Object.GetOnlyProperty;
+            Assert.Equal(frozenString, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void SetsUpVirtualPropertyGetters_ToRetrieveReturnValueFromContext()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var frozenString = fixture.Freeze<string>();
+            var mock = new Mock<TypeWithVirtualMembers>();
+
+            var sut = new MockVirtualMethodsCommand();
+            // Exercise system
+            sut.Execute(mock, new SpecimenContext(fixture));
+            // Verify outcome
+            var result = mock.Object.VirtualGetOnlyProperty;
             Assert.Equal(frozenString, result);
             // Teardown
         }
@@ -285,6 +302,36 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
             Assert.DoesNotThrow(() => sut.Execute(specimen, context.Object));
+        }
+
+        [Fact]
+        public void IgnoresPropertiesWithGettersAndSetters()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var mock = new Mock<IInterfaceWithProperty>();
+
+            var sut = new MockVirtualMethodsCommand();
+            // Exercise system
+            sut.Execute(mock, new SpecimenContext(fixture));
+            // Verify outcome
+            var result = mock.Object;
+            Assert.Null(result.Property);
+        }
+
+        [Fact]
+        public void IgnoresVirtualPropertiesWithGettersAndSetters()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            var mock = new Mock<TypeWithVirtualMembers>();
+
+            var sut = new MockVirtualMethodsCommand();
+            // Exercise system
+            sut.Execute(mock, new SpecimenContext(fixture));
+            // Verify outcome
+            var result = mock.Object;
+            Assert.Null(result.VirtualProperty);
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithGetOnlyProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IInterfaceWithGetOnlyProperty.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes
+{
+    public interface IInterfaceWithGetOnlyProperty
+    {
+        string GetOnlyProperty { get; }
+    }
+}

--- a/Src/AutoMoqUnitTest/TestTypes/TypeWithVirtualMembers.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/TypeWithVirtualMembers.cs
@@ -2,6 +2,8 @@
 {
     public class TypeWithVirtualMembers
     {
+        public virtual string VirtualGetOnlyProperty { get; } = "Awesome string";
+
         public virtual string VirtualProperty { get; set; }
 
         public virtual string VirtualMethod()


### PR DESCRIPTION
This PR fixes #434.

It is my first time contributing to this project, and first time looking at its source. So I'm sure there's some feedback. :)

Before this fix, get/set properties would get mocked by MockVirtualMethodsCommand and later overwritten by Moq's SetupAllProperties() in StubPropertiesCommand. Because of a breaking change of Moq now also setting up get-only properties, I had to swap both commands.

So now SetupAllProperties in StubPropertiesCommand is ran, and then MockVirtualMethodsCommand is ran.

Because MockVirtualMethodsCommand also mocks get/set properties, which overrides the stub, I have black-listed get/set properties from being mocked in MockVirtualMethodsCommand.