### PR TITLE
Set upper boundary for external dependencies

### DIFF
--- a/Src/All.sln
+++ b/Src/All.sln
@@ -73,6 +73,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy2U
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy3UnitTest", "AutoFakeItEasy.FakeItEasy3UnitTest\AutoFakeItEasy.FakeItEasy3UnitTest.csproj", "{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy4UnitTest", "AutoFakeItEasy.FakeItEasy4UnitTest\AutoFakeItEasy.FakeItEasy4UnitTest.csproj", "{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -266,6 +268,12 @@ Global
 		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{A7AE8091-3AC8-42A3-ACEB-32F49A8B05D1}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/All.sln
+++ b/Src/All.sln
@@ -75,6 +75,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy3U
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy4UnitTest", "AutoFakeItEasy.FakeItEasy4UnitTest\AutoFakeItEasy.FakeItEasy4UnitTest.csproj", "{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Idioms.FsCheck.FsCheck1UnitTest", "Idioms.FsCheck.FsCheck1UnitTest\Idioms.FsCheck.FsCheck1UnitTest.fsproj", "{42270230-D6FC-4FE8-ACE9-334006BF6692}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Idioms.FsCheck.FsCheck2UnitTest", "Idioms.FsCheck.FsCheck2UnitTest\Idioms.FsCheck.FsCheck2UnitTest.fsproj", "{3C9C7C3E-452D-4ECE-9124-854406758A6D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -274,6 +278,18 @@ Global
 		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{B8B07C7C-E7C8-4272-AAA4-E4ED4CCD249C}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{42270230-D6FC-4FE8-ACE9-334006BF6692}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42270230-D6FC-4FE8-ACE9-334006BF6692}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42270230-D6FC-4FE8-ACE9-334006BF6692}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42270230-D6FC-4FE8-ACE9-334006BF6692}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42270230-D6FC-4FE8-ACE9-334006BF6692}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{42270230-D6FC-4FE8-ACE9-334006BF6692}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{3C9C7C3E-452D-4ECE-9124-854406758A6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C9C7C3E-452D-4ECE-9124-854406758A6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C9C7C3E-452D-4ECE-9124-854406758A6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C9C7C3E-452D-4ECE-9124-854406758A6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C9C7C3E-452D-4ECE-9124-854406758A6D}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{3C9C7C3E-452D-4ECE-9124-854406758A6D}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="2.0.0" />
+    <PackageReference Include="FakeItEasy" Version="[2.0.0]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy4UnitTest/AutoFakeItEasy.FakeItEasy4UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy4UnitTest/AutoFakeItEasy.FakeItEasy4UnitTest.csproj
@@ -5,8 +5,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
-    <AssemblyTitle>AutoFakeItEasy.FakeItEasy3.UnitTest</AssemblyTitle>
-    <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.FakeItEasy3UnitTest</AssemblyName>
+    <AssemblyTitle>AutoFakeItEasy.FakeItEasy4.UnitTest</AssemblyTitle>
+    <AssemblyName>Ploeh.AutoFixture.AutoFakeItEasy.FakeItEasy4UnitTest</AssemblyName>
     <RootNamespace>Ploeh.AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
 
     <!--  Suppress warning about invalid dependency version in Castle.Core.
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="[3.0.0]" />
+    <PackageReference Include="FakeItEasy" Version="[4.0.0]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.sln
+++ b/Src/AutoFakeItEasy.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy2U
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy3UnitTest", "AutoFakeItEasy.FakeItEasy3UnitTest\AutoFakeItEasy.FakeItEasy3UnitTest.csproj", "{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy4UnitTest", "AutoFakeItEasy.FakeItEasy4UnitTest\AutoFakeItEasy.FakeItEasy4UnitTest.csproj", "{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +68,12 @@ Global
 		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{B8FEC47B-ABF1-41DB-8DF8-4343B8F50910}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -19,12 +19,9 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
-    <PackageReference Include="FakeItEasy" Version="1.7.4109.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.6' ">
-    <PackageReference Include="FakeItEasy" Version="3.0.0" />
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="[1.7.4109.1,5.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="FakeItEasy" Version="[3.0.0,5.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.6' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -19,12 +19,9 @@
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
-    <PackageReference Include="NUnit" Version="3.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
-    <PackageReference Include="NUnit" Version="3.7.0" />
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="[3.0.1,4.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="NUnit" Version="[3.7.0,4.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -14,12 +14,9 @@
     <Description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
-    <PackageReference Include="xunit.core" Version="[2.0.0,3.0.0)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
-    <PackageReference Include="xunit.core" Version="[2.2.0,3.0.0)" />
+  <ItemGroup>
+    <PackageReference Include="xunit.core" Version="[2.0.0,3.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="xunit.core" Version="[2.2.0,3.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Foq" Version="[1.5.1,2.0.0)" />
     <PackageReference Include="FSharp.Core" Version="3.0.2" PrivateAssets="All" />
-    <PackageReference Include="Foq" Version="1.5.1" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -22,12 +22,9 @@
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
-    <PackageReference Include="Moq" Version="4.1.1308.2120" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
-    <PackageReference Include="Moq" Version="4.7.0" />
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="[4.1.1308.2120,5.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="Moq" Version="[4.7.0,5.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="NSubstitute" Version="[2.0.3,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoRhinoMock/AutoRhinoMock.csproj
+++ b/Src/AutoRhinoMock/AutoRhinoMock.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RhinoMocks" Version="3.6" />
+    <PackageReference Include="RhinoMocks" Version="[3.6,4.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+  <Import Project="..\Common.props" />
+  <Import Project="..\Common.Test.props" />
+  <Import Project="..\Common.Test.xUnit.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+    <AssemblyTitle>Idioms.FsCheck.FsCheck1UnitTest</AssemblyTitle>
+    <AssemblyName>Ploeh.Idioms.FsCheck.FsCheck1UnitTest</AssemblyName>
+    <RootNamespace>Idioms.FsCheckUnitTest</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Idioms.FsCheckUnitTest\TestDsl.fs" Link="TestDsl.fs" />
+    <Compile Include="..\Idioms.FsCheckUnitTest\TestTypes.fs" Link="TestTypes.fs" />
+    <Compile Include="..\Idioms.FsCheckUnitTest\ReturnValueMustNotBeNullAssertionTest.fs" Link="ReturnValueMustNotBeNullAssertionTest.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsCheck" Version="[1.0.0]" />
+
+    <PackageReference Include="Unquote" Version="3.1.0" />
+    <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+    <ProjectReference Include="..\Idioms\Idioms.csproj" />
+    <ProjectReference Include="..\Idioms.FsCheck\Idioms.FsCheck.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+  <Import Project="..\Common.props" />
+  <Import Project="..\Common.Test.props" />
+  <Import Project="..\Common.Test.xUnit.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+    <AssemblyTitle>Idioms.FsCheck.FsCheck2UnitTest</AssemblyTitle>
+    <AssemblyName>Ploeh.Idioms.FsCheck.FsCheck2UnitTest</AssemblyName>
+    <RootNamespace>Idioms.FsCheckUnitTest</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Idioms.FsCheckUnitTest\TestDsl.fs" Link="TestDsl.fs" />
+    <Compile Include="..\Idioms.FsCheckUnitTest\TestTypes.fs" Link="TestTypes.fs" />
+    <Compile Include="..\Idioms.FsCheckUnitTest\ReturnValueMustNotBeNullAssertionTest.fs" Link="ReturnValueMustNotBeNullAssertionTest.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FsCheck" Version="[2.0.1]" />
+
+    <PackageReference Include="Unquote" Version="3.1.0" />
+    <PackageReference Include="FSharp.Core" Version="3.1.2.1" PrivateAssets="All" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+    <ProjectReference Include="..\Idioms\Idioms.csproj" />
+    <ProjectReference Include="..\Idioms.FsCheck\Idioms.FsCheck.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/Src/Idioms.FsCheck.sln
+++ b/Src/Idioms.FsCheck.sln
@@ -17,6 +17,10 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Idioms.FsCheck", "Idioms.Fs
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Idioms.FsCheckUnitTest", "Idioms.FsCheckUnitTest\Idioms.FsCheckUnitTest.fsproj", "{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Idioms.FsCheck.FsCheck1UnitTest", "Idioms.FsCheck.FsCheck1UnitTest\Idioms.FsCheck.FsCheck1UnitTest.fsproj", "{7D094E6B-4C40-47CB-91B4-A6C47DAE7366}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Idioms.FsCheck.FsCheck2UnitTest", "Idioms.FsCheck.FsCheck2UnitTest\Idioms.FsCheck.FsCheck2UnitTest.fsproj", "{BC4451C6-EAD4-43E6-A1EC-CAA88CCABD4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +70,18 @@ Global
 		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{B3CE0FC0-BB92-47F3-B43E-92B87F7956B8}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{7D094E6B-4C40-47CB-91B4-A6C47DAE7366}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D094E6B-4C40-47CB-91B4-A6C47DAE7366}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D094E6B-4C40-47CB-91B4-A6C47DAE7366}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D094E6B-4C40-47CB-91B4-A6C47DAE7366}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D094E6B-4C40-47CB-91B4-A6C47DAE7366}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{7D094E6B-4C40-47CB-91B4-A6C47DAE7366}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{BC4451C6-EAD4-43E6-A1EC-CAA88CCABD4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC4451C6-EAD4-43E6-A1EC-CAA88CCABD4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC4451C6-EAD4-43E6-A1EC-CAA88CCABD4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC4451C6-EAD4-43E6-A1EC-CAA88CCABD4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC4451C6-EAD4-43E6-A1EC-CAA88CCABD4A}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{BC4451C6-EAD4-43E6-A1EC-CAA88CCABD4A}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsCheck" Version="0.9.2" />
+    <PackageReference Include="FsCheck" Version="[0.9.2,3.0.0)" />
     <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Albedo" Version="1.0.0" />
+    <PackageReference Include="Albedo" Version="[1.0.0,2.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #747.

Reviewed all the projects and ensured that upper boundary for dependency is always set. In fact, we have only 2 noticeable changes:
1. Support FakeItEasy4 explicitly, therefore added the `AutoFakeItEasy.FakeItEasy4UnitTest` project. I prefer to have test projects for all the supported versions - it costs almost nothing to support them, but we can be sure that we suddenly don't break some intermediate version support.
1. Explicitly support `FsCheck` till v2 inclusively for `Idioms.FsCheck` library. I've added 2 test projects: `Idioms.FsCheck.FsCheck1UnitTest` and `Idioms.FsCheck.FsCheck2UnitTest`. The idea is the same as for the `FakeItEasy` - if we support library, we should have the covering tests.

@moodmosaic @adamchester Please let me know whether you have any concerns 😉