### PR TITLE
Improve fixture customization performance by adding laziness to adapted collection

### DIFF
--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -33,14 +33,13 @@ namespace Ploeh.AutoFixture
                 // Some of the collections are not even touched after the construction and are immediately
                 // recreated again after a subsequent customization.
                 // To cover such scenarios we evaluate value on demand only saving the initialization time. 
-                if (this.adaptedBuilderNode != null) return this.adaptedBuilderNode;
-
-                var markerNode = this.Graph.FindFirstNode(this.isAdaptedBuilder);
+                if (this.adaptedBuilderNode != null)
+                    return this.adaptedBuilderNode;
 
                 // The intermediate "result" variable is needed to ensure that null value can be never returned
-                // in case of concurrency (we set field to null). While current collection implementation doesn't 
+                // in case of concurrency (we can set field to null). While current collection implementation doesn't 
                 // seem to support concurrency, the additional guard adds more safety.
-                var result = this.adaptedBuilderNode = (ISpecimenBuilderNode)markerNode.First();
+                var result = this.adaptedBuilderNode = this.FindAdaptedSpecimenBuilderNode();
                 return result;
             }
         }
@@ -455,6 +454,12 @@ namespace Ploeh.AutoFixture
                 when: adaptedNode.Equals);
 
             this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
+        }
+
+        private ISpecimenBuilderNode FindAdaptedSpecimenBuilderNode()
+        {
+            var markerNode = this.Graph.FindFirstNode(this.isAdaptedBuilder);
+            return (ISpecimenBuilderNode) markerNode.First();
         }
     }
 }

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -22,6 +22,7 @@ namespace Ploeh.AutoFixture
     {
         private readonly Func<ISpecimenBuilderNode, bool> isAdaptedBuilder;
         private IEnumerable<ISpecimenBuilder> adaptedBuilders;
+        private ISpecimenBuilderNode graph;
 
         private IEnumerable<ISpecimenBuilder> AdaptedBuilders
         {
@@ -419,7 +420,15 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         /// <seealso cref="SpecimenBuilderNodeAdapterCollection" />
         /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
-        public ISpecimenBuilderNode Graph { get; private set; }
+        public ISpecimenBuilderNode Graph
+        {
+            get => this.graph;
+            private set
+            {
+                this.graph = value;
+                this.InvalidateCachedAdaptedBuilders();
+            }
+        }
 
         /// <summary>Raises the <see cref="E:GraphChanged" /> event.</summary>
         /// <param name="e">
@@ -440,8 +449,6 @@ namespace Ploeh.AutoFixture
             this.Graph = this.Graph.ReplaceNodes(
                 with: builders,
                 when: adaptedBuilder.Equals);
-            
-            this.InvalidateCachedAdaptedBuilders();
 
             this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
         }

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -37,7 +37,7 @@ namespace Ploeh.AutoFixture
                 // The intermediate "result" variable is needed to ensure that null value can be never returned
                 // in case of concurrency (we set field to null). While current collection implementation doesn't 
                 // seem to support concurrency, the additional guard adds more safety.
-                var result = this.adaptedBuilders = Graph.FindFirstNode(TargetMemo.IsSpecifiedBy);
+                var result = this.adaptedBuilders = FindAdaptedBuilderNode();
                 return result;
             }
         }
@@ -435,38 +435,21 @@ namespace Ploeh.AutoFixture
 
         private void Mutate(IEnumerable<ISpecimenBuilder> builders)
         {
+            var adaptedBuilder = FindAdaptedBuilderNode();
+            
             this.Graph = this.Graph.ReplaceNodes(
                 with: builders,
-                when: this.TargetMemo.IsSpecifiedBy);
+                when: adaptedBuilder.Equals);
             
             this.InvalidateCachedAdaptedBuilders();
 
             this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
         }
 
-        private TargetSpecification TargetMemo
+        private ISpecimenBuilderNode FindAdaptedBuilderNode()
         {
-            get
-            {
-                var markerNode = this.Graph.FindFirstNode(this.isAdaptedBuilder);
-                var target = (ISpecimenBuilderNode)markerNode.First();
-                return new TargetSpecification(target);
-            }
-        }
-
-        private class TargetSpecification
-        {
-            private readonly ISpecimenBuilderNode target;
-
-            public TargetSpecification(ISpecimenBuilderNode target)
-            {
-                this.target = target;
-            }
-
-            public bool IsSpecifiedBy(ISpecimenBuilderNode n)
-            {
-                return object.Equals(this.target, n);
-            }
+            var markerNode = this.Graph.FindFirstNode(this.isAdaptedBuilder);
+            return (ISpecimenBuilderNode) markerNode.First();
         }
     }
 }

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -75,7 +75,7 @@ namespace Ploeh.AutoFixture
             ISpecimenBuilderNode graph,
             Func<ISpecimenBuilderNode, bool> adaptedBuilderPredicate)
         {
-            this.Graph = graph;
+            this.graph = graph;
             this.isAdaptedBuilder = adaptedBuilderPredicate;
         }
 
@@ -430,6 +430,7 @@ namespace Ploeh.AutoFixture
             {
                 this.graph = value;
                 this.InvalidateCachedAdaptedBuilderNode();
+                this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(value));
             }
         }
 
@@ -440,9 +441,7 @@ namespace Ploeh.AutoFixture
         /// </param>
         protected virtual void OnGraphChanged(SpecimenBuilderNodeEventArgs e)
         {
-            var handler = this.GraphChanged;
-            if (handler != null)
-                handler(this, e);
+            this.GraphChanged?.Invoke(this, e);
         }
 
         private void Mutate(IEnumerable<ISpecimenBuilder> builders)
@@ -452,8 +451,6 @@ namespace Ploeh.AutoFixture
             this.Graph = this.Graph.ReplaceNodes(
                 with: builders,
                 when: adaptedNode.Equals);
-
-            this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
         }
 
         private ISpecimenBuilderNode FindAdaptedSpecimenBuilderNode()


### PR DESCRIPTION
## Introduction

Usually Fixture is used together with other glue libraries like `AutoMoq` or `AutoNSubstitute`. Also often fixture is customized per project needs and later the customized fixture instance is used all over the project (e.g. via custom `AutoData` attribute).

For xUnit you have a single `AutoData` attribute per method, so during test discovery (and execution) fixture is created large number of times and is being customized on construction for each time. The customization performance affects the discovery speed and with runners like NCrunch (that re-run tests on each modification you make) we are sensitive to that speed (usually you want to see whether nothing was broken after the change, so you wait for results).

## Issue

I've profiled fixture customization and found a redundancy that helps to save some time. It appeared that each time a customization is added, we re-create the `Customizations` and `ResidueCollector` objects. If you apply a few customizations in a row, the e.g. `ResidueCollector` instances might be never touched. However there is an expensive lookup in object constructor which takes time even if value is never used later. I've fixed the issue by adding the lazy evaluation, so we perform expensive lookup only if that's indeed required.

Also I found that logic had redundancy and we performed lookup twice. That has been fixed as well.

## Measurements
I used BenchmarkDotNet tool to measure results. Here is my setup:
```csharp
[ClrJob]
public class CustomizationSpeedTest
{
    [Benchmark]
    public void CreateFixture() => new Fixture().Customize(new TestCustomization());
}

class TestCustomization: ICustomization
{
    public void Customize(IFixture fixture)
    {
        fixture.Customize(new AutoConfiguredNSubstituteCustomization());
        fixture.Customize(new IncrementingDateTimeCustomization());
        fixture.Customize(new NoDataAnnotationsCustomization());
        fixture.Inject(42);
        fixture.Freeze<object>();
    }
}
```
Before (v. 3.50.6):
```
BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 1 (10.0.14393)
Processor=Intel Core i7-4770 CPU 3.40GHz (Haswell), ProcessorCount=8
Frequency=3320309 Hz, Resolution=301.1768 ns, Timer=TSC
  [Host] : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2102.0
  Clr    : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2102.0

Job=Clr  Runtime=Clr

        Method |     Mean |    Error |   StdDev |
-------------- |---------:|---------:|---------:|
 CreateFixture | 213.9 us | 1.942 us | 1.621 us |
```

After:
```
BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 1 (10.0.14393)
Processor=Intel Core i7-4770 CPU 3.40GHz (Haswell), ProcessorCount=8
Frequency=3320309 Hz, Resolution=301.1768 ns, Timer=TSC
  [Host] : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2102.0
  Clr    : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.2102.0

Job=Clr  Runtime=Clr

        Method |     Mean |     Error |    StdDev |
-------------- |---------:|----------:|----------:|
 CreateFixture | 148.5 us | 0.6110 us | 0.5716 us |
```

The mean value changes from ~213us to ~149us - that is about 30% boost. Not too bad for such a small change :)

On my working solution NCrunch test discovery decreased from approx. 4.5 sec to 3.7 sec. Given that this is delay after each code change - result is great.

---

@adamchester This PR might be interesting to you as it's about performance.
@moodmosaic Your review is also expected if possible 😃

P.S. I've tuned the number after the initial PR creation - that's because I did measurements before I discovered one more place to improve.