### PR TITLE
Add `IParameterCustomizationSource` interface and consume it in glue libraries

### DIFF
--- a/Src/AutoFixture.NUnit2.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/CustomizeAttributeTest.cs
@@ -27,5 +27,16 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             Assert.IsInstanceOf<Attribute>(sut);
             // Teardown
         }
+        
+        [Test]
+        public void SutImplementsIParameterCustomizationSource()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new DelegatingCustomizeAttribute();
+            // Verify outcome
+            Assert.IsInstanceOf<IParameterCustomizationSource>(sut);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
@@ -105,9 +105,8 @@ namespace Ploeh.AutoFixture.NUnit2
 
         private void CustomizeFixture(ParameterInfo p)
         {
-            var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy)
-                .OfType<CustomizeAttribute>()
+            var customizeAttributes = p.GetCustomAttributes()
+                .OfType<IParameterCustomizationSource>()
                 .OrderBy(x => x, new CustomizeAttributeComparer());
 
             foreach (var ca in customizeAttributes)

--- a/Src/AutoFixture.NUnit2/CustomizeAttribute.cs
+++ b/Src/AutoFixture.NUnit2/CustomizeAttribute.cs
@@ -8,7 +8,7 @@ namespace Ploeh.AutoFixture.NUnit2
     /// <see cref="AutoDataAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class CustomizeAttribute : Attribute
+    public abstract class CustomizeAttribute : Attribute, IParameterCustomizationSource
     {
         /// <summary>
         /// Gets a customization for a parameter.

--- a/Src/AutoFixture.NUnit2/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.NUnit2/CustomizeAttributeComparer.cs
@@ -2,9 +2,9 @@
 
 namespace Ploeh.AutoFixture.NUnit2
 {
-    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    internal class CustomizeAttributeComparer : Comparer<IParameterCustomizationSource>
     {
-        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        public override int Compare(IParameterCustomizationSource x, IParameterCustomizationSource y)
         {
             var xfrozen = x is FrozenAttribute;
             var yfrozen = y is FrozenAttribute;

--- a/Src/AutoFixture.NUnit3.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/CustomizeAttributeTest.cs
@@ -27,5 +27,16 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
             Assert.IsInstanceOf<Attribute>(sut);
             // Teardown
         }
+
+        [Test]
+        public void SutImplementsIParameterCustomizationSource()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new DelegatingCustomizeAttribute();
+            // Verify outcome
+            Assert.IsInstanceOf<IParameterCustomizationSource>(sut);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Ploeh.AutoFixture.NUnit3.UnitTest
@@ -31,7 +32,7 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
 
             var fixtureType = this.GetType();
 
-            var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod("DummyTestMethod"));
+            var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod(nameof(DummyTestMethod)));
             var testSuite = new TestSuite(fixtureType);
 
             // Act
@@ -62,6 +63,52 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
         /// </summary>
         public void DummyTestMethod(int anyInt, double anyDouble)
         {
+        }
+
+        private class TypeWithIParameterCustomizationSourceUsage
+        {
+            public void DecoratedMethod(int dummy, [CustomizationSourceAttribute] int customizedArg)
+            {
+            }
+
+            public class CustomizationSourceAttribute : Attribute, IParameterCustomizationSource
+            {
+                public ICustomization GetCustomization(ParameterInfo parameter)
+                {
+                    return new Customization();
+                }
+            }
+
+            public class Customization : ICustomization
+            {
+                public void Customize(IFixture fixture)
+                {
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldRecognizeAttributesImplementingIParameterCustomizationSource()
+        {
+            // Fixture setup
+            var method = new MethodWrapper(
+                typeof(TypeWithIParameterCustomizationSourceUsage),
+                nameof(TypeWithIParameterCustomizationSourceUsage.DecoratedMethod));
+
+            var customizationLog = new List<ICustomization>();
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = c =>
+            {
+                customizationLog.Add(c);
+                return fixture;
+            };
+            var sut = new InlineAutoDataAttributeStub(fixture, new[] {42});
+
+            // Exercise system
+            sut.BuildFrom(method, new TestSuite(this.GetType())).ToArray();
+            // Verify outcome
+            Assert.True(customizationLog[0] is TypeWithIParameterCustomizationSourceUsage.Customization);
+            // Teardown
         }
     }
 }

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -81,7 +81,8 @@ namespace Ploeh.AutoFixture.NUnit3
 
         private void CustomizeFixtureByParameter(IParameterInfo parameter)
         {
-            var customizeAttributes = parameter.GetCustomAttributes<CustomizeAttribute>(false)
+            var customizeAttributes = parameter.GetCustomAttributes<Attribute>(false)
+                .OfType<IParameterCustomizationSource>()
                 .OrderBy(x => x, new CustomizeAttributeComparer());
 
             foreach (var ca in customizeAttributes)

--- a/Src/AutoFixture.NUnit3/CustomizeAttribute.cs
+++ b/Src/AutoFixture.NUnit3/CustomizeAttribute.cs
@@ -11,7 +11,7 @@ namespace Ploeh.AutoFixture.NUnit3
     /// <see cref="AutoDataAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class CustomizeAttribute : Attribute
+    public abstract class CustomizeAttribute : Attribute, IParameterCustomizationSource
     {
         /// <summary>
         /// Gets a customization for a parameter.

--- a/Src/AutoFixture.NUnit3/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.NUnit3/CustomizeAttributeComparer.cs
@@ -2,9 +2,9 @@
 
 namespace Ploeh.AutoFixture.NUnit3
 {
-    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    internal class CustomizeAttributeComparer : Comparer<IParameterCustomizationSource>
     {
-        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        public override int Compare(IParameterCustomizationSource x, IParameterCustomizationSource y)
         {
             var xfrozen = x is FrozenAttribute;
             var yfrozen = y is FrozenAttribute;

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -112,7 +112,9 @@ namespace Ploeh.AutoFixture.NUnit3
 
         private void CustomizeFixtureByParameter(IParameterInfo parameter)
         {
-            var customizeAttributes = parameter.GetCustomAttributes<CustomizeAttribute>(false);
+            var customizeAttributes = parameter.GetCustomAttributes<Attribute>(false)
+                .OfType<IParameterCustomizationSource>();
+            
             foreach (var ca in customizeAttributes)
             {
                 var customization = ca.GetCustomization(parameter.ParameterInfo);

--- a/Src/AutoFixture.xUnit.net.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/CustomizeAttributeTest.cs
@@ -26,5 +26,16 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             Assert.IsAssignableFrom<Attribute>(sut);
             // Teardown
         }
+
+        [Fact]
+        public void SutImplementsIParameterCustomizationSource()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new DelegatingCustomizeAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<IParameterCustomizationSource>(sut);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
@@ -106,9 +106,8 @@ namespace Ploeh.AutoFixture.Xunit
 
         private void CustomizeFixture(ParameterInfo p)
         {
-            var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy)
-                .OfType<CustomizeAttribute>()
+            var customizeAttributes = p.GetCustomAttributes()
+                .OfType<IParameterCustomizationSource>()
                 .OrderBy(x => x, new CustomizeAttributeComparer());
 
             foreach (var ca in customizeAttributes)

--- a/Src/AutoFixture.xUnit.net/CustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/CustomizeAttribute.cs
@@ -8,7 +8,7 @@ namespace Ploeh.AutoFixture.Xunit
     /// <see cref="AutoDataAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class CustomizeAttribute : Attribute
+    public abstract class CustomizeAttribute : Attribute, IParameterCustomizationSource
     {
         /// <summary>
         /// Gets a customization for a parameter.

--- a/Src/AutoFixture.xUnit.net/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.xUnit.net/CustomizeAttributeComparer.cs
@@ -2,9 +2,9 @@
 
 namespace Ploeh.AutoFixture.Xunit
 {
-    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    internal class CustomizeAttributeComparer : Comparer<IParameterCustomizationSource>
     {
-        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        public override int Compare(IParameterCustomizationSource x, IParameterCustomizationSource y)
         {
             var xfrozen = x is FrozenAttribute;
             var yfrozen = y is FrozenAttribute;

--- a/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/AutoDataAttributeTest.cs
@@ -198,5 +198,50 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
             // Teardown
         }
+        
+        private class TypeWithIParameterCustomizationSourceUsage
+        {
+            public void DecoratedMethod([CustomizationSourceAttribute] int arg)
+            {
+            }
+
+            public class CustomizationSourceAttribute : Attribute, IParameterCustomizationSource
+            {
+                public ICustomization GetCustomization(ParameterInfo parameter)
+                {
+                    return new Customization();
+                }
+            }
+
+            public class Customization : ICustomization
+            {
+                public void Customize(IFixture fixture)
+                {
+                }
+            }
+        }
+
+        [Fact]
+        public void ShouldRecognizeAttributesImplementingIParameterCustomizationSource()
+        {
+            // Fixture setup
+            var method = typeof(TypeWithIParameterCustomizationSourceUsage)
+                .GetMethod(nameof(TypeWithIParameterCustomizationSourceUsage.DecoratedMethod));
+            
+            var customizationLog = new List<ICustomization>();
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = c =>
+            {
+                customizationLog.Add(c);
+                return fixture;
+            };
+            var sut = new DerivedAutoDataAttribute(fixture);
+            
+            // Exercise system
+            sut.GetData(method);
+            // Verify outcome
+            Assert.True(customizationLog[0] is TypeWithIParameterCustomizationSourceUsage.Customization);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/CustomizeAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/CustomizeAttributeTest.cs
@@ -26,5 +26,16 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             Assert.IsAssignableFrom<Attribute>(sut);
             // Teardown
         }
+        
+        [Fact]
+        public void SutImplementsIParameterCustomizationSource()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new DelegatingCustomizeAttribute();
+            // Verify outcome
+            Assert.IsAssignableFrom<IParameterCustomizationSource>(sut);
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
@@ -108,9 +108,8 @@ namespace Ploeh.AutoFixture.Xunit2
 
         private void CustomizeFixture(ParameterInfo p)
         {
-            var dummy = false;
-            var customizeAttributes = p.GetCustomAttributes(typeof(CustomizeAttribute), dummy)
-                .OfType<CustomizeAttribute>()
+            var customizeAttributes = p.GetCustomAttributes()
+                .OfType<IParameterCustomizationSource>()
                 .OrderBy(x => x, new CustomizeAttributeComparer());
 
             foreach (var ca in customizeAttributes)

--- a/Src/AutoFixture.xUnit.net2/CustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/CustomizeAttribute.cs
@@ -8,7 +8,7 @@ namespace Ploeh.AutoFixture.Xunit2
     /// <see cref="AutoDataAttribute"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = true)]
-    public abstract class CustomizeAttribute : Attribute
+    public abstract class CustomizeAttribute : Attribute, IParameterCustomizationSource
     {
         /// <summary>
         /// Gets a customization for a parameter.

--- a/Src/AutoFixture.xUnit.net2/CustomizeAttributeComparer.cs
+++ b/Src/AutoFixture.xUnit.net2/CustomizeAttributeComparer.cs
@@ -2,9 +2,9 @@
 
 namespace Ploeh.AutoFixture.Xunit2
 {
-    internal class CustomizeAttributeComparer : Comparer<CustomizeAttribute>
+    internal class CustomizeAttributeComparer : Comparer<IParameterCustomizationSource>
     {
-        public override int Compare(CustomizeAttribute x, CustomizeAttribute y)
+        public override int Compare(IParameterCustomizationSource x, IParameterCustomizationSource y)
         {
             var xfrozen = x is FrozenAttribute;
             var yfrozen = y is FrozenAttribute;

--- a/Src/AutoFixture/IParameterCustomizationSource.cs
+++ b/Src/AutoFixture/IParameterCustomizationSource.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    ///     Source of the <see cref="ICustomization" /> instances specific for the particular
+    ///     <see cref="ParameterInfo" /> parameter.
+    ///     The main clients of this interface might be glue libraries which provide support for the parameter specific
+    ///     customizations.
+    /// </summary>
+    public interface IParameterCustomizationSource
+    {
+        /// <summary>
+        ///     Gets a customization for a parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the customization is requested.</param>
+        /// <returns></returns>
+        ICustomization GetCustomization(ParameterInfo parameter);
+    }
+}


### PR DESCRIPTION
Closes #842.

Add the `IParameterCustomizationSource` interface to the AutoFixture library as discussed in #842. Additionally, I've modified all the test framework glue libraries to consume that interface and apply all the customization attributes for parameter that support this interface. The `CustomizeAttribute` in each glue library now implements this interface as it's only one of the interface clients (while it still the main extension point for the customers).

@adamchester @moodmosaic @ecampidoglio Please take a look and let me know if you have any concerns.