### PR TITLE
Add a badge with version to project ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/qlmobf6rt05pmt7e/branch/master?svg=true)](https://ci.appveyor.com/project/AutoFixture/autofixture/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/qlmobf6rt05pmt7e/branch/master?svg=true)](https://ci.appveyor.com/project/AutoFixture/autofixture/branch/master) [![NuGet version](https://img.shields.io/nuget/v/AutoFixture.svg)](https://www.nuget.org/packages/AutoFixture)
 
 ## Project Description ##
 


### PR DESCRIPTION
Badge is being automatically updated, so no need in manual support. For preview click [here](https://github.com/AutoFixture/AutoFixture/tree/zvirja/add-nuget-badge-to-readme).