### PR TITLE
Use RandomRangedNumberGenerator by default

### DIFF
--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -28,7 +28,7 @@ namespace Ploeh.AutoFixture
             yield return new RandomCharSequenceGenerator();
             yield return new UriGenerator();
             yield return new UriSchemeGenerator();
-            yield return new RangedNumberGenerator();
+            yield return new RandomRangedNumberGenerator();
             yield return new RegularExpressionGenerator();
             yield return new RandomDateTimeSequenceGenerator();
             yield return new BooleanSwitch();

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -34,7 +34,7 @@ namespace Ploeh.AutoFixtureUnitTest
                     typeof(RandomCharSequenceGenerator),
                     typeof(UriGenerator),
                     typeof(UriSchemeGenerator),
-                    typeof(RangedNumberGenerator),
+                    typeof(RandomRangedNumberGenerator),
                     typeof(RegularExpressionGenerator),
                     typeof(RandomDateTimeSequenceGenerator),
                     typeof(BooleanSwitch),


### PR DESCRIPTION
Closes #213 - RandomRangedNumberGenerator should be the default handler of RangedNumberRequest.

@moodmosaic @adamchester Please take a look.

P.S. Over and over again hate those [structural inspection](http://enterprisecraftsmanship.com/2016/07/21/unit-testing-anti-patterns-structural-inspection/) tests as they are simply a copy-paste of the original source code 😕