### PR TITLE
Add guard to fail fast when nested members used during customization

### DIFF
--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -292,6 +292,8 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker)
         {
+            ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);
+            
             var targetToDecorate = this.FindFirstNode(n => n is NoSpecimenOutputGuard);
 
             return (NodeComposer<T>)this.ReplaceNodes(
@@ -324,6 +326,8 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
+            ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);
+            
             var graphWithAutoPropertiesNode = this.GetGraphWithAutoPropertiesNode();
             var graphWithoutSeedIgnoringRelay = WithoutSeedIgnoringRelay(graphWithAutoPropertiesNode);
 
@@ -382,6 +386,8 @@ namespace Ploeh.AutoFixture.Dsl
         public IPostprocessComposer<T> Without<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker)
         {
+            ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);
+            
             var member = propertyPicker.GetWritableMember().Member;
             var graphWithAutoPropertiesNode = GetGraphWithAutoPropertiesNode();
 

--- a/Src/AutoFixture/Kernel/ExpressionReflector.cs
+++ b/Src/AutoFixture/Kernel/ExpressionReflector.cs
@@ -23,6 +23,16 @@ namespace Ploeh.AutoFixture.Kernel
             return me;
         }
 
+        internal static void VerifyIsNonNestedWritableMemberExpression(LambdaExpression expression)
+        {
+            var me = expression.GetWritableMember();
+            if (!(me.Expression is ParameterExpression))
+                throw new ArgumentException(
+                    "The expression contains access to a nested property or field. " +
+                    "Configuration API doesn't support this feature, therefore please rewrite the expression to avoid nested fields or properties.",
+                    nameof(expression));
+        }
+
         /// <summary>
         /// Attempt to unwrap a member access expression from within a
         /// conversion expression.

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6011,6 +6011,109 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
+        [Fact]
+        public void Issue724_ShouldFailWithMeaningfulException_WhenNestedPropertyConfiguredViaBuildWithValue()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            
+            // Excercise system and verify outcome
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                return fixture
+                    .Build<PropertyHolder<ConcreteType>>()
+                    .With(x => x.Property.Property1, "Dummy");
+            });
+            Assert.Contains("nested property or field", ex.Message);
+
+            // Teardown
+        }
+        
+        [Fact]
+        public void Issue724_ShouldFailWithMeaningfulException_WhenNestedPropertyConfiguredViaBuildWith()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            
+            // Excercise system and verify outcome
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                return fixture
+                    .Build<PropertyHolder<ConcreteType>>()
+                    .With(x => x.Property.Property1);
+            });
+            Assert.Contains("nested property or field", ex.Message);
+
+            // Teardown
+        }
+        
+        
+        [Fact]
+        public void Issue724_ShouldFailWithMeaningfulException_WhenNestedPropertyConfiguredViaBuildWithout()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            
+            // Excercise system and verify outcome
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                return fixture
+                    .Build<PropertyHolder<ConcreteType>>()
+                    .Without(x => x.Property.Property1);
+            });
+            Assert.Contains("nested property or field", ex.Message);
+
+            // Teardown
+        }
+        
+        [Fact]
+        public void Issue724_ShouldFailWithMeaningfulException_WhenNestedPropertyConfiguredViaCustomizeWithValue()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            
+            // Excercise system and verify outcome
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                fixture.Customize<PropertyHolder<ConcreteType>>(c => c.With(x => x.Property.Property1, "dummy"));
+            });
+            Assert.Contains("nested property or field", ex.Message);
+
+            // Teardown
+        }
+        
+        [Fact]
+        public void Issue724_ShouldFailWithMeaningfulException_WhenNestedPropertyConfiguredViaCustomizeWith()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            
+            // Excercise system and verify outcome
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                fixture.Customize<PropertyHolder<ConcreteType>>(c => c.With(x => x.Property.Property1));
+            });
+            Assert.Contains("nested property or field", ex.Message);
+
+            // Teardown
+        }
+        
+        [Fact]
+        public void Issue724_ShouldFailWithMeaningfulException_WhenNestedPropertyConfiguredViaCustomizeWithout()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            
+            // Excercise system and verify outcome
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                fixture.Customize<PropertyHolder<ConcreteType>>(c => c.Without(x => x.Property.Property1));
+            });
+            Assert.Contains("nested property or field", ex.Message);
+
+            // Teardown
+        }
+
 #if SYSTEM_NET_MAIL
         [Fact]
         public void CreateAnonymousWithMailAddressReturnsValidResult()


### PR DESCRIPTION
Fixes #724.

Nested fields/properties are not supported in `fixture.Build<T>()` or `fixture.Create<T>(....)` configuration API. Instead of failing with unclear exception during object construction, I've added a guard to fail immediately during the customization:

`
System.ArgumentException : The expression contains access to a nested property or field. Configuration API doesn't support this feature, therefore please rewrite the expression to avoid nested fields or properties.
`

@moodmosaic @adamchester Looking forward to your notes.

P.S. Targeted `v4` as I did some refactoring around in #781, so I would like to avoid potential conflicts.