### PR TITLE
Removed governance announcement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/qlmobf6rt05pmt7e/branch/master?svg=true)](https://ci.appveyor.com/project/AutoFixture/autofixture/branch/master)
 
-## Announcement ##
-
-[AutoFixture is getting a new governance model](https://github.com/AutoFixture/AutoFixture/issues/703). This most likely means that you can expect delays if you have questions, issues, or pull requests.
-
 ## Project Description ##
 
 Write maintainable unit tests, faster.


### PR DESCRIPTION
The linked issue has now been closed for over four months, so the new
governance model is no longer that new. Additionally, it seems that most
people don't read the announcement anyway, because I still get a fair
amount of tweets and such about AutoFixture...