### PR TITLE
Add guard dependencies to xUnit and NUnit2 integrations

### DIFF
--- a/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
+++ b/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
@@ -31,6 +31,12 @@
       <HintPath>..\..\References\NUnit.2.6.2\nunit.core.interfaces.dll</HintPath>
     </Reference>
   </ItemGroup>
+  
+  <ItemGroup>
+    <!-- Isn't actually needed by this library, but is present as a NuGet guard to prevent installation of this package 
+     together with NUnit3 and higher. -->
+    <PackageReference Include="NUnit" Version="[2.6.2,3.0.0)" />
+  </ItemGroup>
 
   <!-- Include additional files to NuGet package -->
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
+++ b/Src/AutoFixture.xUnit.net/AutoFixture.xUnit.net.csproj
@@ -20,6 +20,9 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.extensions" Version="[1.8.0.1549,2.0.0)" />
+    <!-- Isn't actually needed by this library, but is present as a NuGet guard to prevent installation of this package 
+     together with xUnit2 and higher. -->
+    <PackageReference Include="xunit" Version="[1.8.0.1549,2.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently xUnit and NUnit2 integrations don't have dependencies on test framework packages that users install to solution (i.e. `xunit` or `NUnit`). Therefore, it is possible to install `xunit` v2 together with `AutoFixture.xunit`. Obviously, for xUnit 2 you need to use `AutoFixture.xunit2` instead.

The worse thing is that this invalid installation doesn't break the compilation (for xUnit) and you simply see that all the tests fail. Only some time later you realize that you installed invalid glue library.

In order to prevent accidental installation of incompatible glue libraries I added a dependency to the test framework packages. Now if you try to install `AutoFixture.xunit` for xUnit v2 you will get a NuGet error:

`
Unable to resolve dependencies. 'xunit 2.2.0' is not compatible with 'AutoFixture.Xunit 3.21.1.227 constraint: xunit (>= 1.8.0.1549 && < 2.0.0)', 'xunit.extensions 1.9.2 constraint: xunit (= 1.9.2)'.
`

This very cool and clear behavior that will help our users to avoid confusion (especially if they are new to AutoFixture).

@adamchester @moodmosaic Let me know if you have any objections.