### PR TITLE
Use exact type match for ConstructorInitializedMemberAssertion 

### DIFF
--- a/Src/Idioms/ConstructorInitializedMemberAssertion.cs
+++ b/Src/Idioms/ConstructorInitializedMemberAssertion.cs
@@ -144,7 +144,7 @@ namespace Ploeh.AutoFixture.Idioms
             IEqualityComparer<IReflectionElement> matcher =
                 this.parameterMemberMatcher is DefaultParameterMemberMatcher
                     ? new DefaultParameterMemberMatcher(
-                        new DefaultParameterMemberMatcher.NameIgnoreCaseAndTypeAssignableComparer())
+                        new DefaultParameterMemberMatcher.NameIgnoreCaseAndTypeEqualComparer())
                     : this.parameterMemberMatcher;
 
             var firstParameterNotExposed = parameters.FirstOrDefault(
@@ -411,14 +411,14 @@ namespace Ploeh.AutoFixture.Idioms
 
         private class DefaultParameterMemberMatcher : ReflectionVisitorElementComparer<NameAndType>
         {
-            public class NameIgnoreCaseAndTypeAssignableComparer : IEqualityComparer<NameAndType>
+            public class NameIgnoreCaseAndTypeEqualComparer : IEqualityComparer<NameAndType>
             {
                 public bool Equals(NameAndType x, NameAndType y)
                 {
                     if (x == null) throw new ArgumentNullException("x");
                     if (y == null) throw new ArgumentNullException("y");
                     return x.Name.Equals(y.Name, StringComparison.CurrentCultureIgnoreCase)
-                           && (x.Type.IsAssignableFrom(y.Type) || y.Type.IsAssignableFrom(x.Type));
+                           && x.Type == y.Type;
                 }
 
                 public int GetHashCode(NameAndType obj)

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -341,15 +341,15 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
-        public void VerifyWhenPropertyTypeIsAssignableFromParameterTypeDoesNotThrow()
+        public void VerifyWhenPropertyTypeIsAssignableFromParameterTypeShouldThrow()
         {
             // Fixture setup
             var dummyComposer = new Fixture();
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             var ctor = typeof(PropertyIsAssignableFromConstructorArgumentType).GetConstructors().First();
             // Exercise system and verify outcome
-            Assert.Null(Record.Exception(() =>
-                sut.Verify(ctor)));
+            Assert.Throws<ConstructorInitializedMemberException>(() =>
+                sut.Verify(ctor));
             // Teardown
         }
 


### PR DESCRIPTION
Closes #207.

@moodmosaic @adamchester Please take a look - I haven't used the Idioms library too much before. However, it looks like @ploeh meant this exact place.