### PR TITLE
Define test service marker in each test project

### DIFF
--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
@@ -28,4 +28,8 @@
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFakeItEasy2.UnitTest/AutoFakeItEasy2.UnitTest.csproj
+++ b/Src/AutoFakeItEasy2.UnitTest/AutoFakeItEasy2.UnitTest.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
+++ b/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
@@ -24,4 +24,8 @@
       <HintPath>..\..\References\NUnit.2.6.2\nunit.core.interfaces.dll</HintPath>
     </Reference>
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\AutoFixture.NUnit3\AutoFixture.NUnit3.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\AutoFixture.xUnit.net\AutoFixture.xUnit.net.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -21,4 +21,8 @@
     <ProjectReference Include="..\AutoFixture.xUnit.net2\AutoFixture.xUnit.net2.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
+++ b/Src/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
@@ -20,4 +20,8 @@
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -42,5 +42,9 @@
   <ItemGroup Condition=" '$(TargetFramework)'=='netcoreapp1.1' ">
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>
 

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\AutoMoq\AutoMoq.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
+++ b/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\AutoNSubstitute\AutoNSubstitute.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
+++ b/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\AutoRhinoMock\AutoRhinoMock.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/CommonTestProperties.props
+++ b/Src/CommonTestProperties.props
@@ -6,8 +6,4 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\Empty.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>

--- a/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\Idioms\Idioms.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Src/SemanticComparisonUnitTest/SemanticComparisonUnitTest.csproj
+++ b/Src/SemanticComparisonUnitTest/SemanticComparisonUnitTest.csproj
@@ -21,5 +21,8 @@
     <ProjectReference Include="..\SemanticComparison\SemanticComparison.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
For each test project VS insert a [special marker](https://stackoverflow.com/questions/18614342/what-is-service-include-in-a-csproj-file-for) to quickly discover projects with tests. Previously I tried to normalize that and defined this option in the `CommonTestProperties.props` that is imported to each test project. However, it doesn't work as VS still inserts this nodes to the project file itself.

I decided to commit this to repo, so you no longer need to revert these changes each time you run the tests (which is pretty annoying BTW 😢).