### PR TITLE
Migrate AutoMoq to net core

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -183,6 +183,7 @@ Target "TestOnly" (fun _ ->
         "AutoFixtureDocumentationTest"
         "SemanticComparisonUnitTest"
         "AutoNSubstituteUnitTest"
+        "AutoMoqUnitTest"
         "AutoFixture.xUnit.net2.UnitTest"
     ]
 

--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -12,6 +12,10 @@
     <PackageId>AutoFixture.AutoMoq</PackageId>
     <Title>AutoFixture with Auto Mocking using Moq</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by Moq. To use it, add the AutoMoqCustomization to your Fixture instance. Read more at http://blog.ploeh.dk/2010/08/19/AutoFixtureAsAnAutomockingContainer.aspx</Description>
+
+    <!--  Suppress warning about invalid dependency version in Castle.Core.
+          That is Moq dependency and we cannot fix that somehow. -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoMoq</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoMoq</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoMoq</RootNamespace>
@@ -18,8 +18,12 @@
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
     <PackageReference Include="Moq" Version="4.1.1308.2120" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
+    <PackageReference Include="Moq" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoMoq/GreedyMockConstructorQuery.cs
+++ b/Src/AutoMoq/GreedyMockConstructorQuery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.AutoMoq
@@ -41,7 +42,7 @@ namespace Ploeh.AutoFixture.AutoMoq
             }
 
             var mockType = type.GetMockedType();
-            if (mockType.IsInterface)
+            if (mockType.GetTypeInfo().IsInterface)
             {
                 return new[] { new ConstructorMethod(type.GetDefaultConstructor()) };
             }

--- a/Src/AutoMoq/MockConstructorQuery.cs
+++ b/Src/AutoMoq/MockConstructorQuery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.AutoMoq
@@ -41,7 +42,7 @@ namespace Ploeh.AutoFixture.AutoMoq
             }
 
             var mockType = type.GetMockedType();
-            if (mockType.IsInterface || mockType.IsDelegate())
+            if (mockType.GetTypeInfo().IsInterface || mockType.IsDelegate())
             {
                 return new[] { new ConstructorMethod(type.GetDefaultConstructor()) };
             }

--- a/Src/AutoMoq/MockRelay.cs
+++ b/Src/AutoMoq/MockRelay.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Moq;
 using Ploeh.AutoFixture.Kernel;
 
@@ -106,8 +107,7 @@ namespace Ploeh.AutoFixture.AutoMoq
                 if (t == null)
                     return false;
 
-                return (t != null)
-                    && ((t.IsAbstract) || (t.IsInterface));
+                return t.GetTypeInfo().IsAbstract || t.GetTypeInfo().IsInterface;
             }
         }
     }

--- a/Src/AutoMoq/MockType.cs
+++ b/Src/AutoMoq/MockType.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Moq;
 using Moq.Language;
@@ -38,7 +37,7 @@ namespace Ploeh.AutoFixture.AutoMoq
         internal static bool IsMock(this Type type)
         {
             return (type != null
-                && type.IsGenericType
+                && type.GetTypeInfo().IsGenericType
                 && typeof(Mock<>).IsAssignableFrom(type.GetGenericTypeDefinition())
                 && !type.GetMockedType().IsGenericParameter);
         }
@@ -50,7 +49,7 @@ namespace Ploeh.AutoFixture.AutoMoq
              * and MulticaseDelegate] are merged and that only 
              * MulticastDelegate exists."
              * http://blogs.msdn.com/b/brada/archive/2004/02/05/68415.aspx */
-            return typeof(MulticastDelegate).IsAssignableFrom(type.BaseType);
+            return typeof(MulticastDelegate).IsAssignableFrom(type.GetTypeInfo().BaseType);
         }
 
         internal static ConstructorInfo GetDefaultConstructor(this Type type)

--- a/Src/AutoMoq/MockVirtualMethodsCommand.cs
+++ b/Src/AutoMoq/MockVirtualMethodsCommand.cs
@@ -112,7 +112,7 @@ namespace Ploeh.AutoFixture.AutoMoq
         {
             // If "type" is an interface, "GetMethods" does not return methods declared on other interfaces extended by "type".
             // In these cases, we use the "GetInterfaceMethods" extension method instead.
-            var methods = type.IsInterface
+            var methods = type.GetTypeInfo().IsInterface
                               ? type.GetInterfaceMethods()
                               : type.GetMethods();
 

--- a/Src/AutoMoq/StubPropertiesCommand.cs
+++ b/Src/AutoMoq/StubPropertiesCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Moq;
 using Ploeh.AutoFixture.Kernel;

--- a/Src/AutoMoqUnitTest/AutoConfiguredMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/AutoConfiguredMoqCustomizationTest.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Moq;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {

--- a/Src/AutoMoqUnitTest/AutoMockPropertiesCommandTest.cs
+++ b/Src/AutoMoqUnitTest/AutoMockPropertiesCommandTest.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using Moq;
 using Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
@@ -21,7 +17,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var context = new Mock<ISpecimenContext>().Object;
             var sut = new AutoMockPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(validNonMockSpecimen, context));
+            Assert.Null(Record.Exception(() => sut.Execute(validNonMockSpecimen, context)));
         }
 
         [Fact]
@@ -42,7 +38,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var context = new Mock<ISpecimenContext>().Object;
             var sut = new AutoMockPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(specimen, context));
+            Assert.Null(Record.Exception(() => sut.Execute(specimen, context)));
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/AutoMockPropertiesCommandTest.cs
+++ b/Src/AutoMoqUnitTest/AutoMockPropertiesCommandTest.cs
@@ -83,7 +83,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Fixture setup
             var specimen = new Mock<IInterfaceWithoutMembers>();
             var proxyField = specimen.Object.GetType().GetField(proxyFieldName);
-            var initialProxyFieldValue = proxyField.GetValue(specimen.Object);
+            var initialProxyFieldValue = proxyField?.GetValue(specimen.Object);
 
             var contextStub = new Mock<ISpecimenContext>();
             contextStub.Setup(ctx => ctx.Resolve(It.IsAny<FieldInfo>()))
@@ -95,7 +95,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             sut.Execute(specimen, contextStub.Object);
             // Verify outcome
-            var finalProxyFieldValue = proxyField.GetValue(specimen.Object);
+            var finalProxyFieldValue = proxyField?.GetValue(specimen.Object);
             Assert.Same(initialProxyFieldValue, finalProxyFieldValue);
         }
     }

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -7,6 +7,10 @@
     <AssemblyTitle>AutoMoqUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoMoq.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoMoq.UnitTest</RootNamespace>
+
+    <!--  Suppress warning about invalid dependency version in Castle.Core.
+          That is Moq dependency and we cannot fix that somehow. -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -3,18 +3,18 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
     <AssemblyTitle>AutoMoqUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoMoq.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoMoq.UnitTest</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
-    <PackageReference Include="xunit.extensions" Version="1.8.0.1549" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoMoqUnitTest/DependencyConstraints.cs
+++ b/Src/AutoMoqUnitTest/DependencyConstraints.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
+using System.Reflection;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
@@ -15,7 +15,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         {
             // Fixture setup
             // Exercise system
-            var references = typeof(AutoMoqCustomization).Assembly.GetReferencedAssemblies();
+            var references = typeof(AutoMoqCustomization).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
             Assert.False(references.Any(an => an.Name == assemblyName));
             // Teardown
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
         {
             // Fixture setup
             // Exercise system
-            var references = this.GetType().Assembly.GetReferencedAssemblies();
+            var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
             Assert.False(references.Any(an => an.Name == assemblyName));
             // Teardown

--- a/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Moq;
+﻿using Moq;
 using Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Xunit;
 
@@ -203,7 +199,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
             Mock<TypeWithSealedMembers> result = null;
-            Assert.DoesNotThrow(() => result = fixture.Create<Mock<TypeWithSealedMembers>>());
+            Assert.Null(Record.Exception(() => result = fixture.Create<Mock<TypeWithSealedMembers>>()));
             Assert.NotEqual(frozenString, result.Object.ImplicitlySealedMethod());
             Assert.NotEqual(frozenString, result.Object.ExplicitlySealedMethod());
         }
@@ -216,7 +212,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
             IInterfaceWithRefMethod result = null;
-            Assert.DoesNotThrow(() => result = fixture.Create<IInterfaceWithRefMethod>());
+            Assert.Null(Record.Exception(() => result = fixture.Create<IInterfaceWithRefMethod>()));
 
             string refResult = "";
             string returnValue = result.Method(ref refResult);
@@ -232,7 +228,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
             IInterfaceWithGenericMethod result = null;
-            Assert.DoesNotThrow(() => result = fixture.Create<IInterfaceWithGenericMethod>());
+            Assert.Null(Record.Exception(() => result = fixture.Create<IInterfaceWithGenericMethod>()));
 
             Assert.NotEqual(frozenString, result.GenericMethod<string>());
         }
@@ -244,7 +240,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<Mock<TypeWithStaticMethod>>());
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithStaticMethod>>()));
         }
 
         [Fact]
@@ -254,7 +250,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<Mock<TypeWithStaticProperty>>());
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithStaticProperty>>()));
             Assert.NotEqual(frozenString, TypeWithStaticProperty.Property);
         }
 
@@ -266,7 +262,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
             Mock<TypeWithPrivateField> result = null;
-            Assert.DoesNotThrow(() => result = fixture.Create<Mock<TypeWithPrivateField>>());
+            Assert.Null(Record.Exception(() => result = fixture.Create<Mock<TypeWithPrivateField>>()));
 
             Assert.NotEqual(frozenString, result.Object.GetPrivateField());
         }
@@ -279,7 +275,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
             Mock<TypeWithReadonlyField> result = null;
-            Assert.DoesNotThrow(() => result = fixture.Create<Mock<TypeWithReadonlyField>>());
+            Assert.Null(Record.Exception(() => result = fixture.Create<Mock<TypeWithReadonlyField>>()));
 
             Assert.NotEqual(frozenString, result.Object.ReadonlyField);
         }
@@ -291,7 +287,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<Mock<TypeWithConstField>>());
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithConstField>>()));
             Assert.NotEqual(frozenString, TypeWithConstField.ConstField);
         }
 
@@ -302,7 +298,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());
             var frozenString = fixture.Freeze<string>();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => fixture.Create<Mock<TypeWithStaticField>>());
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithStaticField>>()));
             Assert.NotEqual(frozenString, TypeWithStaticField.StaticField);
         }
 

--- a/Src/AutoMoqUnitTest/GreedyMockConstructorQueryTest.cs
+++ b/Src/AutoMoqUnitTest/GreedyMockConstructorQueryTest.cs
@@ -5,7 +5,6 @@ using Moq;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {

--- a/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
+++ b/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
@@ -5,7 +5,6 @@ using Moq;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {

--- a/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
+++ b/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
@@ -3,7 +3,6 @@ using Moq;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {

--- a/Src/AutoMoqUnitTest/MockRelayTest.cs
+++ b/Src/AutoMoqUnitTest/MockRelayTest.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+using System.Reflection;
 using Moq;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {

--- a/Src/AutoMoqUnitTest/MockSealedPropertiesCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockSealedPropertiesCommandTest.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using Moq;
 using Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
@@ -81,7 +77,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             //Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
         }
 
         [Fact]
@@ -94,7 +90,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, mock.Object.VirtualProperty);
         }
 
@@ -108,7 +104,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, mock.Object.PropertyWithPrivateSetter);
         }
 
@@ -125,7 +121,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, privateProperty.GetValue(mock.Object, null));
         }
 
@@ -139,7 +135,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, mock.Object.Property);
         }
 
@@ -153,7 +149,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, TypeWithStaticProperty.Property);
         }
 
@@ -167,7 +163,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenInt, mock.Object[2]);
         }
 
@@ -181,7 +177,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, mock.Object.GetPrivateField());
         }
 
@@ -195,7 +191,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, mock.Object.ReadonlyField);
         }
 
@@ -209,7 +205,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, TypeWithConstField.ConstField);
         }
 
@@ -223,7 +219,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, TypeWithStaticField.StaticField);
         }
 
@@ -237,7 +233,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockSealedPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(specimen, context.Object));
+            Assert.Null(Record.Exception(() => sut.Execute(specimen, context.Object)));
         }
     }
 #pragma warning restore 618

--- a/Src/AutoMoqUnitTest/MockTypeTest.cs
+++ b/Src/AutoMoqUnitTest/MockTypeTest.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Moq;
 using Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {

--- a/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using Moq;
 using Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
@@ -21,8 +16,8 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var context = new Mock<ISpecimenContext>();
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(
-                () => sut.Execute(validNonMockSpecimen, context.Object));
+            Assert.Null(
+                Record.Exception(() => sut.Execute(validNonMockSpecimen, context.Object)));
             // Teardown
         }
 
@@ -235,7 +230,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
         }
 
         [Fact]
@@ -248,7 +243,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, mock.Object.ImplicitlySealedMethod());
             Assert.NotEqual(frozenString, mock.Object.ExplicitlySealedMethod());
         }
@@ -262,7 +257,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
         }
 
         [Fact]
@@ -275,7 +270,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
             Assert.NotEqual(frozenString, mock.Object.GenericMethod<string>());
         }
 
@@ -288,7 +283,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(mock, new SpecimenContext(fixture)));
+            Assert.Null(Record.Exception(() => sut.Execute(mock, new SpecimenContext(fixture))));
         }
 
         [Fact]
@@ -301,7 +296,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 
             var sut = new MockVirtualMethodsCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(specimen, context.Object));
+            Assert.Null(Record.Exception(() => sut.Execute(specimen, context.Object)));
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/StubPropertiesCommandTest.cs
+++ b/Src/AutoMoqUnitTest/StubPropertiesCommandTest.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Moq;
 using Ploeh.AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoMoq.UnitTest
 {
@@ -21,7 +16,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var context = new Mock<ISpecimenContext>().Object;
             var sut = new StubPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(validNonMockSpecimen, context));
+            Assert.Null(Record.Exception(() => sut.Execute(validNonMockSpecimen, context)));
         }
 
         [Fact]
@@ -32,7 +27,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var context = new Mock<ISpecimenContext>().Object;
             var sut = new StubPropertiesCommand();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Execute(request, context));
+            Assert.Null(Record.Exception(() => sut.Execute(request, context)));
         }
 
         [Fact]


### PR DESCRIPTION
Migrated AutoMoq project to .NET Core. Different targets has different Moq dependencies:
- `4.1.1308.2120` for .NET Framework 4.5
- `4.7.0` for .NET Standard 1.5

Most of the changes are the regular migration noise. However, there is one change that you should be aware of. It appeared for the full framework runtime the proxy objects, generated by Castle, contains two fields: `__interceptors` and `__target`, while for .NET Core runtime only the `__interceptors` field is present. I've updated test to make that field optional and do not fail if field is missing. See [this](https://github.com/AutoFixture/AutoFixture/commit/96e15ede41f278b2b212156566b6b3ca8041c64b) commit for more detail. That shouldn't affect the logic somehow - we always ignore these fields, so if it's missing - we should do nothing 😅

@moodmosaic @adamchester Looking forward to your review. If you know somebody else who could also take a look in a timely fashion - please invite 😉
