### PR TITLE
Use ThreadLocal<> instead of the ConcurrentDictionary

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture/Kernel/RecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/RecursionGuard.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Ploeh.AutoFixture.Kernel
@@ -11,16 +10,16 @@ namespace Ploeh.AutoFixture.Kernel
     /// Base class for recursion handling. Tracks requests and reacts when a recursion point in the
     /// specimen creation process is detected.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
+    [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", 
+        Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
+    [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
+        Justification = "Fixture doesn't support disposal, so we cannot dispose current builder somehow.")]
     public class RecursionGuard : ISpecimenBuilderNode
     {
-        private readonly ConcurrentDictionary<Thread, Stack<object>>
-            _requestsByThread = new ConcurrentDictionary<Thread, Stack<object>>();
+        private readonly ThreadLocal<Stack<object>> _requestsByThread
+            = new ThreadLocal<Stack<object>>(() => new Stack<object>());
 
-        private Stack<object> GetMonitoredRequestsForCurrentThread()
-        {
-            return _requestsByThread.GetOrAdd(Thread.CurrentThread, _ => new Stack<object>());
-        }
+        private Stack<object> GetMonitoredRequestsForCurrentThread() => _requestsByThread.Value;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RecursionGuard"/> class.

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -15,15 +14,14 @@ namespace Ploeh.AutoFixture.Kernel
     /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix",
         Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
+    [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
+        Justification = "Fixture doesn't support disposal, so we cannot dispose current builder somehow.")]
     public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
     {
-        private readonly ConcurrentDictionary<Thread, Stack<object>>
-            _requestPathsByThread = new ConcurrentDictionary<Thread, Stack<object>>();
+        private readonly ThreadLocal<Stack<object>> _requestsByThread
+            = new ThreadLocal<Stack<object>>(() => new Stack<object>());
 
-        private Stack<object> GetPathForCurrentThread()
-        {
-            return _requestPathsByThread.GetOrAdd(Thread.CurrentThread, _ => new Stack<object>());
-        }
+        private Stack<object> GetPathForCurrentThread() => _requestsByThread.Value;
 
         /// <summary>
         /// Creates a new <see cref="TerminatingWithPathSpecimenBuilder"/> instance.


### PR DESCRIPTION
Usage of the `ThreadLocal<>` instead of custom dictionary allows to remove the package dependency on `System.Threading.Thread` and make the code cleaner.

Also it offers better performance as far as I briefly spotted in the profiler. I haven't tested that, though.

Unless you know about any special reason why you used the dictionary (likely, simply for historical reasons), I suggest to the the `ThreadLocal<>` - it has been designed for exactly such scenarios.