### PR TITLE
Passive Customization Attributes are ignored when used in combination with [Frozen] (#637, xUnit.net, v4)

### DIFF
--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Ploeh.TestTypeFoundation;
 using Xunit;
 using Xunit.Extensions;
+using System.ComponentModel.DataAnnotations;
 
 namespace Ploeh.AutoFixture.Xunit.UnitTest
 {
@@ -416,6 +417,13 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             FieldHolder<string> p2)
         {
             Assert.NotEqual(p1, p2.Field);
+        }
+
+        [Theory, AutoData]
+        public void FreezeParameterWithStringLengthConstraintShouldCreateConstrainedSpecimen(
+            [Frozen, StringLength(3)]string p)
+        {
+            Assert.True(p.Length == 3);
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -110,7 +110,7 @@ namespace Ploeh.AutoFixture.Xunit
                 .Or(ByParameterName(type, name))
                 .Or(ByFieldName(type, name));
 
-            return new FreezeOnMatchCustomization(type, filter);
+            return new FreezeOnMatchCustomization(parameter, filter);
         }
 
         private static IRequestSpecification ByEqual(object target)


### PR DESCRIPTION
Solves #637 for xUnit.net.