### PR TITLE
Passive Customization Attributes are ignored when used in combination with [Frozen] (#637, NUnit3, v4)

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -23,6 +23,10 @@
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+  </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using NUnit.Framework;
 using Ploeh.TestTypeFoundation;
+using System.ComponentModel.DataAnnotations;
 
 namespace Ploeh.AutoFixture.NUnit3.UnitTest
 {
@@ -386,6 +387,13 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
             Assert.That(ph1.Property, Is.EqualTo(default(object)));
             Assert.That(ph2.Property, Is.EqualTo(default(string)));
             Assert.That(ph3.Property, Is.EqualTo(default(int)));
+        }
+
+        [Theory, AutoData]
+        public void FreezeParameterWithStringLengthConstraintShouldCreateConstrainedSpecimen(
+            [Frozen, StringLength(3)]string p)
+        {
+            Assert.True(p.Length == 3);
         }
     }
 }

--- a/Src/AutoFixture.NUnit3/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit3/FrozenAttribute.cs
@@ -39,7 +39,7 @@ namespace Ploeh.AutoFixture.NUnit3
         {
             this.by = by;
         }
-        
+
         /// <summary>
         /// Gets the <see cref="Matching"/> criteria used to determine
         /// which requests will be satisfied by the frozen parameter value.
@@ -71,7 +71,7 @@ namespace Ploeh.AutoFixture.NUnit3
 
             return FreezeByCriteria(parameter);
         }
-        
+
         private ICustomization FreezeByCriteria(ParameterInfo parameter)
         {
             var type = parameter.ParameterType;
@@ -85,7 +85,7 @@ namespace Ploeh.AutoFixture.NUnit3
                 .Or(ByParameterName(type, name))
                 .Or(ByFieldName(type, name));
 
-            return new FreezeOnMatchCustomization(type, filter);
+            return new FreezeOnMatchCustomization(parameter, filter);
         }
 
         private static IRequestSpecification ByEqual(object target)


### PR DESCRIPTION
Solves #637 for NUnit3.