### PR TITLE
[Housekeeping] Update xUnit version to v2.3 beta5

### DIFF
--- a/Src/AutoFakeItEasyUnitTest/DependencyConstraints.cs
+++ b/Src/AutoFakeItEasyUnitTest/DependencyConstraints.cs
@@ -18,7 +18,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             // Exercise system
             var references = typeof(AutoFakeItEasyCustomization).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
 
@@ -31,7 +31,7 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy.UnitTest
             // Exercise system
             var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/DependencyConstraints.cs
@@ -23,7 +23,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             // Exercise system
             var references = typeof(AutoDataAttribute).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
 
@@ -44,7 +44,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             // Exercise system
             var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -81,7 +81,9 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         [MyCustomInlineAutoData(1337)]
         [MyCustomInlineAutoData(1337, 7)]
         [MyCustomInlineAutoData(1337, 7, 42)]
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters - it's required by the test logic.
         public void CustomInlineDataSuppliesExtraValues(int x, int y, int z)
+#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
         {
             Assert.Equal(1337, x);
             // y can vary, so we can't express any meaningful assertion for it.
@@ -156,6 +158,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         [Theory, AutoData]
         public void BothFrozenAndGreedyAttributesCanBeAppliedToSameParameter([Frozen][Greedy]MultiUnorderedConstructorType p1, MultiUnorderedConstructorType p2)
         {
+            Assert.NotNull(p1);
             Assert.False(string.IsNullOrEmpty(p2.Text));
             Assert.NotEqual(0, p2.Number);
         }

--- a/Src/AutoFixtureDocumentationTest/DependencyConstraints.cs
+++ b/Src/AutoFixtureDocumentationTest/DependencyConstraints.cs
@@ -15,7 +15,7 @@ namespace Ploeh.AutoFixtureDocumentationTest
             // Exercise system
             var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
@@ -116,7 +116,9 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory, ClassData(typeof(MinimumLengthMaximumLengthTestCases))]
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters - the minLength is needed to access the maxLenght.
         public void CreateReturnsStringWithCorrectLengthMultipleCall(int minimumLength, int maximumLength)
+#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
         {
             // Fixture setup
             var request = new ConstrainedStringRequest(maximumLength);

--- a/Src/AutoFixtureUnitTest/CurrentDateTimeCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/CurrentDateTimeCustomizationTest.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var sut = new CurrentDateTimeCustomization();
             // Exercise system and verify outcome
-            Assert.Throws(typeof(ArgumentNullException), () => sut.Customize(null));
+            Assert.Throws<ArgumentNullException>(() => sut.Customize(null));
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
@@ -118,22 +118,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         }
 
         [Theory]
-        [InlineData("Property", 10, 20)]
-        [InlineData("Property", -2, -1)]
-        [InlineData("Property", "10.1", "20.2")]
-        [InlineData("Property", "-2.2", "-1.1")]
-        [InlineData("Property", 10.0, 20.0)]
-        [InlineData("Property", -2.0, -1.0)]
-        [InlineData("NullableTypeProperty", 10, 20)]
-        [InlineData("NullableTypeProperty", -2, -1)]
-        [InlineData("NullableTypeProperty", "10.1", "20.2")]
-        [InlineData("NullableTypeProperty", "-2.2", "-1.1")]
-        [InlineData("NullableTypeProperty", 10.0, 20.0)]
-        [InlineData("NullableTypeProperty", -2.0, -1.0)]
-        public void CreateWithPropertyDecoratedWithRangeAttributeReturnsCorrectResult(
-            string name,
-            object attributeMinimum, 
-            object attributeMaximum)
+        [InlineData("Property")]
+        [InlineData("NullableTypeProperty")]
+        public void CreateWithPropertyDecoratedWithRangeAttributeReturnsCorrectResult(string name)
         {
             // Fixture setup
             var request = typeof(RangeValidatedType).GetProperty(name);
@@ -160,22 +147,9 @@ namespace Ploeh.AutoFixtureUnitTest.DataAnnotations
         }
 
         [Theory]
-        [InlineData("Field", 10, 20)]
-        [InlineData("Field", -2, -1)]
-        [InlineData("Field", "10.1", "20.2")]
-        [InlineData("Field", "-2.2", "-1.1")]
-        [InlineData("Field", 10.0, 20.0)]
-        [InlineData("Field", -2.0, -1.0)]
-        [InlineData("NullableTypeField", 10, 20)]
-        [InlineData("NullableTypeField", -2, -1)]
-        [InlineData("NullableTypeField", "10.1", "20.2")]
-        [InlineData("NullableTypeField", "-2.2", "-1.1")]
-        [InlineData("NullableTypeField", 10.0, 20.0)]
-        [InlineData("NullableTypeField", -2.0, -1.0)]
-        public void CreateWithFieldDecoratedWithRangeAttributeReturnsCorrectResult(
-            string name,
-            object attributeMinimum,
-            object attributeMaximum)
+        [InlineData("Field")]
+        [InlineData("NullableTypeField")]
+        public void CreateWithFieldDecoratedWithRangeAttributeReturnsCorrectResult(string name)
         {
             // Fixture setup
             var request = typeof(RangeValidatedType).GetField(name);

--- a/Src/AutoFixtureUnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixtureUnitTest/DependencyConstraints.cs
@@ -19,7 +19,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var references = typeof(Fixture).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
 
@@ -32,7 +32,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/Dsl/ComposerAssert.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/ComposerAssert.cs
@@ -16,7 +16,7 @@ namespace Ploeh.AutoFixtureUnitTest.Dsl
         internal static FilteringSpecimenBuilder ShouldContain(this FilteringSpecimenBuilder filter, Func<ISpecimenBuilder, bool> predicate)
         {
             var composite = Assert.IsAssignableFrom<CompositeSpecimenBuilder>(filter.Builder);
-            Assert.True(composite.Any(predicate));
+            Assert.Contains(composite, c => predicate(c));
             return filter;
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/ArrayFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ArrayFavoringConstructorQueryTest.cs
@@ -77,7 +77,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.SelectMethods(type);
             // Verify outcome
-            Assert.True(result.First().Parameters.Any(p => p.ParameterType.IsArray));
+            Assert.Contains(result.First().Parameters, p => p.ParameterType.IsArray);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
@@ -37,7 +37,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var dummyRequest = new object();
             var sut = new DelegateGenerator();
             // Exercise system and verify outcome
-            Assert.Throws(typeof(ArgumentNullException), () => sut.Create(dummyRequest, null));
+            Assert.Throws<ArgumentNullException>(() => sut.Create(dummyRequest, null));
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
@@ -81,7 +81,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var result = sut.SelectMethods(type);
             // Verify outcome
             var genericParameterType = type.GetGenericArguments().Single();
-            Assert.True(result.First().Parameters.Any(p => typeof(IEnumerable<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType)));
+            Assert.Contains(result.First().Parameters, p => typeof(IEnumerable<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType));
             // Teardown
         }
 
@@ -117,7 +117,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.SelectMethods(type);
             // Verify outcome
-            Assert.True(result.First().Parameters.Any(p => expected == p.ParameterType));
+            Assert.Contains(result.First().Parameters, p => expected == p.ParameterType);
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
@@ -79,7 +79,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var result = sut.SelectMethods(type);
             // Verify outcome
             var genericParameterType = type.GetGenericArguments().Single();
-            Assert.True(result.First().Parameters.Any(p => typeof(IList<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType)));
+            Assert.Contains(result.First().Parameters, p => typeof(IList<>).MakeGenericType(genericParameterType).IsAssignableFrom(p.ParameterType));
             // Teardown
         }
 
@@ -114,7 +114,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var result = sut.SelectMethods(type);
             // Verify outcome
-            Assert.True(result.First().Parameters.Any(p => typeof(IList<object>) == p.ParameterType));
+            Assert.Contains(result.First().Parameters, p => typeof(IList<object>) == p.ParameterType);
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/OmitSpecimenTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitSpecimenTest.cs
@@ -24,7 +24,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Exercise system
             var actual = BothEquals(sut, null);
             // Verify outcome
-            Assert.False(actual.Any(b => b));
+            Assert.DoesNotContain(actual, b => b);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/ThrowingRecursionGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ThrowingRecursionGuardTest.cs
@@ -44,7 +44,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             container.OnResolve = r => sut.Create(r, container); // Provoke recursion
 
             // Exercise system
-            Assert.Throws(typeof(ObjectCreationException), () => sut.Create(Guid.NewGuid(), container));
+            Assert.Throws<ObjectCreationException>(() => sut.Create(Guid.NewGuid(), container));
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/MultipleCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/MultipleCustomizationTest.cs
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             sut.Customize(fixture);
             // Verify outcome
-            Assert.True(fixture.ResidueCollectors.Any(b => relayType.IsAssignableFrom(b.GetType())));
+            Assert.Contains(fixture.ResidueCollectors, relayType.IsInstanceOfType);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/NumericSequencePerTypeCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/NumericSequencePerTypeCustomizationTest.cs
@@ -25,7 +25,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Fixture setup
             var sut = new NumericSequencePerTypeCustomization();
             // Exercise system and verify outcome
-            Assert.Throws(typeof(ArgumentNullException), () => sut.Customize(null));
+            Assert.Throws<ArgumentNullException>(() => sut.Customize(null));
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/SpecimenBuilderNodeAdapterCollectionTest.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenBuilderNodeAdapterCollectionTest.cs
@@ -125,7 +125,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             this.sut.RemoveAt(index);
             // Verify outcome
-            Assert.False(this.sut.Contains(itemToBeRemoved));
+            Assert.DoesNotContain(itemToBeRemoved, this.sut);
             // Teardown
         }
 
@@ -177,7 +177,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             this.sut[index] = new DelegatingSpecimenBuilder();
             // Verify outcome
-            Assert.False(this.sut.Contains(itemToReplace));
+            Assert.DoesNotContain(itemToReplace, this.sut);
             // Teardown
         }
 
@@ -269,7 +269,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system
             this.sut.Remove(item);
             // Verify outcome
-            Assert.False(this.sut.Contains(item));
+            Assert.DoesNotContain(item, this.sut);
             // Teardown
         }
 

--- a/Src/AutoMoqUnitTest/AutoConfiguredMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/AutoConfiguredMoqCustomizationTest.cs
@@ -52,7 +52,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             sut.Customize(fixture.Object);
             // Verify outcome
-            Assert.True(customizations.Any(builder => builder is Postprocessor));
+            Assert.Contains(customizations, builder => builder is Postprocessor);
             // Teardown
         }
 
@@ -75,7 +75,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var postprocessor = (Postprocessor) customizations.Single(builder => builder is Postprocessor);
             var compositeCommand = (CompositeSpecimenCommand) postprocessor.Command;
 
-            Assert.True(compositeCommand.Commands.Any(command => command.GetType() == expectedCommandType));
+            Assert.Contains(compositeCommand.Commands, command => command.GetType() == expectedCommandType);
             // Teardown
         }
 

--- a/Src/AutoMoqUnitTest/DependencyConstraints.cs
+++ b/Src/AutoMoqUnitTest/DependencyConstraints.cs
@@ -17,7 +17,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             var references = typeof(AutoMoqCustomization).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
 
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
+++ b/Src/AutoMoqUnitTest/MockConstructorQueryTest.cs
@@ -112,7 +112,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             // Exercise system
             var result = sut.SelectMethods(typeof(Mock<ConcreteTypeWithPrivateParameterlessConstructor>));
             // Verify outcome
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             // Teardown
         }
     }

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultResolverTests.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallResultResolverTests.cs
@@ -75,7 +75,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
             var callResult = sut.ResolveResult(call);
 
             // Verify outcome
-            Assert.Equal(1, callResult.ArgumentValues.Count());
+            Assert.Single(callResult.ArgumentValues);
             Assert.Equal(1, callResult.ArgumentValues.First().Index);
             Assert.Equal(42, callResult.ArgumentValues.First().Value);
 
@@ -99,7 +99,7 @@ namespace Ploeh.AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
             var callResult = sut.ResolveResult(call);
 
             // Verify outcome
-            Assert.Equal(1, callResult.ArgumentValues.Count());
+            Assert.Single(callResult.ArgumentValues);
             Assert.Equal(0, callResult.ArgumentValues.First().Index);
             Assert.Equal(42, callResult.ArgumentValues.First().Value);
 

--- a/Src/AutoRhinoMockUnitTest/DependencyConstraints.cs
+++ b/Src/AutoRhinoMockUnitTest/DependencyConstraints.cs
@@ -16,7 +16,7 @@ namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
             // Exercise system
             var references = typeof(AutoRhinoMockCustomization).Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
 
@@ -29,7 +29,7 @@ namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
             // Exercise system
             var references = this.GetType().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/AutoRhinoMockUnitTest/RhinoMockConstructorQueryTest.cs
+++ b/Src/AutoRhinoMockUnitTest/RhinoMockConstructorQueryTest.cs
@@ -59,7 +59,7 @@ namespace Ploeh.AutoFixture.AutoRhinoMock.UnitTest
             // Exercise system
             var result = sut.SelectMethods(t);
             // Verify outcome
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             // Teardown
         }
 

--- a/Src/Common.Test.xUnit.props
+++ b/Src/Common.Test.xUnit.props
@@ -1,8 +1,8 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -150,7 +150,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             var sut = new ConstructorInitializedMemberAssertion(dummyComposer);
             // Exercise system and verify outcome
             var constructorWithNoParameters = typeof (PropertyHolder<object>).GetConstructors().First();
-            Assert.Equal(0, constructorWithNoParameters.GetParameters().Length);
+            Assert.Empty(constructorWithNoParameters.GetParameters());
             Assert.Null(Record.Exception(() =>
                 sut.Verify(constructorWithNoParameters)));
             // Teardown
@@ -583,7 +583,6 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
         [Theory]
         [InlineData(typeof(ReadOnlyFieldInitializedViaConstructor<TestDefaultOnlyEnum>))]
         [InlineData(typeof(ReadOnlyPropertyInitializedViaConstructor<TestDefaultOnlyEnum>))]
-        [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestDefaultOnlyEnum>))]
         [InlineData(typeof(ReadOnlyPropertyIncorrectlyInitializedViaConstructor<TestDefaultOnlyEnum>))]
         public void VerifyDefaultOnlyEnumDoesThrowBecauseOfPotentialFalsePositive(Type type)
         {

--- a/Src/IdiomsUnitTest/DependencyConstraints.cs
+++ b/Src/IdiomsUnitTest/DependencyConstraints.cs
@@ -17,7 +17,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             // Exercise system
             var references = typeof(IIdiomaticAssertion).Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
 
@@ -30,7 +30,7 @@ namespace Ploeh.AutoFixture.IdiomsUnitTest
             // Exercise system
             var references = this.GetType().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/SemanticComparisonUnitTest/DependencyConstraints.cs
+++ b/Src/SemanticComparisonUnitTest/DependencyConstraints.cs
@@ -18,7 +18,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Exercise system
             var references = typeof(Likeness<object, object>).GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
 
@@ -32,7 +32,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Exercise system
             var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Verify outcome
-            Assert.False(references.Any(an => an.Name == assemblyName));
+            Assert.DoesNotContain(references, an => an.Name == assemblyName);
             // Teardown
         }
     }

--- a/Src/SemanticComparisonUnitTest/LikenessTest.cs
+++ b/Src/SemanticComparisonUnitTest/LikenessTest.cs
@@ -1536,7 +1536,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Exercise system
             var actual = BothEquals(sut, (object)null);
             // Verify outcome
-            Assert.False(actual.Any(b => b));
+            Assert.DoesNotContain(actual, b => b);
             // Teardown
         }
 
@@ -1549,7 +1549,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Exercise system
             var actual = BothEquals(sut, nullValue);
             // Verify outcome
-            Assert.True(actual.Any(b => b));
+            Assert.Contains(actual, b => b);
             // Teardown
         }
 
@@ -1562,7 +1562,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Exercise system
             var actual = BothEquals(sut, nullValue);
             // Verify outcome
-            Assert.False(actual.Any(b => b));
+            Assert.DoesNotContain(actual, b => b);
             // Teardown
         }
 
@@ -1641,7 +1641,7 @@ namespace Ploeh.SemanticComparison.UnitTest
             // Exercise system
             var actual = BothEquals(sut, other);
             // Verify outcome
-            Assert.True(actual.Any(b => b));
+            Assert.Contains(actual, b => b);
             // Teardown
         }
 


### PR DESCRIPTION
Updated the xUnit version we use.

Most of the changes are to fix the xUnit analyzer warnings as there is a better way to assert test outcome. Also it appeared that for the `CreateWithPropertyDecoratedWithRangeAttributeReturnsCorrectResult` and `CreateWithFieldDecoratedWithRangeAttributeReturnsCorrectResult` tests we don't use the passed inline data, so we could simplify the logic.

@moodmosaic @adamchester Please take a look 😉