### PR TITLE
Heavily improve customization performance

### DIFF
--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -234,9 +234,7 @@ namespace Ploeh.AutoFixture.Dsl
         private static ISpecimenBuilderNode FindAutoPropertiesNode(
             ISpecimenBuilderNode graph)
         {
-            return graph
-                .SelectNodes(IsAutoPropertyNode)
-                .FirstOrDefault();
+            return graph.FindFirstNodeOrDefault(IsAutoPropertyNode);
         }
 
         private static bool IsAutoPropertyNode(ISpecimenBuilderNode n)
@@ -302,9 +300,7 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker)
         {
-            var targetToDecorate = this
-                .SelectNodes(n => n is NoSpecimenOutputGuard)
-                .First();
+            var targetToDecorate = this.FindFirstNode(n => n is NoSpecimenOutputGuard);
 
             return (NodeComposer<T>)this.ReplaceNodes(
                 with: n => new Postprocessor<T>(
@@ -535,13 +531,9 @@ namespace Ploeh.AutoFixture.Dsl
             return g;
         }
 
-        private static ISpecimenBuilderNode FindContainer(
-            ISpecimenBuilderNode graph)
+        private static ISpecimenBuilderNode FindContainer(ISpecimenBuilderNode graph)
         {
-            var container = graph
-                .SelectNodes(n => n is FilteringSpecimenBuilder)
-                .First();
-            return container;
+            return graph.FindFirstNode(n => n is FilteringSpecimenBuilder);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/SpecimenBuilderNode.cs
+++ b/Src/AutoFixture/Kernel/SpecimenBuilderNode.cs
@@ -182,20 +182,41 @@ namespace Ploeh.AutoFixture.Kernel
             }
         }
 
-        internal static IEnumerable<ISpecimenBuilderNode> SelectNodes(
-            this ISpecimenBuilderNode graph,
-            Func<ISpecimenBuilderNode, bool> predicate)
+        /// <summary>
+        /// Finds the first node in the passed graph that matches the specified predicate.
+        /// If nothing is found - null is returned.
+        /// </summary>
+        internal static ISpecimenBuilderNode FindFirstNodeOrDefault(this ISpecimenBuilderNode graph, Func<ISpecimenBuilderNode, bool> predicate)
         {
-            if (predicate(graph))
-                yield return graph;
+            if (predicate.Invoke(graph))
+                return graph;
 
-            foreach (var b in graph)
+            foreach (var builder in graph)
             {
-                var n = b as ISpecimenBuilderNode;
-                if (n != null)
-                    foreach (var n1 in n.SelectNodes(predicate))
-                        yield return n1;
+                var builderNode = builder as ISpecimenBuilderNode;
+                if (builderNode != null)
+                {
+                    var result = FindFirstNodeOrDefault(builderNode, predicate);
+                    if (result != null) return result;
+                }
             }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the first node in the graph that matches the specified predicate.
+        /// If no node is present - fails with exception.
+        /// </summary>
+        internal static ISpecimenBuilderNode FindFirstNode(this ISpecimenBuilderNode graph, Func<ISpecimenBuilderNode, bool> predicate)
+        {
+            var result = graph.FindFirstNodeOrDefault(predicate);
+            if (result == null)
+            {
+                throw new InvalidOperationException("Unable to find node matching the specified predicate.");
+            }
+
+            return result;
         }
     }
 }

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -168,15 +168,6 @@ namespace Ploeh.AutoFixture.Kernel
                 .Aggregate((s1, s2) => s1 + " --> " + Environment.NewLine + s2);
         }
 
-        internal static ISpecimenBuilder ComposeIfMultiple(IEnumerable<ISpecimenBuilder> builders)
-        {
-            var isSingle = builders.Take(2).Count() == 1;
-            if (isSingle)
-                return builders.Single();
-
-            return new CompositeSpecimenBuilder(builders);
-        }
-
         /// <summary>Composes the supplied builders.</summary>
         /// <param name="builders">The builders to compose.</param>
         /// <returns>
@@ -185,7 +176,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </returns>
         public virtual ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
-            var builder = ComposeIfMultiple(builders);
+            var builder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
             return new TerminatingWithPathSpecimenBuilder(new TracingBuilder(builder));
         }
 

--- a/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
+++ b/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
@@ -191,7 +191,7 @@ namespace Ploeh.AutoFixture
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ISpecimenBuilderNode"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ISpecimenBuilderTransformation", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         private void UpdateGraph()
         {
-            ISpecimenBuilder g = this.Graph.SelectNodes(this.isWrappedGraph).First();
+            ISpecimenBuilder g = this.Graph.FindFirstNode(this.isWrappedGraph);
             var builder = this.Aggregate(g, (b, t) => t.Transform(b));
 
             var node = builder as ISpecimenBuilderNode;

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -52,8 +52,7 @@ namespace Ploeh.AutoFixture
         {
             this.Graph = graph;
             this.isAdaptedBuilder = adaptedBuilderPredicate;
-            this.adaptedBuilders = 
-                this.Graph.SelectNodes(this.TargetMemo.IsSpecifiedBy).First();
+            this.adaptedBuilders = this.Graph.FindFirstNode(this.TargetMemo.IsSpecifiedBy);
         }
 
         /// <summary>
@@ -419,8 +418,7 @@ namespace Ploeh.AutoFixture
             this.Graph = this.Graph.ReplaceNodes(
                 with: builders,
                 when: this.TargetMemo.IsSpecifiedBy);
-            this.adaptedBuilders = 
-                this.Graph.SelectNodes(this.TargetMemo.IsSpecifiedBy).First();
+            this.adaptedBuilders = this.Graph.FindFirstNode(this.TargetMemo.IsSpecifiedBy);
 
             this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
         }
@@ -429,8 +427,7 @@ namespace Ploeh.AutoFixture
         {
             get
             {
-                var markerNode =
-                    this.Graph.SelectNodes(this.isAdaptedBuilder).First();
+                var markerNode = this.Graph.FindFirstNode(this.isAdaptedBuilder);
                 var target = (ISpecimenBuilderNode)markerNode.First();
                 return new TargetSpecification(target);
             }


### PR DESCRIPTION
## Background
I've found that on my real solution it takes about 15 second for NCrunch to discover all the tests. After I profiled things a bit I found that slowdown is caused by the AutoFixture and it's customization performance. After I applied the fixes from this this PR speed become about 4.5 second - more then 3 times faster.

This issue is reproducible when you perform customization of the fixture instance. The more customizations you have, the more you feel the slow down.  I've found two main places to improve.
1. Multiple enumeration in the `ComposeIfMultiple()` method. This is a hot place when we recompose a graph. That multiple enumeration causes graph to be re-composed a lot of times during a single composition, which costs time.
2. The `SelectNodes()` method which is called recursively to find all the matching nodes. It creates state machines on each recursion layer and this costs. It appeared that actually we don't need all the matching nodes and use the first one only. That allowed to save some time.

## Measurements

I used the BenchmarkDotNet tool and the following code as a baseline:
```csharp
[ClrJob]
public class CustomizationSpeedTest
{
    [Benchmark]
    public void CreateFixture() => new Fixture().Customize(new TestCustomization());
}

class TestCustomization: ICustomization
{
    public void Customize(IFixture fixture)
    {
        fixture.Customize(new AutoConfiguredNSubstituteCustomization());
        fixture.Customize(new IncrementingDateTimeCustomization());
        fixture.Inject(42);
        fixture.Freeze<object>();
    }
}
```
Idea was to have a couple of customizations which is a regular things for the real projects.

Environment:
```
BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 1 (10.0.14393)
Processor=Intel Core i7-4770 CPU 3.40GHz (Haswell), ProcessorCount=8
Frequency=3320307 Hz, Resolution=301.1770 ns, Timer=TSC
  [Host] : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2101.1
  Clr    : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2101.1
```

### Before fix
```
        Method |     Mean |     Error |    StdDev |
-------------- |---------:|----------:|----------:|
 CreateFixture | 1.203 ms | 0.0231 ms | 0.0216 ms |
```

### First commit applied only (refactored `ComposeIfMultiple()`)
```
        Method |     Mean |    Error |   StdDev |
-------------- |---------:|---------:|---------:|
 CreateFixture | 202.3 us | 3.939 us | 3.684 us |
```

### First and second commits (final result)
```
        Method |     Mean |    Error |   StdDev |
-------------- |---------:|---------:|---------:|
 CreateFixture | 178.5 us | 3.543 us | 3.638 us |
```

This PR makes the test above about 6.75 times quicker! The main boost is provided by the first commit (~5.95 quicker). The second commit adds yet another ~12% of boost.

Also the boost can be observed for AutoFixture's xUnit tests. Previously all them took ~16,2 secs on my machine, now they take ~12.5 secs - about 30% quicker 😮

----
The most exciting thing here is that we can achieve this boost with relatively simple code changes.

@adamchester Given that you worked on [the similar task](218) in past, it might be interesting to you 😉 
@moodmosaic Review from you is also expected if possible 😄

P.S. It might be easier to review this PR commit by commit.