### PR TITLE
Passive Customization Attributes are ignored when used in combination with [Frozen] (#637, xUnit.net2, v4)

### DIFF
--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoFixture.xUnit.net2.UnitTest.csproj
@@ -23,6 +23,10 @@
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' " >
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Ploeh.TestTypeFoundation;
 using Xunit;
@@ -415,6 +416,13 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             FieldHolder<string> p2)
         {
             Assert.NotEqual(p1, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeParameterWithStringLengthConstraintShouldCreateConstrainedSpecimen(
+            [Frozen, StringLength(3)]string p)
+        {
+            Assert.True(p.Length == 3);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -110,7 +110,7 @@ namespace Ploeh.AutoFixture.Xunit2
                 .Or(ByParameterName(type, name))
                 .Or(ByFieldName(type, name));
 
-            return new FreezeOnMatchCustomization(type, filter);
+            return new FreezeOnMatchCustomization(parameter, filter);
         }
 
         private static IRequestSpecification ByEqual(object target)


### PR DESCRIPTION
Partially solves #637 as other frameworks (xUnit, NUnit[1,2]) are not fixed.
Same as #695 but targets v4.