### PR TITLE
Use MSBuild based NuGet restore

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -8,7 +8,6 @@ open System
 open System.Diagnostics;
 open System.Text.RegularExpressions
 
-let nuGetRestoreFolder = "Packages"
 let nuGetOutputFolder = "NuGetPackages"
 let nuGetPackages = !! (nuGetOutputFolder @@ "*.nupkg" )
                     // Skip symbol packages because NuGet publish symbols automatically when package is published
@@ -164,7 +163,7 @@ Target "CleanVerify"        (fun _ -> clean "Verify")
 Target "CleanRelease"       (fun _ -> clean "Release")
 
 // Configuration doesn't matter for restore and is ignored by MSBuild.
-let restoreNugetPackages() = build "Restore" "Release" [ "RestorePackagesPath", FullName nuGetRestoreFolder ]
+let restoreNugetPackages() = build "Restore" "Release" []
 
 Target "RestoreNuGetPackages" (fun _ -> restoreNugetPackages())
 

--- a/tools/update-fake.bat
+++ b/tools/update-fake.bat
@@ -1,3 +1,3 @@
 cls
-NuGet\NuGet.exe install "FAKE.Core" -OutputDirectory . -ExcludeVersion
+NuGet.exe install "FAKE.Core" -OutputDirectory . -ExcludeVersion
 @pause


### PR DESCRIPTION
Currently we use NuGet.exe directly to restore packages for the project. However after we migrated all our projects to a new format (.NET Core SDK) that is no longer required and we can use built-in MSBuild restore.

Additionally, I've changed the restore to not specify the specific packages location and use the default one. That was done for a few reasons:
1. To not fight with VS. Currently if you build solution via FAKE and later open the solution, VS will re-restore the packages to the default location.
2. By default MSBuild restores packages to the machine-wide packages cache. When we restore to a custom location we in fact make a copy of packages. As result restore takes longer and project occupies unnecessary space on the hard drive.

I've checked project after the refactoring and can confirm that you can work in offline after you run the `build.cmd` - MSBuild uses the already cached packages and is able to successfully compile the project.

@moodmosaic @adamchester @klimisa Please review and confirm if you are fine.