### PR TITLE
Decrease build log verbosity level to Minimal

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -151,7 +151,7 @@ let runMsBuild target configuration properties =
                     | "normal" | "n"        -> Normal
                     | "detailed" | "d"      -> Detailed
                     | "diagnostic" | "diag" -> Diagnostic
-                    | _ -> Normal
+                    | _ -> Minimal
 
     let configProperty = match configuration with
                          | Some c -> [ "Configuration", c ]


### PR DESCRIPTION
After we switched all our projects to .NET Core SDK the build output became very verbose. Previously [we had](https://ci.appveyor.com/project/AutoFixture/autofixture/branch/master) about 3,000 lines of output, while now we have about 11,000 lines. If you open e.g. [this log](https://ci.appveyor.com/project/AutoFixture/autofixture/build/4.0.0.290) in browser, you'll see that browser hangs and it's very difficult to navigate through the output.

Another issue with current output is that it's really hard to focus on what is going on as your output is polluted with a ton of unimportant stuff. When you notice a warning during the build, it's almost impossible to find it in the local console, as it's being pushed by other output and finally pushed out from the console buffer. The most upset thing is that this additional information was never needed in my experience with this project.

In this PR I'm changing the verbosity level to `Minimal`. That is the default verbosity level if you use `dotnet build` or `dotnet restore`. With that configuration build output now takes only about 1,000 lines (see example [here](https://ci.appveyor.com/project/AutoFixture/autofixture/build/3.21.1.288)). Now it's easy to find the important messages and output prints valuable information only. Also browser feels perfect!

If somewhere in future we'll need to troubleshoot some issue and minimal output will be not enough, we could easily enable chatty output back:
- for local build simply pass the `BuildVerbosity=normal` parameter;
- for AppVeyor we can use UI and define the `BuildVerbosity` environment variable with `normal` value and re-run the build in question.

@moodmosaic @adamchester @ecampidoglio Do you have any objections regarding that change? Current configuration causes a lot of inconvenience for me as I work with build output quite often.