### PR TITLE
[Housekeeping] Enable SourceLink support

### DIFF
--- a/Src/AutoFixture.NUnit2/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.NUnit2/Properties/AssemblyInfo.cs
@@ -30,4 +30,3 @@ using System.Resources;
         Scope = "namespace",
         Target = "Ploeh.AutoFixture.NUnit2.Addins.Builders",
         Justification = "It has been ported from other project and I don't want to introduce the breaking changes.")]
-        

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -8,6 +8,8 @@
     <RootNamespace>Ploeh.AutoFixture.AutoFoq</RootNamespace>
     <Copyright>Copyright © Ploeh 2013</Copyright>
     <SignAssembly>False</SignAssembly>
+    <!-- Disable source link support for F# projects as they don't support this feature. -->
+    <SourceLinkCreate>false</SourceLinkCreate>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.AutoFoq</PackageId>

--- a/Src/Common.Test.props
+++ b/Src/Common.Test.props
@@ -10,5 +10,7 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\Empty.ruleset</CodeAnalysisRuleSet>
 
     <IsPackable>false</IsPackable>
+    <!-- Disable source link support for test projects as they are not publishable. -->
+    <SourceLinkCreate>false</SourceLinkCreate>
   </PropertyGroup>
 </Project>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -68,6 +68,7 @@
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.4.0" />
   </ItemGroup>
   <PropertyGroup>
+    <SourceLinkCreate Condition=" '$(SourceLinkCreateOverride)'!='' ">$(SourceLinkCreateOverride)</SourceLinkCreate>
     <SourceLinkNotInGit>error</SourceLinkNotInGit>
     <SourceLinkHashMismatch>error</SourceLinkHashMismatch>
     <SourceLinkNoAutoLF>true</SourceLinkNoAutoLF>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -62,4 +62,20 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" ExcludeAssets="all" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.4.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.4.0" />
+  </ItemGroup>
+  <PropertyGroup>
+    <SourceLinkNotInGit>error</SourceLinkNotInGit>
+    <SourceLinkHashMismatch>error</SourceLinkHashMismatch>
+    <SourceLinkNoAutoLF>true</SourceLinkNoAutoLF>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  <Target Name="IncludePDBsInPackage" Condition=" '$(IncludeBuildOutput)'!='false' ">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib\$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -8,6 +8,8 @@
     <RootNamespace>Ploeh.AutoFixture.Idioms.FsCheck</RootNamespace>
     <Copyright>Copyright © Ploeh 2014</Copyright>
     <SignAssembly>False</SignAssembly>
+    <!-- Disable source link support for F# projects as they don't support this feature. -->
+    <SourceLinkCreate>false</SourceLinkCreate>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.Idioms.FsCheck</PackageId>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,11 @@ environment:
 pull_requests:
   do_not_increment_build_number: true
 
+# Is required by SourceLink to have valid file hashes.
+# See more detail here: https://github.com/ctaggart/SourceLink/wiki/Line-Endings
+init:
+  - git config --global core.autocrlf input
+
 build_script:
 - ps: |
     & .\build.cmd AppVeyor NuGetPublicKey="$($Env:NUGET_API_KEY)" NuGetPrivateKey="$($Env:MYGET_API_KEY)" BuildVersion=git BuildNumber=$($Env:APPVEYOR_BUILD_NUMBER)


### PR DESCRIPTION
Closes #770.

Add SourceLink support to enable easier source code stepping. SourceLink is a new approach that allows to embed information about source code location. In our case source code will be downloaded directly from GitHub repository.