### PR TITLE
Passive Customization Attributes are ignored when used in combination with [Frozen] (#637, NUnit2, v4)

### DIFF
--- a/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
@@ -23,6 +23,7 @@
     <Reference Include="nunit.core.interfaces">
       <HintPath>..\..\References\NUnit.2.6.2\nunit.core.interfaces.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/Scenario.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using NUnit.Framework;
 using Ploeh.TestTypeFoundation;
+using System.ComponentModel.DataAnnotations;
 
 namespace Ploeh.AutoFixture.NUnit2.UnitTest
 {
@@ -349,6 +350,13 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             FieldHolder<string> p2)
         {
             Assert.AreNotEqual(p1, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeParameterWithStringLengthConstraintShouldCreateConstrainedSpecimen(
+            [Frozen, StringLength(3)]string p)
+        {
+            Assert.True(p.Length == 3);
         }
     }
 }

--- a/Src/AutoFixture.NUnit2/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit2/FrozenAttribute.cs
@@ -110,7 +110,7 @@ namespace Ploeh.AutoFixture.NUnit2
                 .Or(ByParameterName(type, name))
                 .Or(ByFieldName(type, name));
 
-            return new FreezeOnMatchCustomization(type, filter);
+            return new FreezeOnMatchCustomization(parameter, filter);
         }
 
         private static IRequestSpecification ByEqual(object target)


### PR DESCRIPTION
Solves #637 for NUnit2.