### PR TITLE
Update target framework to .NET 4.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,21 +72,21 @@ Using AutoFixture is as easy as referencing the library and creating a new insta
 
 ## .NET platforms compatibility table
 
-| Product            | .NET Framework           | .NET Standard            |
-| ------------------ | ------------------------ | ------------------------ |
-| AutoFixture        | :heavy_check_mark: 4.5   | :heavy_check_mark: 1.5   |
-| AutoFixture.xUnit  | :heavy_check_mark: 4.5   | :heavy_minus_sign:       |
-| AutoFixture.xUnit2 | :heavy_check_mark: 4.5   | :heavy_check_mark: 1.5   |
-| AutoFixture.NUnit2 | :heavy_check_mark: 4.5   | :heavy_minus_sign:       |
-| AutoFixture.NUnit3 | :heavy_check_mark: 4.5   | :heavy_check_mark: 1.5   |
-| AutoFakeItEasy     | :heavy_check_mark: 4.5   | :heavy_check_mark: 1.6   |
-| AutoFoq            | :heavy_check_mark: 4.5   | :heavy_minus_sign:       |
-| AutoMoq            | :heavy_check_mark: 4.5   | :heavy_check_mark: 1.5   |
-| AutoNSubstitute    | :heavy_check_mark: 4.5   | :heavy_check_mark: 1.5   |
-| AutoRhinoMock      | :heavy_check_mark: 4.5   | :heavy_minus_sign:       |
-| Idioms             | :heavy_check_mark: 4.5   | :heavy_minus_sign:       |
-| Idioms.FsCheck     | :heavy_check_mark: 4.5   | :heavy_minus_sign:       |
-| SemanticComparison | :heavy_check_mark: 4.5   | :heavy_check_mark: 1.5   |
+| Product            | .NET Framework            | .NET Standard            |
+| ------------------ | ------------------------  | ------------------------ |
+| AutoFixture        | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoFixture.xUnit  | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| AutoFixture.xUnit2 | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoFixture.NUnit2 | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| AutoFixture.NUnit3 | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoFakeItEasy     | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.6   |
+| AutoFoq            | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| AutoMoq            | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoNSubstitute    | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoRhinoMock      | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| Idioms             | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| Idioms.FsCheck     | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| SemanticComparison | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
 
 ## Downloads
 

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
     <AssemblyTitle>AutoFakeItEasy</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy</RootNamespace>
@@ -19,7 +19,7 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
     <PackageReference Include="FakeItEasy" Version="1.7.4109.1" />
   </ItemGroup>
 

--- a/Src/AutoFakeItEasy2/AutoFakeItEasy2.csproj
+++ b/Src/AutoFakeItEasy2/AutoFakeItEasy2.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFakeItEasy</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy2</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy2</RootNamespace>

--- a/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoFixture.NUnit2.UnitTest.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.NUnit2.UnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.NUnit2.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.NUnit2.UnitTest</RootNamespace>

--- a/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
+++ b/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.NUnit2</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.NUnit2</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.NUnit2</RootNamespace>

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoFixture.NUnit3</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.NUnit3</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.NUnit3</RootNamespace>
@@ -19,7 +19,7 @@
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
     <PackageReference Include="NUnit" Version="3.0.1" />
   </ItemGroup>
 

--- a/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit.net.UnitTest/AutoFixture.xUnit.net.UnitTest.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.xUnit.net.UnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Xunit.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.Xunit.UnitTest</RootNamespace>

--- a/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
+++ b/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.xUnit.net</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Xunit</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.Xunit</RootNamespace>

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoFixture.xUnit.net2</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Xunit2</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.Xunit2</RootNamespace>
@@ -14,7 +14,7 @@
     <Description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
     <PackageReference Include="xunit.core" Version="[2.0.0,3.0.0)" />
   </ItemGroup>
 

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoFixture</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture</RootNamespace>
@@ -14,7 +14,7 @@
     <Description>AutoFixture makes it easier for developers to do Test-Driven Development by automating non-relevant Test Fixture Setup, allowing the Test Developer to focus on the essentials of each test case.</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.AutoFoq</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFoq</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFoq</RootNamespace>

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.AutoFoq.UnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoFoq.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFoq.UnitTest</RootNamespace>

--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoMoq</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoMoq</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoMoq</RootNamespace>
@@ -22,7 +22,7 @@
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
     <PackageReference Include="Moq" Version="4.1.1308.2120" />
   </ItemGroup>
 

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>AutoNSubstitute</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoNSubstitute</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoNSubstitute</RootNamespace>

--- a/Src/AutoRhinoMock/AutoRhinoMock.csproj
+++ b/Src/AutoRhinoMock/AutoRhinoMock.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.AutoRhinoMock</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoRhinoMock</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoRhinoMock</RootNamespace>

--- a/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
+++ b/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoRhinoMockUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.AutoRhinoMock.UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoRhinoMock.UnitTest</RootNamespace>

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.Idioms.FsCheck</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Idioms.FsCheck</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.Idioms.FsCheck</RootNamespace>

--- a/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
+++ b/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.Idioms.FsCheckUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Idioms.FsCheckUnitTest</AssemblyName>
     <RootNamespace>Idioms.FsCheckUnitTest</RootNamespace>

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>AutoFixture.Idioms</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.Idioms</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.Idioms</RootNamespace>

--- a/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyTitle>IdiomsUnitTest</AssemblyTitle>
     <AssemblyName>Ploeh.AutoFixture.IdiomsUnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.IdiomsUnitTest</RootNamespace>

--- a/Src/SemanticComparison/SemanticComparison.csproj
+++ b/Src/SemanticComparison/SemanticComparison.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\CommonProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
     <AssemblyTitle>SemanticComparison</AssemblyTitle>
     <AssemblyName>Ploeh.SemanticComparison</AssemblyName>
     <RootNamespace>Ploeh.SemanticComparison</RootNamespace>

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonTestProperties.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.2</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.2</TargetFrameworks>
     <AssemblyTitle>TestTypeFoundation</AssemblyTitle>
     <AssemblyName>Ploeh.TestTypeFoundation</AssemblyName>
     <RootNamespace>Ploeh.TestTypeFoundation</RootNamespace>


### PR DESCRIPTION
Closes #815.

The .NET 4.5 support has been abandoned and 452 is the only version for 4.5 family supported by MS.
In this PR I switch all our projects to target that version.