### PR TITLE
[Housekeeping] Use TheoryData<> for complex test theory data

### DIFF
--- a/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
@@ -97,7 +97,8 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Theory, ClassData(typeof(MinimumLengthMaximumLengthTestCases))]
+        [Theory]
+        [MemberData(nameof(MinimumLengthMaximumLengthTestCases))]
         public void CreateReturnsStringWithCorrectLength(int expectedMinimumLength, int expectedMaximumLength)
         {
             // Fixture setup
@@ -115,7 +116,8 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Theory, ClassData(typeof(MinimumLengthMaximumLengthTestCases))]
+        [Theory]
+        [MemberData(nameof(MinimumLengthMaximumLengthTestCases))]
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters - the minLength is needed to access the maxLenght.
         public void CreateReturnsStringWithCorrectLengthMultipleCall(int minimumLength, int maximumLength)
 #pragma warning restore xUnit1026 // Theory methods should use all of their parameters
@@ -137,33 +139,26 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        private sealed class MinimumLengthMaximumLengthTestCases : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
+        public static TheoryData<int, int> MinimumLengthMaximumLengthTestCases =>
+            new TheoryData<int, int>
             {
-                yield return new object[] {   0,   3 };
-                yield return new object[] {   0,  10 };
-                yield return new object[] {   0,  20 };
-                yield return new object[] {   0,  30 };
-                yield return new object[] {   0,  60 };
-                yield return new object[] {   0,  90 };
-                yield return new object[] {   3,  90 };
-                yield return new object[] {  10, 100 };
-                yield return new object[] {  20, 120 };
-                yield return new object[] {  30, 130 };
-                yield return new object[] {  60, 160 };
-                yield return new object[] {  90, 190 };
-                yield return new object[] { 100, 200 };
-                yield return new object[] { 120, 210 };
-                yield return new object[] { 130, 220 };
-                yield return new object[] { 160, 230 };
-                yield return new object[] { 190, 240 };
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
+                {0, 3},
+                {0, 10},
+                {0, 20},
+                {0, 30},
+                {0, 60},
+                {0, 90},
+                {3, 90},
+                {10, 100},
+                {20, 120},
+                {30, 130},
+                {60, 160},
+                {90, 190},
+                {100, 200},
+                {120, 210},
+                {130, 220},
+                {160, 230},
+                {190, 240},
+            };
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5746,16 +5746,10 @@ namespace Ploeh.AutoFixtureUnitTest
             }
         }
 
-        public static IEnumerable<object[]> CreateComplexArrayTypeReturnsCorrectResult_Data =>
-            new[]
-                {
-                    typeof(string[][,,][]),
-                    typeof(object[,,][][,])
-                }
-                .Select(x => new object[] {x});
-
-        [Theory, MemberData(nameof(CreateComplexArrayTypeReturnsCorrectResult_Data))]
-        public void CreateComplexArrayTypeReturnsCorrectResult(object request)
+        [Theory]
+        [InlineData(typeof(string[][,,][]))]
+        [InlineData(typeof(object[,,][][,]))]
+        public void CreateComplexArrayTypeReturnsCorrectResult(Type request)
         {
             var sut = new Fixture();
             var context = new SpecimenContext(sut);

--- a/Src/AutoFixtureUnitTest/Kernel/GenericMethodTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/GenericMethodTests.cs
@@ -133,7 +133,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Theory]
-        [ClassData(typeof(GenericMethodTestCase))]
+        [MemberData(nameof(GenericMethodTestCases))]
         public void InvokeWithGenericMethodReturnsCorrectResult(Type targetType, int index, object values)
         {
             var method = (from mi in targetType
@@ -168,23 +168,16 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                 () => sut.Invoke((object[])values));
             Assert.Contains(method.Name, exception.Message);
         }
-    }
 
-    public class GenericMethodTestCase : IEnumerable<object[]>
-    {
-        public IEnumerator<object[]> GetEnumerator()
-        {
-            yield return new object[] { typeof(TypeWithGenericMethod), 0, new object[] { "abc" } };
-            yield return new object[] { typeof(TypeWithGenericMethod), 1, new object[] { new string[] { "ab", "c" } } };
-            yield return new object[] { typeof(TypeWithGenericMethod), 2, new object[] { "ab", 2 } };
-            yield return new object[] { typeof(TypeWithGenericMethod), 3, new object[] { "ab", new Func<string, int>(x => x.Length) } };
-            yield return new object[] { typeof(TypeWithGenericMethod), 4, new object[] { new int[] { 1, 2 }, new string[] { "ab", "c" } } };
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        public static TheoryData<Type, int, object> GenericMethodTestCases =>
+            new TheoryData<Type, int, object>
+            {
+                {typeof(TypeWithGenericMethod), 0, new object[] {"abc"}},
+                {typeof(TypeWithGenericMethod), 1, new object[] {new string[] {"ab", "c"}}},
+                {typeof(TypeWithGenericMethod), 2, new object[] {"ab", 2}},
+                {typeof(TypeWithGenericMethod), 3, new object[] {"ab", new Func<string, int>(x => x.Length)}},
+                {typeof(TypeWithGenericMethod), 4, new object[] {new int[] {1, 2}, new string[] {"ab", "c"}}}
+            };
     }
 
     public class TypeWithGenericMethod

--- a/Src/AutoFixtureUnitTest/Kernel/GraphEqualsTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/GraphEqualsTest.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Xunit;
 using Ploeh.AutoFixture.Kernel;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixtureUnitTest.Kernel
 {
@@ -72,7 +68,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        [Theory, ClassData(typeof(IdenticallyShapedGraphs))]
+        [Theory]
+        [MemberData(nameof(IdenticallyShapedGraphs))]
         public void NodesWithIdenticalShapesAreEqualWhenComparerIsAlwaysTrue(
             ISpecimenBuilderNode first,
             ISpecimenBuilderNode second)
@@ -86,7 +83,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        [Theory, ClassData(typeof(DifferentlyShapedGraphs))]
+        [Theory]
+        [MemberData(nameof(DifferentlyShapedGraphs))]
         public void NodesWithDifferentShapesAreNotEqualEvenWhenComparerIsAlwaysTrue(
             ISpecimenBuilderNode first,
             ISpecimenBuilderNode second)
@@ -100,7 +98,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        [Theory, ClassData(typeof(SameGraphs))]
+        [Theory]
+        [MemberData(nameof(SameGraphs))]
         public void IdenticalNodesAreEqual(
             ISpecimenBuilderNode first,
             ISpecimenBuilderNode second)
@@ -114,8 +113,8 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Theory]
-        [ClassData(typeof(DifferentlyShapedGraphs))]
-        [ClassData(typeof(IdenticallyShapedGraphs))]
+        [MemberData(nameof(DifferentlyShapedGraphs))]
+        [MemberData(nameof(IdenticallyShapedGraphs))]
         public void DifferentNodesAreNotEqualWhenComparerIsOmitted(
             ISpecimenBuilderNode first,
             ISpecimenBuilderNode second)
@@ -129,7 +128,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Theory]
-        [ClassData(typeof(SimilarTaggedGraphs))]
+        [MemberData(nameof(SimilarTaggedGraphs))]
         public void SimilarNodesAreEqualAccordingToTags(
             ISpecimenBuilderNode first,
             ISpecimenBuilderNode second)
@@ -143,7 +142,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Theory]
-        [ClassData(typeof(DifferentTaggedGraphs))]
+        [MemberData(nameof(DifferentTaggedGraphs))]
         public void DifferentNodesAreNotEqualAccordingToTags(
             ISpecimenBuilderNode first,
             ISpecimenBuilderNode second)
@@ -156,23 +155,19 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        private class IdenticallyShapedGraphs : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
+        public static TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode> IdenticallyShapedGraphs =>
+            new TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode>
             {
-                yield return new object[] 
                 {
                     new CompositeSpecimenBuilder(),
                     new CompositeSpecimenBuilder()
-                };
-                yield return new object[]
+                },
                 {
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder()),
                     new CompositeSpecimenBuilder(
-                        new[] { new CompositeSpecimenBuilder() })
-                };
-                yield return new object[]
+                        new[] {new CompositeSpecimenBuilder()})
+                },
                 {
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder(),
@@ -180,34 +175,27 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder(),
                         new CompositeSpecimenBuilder())
-                };
-            }
+                }
+            };
 
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
+        public static TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode> DifferentlyShapedGraphs =>
+            new TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode>
 
-        private class DifferentlyShapedGraphs : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
             {
-                yield return new object[]
                 {
                     new CompositeSpecimenBuilder(),
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder())
-                };
-                yield return new object[]
+                },
                 {
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder()),
-                    new CompositeSpecimenBuilder(new []{
+                    new CompositeSpecimenBuilder(new[]
+                    {
                         new CompositeSpecimenBuilder(
-                            new DelegatingSpecimenBuilder())})
-                };
-                yield return new object[]
+                            new DelegatingSpecimenBuilder())
+                    })
+                },
                 {
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder(),
@@ -216,8 +204,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder(),
                         new CompositeSpecimenBuilder())
-                };
-                yield return new object[]
+                },
                 {
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder(),
@@ -226,8 +213,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder(),
                         new DelegatingSpecimenBuilder())
-                };
-                yield return new object[]
+                },
                 {
                     new CompositeSpecimenBuilder(
                         new DelegatingSpecimenBuilder(),
@@ -236,97 +222,80 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                         new DelegatingSpecimenBuilder(),
                         new DelegatingSpecimenBuilder(),
                         new DelegatingSpecimenBuilder())
-                };
-            }
+                }
+            };
 
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
-
-        private class SameGraphs : IEnumerable<object[]>
+        public static TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode> SameGraphs
         {
-            public IEnumerator<object[]> GetEnumerator()
+            get
             {
                 var g1 = new CompositeSpecimenBuilder();
-                yield return new object[] { g1, g1 };
-
                 var g2 = new CompositeSpecimenBuilder(
                     new DelegatingSpecimenBuilder());
-                yield return new object[] { g2, g2 };
-            }
 
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
+                return new TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode>
+                {
+                    {g1, g1},
+                    {g2, g2}
+                };
             }
         }
 
-        private class SimilarTaggedGraphs : IEnumerable<object[]>
+        public static TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode> SimilarTaggedGraphs
         {
-            public IEnumerator<object[]> GetEnumerator()
+            get
             {
                 var leaf = new DelegatingSpecimenBuilder();
 
-                yield return new object[]
+                return new TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode>
                 {
-                    new TaggedNode(1),
-                    new TaggedNode(1)
+                    {
+                        new TaggedNode(1),
+                        new TaggedNode(1)
+                    },
+                    {
+                        new TaggedNode(1,
+                            new TaggedNode(2),
+                            new TaggedNode(3)),
+                        new TaggedNode(1,
+                            new TaggedNode(2),
+                            new TaggedNode(3))
+                    },
+                    {
+                        new TaggedNode(1, leaf),
+                        new TaggedNode(1, leaf)
+                    },
+                    {
+                        new TaggedNode(1,
+                            new TaggedNode(2,
+                                leaf,
+                                leaf,
+                                leaf),
+                            new TaggedNode(3,
+                                leaf,
+                                leaf,
+                                leaf)),
+                        new TaggedNode(1,
+                            new TaggedNode(2,
+                                leaf,
+                                leaf,
+                                leaf),
+                            new TaggedNode(3,
+                                leaf,
+                                leaf,
+                                leaf))
+                    }
                 };
-                yield return new object[]
-                {
-                    new TaggedNode(1,
-                        new TaggedNode(2),
-                        new TaggedNode(3)),
-                    new TaggedNode(1,
-                        new TaggedNode(2),
-                        new TaggedNode(3))
-                };
-                yield return new object[]
-                {
-                    new TaggedNode(1, leaf),
-                    new TaggedNode(1, leaf)
-                };
-                yield return new object[]
-                {
-                    new TaggedNode(1,
-                        new TaggedNode(2,
-                            leaf,
-                            leaf,
-                            leaf),
-                        new TaggedNode(3,
-                            leaf,
-                            leaf,
-                            leaf)),
-                    new TaggedNode(1,
-                        new TaggedNode(2,
-                            leaf,
-                            leaf,
-                            leaf),
-                        new TaggedNode(3,
-                            leaf,
-                            leaf,
-                            leaf))
-                };
-            }
-
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
             }
         }
 
-        private class DifferentTaggedGraphs : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
+        public static TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode> DifferentTaggedGraphs =>
+            new TheoryData<ISpecimenBuilderNode, ISpecimenBuilderNode>
             {
-                yield return new object[]
                 {
                     new TaggedNode(1),
                     new TaggedNode("A")
-                };
-                yield return new object[]
+                },
                 {
                     new TaggedNode(1,
                         new TaggedNode(2),
@@ -334,20 +303,13 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                     new TaggedNode(1,
                         new TaggedNode(2),
                         new TaggedNode("A"))
-                };
-                yield return new object[]
+                },
                 {
                     new TaggedNode(1,
                         new DelegatingSpecimenBuilder()),
                     new TaggedNode(1,
                         new DelegatingSpecimenBuilder())
-                };
-            }
-
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
+                }
+            };
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
@@ -34,7 +34,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
                     typeof(object[]),
                     typeof(string[][])
                 }
-                .Select(x => new[] { x });
+                .Select(x => new[] {x});
 
         [Theory, MemberData(nameof(CreateWithInvalidRequestReturnsNoSpecimen_InvalidRequests))]
         public void CreateWithInvalidRequestReturnsNoSpecimen(object invalidRequest)

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -2,12 +2,10 @@
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.AutoFixtureUnitTest.Kernel;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixtureUnitTest
 {
@@ -211,7 +209,7 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [ClassData(typeof(LimitSequenceTestCases))]
+        [MemberData(nameof(LimitSequenceTestCases))]
         public void CreateReturnsNumberInCorrectRange(long[] limits)
         {
             // Fixture setup
@@ -230,7 +228,7 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [ClassData(typeof(LimitSequenceTestCases))]
+        [MemberData(nameof(LimitSequenceTestCases))]
         public void CreateReturnsNumberInCorrectRangeOnMultipleCall(long[] limits)
         {
             // Fixture setup
@@ -290,16 +288,16 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [InlineData(new object[] { new long[] { -30, -9, -5, 2, 9, 15 }, 0, 1 })]
-        [InlineData(new object[] { new long[] { -30, -9, -5, 2, 9, 15 }, 1, 2 })]
-        [InlineData(new object[] { new long[] { -30, -9, -5, 2, 9, 15 }, 2, 3 })]
-        [InlineData(new object[] { new long[] { -30, -9, -5, 2, 9, 15 }, 3, 4 })]
-        [InlineData(new object[] { new long[] { -30, -9, -5, 2, 9, 15 }, 4, 5 })]
-        [InlineData(new object[] { new long[] { 1, 5, 9, 30, 128, 255 }, 0, 1 })]
-        [InlineData(new object[] { new long[] { 1, 5, 9, 30, 128, 255 }, 1, 2 })]
-        [InlineData(new object[] { new long[] { 1, 5, 9, 30, 128, 255 }, 2, 3 })]
-        [InlineData(new object[] { new long[] { 1, 5, 9, 30, 128, 255 }, 3, 5 })]
-        [InlineData(new object[] { new long[] { 1, 5, 9, 30, 128, 255 }, 4, 5 })]
+        [InlineData(new long[] { -30, -9, -5, 2, 9, 15 }, 0, 1)]
+        [InlineData(new long[] { -30, -9, -5, 2, 9, 15 }, 1, 2)]
+        [InlineData(new long[] { -30, -9, -5, 2, 9, 15 }, 2, 3)]
+        [InlineData(new long[] { -30, -9, -5, 2, 9, 15 }, 3, 4)]
+        [InlineData(new long[] { -30, -9, -5, 2, 9, 15 }, 4, 5)]
+        [InlineData(new long[] { 1, 5, 9, 30, 128, 255 }, 0, 1)]
+        [InlineData(new long[] { 1, 5, 9, 30, 128, 255 }, 1, 2)]
+        [InlineData(new long[] { 1, 5, 9, 30, 128, 255 }, 2, 3)]
+        [InlineData(new long[] { 1, 5, 9, 30, 128, 255 }, 3, 5)]
+        [InlineData(new long[] { 1, 5, 9, 30, 128, 255 }, 4, 5)]
         public void CreateReturnsNumberInCorrectRangeProgressivelyOnMultipleCall(
             long[] limits, int indexOfLower, int indexOfUpper)
         {
@@ -323,7 +321,7 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [ClassData(typeof(LimitSequenceTestCases))]
+        [MemberData(nameof(LimitSequenceTestCases))]
         public void CreateWhenLimitIsReachedStartsFromTheBeginning(long[] limits)
         {
             // Fixture setup
@@ -348,7 +346,7 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [ClassData(typeof(LimitSequenceTestCases))]
+        [MemberData(nameof(LimitSequenceTestCases))]
         public void CreateReturnsUniqueNumbersOnMultipleCall(long[] limits)
         {
             // Fixture setup
@@ -370,7 +368,7 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Theory]
-        [ClassData(typeof(LimitSequenceTestCases))]
+        [MemberData(nameof(LimitSequenceTestCases))]
         public void CreateReturnsUniqueNumbersOnMultipleCallAsynchronously(long[] limits)
         {
             // Fixture setup
@@ -407,19 +405,13 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        private sealed class LimitSequenceTestCases : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
+        public static TheoryData<long[]> LimitSequenceTestCases =>
+            new TheoryData<long[]>
             {
-                yield return new object[] { new long[] { 2, 5, 9, 30, 255 } };
-                yield return new object[] { new long[] { 2, 5, 9, 30, 255, 512 } };
-                yield return new object[] { new long[] { -30, -9, -5, 2, 5, 9, 30 } };
-            }
+                new long[] {2, 5, 9, 30, 255},
+                new long[] {2, 5, 9, 30, 255, 512},
+                new long[] {-30, -9, -5, 2, 5, 9, 30}
+            };
 
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
     }
 }

--- a/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
@@ -317,96 +317,96 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
 
-        public static IEnumerable<object[]> MinLimitToMaxLimitRequests =>
-            new[]
+        public static TheoryData<Type, IConvertible, IConvertible> MinLimitToMaxLimitRequests =>
+            new TheoryData<Type, IConvertible, IConvertible>
             {
-                new object[] {typeof(float), float.MinValue, float.MaxValue},
-                new object[] {typeof(double), double.MinValue, double.MaxValue},
-                new object[] {typeof(decimal), decimal.MinValue, decimal.MaxValue},
-                new object[] {typeof(sbyte), sbyte.MinValue, sbyte.MaxValue},
-                new object[] {typeof(byte), byte.MinValue, byte.MaxValue},
-                new object[] {typeof(short), short.MinValue, short.MaxValue},
-                new object[] {typeof(ushort), ushort.MinValue, ushort.MaxValue},
-                new object[] {typeof(int), int.MinValue, int.MaxValue},
-                new object[] {typeof(uint), uint.MinValue, uint.MaxValue},
-                new object[] {typeof(long), long.MinValue, long.MaxValue},
-                new object[] {typeof(ulong), ulong.MinValue, ulong.MaxValue}
+                {typeof(float), float.MinValue, float.MaxValue},
+                {typeof(double), double.MinValue, double.MaxValue},
+                {typeof(decimal), decimal.MinValue, decimal.MaxValue},
+                {typeof(sbyte), sbyte.MinValue, sbyte.MaxValue},
+                {typeof(byte), byte.MinValue, byte.MaxValue},
+                {typeof(short), short.MinValue, short.MaxValue},
+                {typeof(ushort), ushort.MinValue, ushort.MaxValue},
+                {typeof(int), int.MinValue, int.MaxValue},
+                {typeof(uint), uint.MinValue, uint.MaxValue},
+                {typeof(long), long.MinValue, long.MaxValue},
+                {typeof(ulong), ulong.MinValue, ulong.MaxValue}
             };
 
-        public static IEnumerable<object[]> RequestsWithLimitsToZeroRange =>
-            new[]
+        public static TheoryData<Type, IConvertible, IConvertible> RequestsWithLimitsToZeroRange =>
+            new TheoryData<Type, IConvertible, IConvertible>
             {
-                new object[] {typeof(float), float.MinValue, (float) 0},
-                new object[] {typeof(float), (float) 0, float.MaxValue},
+                {typeof(float), float.MinValue, (float) 0},
+                {typeof(float), (float) 0, float.MaxValue},
 
-                new object[] {typeof(double), double.MinValue, (double) 0},
-                new object[] {typeof(double), (double) 0, double.MaxValue},
+                {typeof(double), double.MinValue, (double) 0},
+                {typeof(double), (double) 0, double.MaxValue},
 
-                new object[] {typeof(decimal), decimal.MinValue, (decimal) 0},
-                new object[] {typeof(decimal), (decimal) 0, decimal.MaxValue},
+                {typeof(decimal), decimal.MinValue, (decimal) 0},
+                {typeof(decimal), (decimal) 0, decimal.MaxValue},
 
-                new object[] {typeof(sbyte), sbyte.MinValue, (sbyte) 0},
-                new object[] {typeof(sbyte), (sbyte) 0, sbyte.MaxValue},
-                new object[] {typeof(byte), (byte) 0, byte.MaxValue},
+                {typeof(sbyte), sbyte.MinValue, (sbyte) 0},
+                {typeof(sbyte), (sbyte) 0, sbyte.MaxValue},
+                {typeof(byte), (byte) 0, byte.MaxValue},
 
-                new object[] {typeof(short), short.MinValue, (short) 0},
-                new object[] {typeof(short), (short) 0, short.MaxValue},
-                new object[] {typeof(ushort), (ushort) 0, ushort.MaxValue},
+                {typeof(short), short.MinValue, (short) 0},
+                {typeof(short), (short) 0, short.MaxValue},
+                {typeof(ushort), (ushort) 0, ushort.MaxValue},
 
-                new object[] {typeof(int), int.MinValue, (int) 0},
-                new object[] {typeof(int), (int) 0, int.MaxValue},
-                new object[] {typeof(uint), (uint) 0, uint.MaxValue},
+                {typeof(int), int.MinValue, (int) 0},
+                {typeof(int), (int) 0, int.MaxValue},
+                {typeof(uint), (uint) 0, uint.MaxValue},
 
-                new object[] {typeof(long), long.MinValue, (long) 0},
-                new object[] {typeof(long), (long) 0, long.MaxValue},
-                new object[] {typeof(ulong), (ulong) 0, ulong.MaxValue}
+                {typeof(long), long.MinValue, (long) 0},
+                {typeof(long), (long) 0, long.MaxValue},
+                {typeof(ulong), (ulong) 0, ulong.MaxValue}
             };
 
-        public static IEnumerable<object[]> PairsOfDifferentIntegerTypes =>
-            new[]
+        public static TheoryData<Type, Type> PairsOfDifferentIntegerTypes =>
+            new TheoryData<Type, Type>
             {
-                new object[] {typeof(sbyte), typeof(int)},
-                new object[] {typeof(sbyte), typeof(byte)},
-                new object[] {typeof(sbyte), typeof(short)},
-                new object[] {typeof(sbyte), typeof(long)},
-                new object[] {typeof(sbyte), typeof(ulong)},
-                new object[] {typeof(sbyte), typeof(ushort)},
+                {typeof(sbyte), typeof(int)},
+                {typeof(sbyte), typeof(byte)},
+                {typeof(sbyte), typeof(short)},
+                {typeof(sbyte), typeof(long)},
+                {typeof(sbyte), typeof(ulong)},
+                {typeof(sbyte), typeof(ushort)},
 
-                new object[] {typeof(long), typeof(int)},
-                new object[] {typeof(long), typeof(byte)},
-                new object[] {typeof(long), typeof(short)},
-                new object[] {typeof(long), typeof(sbyte)},
-                new object[] {typeof(long), typeof(ushort)},
-                new object[] {typeof(long), typeof(uint)},
+                {typeof(long), typeof(int)},
+                {typeof(long), typeof(byte)},
+                {typeof(long), typeof(short)},
+                {typeof(long), typeof(sbyte)},
+                {typeof(long), typeof(ushort)},
+                {typeof(long), typeof(uint)},
 
 
-                new object[] {typeof(int), typeof(ulong)},
-                new object[] {typeof(int), typeof(byte)},
-                new object[] {typeof(int), typeof(short)},
-                new object[] {typeof(int), typeof(long)},
-                new object[] {typeof(int), typeof(ushort)},
-                new object[] {typeof(int), typeof(sbyte)},
+                {typeof(int), typeof(ulong)},
+                {typeof(int), typeof(byte)},
+                {typeof(int), typeof(short)},
+                {typeof(int), typeof(long)},
+                {typeof(int), typeof(ushort)},
+                {typeof(int), typeof(sbyte)},
 
-                new object[] {typeof(short), typeof(int)},
-                new object[] {typeof(short), typeof(byte)},
-                new object[] {typeof(short), typeof(ushort)},
-                new object[] {typeof(short), typeof(long)},
-                new object[] {typeof(short), typeof(sbyte)},
-                new object[] {typeof(short), typeof(ulong)},
+                {typeof(short), typeof(int)},
+                {typeof(short), typeof(byte)},
+                {typeof(short), typeof(ushort)},
+                {typeof(short), typeof(long)},
+                {typeof(short), typeof(sbyte)},
+                {typeof(short), typeof(ulong)},
 
-                new object[] {typeof(byte), typeof(int)},
-                new object[] {typeof(byte), typeof(short)},
-                new object[] {typeof(byte), typeof(sbyte)},
-                new object[] {typeof(byte), typeof(long)},
-                new object[] {typeof(byte), typeof(ushort)},
-                new object[] {typeof(byte), typeof(ulong)},
+                {typeof(byte), typeof(int)},
+                {typeof(byte), typeof(short)},
+                {typeof(byte), typeof(sbyte)},
+                {typeof(byte), typeof(long)},
+                {typeof(byte), typeof(ushort)},
+                {typeof(byte), typeof(ulong)},
 
-                new object[] {typeof(uint), typeof(int)},
-                new object[] {typeof(uint), typeof(short)},
-                new object[] {typeof(uint), typeof(sbyte)},
-                new object[] {typeof(uint), typeof(long)},
-                new object[] {typeof(uint), typeof(ulong)},
-                new object[] {typeof(uint), typeof(byte)},
+                {typeof(uint), typeof(int)},
+                {typeof(uint), typeof(short)},
+                {typeof(uint), typeof(sbyte)},
+                {typeof(uint), typeof(long)},
+                {typeof(uint), typeof(ulong)},
+                {typeof(uint), typeof(byte)}
             };
     }
 }

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -1,11 +1,8 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.Kernel;
 using Ploeh.AutoFixtureUnitTest.Kernel;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Ploeh.AutoFixtureUnitTest
 {
@@ -49,7 +46,54 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Theory, ClassData(typeof(RegexPatternTestCases))]
+        [Theory]
+        [InlineData("[ab]{4,6}")]
+        [InlineData("[ab]{4,6}c")]
+        [InlineData("(a|b)*ab")]
+        [InlineData("[A-Za-z0-9]")]
+        [InlineData("[A-Za-z0-9_]")]
+        [InlineData("[A-Za-z]")]
+        [InlineData("[ \t]")]
+        [InlineData(@"[(?<=\W)(?=\w)|(?<=\w)(?=\W)]")]
+        [InlineData("[\x00-\x1F\x7F]")]
+        [InlineData("[0-9]")]
+        [InlineData("[^0-9]")]
+        [InlineData("[\x21-\x7E]")]
+        [InlineData("[a-z]")]
+        [InlineData("[\x20-\x7E]")]
+        [InlineData("[ \t\r\n\v\f]")]
+        [InlineData("[^ \t\r\n\v\f]")]
+        [InlineData("[A-Z]")]
+        [InlineData("[A-Fa-f0-9]")]
+        [InlineData("in[du]")]
+        [InlineData("x[0-9A-Z]")]
+        [InlineData("[^A-M]in")]
+        [InlineData("W*in")]
+        [InlineData("[xX][0-9a-z]")]
+        [InlineData(@"\(\(\(ab\)*c\)*d\)\(ef\)*\(gh\)\{2\}\(ij\)*\(kl\)*\(mn\)*\(op\)*\(qr\)*")]
+        [InlineData(@"^[a-zA-Z0-9\-\.]+\.(com|org|net|mil|edu|COM|ORG|NET|MIL|EDU)$")]
+        [InlineData(@"((mailto\:|(news|(ht|f)tp(s?))\://){1}\S+)")]
+        [InlineData(@"^http\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$")]
+        [InlineData(@"(http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?")]
+        [InlineData(@"^(http|https|ftp)\://([a-zA-Z0-9\.\-]+(\:[a-zA-Z0-9\.&amp;%\$\-]+)*@)?((25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9])\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[0-9])|([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9\-]+\.[a-zA-Z]{2,4})(\:[0-9]+)?(/[^/][a-zA-Z0-9\.\,\?\'\\/\+&amp;%\$#\=~_\-@]*)*$")]
+        [InlineData(@"^([1-zA-Z0-1@.\s]{1,255})$")]
+        [InlineData("[A-Z][0-9A-Z]{10}")]
+        [InlineData("[A-Z][A-Za-z0-9]{10}")]
+        [InlineData("[A-Z][a-zA-Z0-9]{10}")]
+        [InlineData("[A-Za-z0-9]{11}")]
+        [InlineData("[A-Za-z]{11}")]
+        [InlineData(@"^[a-zA-Z''-'\s]{1,40}$")]
+        [InlineData(@"^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$")]
+        [InlineData(@"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$")]
+        [InlineData(@"\d{8}")]
+        [InlineData(@"\d{5}(-\d{4})?")]
+        [InlineData(@"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")]
+        [InlineData(@"^(?:[a-z0-9])+$")]
+        [InlineData(@"^(?i:[a-z0-9])+$")]
+        [InlineData(@"^(?s:[a-z0-9])+$")]
+        [InlineData(@"^(?m:[a-z0-9])+$")]
+        [InlineData(@"^(?n:[a-z0-9])+$")]
+        [InlineData(@"^(?x:[a-z0-9])+$")]
         public void CreateWithRegularExpressionRequestReturnsCorrectResult(string pattern)
         {
             // Fixture setup
@@ -63,7 +107,9 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Theory, ClassData(typeof(NotSupportedRegexPatternTestCases))]
+        [Theory]
+        [InlineData("[")]
+        [InlineData(@"(?\[Test\]|\[Foo\]|\[Bar\])?(?:-)?(?\[[()a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?")]
         public void CreateWithNotSupportedRegularExpressionRequestReturnsCorrectResult(string pattern)
         {
             // Fixture setup
@@ -75,79 +121,6 @@ namespace Ploeh.AutoFixtureUnitTest
             // Verify outcome
             Assert.Equal(new NoSpecimen(), result);
             // Teardown
-        }
-
-        private sealed class RegexPatternTestCases : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { "[ab]{4,6}" };
-                yield return new object[] { "[ab]{4,6}c" };
-                yield return new object[] { "(a|b)*ab" };
-                yield return new object[] { "[A-Za-z0-9]" };
-                yield return new object[] { "[A-Za-z0-9_]" };
-                yield return new object[] { "[A-Za-z]" };
-                yield return new object[] { "[ \t]" };
-                yield return new object[] { @"[(?<=\W)(?=\w)|(?<=\w)(?=\W)]" };
-                yield return new object[] { "[\x00-\x1F\x7F]" };
-                yield return new object[] { "[0-9]" };
-                yield return new object[] { "[^0-9]" };
-                yield return new object[] { "[\x21-\x7E]" };
-                yield return new object[] { "[a-z]" };
-                yield return new object[] { "[\x20-\x7E]" };
-                yield return new object[] { "[ \t\r\n\v\f]" };
-                yield return new object[] { "[^ \t\r\n\v\f]" };
-                yield return new object[] { "[A-Z]" };
-                yield return new object[] { "[A-Fa-f0-9]" };
-                yield return new object[] { "in[du]" };
-                yield return new object[] { "x[0-9A-Z]" };
-                yield return new object[] { "[^A-M]in" };
-                yield return new object[] { "W*in" };
-                yield return new object[] { "[xX][0-9a-z]" };
-                yield return new object[] { @"\(\(\(ab\)*c\)*d\)\(ef\)*\(gh\)\{2\}\(ij\)*\(kl\)*\(mn\)*\(op\)*\(qr\)*" };
-                yield return new object[] { @"^[a-zA-Z0-9\-\.]+\.(com|org|net|mil|edu|COM|ORG|NET|MIL|EDU)$" };
-                yield return new object[] { @"((mailto\:|(news|(ht|f)tp(s?))\://){1}\S+)" };
-                yield return new object[] { @"^http\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$" };
-                yield return new object[] { @"(http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?" };
-                yield return new object[] { @"^(http|https|ftp)\://([a-zA-Z0-9\.\-]+(\:[a-zA-Z0-9\.&amp;%\$\-]+)*@)?((25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9])\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[1-9]|0)\.(25[0-5]|2[0-4][0-9]|[0-1]{1}[0-9]{2}|[1-9]{1}[0-9]{1}|[0-9])|([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9\-]+\.[a-zA-Z]{2,4})(\:[0-9]+)?(/[^/][a-zA-Z0-9\.\,\?\'\\/\+&amp;%\$#\=~_\-@]*)*$" };
-                yield return new object[] { @"^([1-zA-Z0-1@.\s]{1,255})$" };
-                yield return new object[] { "[A-Z][0-9A-Z]{10}" };
-                yield return new object[] { "[A-Z][A-Za-z0-9]{10}" };
-                yield return new object[] { "[A-Z][a-zA-Z0-9]{10}" };
-                yield return new object[] { "[A-Za-z0-9]{11}" };
-                yield return new object[] { "[A-Za-z]{11}" };
-                yield return new object[] { @"^[a-zA-Z''-'\s]{1,40}$" };
-                yield return new object[] { @"^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$" };
-                yield return new object[] { @"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$" };
-                yield return new object[] { @"\d{8}" };
-                yield return new object[] { @"\d{5}(-\d{4})?" };
-                yield return new object[] { @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}" };
-                yield return new object[] { @"^(?:[a-z0-9])+$" };
-                yield return new object[] { @"^(?i:[a-z0-9])+$" };
-                yield return new object[] { @"^(?s:[a-z0-9])+$" };
-                yield return new object[] { @"^(?m:[a-z0-9])+$" };
-                yield return new object[] { @"^(?n:[a-z0-9])+$" };
-                yield return new object[] { @"^(?x:[a-z0-9])+$" };
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-        }
-
-        private sealed class NotSupportedRegexPatternTestCases : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { "[" };
-                yield return new object[] { @"(?\[Test\]|\[Foo\]|\[Bar\])?(?:-)?(?\[[()a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?" };
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
         }
     }
 }

--- a/Src/SemanticComparisonUnitTest/LikenessTest.cs
+++ b/Src/SemanticComparisonUnitTest/LikenessTest.cs
@@ -2078,7 +2078,7 @@ namespace Ploeh.SemanticComparison.UnitTest
         }
 
         [Theory]
-        [ClassData(typeof(PropertiesThatHaveNullValues))]
+        [MemberData(nameof(PropertiesThatHaveNullValues))]
         public void CreateProxyReturnsCorrectForSourceTypeWithNonNullPropertiesThatHaveNullProperties
                                                     (ConcreteType property1, AbstractType property2, byte property3)
         {
@@ -2152,39 +2152,41 @@ namespace Ploeh.SemanticComparison.UnitTest
             }
         }
 
-        private sealed class PropertiesThatHaveNullValues : IEnumerable<object[]>
+        public static TheoryData<ConcreteType, AbstractType, byte> PropertiesThatHaveNullValues
         {
-
-            public IEnumerator<object[]> GetEnumerator()
+            get
             {
-                yield return new object[] {  
-                    new ConcreteType(null,null),  
-                    new ConcreteType(null, null, null), (byte)12 };
+                string RandomString()
+                {
+                    return Guid.NewGuid().ToString();
+                }
 
-                yield return new object[] {  
-                    new ConcreteType(null, Guid.NewGuid().ToString()),  
-                    new ConcreteType(null, 2, RandomString()), (byte)12 };
-
-                yield return new object[] {  
-                    new ConcreteType(Guid.NewGuid().ToString(), null),  
-                    new ConcreteType(null, 2, RandomString()), (byte)12 };
-
-                yield return new object[] {  
-                    new ConcreteType(Guid.NewGuid().ToString(), null),  
-                    new CompositeType(null, 
-                                        new ConcreteType(null, null), 
-                                        new ConcreteType(RandomString(), null),
-                                        new ConcreteType(null, null)), (byte)12 };
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-
-            private string RandomString()
-            {
-                return Guid.NewGuid().ToString();
+                return new TheoryData<ConcreteType, AbstractType, byte>
+                {
+                    {
+                        new ConcreteType(null, null),
+                        new ConcreteType(null, null, null),
+                        12
+                    },
+                    {
+                        new ConcreteType(null, Guid.NewGuid().ToString()),
+                        new ConcreteType(null, 2, RandomString()),
+                        12
+                    },
+                    {
+                        new ConcreteType(Guid.NewGuid().ToString(), null),
+                        new ConcreteType(null, 2, RandomString()),
+                        12
+                    },
+                    {
+                        new ConcreteType(Guid.NewGuid().ToString(), null),
+                        new CompositeType(null,
+                            new ConcreteType(null, null),
+                            new ConcreteType(RandomString(), null),
+                            new ConcreteType(null, null)),
+                        12
+                    }
+                };
             }
         }
     }


### PR DESCRIPTION
Today I discovered the [`TheoryData<>`](https://stackoverflow.com/a/46051457/2009373) class inside the xUnit library. It provides us with awesome way to declare complex test data. Its syntax is very laconic and it guarantees the type safety.

I rewrote part of our unit tests to this mechanism and I like how it looks now.

@adamchester @moodmosaic Please take a look.