### PR TITLE
Enable this keyword usage in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,10 @@ indent_style = space
 [*.{sln,csproj,fsproj,config,xml}]
 indent_size = 2
 indent_style = space
+
+[*.cs]
+# Require "this." keyword qualification in code
+dotnet_style_qualification_for_field = true:suggestion
+dotnet_style_qualification_for_property = true:suggestion
+dotnet_style_qualification_for_method = true:suggestion
+dotnet_style_qualification_for_event = true:suggestion


### PR DESCRIPTION
I've found that all over the code we use the `this` keyword, so it's de facto a standard for the project. Therefore, I've added the `.editorconfig` [directives](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference) to enable `this`. We will not treat missing `this` as a warning, however VS will stop to suggest to remove the existing `this` keywords 😄