### PR TITLE
Switch master to MSBuild 15

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 environment:
   NUGET_API_KEY:
@@ -29,3 +29,4 @@ artifacts:
   name: NuGet
 
 deploy: off
+


### PR DESCRIPTION
I've switched build image to VS 2017 for the `master` branch to enable C#7 features. That doesn't affect the binaries compatibility somehow, so we are fine.