### PR TITLE
Migrate leftover test projects to xunit2

### DIFF
--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -18,15 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
-    <PackageReference Include="xunit.extensions" Version="1.8.0.1549" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="Unquote" Version="3.1.0" />
 
     <!-- AutoFoq targets FSharp.Core 3.0.2, but we require 3.1.2 as Unquote was compiled against it. -->
     <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFoqUnitTest/FoqMethodQueryTest.fs
+++ b/Src/AutoFoqUnitTest/FoqMethodQueryTest.fs
@@ -8,7 +8,6 @@ open System
 open System.Reflection
 open Swensen.Unquote.Assertions
 open Xunit
-open Xunit.Extensions
 
 let dummyBuilder =
     { new ISpecimenBuilder with
@@ -50,7 +49,7 @@ let SelectMethodReturnsMethodWithoutParametersForInterface() =
     // Verify outcome
     verify <@ result |> Seq.isEmpty @>
 
-[<Theory>][<PropertyData("TypesWithConstructors")>]
+[<Theory>][<MemberData("TypesWithConstructors")>]
 let MethodsAreReturnedInCorrectOrder (request: Type) =
     // Fixture setup
     let expected = 
@@ -69,7 +68,7 @@ let MethodsAreReturnedInCorrectOrder (request: Type) =
     verify <@ (expected, result) ||> Seq.forall2 (=) @>
     // Teardown   
 
-[<Theory>][<PropertyData("TypesWithConstructors")>]
+[<Theory>][<MemberData("TypesWithConstructors")>]
 let SelectMethodsDefineCorrectParameters (request: Type) =
     // Fixture setup
     let expected =

--- a/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
+++ b/Src/AutoRhinoMockUnitTest/AutoRhinoMockUnitTest.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
-    <PackageReference Include="xunit.extensions" Version="1.8.0.1549" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoRhinoMockUnitTest/DependencyConstraints.cs
+++ b/Src/AutoRhinoMockUnitTest/DependencyConstraints.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
 {

--- a/Src/AutoRhinoMockUnitTest/FixtureIntegrationTest.cs
+++ b/Src/AutoRhinoMockUnitTest/FixtureIntegrationTest.cs
@@ -54,7 +54,7 @@ namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
             // Exercise system
             var result = (IMockedObject)fixture.Create<IInterface>();
             // Verify outcome
-            Assert.DoesNotThrow(() => { var repo = result.Repository; });
+            Assert.Null(Record.Exception(() => { var repo = result.Repository; }));
             // Teardown
         }
 

--- a/Src/AutoRhinoMockUnitTest/RhinoMockAroundAdviceTest.cs
+++ b/Src/AutoRhinoMockUnitTest/RhinoMockAroundAdviceTest.cs
@@ -2,7 +2,6 @@
 using Ploeh.AutoFixture.Kernel;
 using Rhino.Mocks;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
 {

--- a/Src/AutoRhinoMockUnitTest/RhinoMockConstructorMethodTest.cs
+++ b/Src/AutoRhinoMockUnitTest/RhinoMockConstructorMethodTest.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
 {

--- a/Src/AutoRhinoMockUnitTest/RhinoMockConstructorQueryTest.cs
+++ b/Src/AutoRhinoMockUnitTest/RhinoMockConstructorQueryTest.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
 {

--- a/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
+++ b/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="Unquote" Version="3.1.0" />
-    <PackageReference Include="Exude" Version="0.2.0" />
 
     <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheckUnitTest/ReturnValueMustNotBeNullAssertionTest.fs
+++ b/Src/Idioms.FsCheckUnitTest/ReturnValueMustNotBeNullAssertionTest.fs
@@ -1,6 +1,5 @@
 ﻿namespace Ploeh.AutoFixture.Idioms.FsCheckUnitTest
 
-open Grean.Exude
 open FsCheck
 open Ploeh.AutoFixture
 open Ploeh.AutoFixture.Idioms
@@ -44,87 +43,74 @@ type ReturnValueMustNotBeNullAssertionTest () =
         let sut = ReturnValueMustNotBeNullAssertion(dummyBuilder)
         raises<ArgumentNullException> <@ sut.Verify(null :> MethodInfo) @>
 
-    [<FirstClassTests>]
-    let VerifyWriteOnlyPropertiesDoesNotThrow () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>)>]
+    [<InlineData(typeof<AStaticClass>)>]
+    let VerifyWriteOnlyPropertiesDoesNotThrow (t: Type) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [   
-            typeof<AClass>.GetProperty("WriteOnlyProperty")
-            typeof<AStaticClass>.GetProperty("WriteOnlyProperty")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () -> sut.Verify(element)))
+        let prop = t.GetProperty("WriteOnlyProperty")
+        sut.Verify(prop)
 
-    [<FirstClassTests>]
-    let VerifyVoidMethodsDoesNotThrow () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>)>]
+    [<InlineData(typeof<AStaticClass>)>]
+    let VerifyVoidMethodsDoesNotThrow (t: Type) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [   
-            typeof<AClass>.GetMethod("VoidMethod")
-            typeof<AStaticClass>.GetMethod("VoidMethod")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () -> sut.Verify(element)))
+        let method = t.GetMethod("VoidMethod")
+        sut.Verify(method)
 
-    [<FirstClassTests>]
-    let VerifyPropertiesWithReturnValueDoesNotThrow () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>)>]
+    [<InlineData(typeof<AStaticClass>)>]
+    let VerifyPropertiesWithReturnValueDoesNotThrow (t: Type) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [   
-            typeof<AClass>.GetProperty("ReadOnlyProperty")
-            typeof<AStaticClass>.GetProperty("ReadOnlyProperty")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () -> sut.Verify(element)))
+        let prop = t.GetProperty("ReadOnlyProperty")
+        sut.Verify(prop)
 
-    [<FirstClassTests>]
-    let VerifyMethodsWithReturnValueDoesNotThrow () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>)>]
+    [<InlineData(typeof<AStaticClass>)>]
+    let VerifyMethodsWithReturnValueDoesNotThrow (t: Type) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [
-            typeof<AClass>.GetMethod("MethodWithReturnValue")
-            typeof<AStaticClass>.GetMethod("MethodWithReturnValue")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () -> sut.Verify(element)))
+        let method = t.GetMethod("MethodWithReturnValue")
+        sut.Verify(method)
 
-    [<FirstClassTests>]
-    let VerifyPropertiesWithNullReturnValueThrows () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>)>]
+    [<InlineData(typeof<AStaticClass>)>]
+    let VerifyPropertiesWithNullReturnValueThrows (t: Type) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [
-            typeof<AClass>.GetProperty("NullReturnValueProperty")
-            typeof<AStaticClass>.GetProperty("NullReturnValueProperty")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () ->
-            raises<ReturnValueMustNotBeNullException> <@ sut.Verify(element) @>))
+        let prop = t.GetProperty("NullReturnValueProperty")
+        raises<ReturnValueMustNotBeNullException> <@ sut.Verify(prop) @>
 
-    [<FirstClassTests>]
-    let VerifyMethodsWithNullReturnValueThrows () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>, "NullReturnValueMethod")>]
+    [<InlineData(typeof<AClass>, "NullReturnValueMethodWithParameters")>]
+    [<InlineData(typeof<AClass>, "NullReturnValueMethodWithManyParameters")>]
+    [<InlineData(typeof<AClass>, "NullReturnValueMethodWithParametersAndBranching")>]
+    [<InlineData(typeof<AStaticClass>, "NullReturnValueMethod")>]
+    [<InlineData(typeof<AStaticClass>, "NullReturnValueMethodWithParameters")>]
+    [<InlineData(typeof<AStaticClass>, "NullReturnValueMethodWithManyParameters")>]
+    [<InlineData(typeof<AStaticClass>, "NullReturnValueMethodWithParametersAndBranching")>]
+    let VerifyMethodsWithNullReturnValueThrows (t: Type, mName) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [
-            typeof<AClass>.GetMethod("NullReturnValueMethod")
-            typeof<AClass>.GetMethod("NullReturnValueMethodWithParameters")
-            typeof<AClass>.GetMethod("NullReturnValueMethodWithManyParameters")
-            typeof<AClass>.GetMethod("NullReturnValueMethodWithParametersAndBranching")
+        let method = t.GetMethod(mName)
+        raises<ReturnValueMustNotBeNullException> <@ sut.Verify(method) @>
 
-            typeof<AStaticClass>.GetMethod("NullReturnValueMethod")
-            typeof<AStaticClass>.GetMethod("NullReturnValueMethodWithParameters")
-            typeof<AStaticClass>.GetMethod("NullReturnValueMethodWithManyParameters")
-            typeof<AStaticClass>.GetMethod("NullReturnValueMethodWithParametersAndBranching")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () ->
-            raises<ReturnValueMustNotBeNullException> <@ sut.Verify(element) @>))
-
-    [<FirstClassTests>]
-    let VerifyMethodsWithComplexParametersDoesNotThrow () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>)>]
+    [<InlineData(typeof<AStaticClass>)>]
+    let VerifyMethodsWithComplexParametersDoesNotThrow (t: Type) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [
-            typeof<AClass>.GetMethod("MethodWithComplexParameters")
-            typeof<AStaticClass>.GetMethod("MethodWithComplexParameters")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () ->
-            Arb.register<Generators>() |> ignore
-            sut.Verify(element)))
+        let method = t.GetMethod("MethodWithComplexParameters")
+        Arb.register<Generators>() |> ignore
+        sut.Verify(method)
 
-    [<FirstClassTests>]
-    let VerifyMethodsWithComplexParametersAndNullReturnValueThrows () =
+    [<Theory>]
+    [<InlineData(typeof<AClass>, "NullReturnValueMethodWithComplexParameters")>]
+    [<InlineData(typeof<AStaticClass>, "NullReturnValueMethodWithComplexParameters")>]
+    let VerifyMethodsWithComplexParametersAndNullReturnValueThrows (t: Type, mName) =
         let sut = ReturnValueMustNotBeNullAssertion(Fixture())
-        [
-            typeof<AClass>.GetMethod("NullReturnValueMethodWithComplexParameters")
-            typeof<AStaticClass>.GetMethod("NullReturnValueMethodWithComplexParameters")
-        ]
-        |> Seq.map (fun element -> TestCase (fun () ->
-            Arb.register<Generators>() |> ignore
-            raises<ReturnValueMustNotBeNullException> <@ sut.Verify(element) @>))
+        let method = t.GetMethod(mName)
+        Arb.register<Generators>() |> ignore
+        raises<ReturnValueMustNotBeNullException> <@ sut.Verify(method) @>

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -10,7 +10,6 @@ using Ploeh.AutoFixture.Idioms;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {
@@ -152,8 +151,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             // Exercise system and verify outcome
             var constructorWithNoParameters = typeof (PropertyHolder<object>).GetConstructors().First();
             Assert.Equal(0, constructorWithNoParameters.GetParameters().Length);
-            Assert.DoesNotThrow(() =>
-                sut.Verify(constructorWithNoParameters));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(constructorWithNoParameters)));
             // Teardown
         }
 
@@ -165,8 +164,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(composer);
             var propertyInfo = typeof(PropertyHolder<object>).GetProperty("Property");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(propertyInfo)));
             // Teardown
         }
 
@@ -178,8 +177,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(composer);
             var propertyInfo = typeof(FieldHolder<object>).GetField("Field");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(propertyInfo)));
             // Teardown
         }
 
@@ -219,7 +218,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var propertyInfo = typeof(ReadOnlyPropertyInitializedViaConstructor<object>).GetProperty("Property");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(propertyInfo)));
             // Teardown
         }
 
@@ -248,7 +247,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var fieldInfo = typeof(ReadOnlyFieldInitializedViaConstructor<object>).GetField("Field");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(fieldInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(fieldInfo)));
             // Teardown
         }
 
@@ -275,9 +274,9 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var ctor2 = typeof(FieldsInitializedViaConstructor<object, int>).GetConstructor(new[] { typeof(int) });
             var ctor3 = typeof(FieldsInitializedViaConstructor<object, int>).GetConstructor(new[] { typeof(object), typeof(int) });
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(ctor1));
-            Assert.DoesNotThrow(() => sut.Verify(ctor2));
-            Assert.DoesNotThrow(() => sut.Verify(ctor3));
+            Assert.Null(Record.Exception(() => sut.Verify(ctor1)));
+            Assert.Null(Record.Exception(() => sut.Verify(ctor2)));
+            Assert.Null(Record.Exception(() => sut.Verify(ctor3)));
             // Teardown
         }
 
@@ -306,9 +305,9 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var ctor2 = typeof(ReadOnlyPropertiesInitializedViaConstructor<object, int>).GetConstructor(new[] { typeof(int) });
             var ctor3 = typeof(ReadOnlyPropertiesInitializedViaConstructor<object, int>).GetConstructor(new[] { typeof(object), typeof(int) });
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(ctor1));
-            Assert.DoesNotThrow(() => sut.Verify(ctor2));
-            Assert.DoesNotThrow(() => sut.Verify(ctor3));
+            Assert.Null(Record.Exception(() => sut.Verify(ctor1)));
+            Assert.Null(Record.Exception(() => sut.Verify(ctor2)));
+            Assert.Null(Record.Exception(() => sut.Verify(ctor3)));
             // Teardown
         }
 
@@ -349,8 +348,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var ctor = typeof(PropertyIsAssignableFromConstructorArgumentType).GetConstructors().First();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(ctor));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(ctor)));
             // Teardown
         }
 
@@ -363,7 +362,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var ctor = typeof(ReadOnlyPropertiesInitializedViaConstructor<ComplexType, object>)
                 .GetConstructor(new[] { typeof(ComplexType), typeof(object) });
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(ctor));
+            Assert.Null(Record.Exception(() => sut.Verify(ctor)));
             // Teardown
         }
 
@@ -391,8 +390,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var ctor = typeof(WriteOnlyPropertyHolder<ComplexType>).GetConstructors().First();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(
-                () => sut.Verify(ctor));
+            Assert.Null(
+                Record.Exception(() => sut.Verify(ctor)));
             // Teardown
         }
 
@@ -404,7 +403,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var propertyInfo = typeof(WriteOnlyPropertyHolder<ComplexType>).GetProperty("WriteOnlyProperty");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(propertyInfo)));
             // Teardown
         }
 
@@ -416,7 +415,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var propertyInfo = typeof(InternalGetterPropertyHolder<ComplexType>).GetProperty("Property");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(propertyInfo)));
             // Teardown
         }
 
@@ -428,7 +427,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var typeToVerify = typeof(PropertyHolder<ComplexType>);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            Assert.Null(Record.Exception(() => sut.Verify(typeToVerify)));
             // Teardown
         }
 
@@ -440,7 +439,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var typeToVerify = typeof(StaticPropertyHolder<ComplexType>);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            Assert.Null(Record.Exception(() => sut.Verify(typeToVerify)));
             // Teardown
         }
 
@@ -452,7 +451,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var typeToVerify = typeof(StaticFieldHolder<ComplexType>);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            Assert.Null(Record.Exception(() => sut.Verify(typeToVerify)));
             // Teardown
         }
 
@@ -464,7 +463,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var typeToVerify = typeof(GuardedConstructorHostHoldingStaticReadOnlyField<ComplexType, int>);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            Assert.Null(Record.Exception(() => sut.Verify(typeToVerify)));
             // Teardown
         }
 
@@ -476,7 +475,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var typeToVerify = typeof(GuardedConstructorHostHoldingStaticReadOnlyProperty<ComplexType, int>);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(typeToVerify));
+            Assert.Null(Record.Exception(() => sut.Verify(typeToVerify)));
             // Teardown
         }
 
@@ -549,7 +548,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(fixture);
 
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(type));
+            Assert.Null(Record.Exception(() => sut.Verify(type)));
         }
 
         [Theory]
@@ -601,26 +600,26 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             Assert.Equal(param, ex.MissingParameter);
             Assert.Equal(ctor, ex.MemberInfo);
             Assert.Equal(ctor, ex.ConstructorInfo);
-            Assert.Equal(null, ex.FieldInfo);
-            Assert.Equal(null, ex.PropertyInfo);
+            Assert.Null(ex.FieldInfo);
+            Assert.Null(ex.PropertyInfo);
         }
 
         static void AssertExceptionPropertiesEqual(ConstructorInitializedMemberException ex, PropertyInfo pi)
         {
-            Assert.Equal(null, ex.ConstructorInfo);
-            Assert.Equal(null, ex.MissingParameter);
+            Assert.Null(ex.ConstructorInfo);
+            Assert.Null(ex.MissingParameter);
             Assert.Equal(pi, ex.MemberInfo);
-            Assert.Equal(null, ex.FieldInfo);
+            Assert.Null(ex.FieldInfo);
             Assert.Equal(pi, ex.PropertyInfo);
         }
 
         static void AssertExceptionPropertiesEqual(ConstructorInitializedMemberException ex, FieldInfo fi)
         {
-            Assert.Equal(null, ex.ConstructorInfo);
-            Assert.Equal(null, ex.MissingParameter);
+            Assert.Null(ex.ConstructorInfo);
+            Assert.Null(ex.MissingParameter);
             Assert.Equal(fi, ex.MemberInfo);
             Assert.Equal(fi, ex.FieldInfo);
-            Assert.Equal(null, ex.PropertyInfo);
+            Assert.Null(ex.PropertyInfo);
         }
 
         class PublicReadOnlyFieldNotInitializedByConstructor
@@ -655,14 +654,14 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
 
             public T GetWriteOnlyProperty()
             {
-                return writeOnlyPropertyBackingField;
+                return this.writeOnlyPropertyBackingField;
             }
 
             public T WriteOnlyProperty
             {
                 set
                 {
-                    writeOnlyPropertyBackingField = value;
+                    this.writeOnlyPropertyBackingField = value;
                 }
             }
         }
@@ -671,7 +670,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         {
             public ComplexType()
             {
-                Children = new Collection<ComplexTypeChild>();
+                this.Children = new Collection<ComplexTypeChild>();
             }
 
             public ICollection<ComplexTypeChild> Children { get; set; }

--- a/Src/IdiomsUnitTest/CopyAndUpdateAssertionTest.cs
+++ b/Src/IdiomsUnitTest/CopyAndUpdateAssertionTest.cs
@@ -4,12 +4,10 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using Ploeh.Albedo;
 using Ploeh.AutoFixture.Idioms;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {
@@ -128,8 +126,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new CopyAndUpdateAssertion(dummyComposer);
             var method = typeWithCopyUpdateMethod.GetMethod(copyUpdateMethodName);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(method));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(method)));
             // Teardown
         }
 

--- a/Src/IdiomsUnitTest/DependencyConstraints.cs
+++ b/Src/IdiomsUnitTest/DependencyConstraints.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using Ploeh.AutoFixture.Idioms;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {

--- a/Src/IdiomsUnitTest/EmptyGuidBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/EmptyGuidBehaviorExpectationTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Ploeh.AutoFixture.Idioms;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {
@@ -84,8 +83,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             };
             var sut = new EmptyGuidBehaviorExpectation();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(cmd));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(cmd)));
             // Teardown
         }
 

--- a/Src/IdiomsUnitTest/EnumerableComparison.cs
+++ b/Src/IdiomsUnitTest/EnumerableComparison.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {

--- a/Src/IdiomsUnitTest/EqualsNewObjectAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualsNewObjectAssertionTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using Ploeh.AutoFixture.Idioms;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
@@ -65,8 +62,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsNewObjectAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals))));
             // Teardown
         }
 
@@ -77,8 +74,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsNewObjectAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(WellBehavedEqualsNewObjectOverride)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualsNewObjectOverride))));
             // Teardown            
         }
 

--- a/Src/IdiomsUnitTest/EqualsNullAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualsNullAssertionTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using Ploeh.AutoFixture.Idioms;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
@@ -65,8 +62,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsNullAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals))));
             // Teardown
         }
 
@@ -77,8 +74,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsNullAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(WellBehavedEqualsNullOverride)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualsNullOverride))));
             // Teardown            
         }
 
@@ -103,8 +100,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var method = (MethodInfo)(new MethodInfoWithNullDeclaringAndReflectedType());
 
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(method));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(method)));
             // Teardown
         }
 

--- a/Src/IdiomsUnitTest/EqualsSelfAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualsSelfAssertionTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using Ploeh.AutoFixture.Idioms;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
@@ -65,8 +62,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsSelfAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals))));
             // Teardown
         }
 
@@ -77,8 +74,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsSelfAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(WellBehavedEqualsSelfObjectOverride)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualsSelfObjectOverride))));
             // Teardown            
         }
 

--- a/Src/IdiomsUnitTest/EqualsSuccessiveAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualsSuccessiveAssertionTest.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using Ploeh.AutoFixture.Idioms;
 using Ploeh.AutoFixture.Kernel;
 using Xunit;
@@ -65,8 +62,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsSuccessiveAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(ClassThatDoesNotOverrideObjectEquals))));
             // Teardown
         }
 
@@ -77,8 +74,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new EqualsSuccessiveAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(WellBehavedEqualsSuccessiveObjectOverride)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualsSuccessiveObjectOverride))));
             // Teardown            
         }
 

--- a/Src/IdiomsUnitTest/GetHashCodeSuccessiveAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GetHashCodeSuccessiveAssertionTest.cs
@@ -62,8 +62,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new GetHashCodeSuccessiveAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(ClassThatDoesNotOverrideObjectGetHashCode)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(ClassThatDoesNotOverrideObjectGetHashCode))));
             // Teardown
         }
 
@@ -74,8 +74,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var dummyComposer = new Fixture();
             var sut = new GetHashCodeSuccessiveAssertion(dummyComposer);
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(typeof(WellBehavedGetHashCodeSelfObjectOverride)));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedGetHashCodeSelfObjectOverride))));
             // Teardown            
         }
 

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -7,7 +7,6 @@ using Ploeh.AutoFixture.Idioms;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 using System.Collections.ObjectModel;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
@@ -101,8 +100,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(dummyComposer);
             // Exercise system and verify outcome
             var property = typeof(SingleParameterType<object>).GetProperty("Parameter");
-            Assert.DoesNotThrow(() =>
-                sut.Verify(property));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(property)));
             // Teardown
         }
 
@@ -742,11 +741,11 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         {
             var sut = new GuardClauseAssertion(new Fixture());
 
-            Assert.DoesNotThrow(
-                () =>
+            Assert.Null(
+                Record.Exception(() =>
                 sut.Verify(
                     typeof(TypeWithPropertyOfTypeWithoutImplementersAndMethod)
-                    .GetConstructors().First()));
+                    .GetConstructors().First())));
         }
 
         [Fact]
@@ -757,11 +756,11 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
                 x => x.OmitAutoProperties());
             var sut = new GuardClauseAssertion(fixture);
 
-            Assert.DoesNotThrow(
-                () =>
+            Assert.Null(
+                Record.Exception(() =>
                 sut.Verify(
                     typeof(TypeWithPropertyOfTypeWithoutImplementers)
-                    .GetProperty("PropertyOfTypeWithoutImplementers")));
+                    .GetProperty("PropertyOfTypeWithoutImplementers"))));
         }
 
         private class TypeWithMethodWithParameterWithoutImplementers
@@ -851,7 +850,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
             var staticMethods = typeof(GuardedStaticMethodOnStaticTypeHost).GetMethods();
             Assert.NotEmpty(staticMethods);
-            Assert.DoesNotThrow(() => sut.Verify(staticMethods));
+            Assert.Null(Record.Exception(() => sut.Verify(staticMethods)));
         }
 
         [Theory]
@@ -862,7 +861,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
             // Exercise system
             // Verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(constructorInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(constructorInfo)));
         }
 
         [Theory]
@@ -873,7 +872,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
             // Exercise system
             // Verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(propertyInfo)));
         }
 
         [Theory]
@@ -884,7 +883,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
             // Exercise system
             // Verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(methodInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(methodInfo)));
         }
 
         [Theory]
@@ -953,8 +952,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
                 OnVerify = c =>
                 {
                     var dynamicInstance = (IDynamicInstanceTestType)GetParameters(c).ElementAt(0);
-                    Assert.DoesNotThrow(() => dynamicInstance.VoidMethod(null, 123));
-                    Assert.DoesNotThrow(() => { dynamicInstance.Property = new object(); });
+                    Assert.Null(Record.Exception(() => dynamicInstance.VoidMethod(null, 123)));
+                    Assert.Null(Record.Exception(() => { dynamicInstance.Property = new object(); }));
                     mockVerification = true;
                 }
             };
@@ -1025,7 +1024,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var methodInfo = typeof(OutParameterTestType).GetMethod("Method");
             // Exercise system
             // Verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(methodInfo));
+            Assert.Null(Record.Exception(() => sut.Verify(methodInfo)));
         }
 
         [Fact]
@@ -1072,7 +1071,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
                             select m.TaskWithCorrectGuardClause(null);
 
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(theMethod));
+            Assert.Null(Record.Exception(() => sut.Verify(theMethod)));
         }
 
         [Fact]
@@ -1086,7 +1085,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
                             select m.TaskOfTWithCorrectGuardClause(null);
 
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() => sut.Verify(theMethod));
+            Assert.Null(Record.Exception(() => sut.Verify(theMethod)));
         }
 
         class AsyncHost

--- a/Src/IdiomsUnitTest/IdiomaticAssertionTest.cs
+++ b/Src/IdiomsUnitTest/IdiomaticAssertionTest.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using Ploeh.AutoFixture.Idioms;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {
@@ -413,8 +412,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var ctor = type.GetConstructors().First();
             var sut = new DelegatingIdiomaticAssertion();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(ctor));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(ctor)));
             // Teardown
         }
 
@@ -470,8 +469,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var field = type.GetFields().First();
             var sut = new DelegatingIdiomaticAssertion();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(field));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(field)));
             // Teardown
         }
 
@@ -533,8 +532,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var method = type.GetMethods().Except(type.GetProperties().SelectMany(p => p.GetAccessors())).First();
             var sut = new DelegatingIdiomaticAssertion();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(method));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(method)));
             // Teardown
         }
 
@@ -590,8 +589,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var property = type.GetProperties().First();
             var sut = new DelegatingIdiomaticAssertion();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(property));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(property)));
             // Teardown
         }
     }

--- a/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="1.9.2" />
-    <PackageReference Include="xunit.extensions" Version="1.8.0.1549" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/IdiomsUnitTest/IndexedReplacementTest.cs
+++ b/Src/IdiomsUnitTest/IndexedReplacementTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Ploeh.AutoFixture.Idioms;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {

--- a/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
@@ -2,7 +2,6 @@
 using Ploeh.AutoFixture.Idioms;
 using Ploeh.TestTypeFoundation;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {
@@ -84,8 +83,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var cmd = new DelegatingGuardClauseCommand { OnExecute = v => { throw new ArgumentNullException(); } };
             var sut = new NullReferenceBehaviorExpectation();
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(cmd));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(cmd)));
             // Teardown
         }
 

--- a/Src/IdiomsUnitTest/ReflectionExceptionUnwrappingCommandTest.cs
+++ b/Src/IdiomsUnitTest/ReflectionExceptionUnwrappingCommandTest.cs
@@ -2,7 +2,6 @@
 using System.Reflection;
 using Ploeh.AutoFixture.Idioms;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixture.IdiomsUnitTest
 {

--- a/Src/IdiomsUnitTest/WritablePropertyAssertionTest.cs
+++ b/Src/IdiomsUnitTest/WritablePropertyAssertionTest.cs
@@ -94,8 +94,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new WritablePropertyAssertion(dummyComposer);
             var propertyInfo = typeof(ReadOnlyPropertyHolder<object>).GetProperty("Property");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(propertyInfo)));
             // Teardown
         }
 
@@ -108,8 +108,8 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
 
             var propertyInfo = typeof(PropertyHolder<object>).GetProperty("Property");
             // Exercise system and verify outcome
-            Assert.DoesNotThrow(() =>
-                sut.Verify(propertyInfo));
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(propertyInfo)));
             // Teardown
         }
     }

--- a/Src/IdiomsUnitTest/WritablePropertyExceptionTest.cs
+++ b/Src/IdiomsUnitTest/WritablePropertyExceptionTest.cs
@@ -72,7 +72,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             // Exercise system
             var result = sut.Message;
             // Verify outcome
-            Assert.Equal<string>(expected, result);
+            Assert.Equal(expected, result);
             // Teardown
         }
 


### PR DESCRIPTION
Most of our test projects use xUnit 2. That was done in the .NET Standard support PRs. There are a few projects left that still use xunit1:

- AutoRhinoMockUnitTest
- IdiomsUnitTest
- AutoFixture.Idioms.FsCheckUnitTest
- AutoFixture.AutoFoq.UnitTest

I want to unify all our test projects so that I can get rid of console runner and extract common xUnit properties to a single `props` file (so it's easier to manage them all) in future. That's the reason behind these changes.

Most of the changes in PR are related to the `Assert.DoesNotThrow()` method usage. However, in `AutoFixture.Idioms.FsCheckUnitTest` I also needed to remove the `Exude` library usage and converted tests to use `InlineData` attribute instead - it was very easy and readability became even better.

@moodmosaic @adamchester Please take a look 😉🍺 