### PR TITLE
Add information about NUnit 2.6.4 to the package readme

### DIFF
--- a/Nuget/Ploeh.AutoFixture.NUnit2.Readme.txt
+++ b/Nuget/Ploeh.AutoFixture.NUnit2.Readme.txt
@@ -1,5 +1,5 @@
 ﻿AutoFixture.NUnit2
-=================================================
+======================
 
 Mark Seemann explains how to use AutoDataAttribute here:
 (http://blog.ploeh.dk/2010/10/08/AutoDataTheorieswithAutoFixture/)
@@ -7,18 +7,32 @@ Mark Seemann explains how to use AutoDataAttribute here:
 Nunit example:
 
 [Test, AutoData]
-public void IntroductoryTest(
-    int expectedNumber, MyClass sut)
+public void IntroductoryTest(int expectedNumber, MyClass sut)
 {
     int result = sut.Echo(expectedNumber);
     Assert.Equal(expectedNumber, result);
 }
 
-Known Issues
 
-* Resharper >= 8.1 uses NUnit 2.6.3 under the covers, need to manually add binding redirect to [web|app].config
+NUnit 2.6.4 support
+======================
+Recent versions of ReSharper and "NUnit Test Adapter 2" use NUnit 2.6.4 under the hood. 
+To support NUnit 2.6.4 you need to add the binding redirects to your [web|app].config file:
 
-<dependentAssembly>
-	<assemblyIdentity name="nunit.core.interfaces" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
-	<bindingRedirect oldVersion="0.0.0.0-2.6.3.13283" newVersion="2.6.3.13283" />
-</dependentAssembly>
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="nunit.core.interfaces" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="nunit.core" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.4.14350" newVersion="2.6.4.14350" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>
+
+See more details here: https://github.com/AutoFixture/AutoFixture/issues/488


### PR DESCRIPTION
Closes #779. Our NUnit integration actually supports NUnit 2.6.4 if proper binding redirects are present. I've updated package Readme to add information about support.