### PR TITLE
[Housekeeping] Remove NuGet.config as it's no longer used

### DIFF
--- a/Src/NuGet.config
+++ b/Src/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <config>
-    <add key="repositoryPath" value="../Packages" />
-  </config>
-</configuration>


### PR DESCRIPTION
Previously this file was used as packages were shipped within the repo. After we changed that, this file is no used and can be safely removed.