### PR TITLE
[Housekeeping] Disable parallel test execution for RhinoMock integration tests

### DIFF
--- a/Src/AutoRhinoMockUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoRhinoMockUnitTest/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -13,3 +14,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1489ac72-1967-48b8-a302-79b2900acbe3")]
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
It appears that RhinoMock is not thread safe and our xUnit tests could fail due to parallel test execution. The issue is intermittent and outcome might be different - from exception to complete hang.
You can read more information about this issue here: http://blog.smithfamily.dk/post/Thread-safe-version-of-Rhino-Mocks

We use an old version of RhinoMock that is no longer supported, so the only option we have is to disable the parallel test execution.

Here is an example of such a failure: [https://ci.appveyor.com/project/AutoFixture/autofixture/build/1.0.323-admnsybb](https://ci.appveyor.com/project/AutoFixture/autofixture/build/1.0.323-admnsybb).

@moodmosaic @adamchester Please take a look 😉