### PR TITLE
Migrate AutoFakeItEasy to .NET Core

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -184,6 +184,9 @@ Target "TestOnly" (fun _ ->
         "SemanticComparisonUnitTest"
         "AutoNSubstituteUnitTest"
         "AutoMoqUnitTest"
+        "AutoFakeItEasyUnitTest"
+        "AutoFakeItEasy.FakeItEasy2UnitTest"
+        "AutoFakeItEasy.FakeItEasy3UnitTest"
         "AutoFixture.xUnit.net2.UnitTest"
     ]
 

--- a/Src/All.sln
+++ b/Src/All.sln
@@ -70,7 +70,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CommonTestProperties.props = CommonTestProperties.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy.FakeItEasy2UnitTest", "AutoFakeItEasy.FakeItEasy2UnitTest\AutoFakeItEasy.FakeItEasy2UnitTest.csproj", "{7F957CC0-79C3-48A1-9A3E-47BED7539248}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy2UnitTest", "AutoFakeItEasy.FakeItEasy2UnitTest\AutoFakeItEasy.FakeItEasy2UnitTest.csproj", "{7F957CC0-79C3-48A1-9A3E-47BED7539248}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy3UnitTest", "AutoFakeItEasy.FakeItEasy3UnitTest\AutoFakeItEasy.FakeItEasy3UnitTest.csproj", "{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -265,6 +267,12 @@ Global
 		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.ActiveCfg = Release|Any CPU
 		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Verify|Any CPU.ActiveCfg = Release|Any CPU
+		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Verify|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
@@ -3,18 +3,18 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFakeItEasy.FakeItEasy2.UnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.FakeItEasy2UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
-    <PackageReference Include="xunit.extensions" Version="1.8.0.1549" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="FakeItEasy" Version="2.0.0" />
   </ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\CommonProperties.props" />
+  <Import Project="..\CommonTestProperties.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <AssemblyTitle>AutoFakeItEasy.FakeItEasy3.UnitTest</AssemblyTitle>
+    <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.FakeItEasy3UnitTest</AssemblyName>
+    <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
+
+    <PackageReference Include="FakeItEasy" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AutoFakeItEasyUnitTest\*.cs" Link="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoFakeItEasy\AutoFakeItEasy.csproj" />
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+    <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
@@ -7,6 +7,10 @@
     <AssemblyTitle>AutoFakeItEasy.FakeItEasy3.UnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.FakeItEasy3UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
+
+    <!--  Suppress warning about invalid dependency version in Castle.Core.
+          That is FakeItEasy dependency and we cannot fix that somehow. -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.sln
+++ b/Src/AutoFakeItEasy.sln
@@ -11,7 +11,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy", "AutoFakeI
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasyUnitTest", "AutoFakeItEasyUnitTest\AutoFakeItEasyUnitTest.csproj", "{CDEB7E7C-85A0-40F1-80F9-34A9511491F1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy.FakeItEasy2UnitTest", "AutoFakeItEasy.FakeItEasy2UnitTest\AutoFakeItEasy.FakeItEasy2UnitTest.csproj", "{7F957CC0-79C3-48A1-9A3E-47BED7539248}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy2UnitTest", "AutoFakeItEasy.FakeItEasy2UnitTest\AutoFakeItEasy.FakeItEasy2UnitTest.csproj", "{7F957CC0-79C3-48A1-9A3E-47BED7539248}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy3UnitTest", "AutoFakeItEasy.FakeItEasy3UnitTest\AutoFakeItEasy.FakeItEasy3UnitTest.csproj", "{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -56,6 +58,12 @@ Global
 		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.ActiveCfg = Release|Any CPU
 		{7F957CC0-79C3-48A1-9A3E-47BED7539248}.Verify|Any CPU.Build.0 = Release|Any CPU
+		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -13,6 +13,10 @@
     <Title>AutoFixture with Auto Mocking using FakeItEasy</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by FakeItEasy. To use it, add the AutoFakeItEasyCustomization to your Fixture instance.</Description>
     <Authors>Nikos Baxevanis,AutoFixture</Authors>
+
+    <!--  Suppress warning about invalid dependency version in Castle.Core.
+          That is FakeItEasy dependency and we cannot fix that somehow. -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <AssemblyTitle>AutoFakeItEasy</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy</RootNamespace>
@@ -15,15 +15,19 @@
     <Authors>Nikos Baxevanis,AutoFixture</Authors>
   </PropertyGroup>
 
-  <ItemGroup>
-    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+    <PackageReference Include="FakeItEasy" Version="1.7.4109.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="1.7.4109.1" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.6' ">
+    <PackageReference Include="FakeItEasy" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 </Project>

--- a/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.AutoFakeItEasy

--- a/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
@@ -33,7 +33,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
             }
 
             var fakeType = type.GetFakedType();
-            if (fakeType.IsInterface)
+            if (fakeType.GetTypeInfo().IsInterface)
             {
                 return new[] { new ConstructorMethod(type.GetDefaultConstructor()) };
             }
@@ -85,7 +85,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
                     }
 
                     var parameterType = constructorParameterInfos[0].ParameterType;
-                    if (!parameterType.IsGenericType ||
+                    if (!parameterType.GetTypeInfo().IsGenericType ||
                         parameterType.GetGenericTypeDefinition() != typeof (Action<>))
                     {
                         continue;

--- a/Src/AutoFakeItEasy/FakeItEasyRelay.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyRelay.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using FakeItEasy;
 using Ploeh.AutoFixture.Kernel;
 
@@ -92,7 +93,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
             public bool IsSatisfiedBy(object request)
             {
                 var t = request as Type;
-                return (t != null) && ((t.IsAbstract) || (t.IsInterface));
+                return (t != null) && ((t.GetTypeInfo().IsAbstract) || (t.GetTypeInfo().IsInterface));
             }
         }
     }

--- a/Src/AutoFakeItEasy/FakeItEasyType.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyType.cs
@@ -11,7 +11,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
         internal static bool IsFake(this Type type)
         {
             return (type != null
-                && type.IsGenericType
+                && type.GetTypeInfo().IsGenericType
                 && typeof(Fake<>).IsAssignableFrom(type.GetGenericTypeDefinition())
                 && !type.GetFakedType().IsGenericParameter);
         }

--- a/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
+++ b/Src/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
@@ -3,18 +3,20 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFakeItEasyUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
-    <PackageReference Include="xunit.extensions" Version="1.8.0.1549" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
+  
+    <PackageReference Include="FakeItEasy" Version="1.7.4109.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasyUnitTest/DependencyConstraints.cs
+++ b/Src/AutoFakeItEasyUnitTest/DependencyConstraints.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Reflection;
 using Xunit;
 using Xunit.Extensions;
 
@@ -15,7 +16,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
         {
             // Fixture setup
             // Exercise system
-            var references = typeof(AutoFakeItEasyCustomization).Assembly.GetReferencedAssemblies();
+            var references = typeof(AutoFakeItEasyCustomization).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
             Assert.False(references.Any(an => an.Name == assemblyName));
             // Teardown
@@ -28,7 +29,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
         {
             // Fixture setup
             // Exercise system
-            var references = this.GetType().Assembly.GetReferencedAssemblies();
+            var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
             Assert.False(references.Any(an => an.Name == assemblyName));
             // Teardown

--- a/Src/AutoFakeItEasyUnitTest/FakeItEasyRelayTest.cs
+++ b/Src/AutoFakeItEasyUnitTest/FakeItEasyRelayTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using FakeItEasy;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;


### PR DESCRIPTION
Added support for .NET Core and AutoFakeItEasy. We have different dependencies depending on target:
- `1.7.4109.1` for .NET Framework 4.5
- `3.0.0` for .NET Standard 1.6

In our glue library I target .NET Standard 1.6 (instead of 1.5 we use everywhere else) as that's required by FakeItEasy.

Additionally I've added one more test project for AutoFakeItEasy to assert its support for FakeItEasy3. The reason is that previous versions (1 and 2) don't support .NET Core, so I needed at least one project where I can run tests under .NET Core runtime.

@adamchester @moodmosaic Your review is expected! 😉
@blairconrad If you have free time, it would be great if you look through and confirm everything looks fine to you ☺️