### PR TITLE
With factory method overload

### DIFF
--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -337,7 +337,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// An expression that identifies the property or field that will have
         /// <paramref name="value"/> assigned.
         /// </param>
-        /// <param name="valueCreator">
+        /// <param name="factory">
         /// A Func that will be called in order to assign to the property or field identified by
         /// <paramref name="propertyPicker"/>.
         /// </param>
@@ -346,11 +346,11 @@ namespace Ploeh.AutoFixture.Dsl
         /// further customize the post-processing of created specimens.
         /// </returns>
         public IPostprocessComposer<T> With<TProperty>(
-            Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+            Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
-                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueCreator),
+                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, factory),
                 when: n => n is NodeComposer<T>);
         }
 

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -323,7 +323,10 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
-            return With(propertyPicker, () => value);
+            return (CompositeNodeComposer<T>)this.ReplaceNodes(
+                with: n =>
+                        (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, value),
+                when: n => n is NodeComposer<T>);
         }
 
         /// <summary>

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -337,8 +337,8 @@ namespace Ploeh.AutoFixture.Dsl
         /// The type of the property of field.
         /// </typeparam>
         /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will have
-        /// <paramref name="value"/> assigned.
+        /// An expression that identifies the property or field that will be populated when
+        /// <paramref name="factory"/> is called.
         /// </param>
         /// <param name="factory">
         /// A Func that will be called in order to assign to the property or field identified by

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -323,9 +323,34 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
+            return With(propertyPicker, () => value);
+        }
+
+        /// <summary>
+        /// Registers that a writable property or field should be assigned a
+        /// value from the supplied factory method as part of specimen post-processing.
+        /// </summary>
+        /// <typeparam name="TProperty">
+        /// The type of the property of field.
+        /// </typeparam>
+        /// <param name="propertyPicker">
+        /// An expression that identifies the property or field that will have
+        /// <paramref name="value"/> assigned.
+        /// </param>
+        /// <param name="valueCreator">
+        /// A Func that will be called in order to assign to the property or field identified by
+        /// <paramref name="propertyPicker"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
+        /// further customize the post-processing of created specimens.
+        /// </returns>
+        public IPostprocessComposer<T> With<TProperty>(
+            Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
-                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, value),
+                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueCreator),
                 when: n => n is NodeComposer<T>);
         }
 

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -117,8 +117,8 @@ namespace Ploeh.AutoFixture.Dsl
         /// </summary>
         /// <typeparam name="TProperty">The type of the property of field.</typeparam>
         /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will have
-        /// <paramref name="value"/> assigned.
+        /// An expression that identifies the property or field that will be populated when
+        /// <paramref name="factory"/> is called.
         /// </param>
         /// <param name="factory">
         /// A function that will be called in order to assign to the property or field identified by

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -112,6 +112,29 @@ namespace Ploeh.AutoFixture.Dsl
         }
 
         /// <summary>
+        /// Registers that a writable property or field should be assigned a specific value as
+        /// part of specimen post-processing.
+        /// </summary>
+        /// <typeparam name="TProperty">The type of the property of field.</typeparam>
+        /// <param name="propertyPicker">
+        /// An expression that identifies the property or field that will have
+        /// <paramref name="value"/> assigned.
+        /// </param>
+        /// <param name="valueCreator">
+        /// A function that will be called in order to assign to the property or field identified by
+        /// <paramref name="propertyPicker"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
+        /// post-processing of created specimens.
+        /// </returns>
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        {
+            return new CompositePostprocessComposer<T>(from c in this.Composers
+                                                       select c.With(propertyPicker, valueCreator));
+        }
+
+        /// <summary>
         /// Enables auto-properties for a type of specimen.
         /// </summary>
         /// <returns>

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -120,7 +120,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// An expression that identifies the property or field that will have
         /// <paramref name="value"/> assigned.
         /// </param>
-        /// <param name="valueCreator">
+        /// <param name="factory">
         /// A function that will be called in order to assign to the property or field identified by
         /// <paramref name="propertyPicker"/>.
         /// </param>
@@ -128,10 +128,10 @@ namespace Ploeh.AutoFixture.Dsl
         /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
         /// post-processing of created specimens.
         /// </returns>
-        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory)
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers
-                                                       select c.With(propertyPicker, valueCreator));
+                                                       select c.With(propertyPicker, factory));
         }
 
         /// <summary>

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -83,6 +83,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
         /// post-processing of created specimens.
         /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "Renaming would be a breaking change.")]
         IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory);
 
         /// <summary>

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -72,8 +72,8 @@ namespace Ploeh.AutoFixture.Dsl
         /// </summary>
         /// <typeparam name="TProperty">The type of the property of field.</typeparam>
         /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will have
-        /// <paramref name="value"/> assigned.
+        /// An expression that identifies the property or field that will be populated when
+        /// <paramref name="factory"/> is called.
         /// </param>
         /// <param name="factory">
         /// A function that will be called in order to assign to the property or field identified by

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -66,6 +66,8 @@ namespace Ploeh.AutoFixture.Dsl
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "Renaming would be a breaking change.")]
         IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value);
 
+        IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator);
+
         /// <summary>
         /// Enables auto-properties for a type of specimen.
         /// </summary>

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -66,7 +66,24 @@ namespace Ploeh.AutoFixture.Dsl
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "Renaming would be a breaking change.")]
         IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value);
 
-        IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator);
+        /// <summary>
+        /// Registers that a writable property or field should be assigned a specific value as
+        /// part of specimen post-processing.
+        /// </summary>
+        /// <typeparam name="TProperty">The type of the property of field.</typeparam>
+        /// <param name="propertyPicker">
+        /// An expression that identifies the property or field that will have
+        /// <paramref name="value"/> assigned.
+        /// </param>
+        /// <param name="factory">
+        /// A function that will be called in order to assign to the property or field identified by
+        /// <paramref name="propertyPicker"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
+        /// post-processing of created specimens.
+        /// </returns>
+        IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory);
 
         /// <summary>
         /// Enables auto-properties for a type of specimen.

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -377,7 +377,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// An expression that identifies the property or field that will have
         /// <paramref name="value"/> assigned.
         /// </param>
-        /// <param name="valueCreator">
+        /// <param name="factory">
         /// The function called in order to assign to the property or field identified by
         /// <paramref name="propertyPicker"/>.
         /// </param>
@@ -386,7 +386,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// further customize the post-processing of created specimens.
         /// </returns>
         public IPostprocessComposer<T> With<TProperty>(
-            Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+            Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory)
         {
             var graphWithoutSeedIgnoringRelay =
                 this.WithoutSeedIgnoringRelay();
@@ -399,7 +399,7 @@ namespace Ploeh.AutoFixture.Dsl
                     {
                         new Postprocessor<T>(
                             CompositeSpecimenBuilder.ComposeIfMultiple(n),
-                            new BindingCommand<T, TProperty>(propertyPicker, valueCreator),
+                            new BindingCommand<T, TProperty>(propertyPicker, factory),
                             CreateSpecification()),
                         new SeedIgnoringRelay()
                     }),

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -374,8 +374,8 @@ namespace Ploeh.AutoFixture.Dsl
         /// The type of the property of field.
         /// </typeparam>
         /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will have
-        /// <paramref name="value"/> assigned.
+        /// An expression that identifies the property or field that will be populated when
+        /// <paramref name="factory"/> is called.
         /// </param>
         /// <param name="factory">
         /// The function called in order to assign to the property or field identified by

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -337,10 +337,10 @@ namespace Ploeh.AutoFixture.Dsl
             Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
             var graphWithoutSeedIgnoringRelay =
-                this.WithoutSeedIgnoringRelay();
+               this.WithoutSeedIgnoringRelay();
 
             var container = FindContainer(graphWithoutSeedIgnoringRelay);
-         
+
             var graphWithProperty = graphWithoutSeedIgnoringRelay.ReplaceNodes(
                 with: n => n.Compose(
                     new ISpecimenBuilder[]
@@ -355,7 +355,59 @@ namespace Ploeh.AutoFixture.Dsl
 
             return (NodeComposer<T>)graphWithProperty.ReplaceNodes(
                 with: n => n.Compose(
-                    new []
+                    new[]
+                    {
+                        new Omitter(
+                            new EqualRequestSpecification(
+                                propertyPicker.GetWritableMember().Member,
+                                new MemberInfoEqualityComparer()))
+                    }
+                    .Concat(n)),
+                when: n => n is NodeComposer<T>);
+        }
+
+        /// <summary>
+        /// Registers that a writable property or field should be assigned a
+        /// value from the supplied factory method as part of specimen post-processing.
+        /// </summary>
+        /// <typeparam name="TProperty">
+        /// The type of the property of field.
+        /// </typeparam>
+        /// <param name="propertyPicker">
+        /// An expression that identifies the property or field that will have
+        /// <paramref name="value"/> assigned.
+        /// </param>
+        /// <param name="valueCreator">
+        /// The function called in order to assign to the property or field identified by
+        /// <paramref name="propertyPicker"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
+        /// further customize the post-processing of created specimens.
+        /// </returns>
+        public IPostprocessComposer<T> With<TProperty>(
+            Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        {
+            var graphWithoutSeedIgnoringRelay =
+                this.WithoutSeedIgnoringRelay();
+
+            var container = FindContainer(graphWithoutSeedIgnoringRelay);
+
+            var graphWithProperty = graphWithoutSeedIgnoringRelay.ReplaceNodes(
+                with: n => n.Compose(
+                    new ISpecimenBuilder[]
+                    {
+                        new Postprocessor<T>(
+                            CompositeSpecimenBuilder.ComposeIfMultiple(n),
+                            new BindingCommand<T, TProperty>(propertyPicker, valueCreator),
+                            CreateSpecification()),
+                        new SeedIgnoringRelay()
+                    }),
+                when: container.Equals);
+
+            return (NodeComposer<T>)graphWithProperty.ReplaceNodes(
+                with: n => n.Compose(
+                    new[]
                     {
                         new Omitter(
                             new EqualRequestSpecification(

--- a/Src/AutoFixture/Dsl/NullComposer.cs
+++ b/Src/AutoFixture/Dsl/NullComposer.cs
@@ -177,9 +177,9 @@ namespace Ploeh.AutoFixture.Dsl
         /// Does nothing
         /// </summary>
         /// <param name="propertyPicker">Ignored.</param>
-        /// <param name="valueCreator">Ignored.</param>
+        /// <param name="factory">Ignored.</param>
         /// <returns>The current instance.</returns>
-        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory)
         {
             return this;
         }

--- a/Src/AutoFixture/Dsl/NullComposer.cs
+++ b/Src/AutoFixture/Dsl/NullComposer.cs
@@ -176,6 +176,17 @@ namespace Ploeh.AutoFixture.Dsl
         /// <summary>
         /// Does nothing
         /// </summary>
+        /// <param name="propertyPicker">Ignored.</param>
+        /// <param name="valueCreator">Ignored.</param>
+        /// <returns>The current instance.</returns>
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// Does nothing
+        /// </summary>
         /// <returns>The current instance.</returns>
         public IPostprocessComposer<T> WithAutoProperties()
         {

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -86,6 +86,22 @@ namespace Ploeh.AutoFixture.Kernel
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="BindingCommand{T, TProperty}"/> class with
+        /// the supplied property picker expression and a function that creates a value to be
+        /// assigned to that property or field.
+        /// </summary>
+        /// <param name="propertyPicker">An expression that identifies a property or field.</param>
+        /// <param name="valueCreator">
+        /// A function that creates a value that will be assigned to the property or field
+        /// identified by <paramref name="propertyPicker"/>.
+        /// </param>
+        public BindingCommand(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+             : this(propertyPicker, c => valueCreator())
+        {
+
+        }
+
+        /// <summary>
         /// Gets the member identified by the expression supplied through the constructor.
         /// </summary>
         public MemberInfo Member { get; }

--- a/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
@@ -499,6 +499,36 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             // Teardown
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public void WithFactoryReturnsCorrectResult(string value)
+        {
+            // Fixture setup
+            var node = new CompositeSpecimenBuilder(
+                new DelegatingSpecimenBuilder(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                new DelegatingSpecimenBuilder());
+            Func<string> factory = () => value;
+            var sut = new CompositeNodeComposer<PropertyHolder<string>>(node);
+            // Exercise system
+            var actual = sut.With(x => x.Property, factory);
+            // Verify outcome
+            var expected = new CompositeNodeComposer<PropertyHolder<string>>(
+                new CompositeSpecimenBuilder(
+                    new DelegatingSpecimenBuilder(),
+                    SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, factory),
+                    SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                    SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, factory),
+                    new DelegatingSpecimenBuilder()));
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+            // Teardown
+        }
+
         [Fact]
         public void WithoutReturnsCorrectResult()
         {

--- a/Src/AutoFixtureUnitTest/Dsl/CompositePostprocessComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositePostprocessComposerTest.cs
@@ -158,7 +158,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             var initialComposers = (from c in expectedComposers
                                     select new DelegatingComposer<PropertyHolder<object>>
                                     {
-                                        OnWithFactory = (f, fac) => f == expectedExpression && fac == factory ? c : new DelegatingComposer<PropertyHolder<object>>()
+                                        OnWithFactory = (f, fac) => f == expectedExpression && (fac as Func<object>) == factory ? c : new DelegatingComposer<PropertyHolder<object>>()
                                     }).ToArray();
             var sut = new CompositePostprocessComposer<PropertyHolder<object>>(initialComposers);
             // Exercise system

--- a/Src/AutoFixtureUnitTest/Dsl/CompositePostprocessComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositePostprocessComposerTest.cs
@@ -148,6 +148,28 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
         }
 
         [Fact]
+        public void WithFactoryReturnsCorrectResult()
+        {
+            // Fixture setup
+            Expression<Func<PropertyHolder<object>, object>> expectedExpression = x => x.Property;
+            Func<object> factory = () => new object();
+
+            var expectedComposers = Enumerable.Range(1, 3).Select(i => new DelegatingComposer<PropertyHolder<object>>()).ToArray();
+            var initialComposers = (from c in expectedComposers
+                                    select new DelegatingComposer<PropertyHolder<object>>
+                                    {
+                                        OnWithFactory = (f, fac) => f == expectedExpression && fac == factory ? c : new DelegatingComposer<PropertyHolder<object>>()
+                                    }).ToArray();
+            var sut = new CompositePostprocessComposer<PropertyHolder<object>>(initialComposers);
+            // Exercise system
+            var result = sut.With(expectedExpression, factory);
+            // Verify outcome
+            var composite = Assert.IsAssignableFrom<CompositePostprocessComposer<PropertyHolder<object>>>(result);
+            Assert.True(expectedComposers.SequenceEqual(composite.Composers));
+            // Teardown
+        }
+
+        [Fact]
         public void WithAutoPropertiesReturnsCorrectResult()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -22,6 +22,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             this.OnOmitAutoProperties = () => new DelegatingComposer<T>();
             this.OnAnonymousWith = f => new DelegatingComposer<T>();
             this.OnWith = (f, v) => new DelegatingComposer<T>();
+            this.OnWithFactory = (f, fac) => new DelegatingComposer<T>();
             this.OnWithAutoProperties = () => new DelegatingComposer<T>();
             this.OnWithout = f => new DelegatingComposer<T>();
             this.OnCreate = (r, c) => new object();
@@ -84,7 +85,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
 
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory)
         {
-            return this.OnWith(propertyPicker, factory);
+            return this.OnWithFactory(propertyPicker, factory);
         }
 
         public IPostprocessComposer<T> WithAutoProperties()
@@ -110,6 +111,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
         internal Func<IPostprocessComposer<T>> OnOmitAutoProperties { get; set; }
         internal Func<object, IPostprocessComposer<T>> OnAnonymousWith { get; set; }
         internal Func<object, object, IPostprocessComposer<T>> OnWith { get; set; }
+        internal Func<object, object, IPostprocessComposer<T>> OnWithFactory { get; set; }
         internal Func<IPostprocessComposer<T>> OnWithAutoProperties { get; set; }
         internal Func<object, IPostprocessComposer<T>> OnWithout { get; set; }
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -82,6 +82,11 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             return this.OnWith(propertyPicker, value);
         }
 
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        {
+            return this.OnWith(propertyPicker, valueCreator);
+        }
+
         public IPostprocessComposer<T> WithAutoProperties()
         {
             return this.OnWithAutoProperties();

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -82,9 +82,9 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             return this.OnWith(propertyPicker, value);
         }
 
-        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueCreator)
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> factory)
         {
-            return this.OnWith(propertyPicker, valueCreator);
+            return this.OnWith(propertyPicker, factory);
         }
 
         public IPostprocessComposer<T> WithAutoProperties()

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Xunit;
@@ -486,6 +485,106 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             var actual = sut
                 .With(x => x.Property1, value1)
                 .With(x => x.Property2, value2);
+            // Verify outcome
+            var expected = new NodeComposer<DoublePropertyHolder<string, int>>(
+                new CompositeSpecimenBuilder(
+                    new Omitter(
+                        new EqualRequestSpecification(
+                            pi2,
+                            new MemberInfoEqualityComparer())),
+                    new CompositeSpecimenBuilder(
+                        new Omitter(
+                            new EqualRequestSpecification(
+                                pi1,
+                                new MemberInfoEqualityComparer())),
+                        new FilteringSpecimenBuilder(
+                            new CompositeSpecimenBuilder(
+                                new Postprocessor<DoublePropertyHolder<string, int>>(
+                                    new Postprocessor<DoublePropertyHolder<string, int>>(
+                                        new NoSpecimenOutputGuard(
+                                            new MethodInvoker(
+                                                new ModestConstructorQuery()),
+                                            new InverseRequestSpecification(
+                                                new SeedRequestSpecification(
+                                                    typeof(DoublePropertyHolder<string, int>)))),
+                                        new BindingCommand<DoublePropertyHolder<string, int>, string>(x => x.Property1, value1),
+                                        new OrRequestSpecification(
+                                            new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
+                                            new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))),
+                                    new BindingCommand<DoublePropertyHolder<string, int>, int>(x => x.Property2, value2),
+                                    new OrRequestSpecification(
+                                        new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
+                                        new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))),
+                                new SeedIgnoringRelay()),
+                            new OrRequestSpecification(
+                                new SeedRequestSpecification(typeof(DoublePropertyHolder<string, int>)),
+                                new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>)))))));
+
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public void WithValueCreatorReturnsCorrectResult(string value)
+        {
+            // Fixture setup
+            var sut = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>();
+            var pi = typeof(PropertyHolder<string>).GetProperty("Property");
+            // Exercise system
+            var actual = sut.With(x => x.Property, () => value);
+            // Verify outcome
+            var expected = new NodeComposer<PropertyHolder<string>>(
+                new CompositeSpecimenBuilder(
+                    new Omitter(
+                        new EqualRequestSpecification(
+                            pi,
+                            new MemberInfoEqualityComparer())),
+                    new FilteringSpecimenBuilder(
+                        new CompositeSpecimenBuilder(
+                            new Postprocessor<PropertyHolder<string>>(
+                                new NoSpecimenOutputGuard(
+                                    new MethodInvoker(
+                                        new ModestConstructorQuery()),
+                                    new InverseRequestSpecification(
+                                        new SeedRequestSpecification(
+                                            typeof(PropertyHolder<string>)))),
+                                new BindingCommand<PropertyHolder<string>, string>(x => x.Property, value),
+                                new OrRequestSpecification(
+                                    new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                                    new ExactTypeSpecification(typeof(PropertyHolder<string>)))),
+                            new SeedIgnoringRelay()),
+                        new OrRequestSpecification(
+                            new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                            new ExactTypeSpecification(typeof(PropertyHolder<string>))))));
+
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("", 1)]
+        [InlineData("bar", 0)]
+        [InlineData("foo", 42)]
+        [InlineData("bar", -1)]
+        public void SuccessiveWithValueCreatorReturnsCorrectResult(
+            string value1,
+            int value2)
+        {
+            // Fixture setup
+            var sut =
+                SpecimenBuilderNodeFactory.CreateComposer<DoublePropertyHolder<string, int>>();
+            var pi1 = typeof(DoublePropertyHolder<string, int>).GetProperty("Property1");
+            var pi2 = typeof(DoublePropertyHolder<string, int>).GetProperty("Property2");
+
+            // Exercise system
+            var actual = sut
+                .With(x => x.Property1, () => value1)
+                .With(x => x.Property2, () => value2);
             // Verify outcome
             var expected = new NodeComposer<DoublePropertyHolder<string, int>>(
                 new CompositeSpecimenBuilder(

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -529,7 +529,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
         [InlineData("")]
         [InlineData("foo")]
         [InlineData("bar")]
-        public void WithValueCreatorReturnsCorrectResult(string value)
+        public void WithFactoryReturnsCorrectResult(string value)
         {
             // Fixture setup
             var sut = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>();
@@ -571,7 +571,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
         [InlineData("bar", 0)]
         [InlineData("foo", 42)]
         [InlineData("bar", -1)]
-        public void SuccessiveWithValueCreatorReturnsCorrectResult(
+        public void SuccessiveWithFactoryReturnsCorrectResult(
             string value1,
             int value2)
         {

--- a/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
@@ -141,7 +141,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
         }
 
         [Fact]
-        public void FromTripeParameterFactoryReturnsCorrectResult()
+        public void FromTripleParameterFactoryReturnsCorrectResult()
         {
             // Fixture setup
             var sut = new NullComposer<object>();
@@ -207,6 +207,18 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
             var sut = new NullComposer<PropertyHolder<object>>();
             // Exercise system
             var result = sut.With(x => x.Property, new object());
+            // Verify outcome
+            Assert.Same(sut, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void WithFactoryReturnsCorrectResult()
+        {
+            // Fixture setup
+            var sut = new NullComposer<PropertyHolder<object>>();
+            // Exercise system
+            var result = sut.With(x => x.Property, () => new object());
             // Verify outcome
             Assert.Same(sut, result);
             // Teardown

--- a/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
@@ -281,6 +281,22 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
+        [Fact]
+        public void ExecuteWillSetCorrectPropertyOnSpecimenWhenValueCreatorIsSupplied()
+        {
+            // Fixture setup
+            var expectedValue = new object();
+            var expectedContainer = new DelegatingSpecimenContext();
+
+            var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, () => expectedValue);
+            var specimen = new PropertyHolder<object>();
+            // Exercise system
+            sut.Execute(specimen, expectedContainer);
+            // Verify outcome
+            Assert.Equal(expectedValue, specimen.Property);
+            // Teardown
+        }
+
 #pragma warning disable 618
         [Fact]
         public void SutIsSpecifiedSpecimenCommand()
@@ -461,6 +477,22 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var dummyContext = new DelegatingSpecimenContext();
             sut.Execute((object)specimen, dummyContext);
+            // Verify outcome
+            Assert.Equal(expectedValue, specimen.Property);
+            // Teardown
+        }
+
+        [Fact]
+        public void ExecuteSetsCorrectPropertyOnSpecimenWhenValueCreatorIsSupplied()
+        {
+            // Fixture setup
+            var expectedValue = new object();
+            var expectedContext = new DelegatingSpecimenContext();
+
+            var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, () => expectedValue);
+            var specimen = new PropertyHolder<object>();
+            // Exercise system
+            sut.Execute((object)specimen, expectedContext);
             // Verify outcome
             Assert.Equal(expectedValue, specimen.Property);
             // Teardown


### PR DESCRIPTION
Closes #708 

- added `With` overload to `IPostprocessComposer` and updated implementations
-  added unit tests where I saw existing classes being tested (didn't see a test class for the `DelegatingComposer`)

I tried to maintain consistency and add unit tests for all changes, so please let me know where I've erred in that regard.

After these changes, I was able to write this test:

```cs
    public class SomeClass
    {
        public string Property { get; set; }
    }

    public class WithFactoryTest
    {
        [Fact]
        public void ShouldUseFactoryForDynamicBuilder()
        {
            var fixture = new Fixture();
            var callCount = 0;
            Func<string> factory = () =>
            {
                callCount++;
                return $"called {callCount} time{(callCount == 1 ? "" : "s")}";
            };
            var someClassBuilder = fixture.Build<SomeClass>().With(t => t.Property, factory);
            var thingOne = someClassBuilder.Create();
            var thingTwo = someClassBuilder.Create();

            Assert.Equal("called 1 time", thingOne.Property);
            Assert.Equal("called 2 times", thingTwo.Property);
        }
    }