### PR TITLE
Rework NSubstitute integration approach

### DIFF
--- a/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NSubstitute.Core;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute
@@ -9,8 +10,6 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
     /// </summary>
     public class AutoConfiguredNSubstituteCustomization : ICustomization
     {
-        private readonly ISpecimenBuilder builder;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoConfiguredNSubstituteCustomization"/> class.
         /// </summary>
@@ -27,9 +26,9 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
         public AutoConfiguredNSubstituteCustomization(ISpecimenBuilder builder)
         {
             if (builder == null)
-                throw new ArgumentNullException("builder");
+                throw new ArgumentNullException(nameof(builder));
 
-            this.builder = builder;
+            this.Builder = builder;
         }
 
         /// <summary>
@@ -37,26 +36,23 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
         /// <see cref="Customize"/> is invoked.
         /// </summary>
         /// <seealso cref="AutoConfiguredNSubstituteCustomization(ISpecimenBuilder)"/>
-        public ISpecimenBuilder Builder
-        {
-            get { return builder; }
-        }
+        public ISpecimenBuilder Builder { get; }
 
         /// <summary>Customizes an <see cref="IFixture"/> to enable auto-mocking with NSubstitute.</summary>
         /// <param name="fixture">The fixture upon which to enable auto-mocking.</param>
         public void Customize(IFixture fixture)
         {
             if (fixture == null)
-                throw new ArgumentNullException("fixture");
+                throw new ArgumentNullException(nameof(fixture));
 
             fixture.Customizations.Insert(0, 
                 new Postprocessor(
                     new SubstituteRequestHandler(new MethodInvoker(new NSubstituteMethodQuery())),
                     new CompositeSpecimenCommand(
-                        new NSubstituteVirtualMethodsCommand(),
+                        new NSubstituteRegisterCallHandlerCommand(SubstitutionContext.Current),
                         new NSubstituteSealedPropertiesCommand())));
             fixture.Customizations.Insert(0, new SubstituteAttributeRelay());
-            fixture.ResidueCollectors.Add(Builder);
+            fixture.ResidueCollectors.Add(this.Builder);
         }
     }
 }

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -19,11 +19,7 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
-    <PackageReference Include="NSubstitute" Version="1.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
+  <ItemGroup>
     <PackageReference Include="NSubstitute" Version="2.0.3" />
   </ItemGroup>
 

--- a/Src/AutoNSubstitute/CustomCallHandler/AutoFixtureValuesHandler.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/AutoFixtureValuesHandler.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute.Core;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <summary>
+    /// CallHandler for NSubstitute to provide auto-values from AutoFixture.
+    /// It resolves return values and sets ref/out parameter values obtained from <see cref="ICallResultResolver"/>.
+    /// Uses cache to resolve value only once per call with specified args.
+    /// </summary>
+    public class AutoFixtureValuesHandler : ICallHandler
+    {
+        /// <summary>
+        /// Factory for the <see cref="ICallSpecification"/> instances used as a cache key.
+        /// </summary>
+        public ICallSpecificationFactory CallSpecificationFactory { get; }
+
+        /// <summary>
+        /// Cache used to store the already resolved call results.
+        /// </summary>
+        public ICallResultCache ResultCache { get; }
+
+        /// <summary>
+        /// Resolver used to obtain call result if not present in cache.
+        /// </summary>
+        public ICallResultResolver ResultResolver { get; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="AutoFixtureValuesHandler"/> with
+        /// related specimen context, results cache and specification factory.
+        /// </summary>
+        public AutoFixtureValuesHandler(ICallResultResolver resultResolver, ICallResultCache resultCache,
+            ICallSpecificationFactory callSpecificationFactory)
+        {
+            if (resultResolver == null) throw new ArgumentNullException(nameof(resultResolver));
+            if (resultCache == null) throw new ArgumentNullException(nameof(resultCache));
+            if (callSpecificationFactory == null) throw new ArgumentNullException(nameof(callSpecificationFactory));
+
+            this.ResultResolver = resultResolver;
+            this.ResultCache = resultCache;
+            this.CallSpecificationFactory = callSpecificationFactory;
+        }
+
+        /// <summary>
+        /// Try to handle the call - set ref/out params and return value.
+        /// </summary>
+        public RouteAction Handle(ICall call)
+        {
+            if (call == null) throw new ArgumentNullException(nameof(call));
+
+            // Don't care about concurrency. If race condition happens - simply use the latest result.
+            CallResultData result;
+            if (!this.ResultCache.TryGetResult(call, out result))
+            {
+                result = this.ResultResolver.ResolveResult(call);
+                var callSpec = this.CallSpecificationFactory.CreateFrom(call, MatchArgs.AsSpecifiedInCall);
+
+                this.ResultCache.AddResult(callSpec, result);
+            }
+
+            var callArguments = call.GetArguments();
+            var originalArguments = call.GetOriginalArguments();
+            foreach (var argumentValue in result.ArgumentValues)
+            {
+                var argIndex = argumentValue.Index;
+
+                // If ref/out value has been already modified (e.g. by When..Do), don't override that value.
+                if (!ArgValueWasModified(callArguments[argIndex], originalArguments[argIndex]))
+                {
+                    callArguments[argIndex] = argumentValue.Value;
+                }
+            }
+
+            return result.ReturnValue.Fold(RouteAction.Continue, RouteAction.Return);
+        }
+
+        private static bool ArgValueWasModified(object current, object original)
+        {
+            return !EqualityComparer<object>.Default.Equals(current, original);
+        }
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultCache.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultCache.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using NSubstitute.Core;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <inheritdoc />
+    public class CallResultCache : ICallResultCache
+    {
+        private ConcurrentStack<ResultForCallSpec> CallResults { get; } = new ConcurrentStack<ResultForCallSpec>();
+
+        /// <inheritdoc />
+        public void AddResult(ICallSpecification callSpecification, CallResultData result)
+        {
+            if (callSpecification == null) throw new ArgumentNullException(nameof(callSpecification));
+            if (result == null) throw new ArgumentNullException(nameof(result));
+
+            this.CallResults.Push(new ResultForCallSpec(callSpecification, result));
+        }
+
+        /// <inheritdoc />
+        public bool TryGetResult(ICall callInfo, out CallResultData callResult)
+        {
+            if (callInfo == null) throw new ArgumentNullException(nameof(callInfo));
+
+            var result = this.CallResults.FirstOrDefault(c => c.IsResultFor(callInfo));
+
+            callResult = result?.Result;
+            return result != null;
+        }
+
+        private class ResultForCallSpec
+        {
+            private readonly ICallSpecification callSpecification;
+            public CallResultData Result { get; }
+
+            public ResultForCallSpec(ICallSpecification callSpecification, CallResultData result)
+            {
+                this.callSpecification = callSpecification;
+                this.Result = result;
+            }
+
+            public bool IsResultFor(ICall call) => this.callSpecification.IsSatisfiedBy(call);
+        }
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultCacheFactory.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultCacheFactory.cs
@@ -1,0 +1,12 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <inheritdoc />
+    public class CallResultCacheFactory : ICallResultCacheFactory
+    {
+        /// <inheritdoc />
+        public ICallResultCache CreateCache()
+        {
+            return new CallResultCache();
+        }
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultData.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultData.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using NSubstitute.Core;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <summary>
+    /// Storage for a single resolved call result.
+    /// </summary>
+    public class CallResultData
+    {
+        /// <summary>
+        /// Value that should be returned.
+        /// </summary>
+        public Maybe<object> ReturnValue { get; }
+
+        /// <summary>
+        /// Ref/Out argument values.
+        /// </summary>
+        public IEnumerable<ArgumentValue> ArgumentValues { get; }
+
+        /// <summary>
+        /// Initializes instance of the <see cref="CallResultData"/>.
+        /// </summary>
+        public CallResultData(Maybe<object> returnValue, IEnumerable<ArgumentValue> argumentValues)
+        {
+            this.ReturnValue = returnValue;
+            this.ArgumentValues = argumentValues;
+        }
+
+        /// <summary>
+        /// Intance represents resolved argument value by index.
+        /// </summary>
+        public class ArgumentValue
+        {
+            /// <summary>
+            /// Argument index starting from zero.
+            /// </summary>
+            public int Index { get; }
+
+            /// <summary>
+            /// Argument value.
+            /// </summary>
+            public object Value { get; }
+
+            /// <summary>
+            /// Creates an instance of <see cref="ArgumentValue"/>.
+            /// </summary>
+            public ArgumentValue(int index, object value)
+            {
+                this.Index = index;
+                this.Value = value;
+            }
+        }
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultResolver.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultResolver.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute.Core;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <inheritdoc />
+    public class CallResultResolver : ICallResultResolver
+    {
+        /// <summary>
+        /// SpecimenContext used to resolve result and argument values.
+        /// </summary>
+        public ISpecimenContext SpecimenContext { get; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="CallResultResolver"/>
+        /// </summary>
+        public CallResultResolver(ISpecimenContext specimenContext)
+        {
+            if (specimenContext == null) throw new ArgumentNullException(nameof(specimenContext));
+
+            this.SpecimenContext = specimenContext;
+        }
+
+        /// <inheritdoc />
+        public CallResultData ResolveResult(ICall callInfo)
+        {
+            var returnValue = this.ResolveReturnValue(callInfo);
+            var returnMaybe = returnValue is OmitSpecimen ? Maybe.Nothing<object>() : Maybe.Just(returnValue);
+
+            //Resolve ref/out parameter values.
+            var argumentValues = new List<CallResultData.ArgumentValue>();
+            var parameterInfos = callInfo.GetMethodInfo().GetParameters();
+            for (var i = 0; i < parameterInfos.Length; i++)
+            {
+                var parameterInfo = parameterInfos[i];
+
+                if (!parameterInfo.ParameterType.IsByRef) continue;
+
+                // Unwrap parameter type, because it is Type& for ref/out methods.
+                var value = this.SpecimenContext.Resolve(parameterInfo.ParameterType.GetElementType());
+                if (value is OmitSpecimen) continue;
+
+                argumentValues.Add(new CallResultData.ArgumentValue(i, value));
+            }
+
+            return new CallResultData(returnMaybe, argumentValues);
+        }
+
+        private object ResolveReturnValue(ICall call)
+        {
+            if (call.GetReturnType() == typeof(void)) return null;
+
+            // If this is a call to a property getter, we resolve value via the 'PropertyInfo' request.
+            var propertyInfo = call.GetMethodInfo().GetPropertyFromGetterCallOrNull();
+            if (propertyInfo != null)
+            {
+                return this.SpecimenContext.Resolve(propertyInfo);
+            }
+
+            return this.SpecimenContext.Resolve(call.GetReturnType());
+        }
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultResolverFactory.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultResolverFactory.cs
@@ -1,0 +1,14 @@
+﻿using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <inheritdoc />
+    public class CallResultResolverFactory : ICallResultResolverFactory
+    {
+        /// <inheritdoc />
+        public ICallResultResolver Create(ISpecimenContext specimenContext)
+        {
+            return new CallResultResolver(specimenContext);
+        }
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/ICallResultCache.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/ICallResultCache.cs
@@ -1,0 +1,20 @@
+﻿using NSubstitute.Core;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <summary>
+    /// Cache for already resolved call results.
+    /// </summary>
+    public interface ICallResultCache
+    {
+        /// <summary>
+        /// Adds result for the passed <paramref name="callSpecification"/>.
+        /// </summary>
+        void AddResult(ICallSpecification callSpecification, CallResultData result);
+
+        /// <summary>
+        /// Returns the latest registered result that matches the passed call.
+        /// </summary>
+        bool TryGetResult(ICall callInfo, out CallResultData callResult);
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/ICallResultCacheFactory.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/ICallResultCacheFactory.cs
@@ -1,0 +1,13 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <summary>
+    ///  Factory to create an instance of the cache used later to store resolved call results. 
+    /// </summary>
+    public interface ICallResultCacheFactory
+    {
+        /// <summary>
+        /// Create a new instance of cache.
+        /// </summary>
+        ICallResultCache CreateCache();
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/ICallResultResolver.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/ICallResultResolver.cs
@@ -1,0 +1,15 @@
+﻿using NSubstitute.Core;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <summary>
+    /// Resolves result for the calls using AutoFixture context.
+    /// </summary>
+    public interface ICallResultResolver
+    {
+        /// <summary>
+        /// Resolve result for the call.
+        /// </summary>
+        CallResultData ResolveResult(ICall callInfo);
+    }
+}

--- a/Src/AutoNSubstitute/CustomCallHandler/ICallResultResolverFactory.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/ICallResultResolverFactory.cs
@@ -1,0 +1,17 @@
+﻿using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler
+{
+    /// <summary>
+    /// Factory to create <see cref="ICallResultResolver"/>.
+    /// </summary>
+    public interface ICallResultResolverFactory
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ICallResultResolver"/>.
+        /// </summary>
+        /// <param name="specimenContext">The <see cref="ISpecimenContext"/> to use to create speciments.</param>
+        /// <returns>The call result resolver.</returns>
+        ICallResultResolver Create(ISpecimenContext specimenContext);
+    }
+}

--- a/Src/AutoNSubstitute/GlobalSuppressions.cs
+++ b/Src/AutoNSubstitute/GlobalSuppressions.cs
@@ -17,3 +17,6 @@ using System.Diagnostics.CodeAnalysis;
     SuppressMessage("Microsoft.Design", "CA2210:AssembliesShouldHaveValidStrongNames", 
         Justification = "AutoFixture itself currently doesn't have a strong name.")]
 
+[assembly:
+    SuppressMessage("Microsoft.Design", "CA1014:MarkAssembliesWithClsCompliant",
+        Justification = "NSubstitute contains non-CLS compliant types and they are used, so lib is not CLS compliant.")]

--- a/Src/AutoNSubstitute/GlobalSuppressions.cs
+++ b/Src/AutoNSubstitute/GlobalSuppressions.cs
@@ -20,3 +20,10 @@ using System.Diagnostics.CodeAnalysis;
 [assembly:
     SuppressMessage("Microsoft.Design", "CA1014:MarkAssembliesWithClsCompliant",
         Justification = "NSubstitute contains non-CLS compliant types and they are used, so lib is not CLS compliant.")]
+
+[assembly:
+    SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible", Scope = "type",
+        Target = "Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler.CallResultData+ArgumentValue",
+        Justification =
+            "It's defined as a sub-class because it's very tiny and it's just a way to group data together." +
+            "It's never used without its parent and doesn't bring any value without parent.")]

--- a/Src/AutoNSubstitute/NSubstituteRegisterCallHandlerCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteRegisterCallHandlerCommand.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using NSubstitute.Core;
+using NSubstitute.Exceptions;
+using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute
+{
+    /// <summary>
+    /// Sets up a substitute object's methods so that the return values will be retrieved from a fixture,
+    /// instead of being created directly by NSubstitute.
+    ///
+    /// This will setup any void/non-void virtual methods (including property getters and generics).
+    /// </summary>
+    /// <remarks>
+    /// This will setup any void, non-void virtual methods.
+    /// This includes:
+    ///  - interface's methods/property getters;
+    ///  - class's abstract/virtual/overridden/non-sealed methods/property getters;
+    ///
+    /// Notes:
+    /// - Calling a method more than once with the same parameters will return the same value by default.
+    ///   To override that behavior pass a custom <see cref="ICallResultCacheFactory"/> instance.
+    /// - Methods inherited from <see cref="Object" /> are not set up due to a limitation in NSubstitute
+    ///     (http://stackoverflow.com/a/21787891)
+    /// </remarks>
+    public class NSubstituteRegisterCallHandlerCommand : ISpecimenCommand
+    {
+        /// <summary>
+        /// The NSubstitute context.
+        /// </summary>
+        public ISubstitutionContext SubstitutionContext { get; }
+
+        /// <summary>
+        /// Factory used to create <see cref="ICallResultCache"/> instances.
+        /// </summary>
+        public ICallResultCacheFactory CallResultCacheFactory { get; }
+
+        /// <summary>
+        /// Factory used to create <see cref="ICallResultResolver"/> instances.
+        /// </summary>
+        public ICallResultResolverFactory CallResultResolverFactory { get; }
+
+        /// <summary>
+        /// Creates an new <see cref="NSubstituteRegisterCallHandlerCommand"/> instance 
+        /// with default <see cref="ICallResultCacheFactory"/> and <see cref="ICallResultResolverFactory"/> instanes.
+        /// </summary>
+        public NSubstituteRegisterCallHandlerCommand(ISubstitutionContext substitutionContext)
+            : this(substitutionContext, new CallResultCacheFactory(), new CallResultResolverFactory())
+        {
+        }
+
+        /// <summary>
+        /// Creates an new <see cref="NSubstituteRegisterCallHandlerCommand"/> instance.
+        /// </summary>
+        public NSubstituteRegisterCallHandlerCommand(
+            ISubstitutionContext substitutionContext,
+            ICallResultCacheFactory callResultCacheFactory,
+            ICallResultResolverFactory callResultResolverFactory)
+        {
+            if (substitutionContext == null) throw new ArgumentNullException(nameof(substitutionContext));
+            if (callResultCacheFactory == null) throw new ArgumentNullException(nameof(callResultCacheFactory));
+            if (callResultResolverFactory == null) throw new ArgumentNullException(nameof(callResultResolverFactory));
+
+            this.SubstitutionContext = substitutionContext;
+            this.CallResultCacheFactory = callResultCacheFactory;
+            this.CallResultResolverFactory = callResultResolverFactory;
+        }
+
+        /// <summary>
+        /// Registers a custom handler for the specified specimen if that is a substitute.
+        /// Custom handler resolves call result and ref/out arguments using the passed <paramref name="context"/>.
+        /// </summary>
+        public void Execute(object specimen, ISpecimenContext context)
+        {
+            if (specimen == null) throw new ArgumentNullException(nameof(specimen));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            ICallRouter router;
+
+            try
+            {
+                router = this.SubstitutionContext.GetCallRouterFor(specimen);
+            }
+            catch (NotASubstituteException)
+            {
+                return;
+            }
+
+            // Add extensibility point for users to allow to use differnt cache implementation.
+            // For intance users might want to disalbe results caching like that is demanded here:
+            // https://github.com/AutoFixture/AutoFixture/issues/625
+            var resultsCacheForSubstitution = this.CallResultCacheFactory.CreateCache();
+            var callResultsResover = this.CallResultResolverFactory.Create(context);
+
+            router.RegisterCustomCallHandlerFactory(
+                substituteState =>
+                    new AutoFixtureValuesHandler(
+                        callResultsResover,
+                        resultsCacheForSubstitution,
+                        substituteState.CallSpecificationFactory));
+        }
+    }
+}

--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -15,6 +15,7 @@ using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute
 {
+
     /// <summary>
     /// Sets up a substitute object's methods so that the return values will be retrieved from a fixture,
     /// instead of being created directly by NSubstitute.
@@ -35,6 +36,8 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
     /// - Methods inherited from <see cref="Object" /> are not set up due to a limitation in NSubstitute
     ///     (http://stackoverflow.com/a/21787891)
     /// </remarks>
+    [Obsolete("This class belongs to the legacy integration approach. " +
+              "Use the NSubstituteRegisterCallHandlerCommand class and its dependencies instead.")]
     public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
     {
         private static readonly MethodInfo[] ObjectMethods = typeof(object).GetMethods();

--- a/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
+++ b/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
@@ -3,6 +3,8 @@ using NSubstitute.Core;
 
 namespace Ploeh.AutoFixture.AutoNSubstitute
 {
+    [Obsolete("This class belongs to the legacy integration approach. " +
+              "Use the NSubstituteRegisterCallHandlerCommand class and its dependencies instead.")]
     internal class NoSetupCallbackHandler : ICallHandler
     {
         private readonly ISubstituteState state;

--- a/Src/AutoNSubstitute/Properties/AssemblyInfo.cs
+++ b/Src/AutoNSubstitute/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
@@ -16,5 +15,4 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("43868c64-c09b-4fed-8fab-207cff140065")]
 
-[assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -581,6 +580,150 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             Assert.Equal(expected, result);
         }
 
+        [Fact]
+        public void GenericMethodsWithRefReturnValueFromFixture()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var expectedInt = fixture.Freeze<int>();
+            var expectedStr = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericRefMethod>();
+
+            // Exercise system
+            string refValue = "dummy";
+            int retValue = substitute.GenericMethod<string>(ref refValue);
+
+            // Verify outcome
+            Assert.Equal(expectedInt, retValue);
+            Assert.Equal(expectedStr, refValue);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void GenericMethodsWithOutReturnValueFromFixture()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var expectedInt = fixture.Freeze<int>();
+            var expectedStr = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericOutMethod>();
+
+            // Exercise system
+            string outvalue;
+            int retValue = substitute.GenericMethod<string>(out outvalue);
+
+            // Verify outcome
+            Assert.Equal(expectedInt, retValue);
+            Assert.Equal(expectedStr, outvalue);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void VoidGenericMethodsWithRefReturnValueFromFixture()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var expected = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericRefVoidMethod>();
+
+            // Exercise system
+            string refValue = "dummy";
+            substitute.GenericMethod<string>(ref refValue);
+
+            // Verify outcome
+            Assert.Equal(expected, refValue);
+            // Teardown
+        }
+
+        [Fact]
+        public void VoidGenericMethodsWithOutReturnValueFromFixture()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var expected = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericOutVoidMethod>();
+
+            // Exercise system
+            string outValue;
+            substitute.GenericMethod<string>(out outValue);
+
+            // Verify outcome
+            Assert.Equal(expected, outValue);
+            // Teardown
+        }
+
+        [Fact]
+        public void ReturnValueIsSameForSameArgumentForGenerics()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var substitute = fixture.Create<IInterfaceWithGenericParameterMethod>();
+
+            var inputValue = 42;
+
+            // Exercise system
+            var result1 = substitute.GenericMethod<int>(inputValue);
+            var result2 = substitute.GenericMethod<int>(inputValue);
+
+            // Verify outcome
+            Assert.Equal(result1, result2);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ReturnValueIsDifferentForDifferentArgumentForGenerics()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var substitute = fixture.Create<IInterfaceWithGenericParameterMethod>();
+
+            // Exercise system
+            var result1 = substitute.GenericMethod<int>(42);
+            var result2 = substitute.GenericMethod<int>(10);
+
+            // Verify outcome
+            Assert.NotEqual(result1, result2);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ResultIsDifferentForDifferentGeneticInstantiations()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var substitute = fixture.Create<IInterfaceWithGenericMethod>();
+
+            // Exercise system
+            var intResult = substitute.GenericMethod<int>();
+            var longResult = substitute.GenericMethod<long>();
+
+            // Verify outcome
+            Assert.NotEqual(intResult, longResult);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void CachedResultIsMatchedByOtherInterfaceSubstituteForGenerics()
+        {
+            // Fixture setup
+            var fixture = new Fixture().Customize(new AutoConfiguredNSubstituteCustomization());
+            var substitute = fixture.Create<IInterfaceWithGenericParameterMethod>();
+            var arg = fixture.Create<IInterfaceWithMethod>();
+
+            // Exercise system
+            int result1 = substitute.GenericMethod<IInterfaceWithMethod>(arg);
+            int result2 = substitute.GenericMethod<IInterfaceWithMethod>(arg);
+
+            // Verify outcome
+            Assert.Equal(result1, result2);
+
+            // Teardown
+        }
 
         [Fact]
         public void Issue630_DontFailIfAllTasksAreInlinedInInlinePhase()

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using NSubstitute;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
@@ -68,7 +66,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
             var substituteFactory = Assert.IsType<MethodInvoker>(substituteRequestHandler.SubstituteFactory);
             Assert.IsType<NSubstituteMethodQuery>(substituteFactory.Query);
             var compositeCommand = Assert.IsAssignableFrom<CompositeSpecimenCommand>(postprocessor.Command);
-            Assert.True(compositeCommand.Commands.OfType<NSubstituteVirtualMethodsCommand>().Any());
+            Assert.True(compositeCommand.Commands.OfType<NSubstituteRegisterCallHandlerCommand>().Any());
             Assert.True(compositeCommand.Commands.OfType<NSubstituteSealedPropertiesCommand>().Any());
             // Teardown
         }

--- a/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
+++ b/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/AutoFixtureValuesHandlerTest.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/AutoFixtureValuesHandlerTest.cs
@@ -1,0 +1,274 @@
+﻿using System.Linq;
+using NSubstitute;
+using NSubstitute.Core;
+using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes;
+using Xunit;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
+{
+    public class AutoFixtureValuesHandlerTest
+    {
+        private static AutoFixtureValuesHandler CreateSutWithMockedDependencies()
+        {
+            var resultResolver = Substitute.For<ICallResultResolver>();
+            var resultsCache = Substitute.For<ICallResultCache>();
+            var callSpecificationFactory = Substitute.For<ICallSpecificationFactory>();
+
+            return new AutoFixtureValuesHandler(resultResolver, resultsCache, callSpecificationFactory);
+        }
+
+        [Fact]
+        public void ShouldSetConstructorValuesToProperties()
+        {
+            // Fixture setup
+            var resultResolver = Substitute.For<ICallResultResolver>();
+            var resultsCache = Substitute.For<ICallResultCache>();
+            var callSpecificationFactory = Substitute.For<ICallSpecificationFactory>();
+
+            // Exercise system
+            var sut = new AutoFixtureValuesHandler(resultResolver, resultsCache, callSpecificationFactory);
+
+            // Verify outcome
+            Assert.Equal(resultResolver, sut.ResultResolver);
+            Assert.Equal(resultsCache, sut.ResultCache);
+            Assert.Equal(callSpecificationFactory, sut.CallSpecificationFactory);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldUseCorrectSpecForValueCaching()
+        {
+            // Fixture setup
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithParameterlessMethod>();
+            var call = CallHelper.CreateCallMock(() => target.Method());
+
+            var callSpec = Substitute.For<ICallSpecification>();
+            sut.CallSpecificationFactory.CreateFrom(call, MatchArgs.AsSpecifiedInCall).Returns(callSpec);
+            sut.ResultResolver.ResolveResult(call).Returns(
+                new CallResultData(Maybe.Nothing<object>(), Enumerable.Empty<CallResultData.ArgumentValue>()));
+
+            // Exercise system
+            sut.Handle(call);
+
+            // Verify outcome
+            sut.ResultCache.Received().AddResult(callSpec, Arg.Any<CallResultData>());
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldCacheResolvedValue()
+        {
+            // Fixture setup
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithParameterlessMethod>();
+            var call = CallHelper.CreateCallMock(() => target.Method());
+
+            var callResult =
+                new CallResultData(Maybe.Nothing<object>(), Enumerable.Empty<CallResultData.ArgumentValue>());
+            sut.ResultResolver.ResolveResult(call).Returns(callResult);
+
+            // Exercise system
+            sut.Handle(call);
+
+            // Verify outcome
+            sut.ResultCache.Received().AddResult(Arg.Any<ICallSpecification>(), callResult);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldReturnValueFromCacheIfPresent()
+        {
+            // Fixture setup
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithParameterlessMethod>();
+            var call = CallHelper.CreateCallMock(() => target.Method());
+
+            var callSpec = Substitute.For<ICallSpecification>();
+            sut.CallSpecificationFactory.CreateFrom(call, MatchArgs.AsSpecifiedInCall).Returns(callSpec);
+
+            var cachedResult = "cachedResult";
+
+            CallResultData _;
+            sut.ResultCache.TryGetResult(call, out _)
+                .Returns(c =>
+                {
+                    c[1] = new CallResultData(Maybe.Just<object>(cachedResult),
+                        Enumerable.Empty<CallResultData.ArgumentValue>());
+                    return true;
+                });
+
+            // Exercise system
+            var actualResult = sut.Handle(call);
+
+            // Verify outcome
+            sut.ResultResolver.DidNotReceive().ResolveResult(Arg.Any<ICall>());
+            Assert.True(actualResult.HasReturnValue);
+            Assert.Equal(cachedResult, actualResult.ReturnValue);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldReturnResolvedValue()
+        {
+            // Fixture setup
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithParameterlessMethod>();
+            var call = CallHelper.CreateCallMock(() => target.Method());
+
+            var callResult = "callResult";
+            sut.ResultResolver.ResolveResult(call).Returns(new CallResultData(
+                Maybe.Just<object>(callResult),
+                Enumerable.Empty<CallResultData.ArgumentValue>()));
+
+            // Exercise system
+            var actualResult = sut.Handle(call);
+
+            // Verify outcome
+            Assert.True(actualResult.HasReturnValue);
+            Assert.Equal(callResult, actualResult.ReturnValue);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldSetRefArgumentValue()
+        {
+            // Fixture setup
+            var sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithRefIntMethod>();
+            int _ = 0;
+            var call = CallHelper.CreateCallMock(() => target.Method(ref _));
+
+            var callResult = new CallResultData(
+                Maybe.Nothing<object>(),
+                new[] {new CallResultData.ArgumentValue(0, 42)});
+
+            sut.ResultResolver.ResolveResult(call).Returns(callResult);
+
+            // Exercise system
+            sut.Handle(call);
+
+            // Verify outcome
+            Assert.Equal(42, call.GetArguments()[0]);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldSetOutArgumentValue()
+        {
+            // Fixture setup
+            var sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithOutVoidMethod>();
+            int _;
+            var call = CallHelper.CreateCallMock(() => target.Method(out _));
+
+            var callResult = new CallResultData(
+                Maybe.Nothing<object>(),
+                new[] {new CallResultData.ArgumentValue(0, 42)});
+
+            sut.ResultResolver.ResolveResult(call).Returns(callResult);
+
+            // Exercise system
+            sut.Handle(call);
+
+            // Verify outcome
+            Assert.Equal(42, call.GetArguments()[0]);
+
+            // Teardown
+        }
+
+
+        [Fact]
+        public void ShouldNotUpdateModifiedRefArgument()
+        {
+            // Fixture setup
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithRefVoidMethod>();
+
+            int origValue = 10;
+            var call = CallHelper.CreateCallMock(() => target.Method(ref origValue));
+            call.GetArguments()[0] = 42;
+
+            var callArgs = call.GetArguments();
+
+            sut.ResultResolver
+                .ResolveResult(call)
+                .Returns(
+                    new CallResultData(
+                        Maybe.Nothing<object>(),
+                        new[] {new CallResultData.ArgumentValue(0, 84)}));
+
+            // Exercise system
+            sut.Handle(call);
+
+            // Verify outcome
+            Assert.Equal(42, callArgs[0]);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldNotUpdateModifiedOutArgument()
+        {
+            // Fixture setup
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithOutVoidMethod>();
+
+            int origValue;
+            var call = CallHelper.CreateCallMock(() => target.Method(out origValue));
+            call.GetArguments()[0] = 42;
+
+
+            sut.ResultResolver
+                .ResolveResult(call)
+                .Returns(
+                    new CallResultData(
+                        Maybe.Nothing<object>(),
+                        new[] {new CallResultData.ArgumentValue(0, 84)}));
+
+            // Exercise system
+            sut.Handle(call);
+
+            // Verify outcome
+            Assert.Equal(42, call.GetArguments()[0]);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldNotSetPropertyIfResultNotResolved()
+        {
+            // Fixture setup
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithProperty>();
+            var call = CallHelper.CreatePropertyGetterCallMock(() => target.Property);
+
+            sut.ResultResolver.ResolveResult(call).Returns(
+                new CallResultData(Maybe.Nothing<object>(), Enumerable.Empty<CallResultData.ArgumentValue>()));
+
+            // Exercise system
+            var result = sut.Handle(call);
+
+            // Verify outcome
+            Assert.False(result.HasReturnValue);
+
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallHelper.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallHelper.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using NSubstitute;
+using NSubstitute.Core;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
+{
+    public static class CallHelper
+    {
+        public static ICall CreateCallMock(Expression<Action> method)
+        {
+            var methodExpression = (MethodCallExpression) method.Body;
+            var args = new List<object>();
+            foreach (var argExpression in methodExpression.Arguments)
+            {
+                var value = Expression.Lambda(argExpression).Compile().DynamicInvoke();
+                args.Add(value);
+            }
+
+            var methodInfo = methodExpression.Method;
+
+            var call = Substitute.For<ICall>();
+            call.GetMethodInfo().Returns(methodInfo);
+            call.GetReturnType().Returns(methodInfo.ReturnType);
+            call.GetArguments().Returns(args.ToArray());
+            call.GetOriginalArguments().Returns(args.ToArray());
+
+            return call;
+        }
+
+        public static ICall CreatePropertyGetterCallMock<T>(Expression<Func<T>> getProp)
+        {
+            var propertyInfo = (PropertyInfo) ((MemberExpression) getProp.Body).Member;
+
+            var call = Substitute.For<ICall>();
+            call.GetMethodInfo().Returns(propertyInfo.GetMethod);
+            call.GetReturnType().Returns(propertyInfo.PropertyType);
+            call.GetArguments().Returns(new object[0]);
+            call.GetOriginalArguments().Returns(new object[0]);
+
+            return call;
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultCacheFactoryTest.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultCacheFactoryTest.cs
@@ -1,0 +1,22 @@
+﻿using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Xunit;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
+{
+    public class CallResultCacheFactoryTest
+    {
+        [Fact]
+        public void SetupReturnsValueOfCorrectType()
+        {
+            // Fixture setup
+            var sut = new CallResultCacheFactory();
+
+            // Exercise system
+            var result = sut.CreateCache();
+
+            // Verify outcome
+            Assert.IsType<CallResultCache>(result);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultCacheTest.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultCacheTest.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Linq;
+using NSubstitute;
+using NSubstitute.Core;
+using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Xunit;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
+{
+    public class CallResultCacheTest
+    {
+        [Fact]
+        public void AddedResultShouldBeReturned()
+        {
+            // Fixture setup
+            var sut = new CallResultCache();
+            var cachedResult = new CallResultData(Maybe.Nothing<object>(), null);
+
+            var call = Substitute.For<ICall>();
+            var callSpec = Substitute.For<ICallSpecification>();
+            callSpec.IsSatisfiedBy(call).Returns(true);
+
+            // Exercise system
+            sut.AddResult(callSpec, cachedResult);
+            CallResultData retrievedResult;
+            var hasResult = sut.TryGetResult(call, out retrievedResult);
+
+            // Verify outcome
+            Assert.True(hasResult);
+            Assert.Same(cachedResult, retrievedResult);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void TheLatestResultShouldBeReturned()
+        {
+            // Fixture setup
+            var sut = new CallResultCache();
+            var cachedResult = new CallResultData(Maybe.Nothing<object>(), null);
+            var call = Substitute.For<ICall>();
+
+            var callSpec1 = Substitute.For<ICallSpecification>();
+            callSpec1.IsSatisfiedBy(call).Returns(true);
+
+            var callSpec2 = Substitute.For<ICallSpecification>();
+            callSpec2.IsSatisfiedBy(call).Returns(true);
+
+            // Exercise system
+            sut.AddResult(callSpec1, new CallResultData(Maybe.Nothing<object>(), null));
+            sut.AddResult(callSpec2, cachedResult);
+
+            CallResultData retrievedResult;
+            var hasResult = sut.TryGetResult(call, out retrievedResult);
+
+            // Verify outcome
+            Assert.True(hasResult);
+            Assert.Same(cachedResult, retrievedResult);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldntReturnIfSpecificationIsNotSatisfied()
+        {
+            // Fixture setup
+            var sut = new CallResultCache();
+
+            var call = Substitute.For<ICall>();
+            var callSpec = Substitute.For<ICallSpecification>();
+            callSpec.IsSatisfiedBy(call).Returns(false);
+
+            var cachedResult = new CallResultData(Maybe.Nothing<object>(), null);
+
+            // Exercise system
+            sut.AddResult(callSpec, cachedResult);
+
+            CallResultData retrievedResult;
+            var hasResult = sut.TryGetResult(call, out retrievedResult);
+
+            // Verify outcome
+            Assert.False(hasResult);
+            Assert.Null(retrievedResult);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldCorrectlyHandleConcurrency()
+        {
+            // Fixture setup
+            int threadsCount = 5;
+            int itemsPerThread = 10;
+
+
+            var dataRows = Enumerable.Range(0, threadsCount * itemsPerThread)
+                .Select(_ =>
+                {
+                    var call = Substitute.For<ICall>();
+                    var callSpec = Substitute.For<ICallSpecification>();
+                    callSpec.IsSatisfiedBy(call).Returns(true);
+                    var result = new CallResultData(Maybe.Nothing<object>(),
+                        Enumerable.Empty<CallResultData.ArgumentValue>());
+
+                    return (call: call, callSpec: callSpec, result: result);
+                })
+                .ToList();
+
+            var sut = new CallResultCache();
+
+            // Exercise system
+            dataRows
+                .AsParallel()
+                .WithExecutionMode(ParallelExecutionMode.ForceParallelism)
+                .WithDegreeOfParallelism(threadsCount)
+                .Select(data =>
+                {
+                    sut.AddResult(data.callSpec, data.result);
+                    return true;
+                })
+                .ToArray();
+
+            // Verify outcome
+            Assert.True(dataRows.All(row =>
+                sut.TryGetResult(row.call, out CallResultData result) && ReferenceEquals(result, row.result)));
+
+            // Teardown
+        }
+
+        [Fact]
+        public void AddRowShouldFailForNullCallSpecification()
+        {
+            // Fixture setup
+            var sut = new CallResultCache();
+            var callResult = new CallResultData(Maybe.Nothing<object>(),
+                Enumerable.Empty<CallResultData.ArgumentValue>());
+
+            // Exercise system & Verify outcome
+            Assert.Throws<ArgumentNullException>(() => sut.AddResult(null, callResult));
+
+            // Teardown
+        }
+
+        [Fact]
+        public void AddRowShouldFailForNullCallResult()
+        {
+            // Fixture setup
+            var sut = new CallResultCache();
+            var callSpec = Substitute.For<ICallSpecification>();
+
+            // Exercise system & Verify outcome
+            Assert.Throws<ArgumentNullException>(() => sut.AddResult(callSpec, null));
+
+            // Teardown
+        }
+
+        [Fact]
+        public void TryGetValueShouldFailForNullCall()
+        {
+            // Fixture setup
+            var sut = new CallResultCache();
+
+            // Exercise system & Verify outcome
+            Assert.Throws<ArgumentNullException>(() => sut.TryGetResult(null, out CallResultData _));
+
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultDataTest.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultDataTest.cs
@@ -1,0 +1,26 @@
+﻿using NSubstitute.Core;
+using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Xunit;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
+{
+    public class CallResultDataTest
+    {
+        [Fact]
+        public void ConstructorShouldSetCorrectProperties()
+        {
+            // Fixture setup
+            var retValue = Maybe.Just(new object());
+            var argumentValues = new CallResultData.ArgumentValue[1];
+
+            // Exercise system
+            var sut = new CallResultData(retValue, argumentValues);
+
+            // Verify outcome
+            Assert.Equal(retValue, sut.ReturnValue);
+            Assert.Same(argumentValues, sut.ArgumentValues);
+
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultResolverFactoryTest.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultResolverFactoryTest.cs
@@ -1,0 +1,41 @@
+﻿using NSubstitute;
+using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
+{
+    public class CallResultResolverFactoryTest
+    {
+        [Fact]
+        public void CreateReturnsResultOfCorrectType()
+        {
+            // Fixture setup
+            var context = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolverFactory();
+
+            // Exercise system
+            var result = sut.Create(context);
+
+            // Verify outcome
+            Assert.IsType<CallResultResolver>(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateShouldPassValueToConstructor()
+        {
+            // Fixture setup
+            var context = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolverFactory();
+
+            // Exercise system
+            var result = sut.Create(context);
+
+            // Verify outcome
+            var resolver = Assert.IsType<CallResultResolver>(result);
+            Assert.Same(context, resolver.SpecimenContext);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultResolverTests.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultResolverTests.cs
@@ -1,0 +1,155 @@
+﻿using System.Linq;
+using System.Reflection;
+using NSubstitute;
+using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
+{
+    public class CallResultResolverTest
+    {
+        [Fact]
+        public void ShouldUseTypeRequestToResolveReturnValue()
+        {
+            // Fixture setup
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolver(specimenContext);
+
+            var target = Substitute.For<IInterfaceWithParameterlessMethod>();
+            var call = CallHelper.CreateCallMock(() => target.Method());
+
+            var returnValue = "returnResult";
+            specimenContext.Resolve(typeof(string)).Returns(returnValue);
+
+            // Exercise system
+            var callResult = sut.ResolveResult(call);
+
+            // Verify outcome
+            Assert.True(callResult.ReturnValue.HasValue());
+            Assert.Equal(returnValue, callResult.ReturnValue.ValueOrDefault());
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldUsePropertyInfoRequestToResolvePropertyValue()
+        {
+            // Fixture setup
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolver(specimenContext);
+
+            var target = Substitute.For<IInterfaceWithProperty>();
+            var call = CallHelper.CreatePropertyGetterCallMock(() => target.Property);
+
+            var propertyInfo = typeof(IInterfaceWithProperty).GetProperty(nameof(IInterfaceWithProperty.Property));
+
+            var retValue = "returnValue";
+            specimenContext.Resolve(propertyInfo).Returns(retValue);
+
+            // Exercise system
+            var result = sut.ResolveResult(call);
+
+            // Verify outcome
+            Assert.True(result.ReturnValue.HasValue());
+            Assert.Equal(retValue, result.ReturnValue.ValueOrDefault());
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldResolveOutParameterValue()
+        {
+            // Fixture setup
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolver(specimenContext);
+
+            var target = Substitute.For<IInterfaceWithParameterAndOutVoidMethod>();
+            int _;
+            var call = CallHelper.CreateCallMock(() => target.Method(null, out _));
+
+            specimenContext.Resolve(typeof(int)).Returns(42);
+
+            // Exercise system
+            var callResult = sut.ResolveResult(call);
+
+            // Verify outcome
+            Assert.Equal(1, callResult.ArgumentValues.Count());
+            Assert.Equal(1, callResult.ArgumentValues.First().Index);
+            Assert.Equal(42, callResult.ArgumentValues.First().Value);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldResolveRefParameterValue()
+        {
+            // Fixture setup
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolver(specimenContext);
+
+            var target = Substitute.For<IInterfaceWithRefIntMethod>();
+            int passedValue = 1;
+            var call = CallHelper.CreateCallMock(() => target.Method(ref passedValue));
+
+            specimenContext.Resolve(typeof(int)).Returns(42);
+
+            // Exercise system
+            var callResult = sut.ResolveResult(call);
+
+            // Verify outcome
+            Assert.Equal(1, callResult.ArgumentValues.Count());
+            Assert.Equal(0, callResult.ArgumentValues.First().Index);
+            Assert.Equal(42, callResult.ArgumentValues.First().Value);
+
+            // Teardown
+        }
+
+
+        [Fact]
+        public void ShouldNotReturnValueIfOmitted()
+        {
+            // Fixture setup
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolver(specimenContext);
+
+            var target = Substitute.For<IInterfaceWithParameterlessMethod>();
+            var call = CallHelper.CreateCallMock(() => target.Method());
+
+            specimenContext.Resolve(typeof(string)).Returns(new OmitSpecimen());
+
+            // Exercise system
+            var result = sut.ResolveResult(call);
+
+            // Verify outcome
+            Assert.False(result.ReturnValue.HasValue());
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldNotResolveArgumentValueIfOmitted()
+        {
+            // Fixture setup
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var sut = new CallResultResolver(specimenContext);
+
+            var target = Substitute.For<IInterfaceWithRefIntMethod>();
+
+            int _ = 0;
+            var call = CallHelper.CreateCallMock(() => target.Method(ref _));
+
+            specimenContext.Resolve(typeof(int)).Returns(new OmitSpecimen());
+
+            // Exercise system
+            var result = sut.ResolveResult(call);
+
+            // Verify outcome
+            Assert.True(result.ReturnValue.HasValue());
+            Assert.Empty(result.ArgumentValues);
+
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute;
+using NSubstitute.Core;
+using NSubstitute.Exceptions;
+using NSubstitute.Routing;
+using Ploeh.AutoFixture.AutoNSubstitute.CustomCallHandler;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
+{
+    public class NSubstituteRegisterCallHandlerCommandTest
+    {
+        [Fact]
+        public void ShouldReturnValuesFromConstructor()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var callResultsCacheFactory = Substitute.For<ICallResultCacheFactory>();
+            var callResultResolverFactory = Substitute.For<ICallResultResolverFactory>();
+
+            // Excercise system
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext, callResultsCacheFactory,
+                callResultResolverFactory);
+
+            // Verify outcome
+            Assert.Equal(substitutionContext, sut.SubstitutionContext);
+            Assert.Equal(callResultsCacheFactory, sut.CallResultCacheFactory);
+            Assert.Equal(callResultResolverFactory, sut.CallResultResolverFactory);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldUseConstructorDefaultsOfCorrectType()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+
+            // Excercise system
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
+
+            // Verify outcome
+            Assert.IsType<CallResultCacheFactory>(sut.CallResultCacheFactory);
+            Assert.IsType<CallResultResolverFactory>(sut.CallResultResolverFactory);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldUseValueFromCallResultsCacheFactory()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var callResultsCacheFactory = Substitute.For<ICallResultCacheFactory>();
+            var callResultResolverFactory = Substitute.For<ICallResultResolverFactory>();
+
+            var sut = new NSubstituteRegisterCallHandlerCommand(
+                substitutionContext, callResultsCacheFactory, callResultResolverFactory);
+
+            var specimen = new object();
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var callRouter = new CallRouterStub();
+            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
+
+            var expectedResultsCache = Substitute.For<ICallResultCache>();
+            callResultsCacheFactory.CreateCache().Returns(expectedResultsCache);
+
+            // Excercise system
+            sut.Execute(specimen, specimenContext);
+
+            // Verify outcome
+            var handler =
+                (AutoFixtureValuesHandler) callRouter.RegisteredFactory.Invoke(Substitute.For<ISubstituteState>());
+            Assert.Equal(expectedResultsCache, handler.ResultCache);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldUseValueFromCallResultResolverFactory()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var callResultsCacheFactory = Substitute.For<ICallResultCacheFactory>();
+            var callResultResolverFactory = Substitute.For<ICallResultResolverFactory>();
+
+            var sut = new NSubstituteRegisterCallHandlerCommand(
+                substitutionContext, callResultsCacheFactory, callResultResolverFactory);
+
+            var specimen = new object();
+            var specimenContext = Substitute.For<ISpecimenContext>();
+            var callRouter = new CallRouterStub();
+            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
+
+            var expectedResultResolver = Substitute.For<ICallResultResolver>();
+            callResultResolverFactory.Create(specimenContext).Returns(expectedResultResolver);
+
+            // Excercise system
+            sut.Execute(specimen, specimenContext);
+
+            // Verify outcome
+            var handler =
+                (AutoFixtureValuesHandler) callRouter.RegisteredFactory.Invoke(Substitute.For<ISubstituteState>());
+            Assert.Equal(expectedResultResolver, handler.ResultResolver);
+
+            // Teardown
+        }
+
+
+        [Fact]
+        public void ShouldSilentlySkipNotASubstituteSpecimen()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
+
+            var specimen = new object();
+            var context = Substitute.For<ISpecimenContext>();
+
+            substitutionContext.When(x => x.GetCallRouterFor(specimen)).Throw<NotASubstituteException>();
+
+            // Exercise system & Verify outcome
+            Assert.Null(Record.Exception(() => sut.Execute(specimen, context)));
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ResultCacheAndCallResultResolverShouldBeSameForEachHandler()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
+
+            var specimen = new object();
+            var context = Substitute.For<ISpecimenContext>();
+            var substituteState = Substitute.For<ISubstituteState>();
+
+            var callRouter = new CallRouterStub();
+            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
+
+            sut.Execute(specimen, context);
+
+            // Exercise system
+            var instance1 = callRouter.RegisteredFactory.Invoke(substituteState);
+            var instance2 = callRouter.RegisteredFactory.Invoke(substituteState);
+
+            // Verify outcome
+            var handler1 = (AutoFixtureValuesHandler) instance1;
+            var handler2 = (AutoFixtureValuesHandler) instance2;
+
+            Assert.NotSame(handler1, handler2);
+            Assert.Same(handler1.ResultResolver, handler2.ResultResolver);
+            Assert.Same(handler1.ResultCache, handler2.ResultCache);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldPassCorrectSpecimenContextToCallResultResolver()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
+
+            var specimen = new object();
+            var context = Substitute.For<ISpecimenContext>();
+            var substituteState = Substitute.For<ISubstituteState>();
+
+            var callRouter = new CallRouterStub();
+            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
+
+            sut.Execute(specimen, context);
+
+            // Exercise system
+            var handler = (AutoFixtureValuesHandler) callRouter.RegisteredFactory.Invoke(substituteState);
+
+            // Verify outcome
+            Assert.Equal(context, ((CallResultResolver) handler.ResultResolver).SpecimenContext);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void ValidCallSpecificationFactoryIsPassedToHandler()
+        {
+            // Fixture setup
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
+
+            var specimen = new object();
+            var context = Substitute.For<ISpecimenContext>();
+            var substituteState = Substitute.For<ISubstituteState>();
+
+            var callRouter = new CallRouterStub();
+            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
+
+            var callSpecFactory = Substitute.For<ICallSpecificationFactory>();
+            substituteState.CallSpecificationFactory.Returns(callSpecFactory);
+
+            sut.Execute(specimen, context);
+
+            // Exercise system
+            var handler = (AutoFixtureValuesHandler) callRouter.RegisteredFactory.Invoke(substituteState);
+
+            // Verify outcome
+            Assert.Equal(callSpecFactory, handler.CallSpecificationFactory);
+
+            // Teardown
+        }
+
+
+        /// <summary>
+        /// It's required to create custom mock, because NSubstitute cannot create fully functional
+        /// mock for the ICallRouter interface - it plays a special role inside NSubstitute.
+        /// </summary>
+        private class CallRouterStub : ICallRouter
+        {
+            public CallHandlerFactory RegisteredFactory { get; private set; }
+
+            public bool IsLastCallInfoPresent() => throw new NotImplementedException();
+
+            public ConfiguredCall LastCallShouldReturn(IReturn returnValue, MatchArgs matchArgs) =>
+                throw new NotImplementedException();
+
+            public object Route(ICall call) => throw new NotImplementedException();
+
+            public IEnumerable<ICall> ReceivedCalls() => throw new NotImplementedException();
+
+            public void SetRoute(Func<ISubstituteState, IRoute> getRoute) => throw new NotImplementedException();
+
+            public void SetReturnForType(Type type, IReturn returnValue) => throw new NotImplementedException();
+
+            public void RegisterCustomCallHandlerFactory(CallHandlerFactory factory)
+            {
+                this.RegisteredFactory = factory;
+            }
+
+            public void Clear(ClearOptions clear) => throw new NotImplementedException();
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/NSubstituteVirtualMethodsCommandTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteVirtualMethodsCommandTest.cs
@@ -4,6 +4,9 @@ using Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
 
+// This class tests the obsolete component, so disable the warning.
+#pragma warning disable 618
+
 namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest
 {
     public class NSubstituteVirtualMethodsCommandTest

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericMethod.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericMethod.cs
@@ -2,6 +2,6 @@
 {
     public interface IInterfaceWithGenericMethod
     {
-        string GenericMethod<T>();
+        T GenericMethod<T>();
     }
 }

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericOutMethod.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericOutMethod.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes
+{
+    public interface IInterfaceWithGenericOutMethod
+    {
+        int GenericMethod<T>(out T retValue);
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericOutVoidMethod.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericOutVoidMethod.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes
+{
+    public interface IInterfaceWithGenericOutVoidMethod
+    {
+        void GenericMethod<T>(out T retValue);
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericParameterMethod.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericParameterMethod.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes
+{
+    public interface IInterfaceWithGenericParameterMethod
+    {
+        int GenericMethod<T>(T arg);
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericRefMethod.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericRefMethod.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes
+{
+    public interface IInterfaceWithGenericRefMethod
+    {
+        int GenericMethod<T>(ref T retValue);
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericRefVoidMethod.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithGenericRefVoidMethod.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes
+{
+    public interface IInterfaceWithGenericRefVoidMethod
+    {
+        void GenericMethod<T>(ref T retValue);
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithMethodReturningOtherInterface.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithMethodReturningOtherInterface.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes
+{
+    public interface IInterfaceWithMethodReturningOtherInterface
+    {
+        IInterfaceWithMethod Method();
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithRefVoidMethod.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/IInterfaceWithRefVoidMethod.cs
@@ -1,0 +1,7 @@
+﻿namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.TestTypes
+{
+    public interface IInterfaceWithRefVoidMethod
+    {
+        void Method(ref int i);
+    }
+}


### PR DESCRIPTION
## Description

Our current integration with NSubstitute is a bit hacky and suffers from issues and limitations:
- generic methods are not supported (#720);
- void methods are ignored due to the way we integrate with NSubstitute. As result the `ref` and `out` parameters are not being filled for the void methods;
- it's impossible to configure return value for methods with `ref` and `out` parameters (#707). That's because AutoFixture substitutes argument values with auto-generated ones and the resulting call specification becomes invalid;
- integration doesn't support concurrency well and integration could fail with exceptions or produce invalid results (#592);
- the property values are resolved via `Type` request instead of `PropertyInfo` which causes some confusion (#653).

To fix these issues I worked tightly with NSubsitute team and we added a better integration point to NSubsitute2 (see [here](https://github.com/nsubstitute/NSubstitute/pull/259)). That was [quite](https://github.com/nsubstitute/NSubstitute/pull/156) [a long](https://github.com/nsubstitute/NSubstitute/pull/234) way started by @mrinaldi some time ago and I finished what he started.
Starting from v2 NSubstitute provides an API to register a custom call handler to resolve call results. This is a "passive" integration compared to the current approach - we are asked about call results rather than we inject hooks into each method we discovered. This approach supports concurrency much better and shouldn't fail because of it. I was capable of fixing all the issues mentioned above simply by using that API.

I think the consumers of this new integration approach should be happy 😃

## Testing

After I enabled a new approach none of the existing scenario (Facade) tests failed except ones asserting that we ignore `void` and `generic` methods - that was a technical limitation rather than a feature. Also I tried the updated integration on my real solution that heavily relies on NSubstitute integration and only a couple of tests failed - those were rather related to obscure NSubstitute usage than to issues with integration. That contributed to my confidence that this integration should work fine.

## NSubstitute 2 dependency

As it has been agreed in #784 I changed the dependency so that now we require NSubstitute 2.0.3 for both .NET Framework and .NET Standard. I need that consume the new API I previously introduced.

## Final notes

I know that PR is pretty large as it changes most of the integration with NSubsitute. However, I don't see any way to split it - most of the changes are logically coupled and should be done together. I'll definitely owe you some beer after the review 🍺🍻😉

Inviting @moodmosaic @adamchester @ecampidoglio to review this PR.
@mrinaldi Would be cool if you could also take a look - you are the author of the current integration.

PR closes #592, #653, #707, #720 and #784.