### PR TITLE
Migrate AutoNSubstitute to net core

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -182,6 +182,7 @@ Target "TestOnly" (fun _ ->
         "AutoFixtureUnitTest"
         "AutoFixtureDocumentationTest"
         "SemanticComparisonUnitTest"
+        "AutoNSubstituteUnitTest"
     ]
 
     let testAssemblies = !! (sprintf "Src/*Test/bin/%s/**/*Test.dll" configuration)

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoNSubstitute</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoNSubstitute</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoNSubstitute</RootNamespace>
@@ -15,15 +15,19 @@
     <Authors>Daniel Hilgarth,AutoFixture</Authors>
   </PropertyGroup>
 
-  <ItemGroup>
-    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+    <PackageReference Include="NSubstitute" Version="1.5.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="1.5.0" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 </Project>

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -13,6 +13,10 @@
     <Title>AutoFixture with Auto Mocking using NSubstitute</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by NSubstitute. To use it, add the AutoNSubstituteCustomization to your Fixture instance.</Description>
     <Authors>Daniel Hilgarth,AutoFixture</Authors>
+
+    <!--  Suppress warning about invalid dependency version in Castle.Core.
+          That is NSubstitute dependency and we cannot fix that somehow. -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">

--- a/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
+++ b/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
@@ -18,7 +18,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             if (type == null)
                 throw new ArgumentNullException("type");
 
-            if (type.IsInterface)
+            if (type.GetTypeInfo().IsInterface)
                 return new[] { SubstituteMethod.Create(type) };
 
             return from ci in type.GetPublicAndProtectedConstructors()

--- a/Src/AutoNSubstitute/NSubstituteType.cs
+++ b/Src/AutoNSubstitute/NSubstituteType.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
 
             return type.GetInterfaces()
                 .Where(i => !interfaces.Contains(i))
-                .Concat(new[] {type.BaseType});
+                .Concat(new[] {type.GetTypeInfo().BaseType});
         }
     }
 }

--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -126,7 +126,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
 
             private static string GetFriendlyName(Type type)
             {
-                if (type.IsGenericType)
+                if (type.GetTypeInfo().IsGenericType)
                     return string.Format(CultureInfo.CurrentCulture,
                         "{0}<{1}>",
                         type.Name.Split('`')[0],
@@ -298,7 +298,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             private static object[] GetDefaultParameters(MethodInfo methodInfo)
             {
                 return methodInfo.GetParameters()
-                    .Select(p => p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null)
+                    .Select(p => p.ParameterType.GetTypeInfo().IsValueType ? Activator.CreateInstance(p.ParameterType) : null)
                     .ToArray();
             }
         }

--- a/Src/AutoNSubstitute/SubstituteRelay.cs
+++ b/Src/AutoNSubstitute/SubstituteRelay.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Reflection;
 using NSubstitute.Core;
 using NSubstitute.Exceptions;
 using Ploeh.AutoFixture.Kernel;
@@ -36,7 +37,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             }
 
             var requestedType = request as Type;
-            if (requestedType == null || !requestedType.IsAbstract)
+            if (requestedType == null || !requestedType.GetTypeInfo().IsAbstract)
             {
                 return new NoSpecimen();
             }

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
@@ -169,7 +169,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<TypeWithStaticMethod>());
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithStaticMethod>()));
             Assert.NotEqual(frozenString, TypeWithStaticMethod.StaticMethod());
         }
 
@@ -180,7 +180,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<TypeWithStaticProperty>());
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithStaticProperty>()));
             Assert.NotEqual(frozenString, TypeWithStaticProperty.Property);
         }
 
@@ -215,7 +215,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<TypeWithConstField>());
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithConstField>()));
             Assert.NotEqual(frozenString, TypeWithConstField.ConstField);
         }
 
@@ -226,7 +226,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<TypeWithStaticField>());
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithStaticField>()));
             Assert.NotEqual(frozenString, TypeWithStaticField.StaticField);
         }
 
@@ -236,7 +236,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             // Fixture setup
             var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<IInterfaceWithCircularDependency>());
+            Assert.Null(Record.Exception(() => fixture.Create<IInterfaceWithCircularDependency>()));
         }
 
         [Fact]

--- a/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
+++ b/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
@@ -7,6 +7,10 @@
     <AssemblyTitle>AutoNSubstituteUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoNSubstitute.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoNSubstitute.UnitTest</RootNamespace>
+
+    <!--  Suppress warning about invalid dependency version in Castle.Core.
+          That is NSubstitute dependency and we cannot fix that somehow. -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
+++ b/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
@@ -3,18 +3,18 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
     <AssemblyTitle>AutoNSubstituteUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoNSubstitute.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoNSubstitute.UnitTest</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
-    <PackageReference Include="xunit.extensions" Version="1.8.0.1549" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoNSubstituteUnitTest/FixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/FixtureIntegrationTest.cs
@@ -6,7 +6,6 @@ using NSubstitute;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
 {

--- a/Src/AutoNSubstituteUnitTest/NSubstituteBuilderTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteBuilderTest.cs
@@ -3,7 +3,6 @@ using NSubstitute;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
 {

--- a/Src/AutoNSubstituteUnitTest/NSubstituteMethodQueryTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteMethodQueryTest.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
 {

--- a/Src/AutoNSubstituteUnitTest/NSubstituteSealedPropertiesCommandTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteSealedPropertiesCommandTest.cs
@@ -73,7 +73,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithGetOnlyProperty>();
             var sut = new NSubstituteSealedPropertiesCommand();
             //Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.GetOnlyProperty);
         }
@@ -87,7 +87,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithVirtualMembers>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.VirtualProperty);
         }
@@ -101,7 +101,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithPropertyWithPrivateSetter>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.PropertyWithPrivateSetter);
         }
@@ -113,13 +113,11 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var fixture = new Fixture();
             var frozenString = fixture.Freeze<string>();
             var substitute = Substitute.For<TypeWithPrivateProperty>();
-            var privateProperty = typeof(TypeWithPrivateProperty)
-                .GetProperty("PrivateProperty",
-                             BindingFlags.Instance | BindingFlags.NonPublic);
+            var privateProperty = typeof(TypeWithPrivateProperty).GetProperty("PrivateProperty", BindingFlags.Instance | BindingFlags.NonPublic);
 
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, privateProperty.GetValue(substitute, null));
         }
@@ -133,7 +131,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<IInterfaceWithProperty>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.Property);
         }
@@ -147,7 +145,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithStaticProperty>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, TypeWithStaticProperty.Property);
         }
@@ -161,7 +159,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithIndexer>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenInt, substitute[2]);
         }
@@ -175,7 +173,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithPrivateField>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.GetPrivateField());
         }
@@ -189,7 +187,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithReadonlyField>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.ReadonlyField);
         }
@@ -203,7 +201,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithConstField>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, TypeWithConstField.ConstField);
         }
@@ -217,7 +215,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithStaticField>();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, TypeWithStaticField.StaticField);
         }
@@ -230,7 +228,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var specimen = new ConcreteTypeWithSealedMembers();
             var sut = new NSubstituteSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(specimen, context));
+            Assert.Null(Record.Exception(() => sut.Execute(specimen, context)));
 
             context.DidNotReceiveWithAnyArgs().Resolve(null);
         }

--- a/Src/AutoNSubstituteUnitTest/NSubstituteVirtualMethodsCommandTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteVirtualMethodsCommandTest.cs
@@ -188,7 +188,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithSealedMembers>();
             var sut = new NSubstituteVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.ImplicitlySealedMethod());
             Assert.NotEqual(frozenString, substitute.ExplicitlySealedMethod());
@@ -202,7 +202,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<IInterfaceWithVoidMethod>();
             var sut = new NSubstituteVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
         }
 
         [Fact]
@@ -213,7 +213,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<IInterfaceWithParameterVoidMethod>();
             var sut = new NSubstituteVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<IInterfaceWithGenericMethod>();
             var sut = new NSubstituteVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
 
             Assert.NotEqual(frozenString, substitute.GenericMethod<string>());
         }
@@ -238,7 +238,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substitute = Substitute.For<TypeWithStaticMethod>();
             var sut = new NSubstituteVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(substitute, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(substitute, new SpecimenContext(fixture))));
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var specimen = new ConcreteTypeWithVirtualMembers();
             var sut = new NSubstituteVirtualMethodsCommand();
 
-            Assert.DoesNotThrow(() => sut.Execute(specimen, context));
+            Assert.Null(Record.Exception(() => sut.Execute(specimen, context)));
             context.DidNotReceiveWithAnyArgs().Resolve(null);
         }
 

--- a/Src/AutoNSubstituteUnitTest/SubstituteAttributeRelayTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteAttributeRelayTest.cs
@@ -123,9 +123,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
         {
             // Fixture setup
             var sut = new SubstituteAttributeRelay();
-            var request = Substitute.For<EventInfo>();
+            var request = Substitute.For<ICustomAttributeProvider>();
             var attribute = new SubstituteAttribute();
-            request.GetCustomAttributes(Arg.Any<Type>(), Arg.Any<bool>()).Returns(new[] { attribute });
+            request.GetCustomAttributes(Arg.Any<Type>(), Arg.Any<bool>()).Returns(new object[] { attribute });
             var context = Substitute.For<ISpecimenContext>();
             // Exercise system
             var e = Assert.Throws<NotSupportedException>(() => sut.Create(request, context));

--- a/Src/AutoNSubstituteUnitTest/SubstituteAttributeTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteAttributeTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
 {
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
         public void AttributeCanBeAppliedToCodeElementsSupportedBySubstituteAttributeRelay(AttributeTargets expectedTarget)
         {
             // Fixture setup
-            var attributeUsage = typeof(SubstituteAttribute).GetCustomAttributes(false)
+            var attributeUsage = typeof(SubstituteAttribute).GetTypeInfo().GetCustomAttributes(false)
                 .OfType<AttributeUsageAttribute>().Single();
             // Exercise system
             Assert.Equal(expectedTarget, attributeUsage.ValidOn & expectedTarget);
@@ -36,7 +36,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
         public void AttributeCanBeAppliedOnlyOnceBecauseDefiningMultipleSubstitutesForSingleArgumentIsMeaningless()
         {
             // Fixture setup
-            var attributeUsage = typeof(SubstituteAttribute).GetCustomAttributes(false)
+            var attributeUsage = typeof(SubstituteAttribute).GetTypeInfo().GetCustomAttributes(false)
                 .OfType<AttributeUsageAttribute>().Single();
             // Exercise system
             Assert.False(attributeUsage.AllowMultiple);

--- a/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
@@ -1,10 +1,10 @@
 ﻿using System;
+using System.Reflection;
 using NSubstitute;
 using NSubstitute.Exceptions;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
 {

--- a/Src/AutoNSubstituteUnitTest/SubstituteRequestHandlerTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteRequestHandlerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using NSubstitute;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;


### PR DESCRIPTION
Add support for .NET Core by NSubstitute. Everything went smoothly and no important changes are present. Currently, we require different minimal versions of NSubsitute for different frameworks:
- `1.5.0` for .NET Framework
- `2.0.3` for .NET Standard

That will be changed in future as discussed in #784, however currently there is no reason to increase the minimal version, so I decided to keep it as is.

@moodmosaic @adamchester Thank you in advance for the review 😉