### PR TITLE
Migrate xUnit 2 glue library to .NET Core

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -183,6 +183,7 @@ Target "TestOnly" (fun _ ->
         "AutoFixtureDocumentationTest"
         "SemanticComparisonUnitTest"
         "AutoNSubstituteUnitTest"
+        "AutoFixture.xUnit.net2.UnitTest"
     ]
 
     let testAssemblies = !! (sprintf "Src/*Test/bin/%s/**/*Test.dll" configuration)

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Sdk;

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -3,17 +3,18 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
     <AssemblyTitle>AutoFixture.xUnit.net2.UnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Xunit2.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.Xunit2.UnitTest</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,3 +27,4 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>
+

--- a/Src/AutoFixture.xUnit.net2.UnitTest/CompositeDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/CompositeDataAttributeTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 using Xunit.Sdk;
 
@@ -34,7 +35,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             // Fixture setup
             Action a = delegate { };
-            var method = a.Method;
+            var method = a.GetMethodInfo();
 
             var attributes = new[]
             {
@@ -66,7 +67,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             // Fixture setup
             Action a = delegate { };
-            var method = a.Method;
+            var method = a.GetMethodInfo();
 
             var attributes = new[]
             {
@@ -99,7 +100,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             // Fixture setup
             Action a = delegate { };
-            var method = a.Method;
+            var method = a.GetMethodInfo();
             var parameters = method.GetParameters();
             var parameterTypes = (from pi in parameters
                                   select pi.ParameterType).ToArray();
@@ -111,8 +112,8 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
                );
 
             // Exercise system and verify outcome
-            var result = sut.GetData(a.Method);
-            Array.ForEach(result.ToArray(), Assert.Empty);
+            var result = sut.GetData(a.GetMethodInfo());
+            result.ToList().ForEach(Assert.Empty);
             // Teardown
         }
     }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DependencyConstraints.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Ploeh.AutoFixture.Xunit2.UnitTest
@@ -20,7 +21,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             // Fixture setup
             // Exercise system
-            var references = typeof(AutoDataAttribute).Assembly.GetReferencedAssemblies();
+            var references = typeof(AutoDataAttribute).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
             Assert.False(references.Any(an => an.Name == assemblyName));
             // Teardown
@@ -41,7 +42,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         {
             // Fixture setup
             // Exercise system
-            var references = this.GetType().Assembly.GetReferencedAssemblies();
+            var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
             Assert.False(references.Any(an => an.Name == assemblyName));
             // Teardown

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FavorArraysAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FavorArraysAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FavorEnumerablesAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FavorEnumerablesAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FavorListsAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FavorListsAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;

--- a/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/FrozenAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 

--- a/Src/AutoFixture.xUnit.net2.UnitTest/GreedyAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/GreedyAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;

--- a/Src/AutoFixture.xUnit.net2.UnitTest/ModestAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/ModestAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;

--- a/Src/AutoFixture.xUnit.net2.UnitTest/NoAutoPropertiesAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/NoAutoPropertiesAttributeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -27,7 +27,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         }
 
         [Theory, AutoData]
-        public void AutoDataProvidesMultipleObjects(PropertyHolder<Version> ph, SingleParameterType<OperatingSystem> spt)
+        public void AutoDataProvidesMultipleObjects(PropertyHolder<Version> ph, SingleParameterType<ConcreteType> spt)
         {
             Assert.NotNull(ph);
             Assert.NotNull(ph.Property);

--- a/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
@@ -133,7 +133,7 @@ namespace Ploeh.AutoFixture.Xunit2
                 throw new ArgumentNullException("type");
             }
 
-            if (!typeof(IFixture).IsAssignableFrom(type))
+            if (!typeof(IFixture).GetTypeInfo().IsAssignableFrom(type))
             {
                 throw new ArgumentException(
                     string.Format(
@@ -143,7 +143,7 @@ namespace Ploeh.AutoFixture.Xunit2
                     "type");
             }
 
-            var ctor = type.GetConstructor(Type.EmptyTypes);
+            var ctor = type.GetTypeInfo().GetConstructor(Type.EmptyTypes);
             if (ctor == null)
             {
                 throw new ArgumentException(

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoFixture.xUnit.net2</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Xunit2</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.Xunit2</RootNamespace>
@@ -14,15 +14,19 @@
     <Description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+    <PackageReference Include="xunit.core" Version="[2.0.0,3.0.0)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="xunit.core" Version="[2.0.0,3.0.0)" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
+    <PackageReference Include="xunit.core" Version="[2.2.0,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 </Project>

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -232,7 +232,7 @@ namespace Ploeh.AutoFixture.Xunit2
                     return true;
                 if (y == null)
                     return false;
-                return y.IsAssignableFrom(x);
+                return y.GetTypeInfo().IsAssignableFrom(x);
             }
 
             public int GetHashCode(Type obj)


### PR DESCRIPTION
Added .NET Core support to xUnit2 glue library. Almost nothing changes - mostly type info usage.
Different xUnit versions are required for different targets:
- 2.0.0 .NET Framework 4.5
- 2.2.0 .NET Standard 1.5

@moodmosaic @adamchester Looking forward to your review 🌮