### PR TITLE
Fix and enable suppressed code analysis rules

### DIFF
--- a/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using FakeItEasy;
@@ -58,6 +59,8 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy
             }
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+            Justification = "It's activated via reflection.")]
         private class FakeMethod<T> : IMethod
         {
             private readonly IEnumerable<ParameterInfo> parameterInfos;

--- a/Src/AutoFakeItEasy2/FakeItEasyMethodQuery.cs
+++ b/Src/AutoFakeItEasy2/FakeItEasyMethodQuery.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using FakeItEasy;
@@ -59,6 +60,8 @@ namespace Ploeh.AutoFixture.AutoFakeItEasy2
             }
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+            Justification = "It's activated via reflection.")]
         private class FakeMethod<T> : IMethod
         {
             private readonly IEnumerable<ParameterInfo> parameterInfos;

--- a/Src/AutoFixture.NUnit2/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit2/FrozenAttribute.cs
@@ -21,7 +21,7 @@ namespace Ploeh.AutoFixture.NUnit2
         /// <remarks>
         /// The <see cref="Matching"/> criteria used to determine
         /// which requests will be satisfied by the frozen parameter value
-        /// is <see cref="F:Matching.ExactType"/>.
+        /// is <see cref="Matching.ExactType"/>.
         /// </remarks>
         public FrozenAttribute()
             : this(Matching.ExactType)

--- a/Src/AutoFixture.NUnit3/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit3/FrozenAttribute.cs
@@ -21,7 +21,7 @@ namespace Ploeh.AutoFixture.NUnit3
         /// <remarks>
         /// The <see cref="Matching"/> criteria used to determine
         /// which requests will be satisfied by the frozen parameter value
-        /// is <see cref="F:Matching.ExactType"/>.
+        /// is <see cref="Matching.ExactType"/>.
         /// </remarks>
         public FrozenAttribute()
             : this(Matching.ExactType)

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -114,7 +114,7 @@
     <Rule Id="CA1716" Action="Warning" />
     <Rule Id="CA1717" Action="Warning" />
     <Rule Id="CA1719" Action="Warning" />
-    <Rule Id="CA1720" Action="Info" />
+    <Rule Id="CA1720" Action="Warning" />
     <Rule Id="CA1721" Action="Info" />
     <Rule Id="CA1722" Action="Warning" />
     <Rule Id="CA1724" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -211,7 +211,7 @@
     <Rule Id="CA2219" Action="Warning" />
     <Rule Id="CA2220" Action="Warning" />
     <Rule Id="CA2221" Action="Warning" />
-    <Rule Id="CA2222" Action="Info" />
+    <Rule Id="CA2222" Action="Warning" />
     <Rule Id="CA2223" Action="Warning" />
     <Rule Id="CA2224" Action="Warning" />
     <Rule Id="CA2225" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -121,7 +121,7 @@
     <Rule Id="CA1725" Action="Warning" />
     <Rule Id="CA1726" Action="Warning" />
     <Rule Id="CA1800" Action="Warning" />
-    <Rule Id="CA1801" Action="Info" />
+    <Rule Id="CA1801" Action="Warning" />
     <Rule Id="CA1802" Action="Warning" />
     <Rule Id="CA1804" Action="Warning" />
     <Rule Id="CA1806" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -224,7 +224,7 @@
     <Rule Id="CA2232" Action="Warning" />
     <Rule Id="CA2233" Action="Warning" />
     <Rule Id="CA2234" Action="Warning" />
-    <Rule Id="CA2235" Action="Info" />
+    <Rule Id="CA2235" Action="Warning" />
     <Rule Id="CA2236" Action="Warning" />
     <Rule Id="CA2237" Action="Warning" />
     <Rule Id="CA2238" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -118,7 +118,7 @@
     <Rule Id="CA1721" Action="Warning" />
     <Rule Id="CA1722" Action="Warning" />
     <Rule Id="CA1724" Action="Warning" />
-    <Rule Id="CA1725" Action="Info" />
+    <Rule Id="CA1725" Action="Warning" />
     <Rule Id="CA1726" Action="Warning" />
     <Rule Id="CA1800" Action="Warning" />
     <Rule Id="CA1801" Action="Info" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -115,7 +115,7 @@
     <Rule Id="CA1717" Action="Warning" />
     <Rule Id="CA1719" Action="Warning" />
     <Rule Id="CA1720" Action="Warning" />
-    <Rule Id="CA1721" Action="Info" />
+    <Rule Id="CA1721" Action="Warning" />
     <Rule Id="CA1722" Action="Warning" />
     <Rule Id="CA1724" Action="Warning" />
     <Rule Id="CA1725" Action="Info" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -199,7 +199,7 @@
     <Rule Id="CA2205" Action="Warning" />
     <Rule Id="CA2207" Action="Warning" />
     <Rule Id="CA2208" Action="Warning" />
-    <Rule Id="CA2210" Action="None" />
+    <Rule Id="CA2210" Action="Warning" />
     <Rule Id="CA2211" Action="Warning" />
     <Rule Id="CA2212" Action="Warning" />
     <Rule Id="CA2213" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -68,11 +68,11 @@
     <Rule Id="CA1302" Action="Warning" />
     <Rule Id="CA1303" Action="Warning" />
     <Rule Id="CA1304" Action="Warning" />
-    <Rule Id="CA1305" Action="Info" />
+    <Rule Id="CA1305" Action="Warning" />
     <Rule Id="CA1306" Action="Warning" />
-    <Rule Id="CA1307" Action="Info" />
+    <Rule Id="CA1307" Action="Warning" />
     <Rule Id="CA1308" Action="Warning" />
-    <Rule Id="CA1309" Action="Info" />
+    <Rule Id="CA1309" Action="Warning" />
     <Rule Id="CA1400" Action="Warning" />
     <Rule Id="CA1401" Action="Warning" />
     <Rule Id="CA1402" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -35,7 +35,7 @@
     <Rule Id="CA1033" Action="Warning" />
     <Rule Id="CA1034" Action="Warning" />
     <Rule Id="CA1035" Action="Warning" />
-    <Rule Id="CA1036" Action="Info" />
+    <Rule Id="CA1036" Action="Warning" />
     <Rule Id="CA1038" Action="Warning" />
     <Rule Id="CA1039" Action="Warning" />
     <Rule Id="CA1040" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -128,7 +128,7 @@
     <Rule Id="CA1809" Action="Warning" />
     <Rule Id="CA1810" Action="Warning" />
     <Rule Id="CA1811" Action="Warning" />
-    <Rule Id="CA1812" Action="Info" />
+    <Rule Id="CA1812" Action="Warning" />
     <Rule Id="CA1813" Action="Warning" />
     <Rule Id="CA1814" Action="Warning" />
     <Rule Id="CA1815" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -12,7 +12,7 @@
     <Rule Id="CA1007" Action="Warning" />
     <Rule Id="CA1008" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />
-    <Rule Id="CA1010" Action="Info" />
+    <Rule Id="CA1010" Action="Warning" />
     <Rule Id="CA1011" Action="Warning" />
     <Rule Id="CA1012" Action="Warning" />
     <Rule Id="CA1013" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -16,7 +16,7 @@
     <Rule Id="CA1011" Action="Warning" />
     <Rule Id="CA1012" Action="Warning" />
     <Rule Id="CA1013" Action="Warning" />
-    <Rule Id="CA1014" Action="Info" />
+    <Rule Id="CA1014" Action="Warning" />
     <Rule Id="CA1016" Action="Warning" />
     <Rule Id="CA1017" Action="Warning" />
     <Rule Id="CA1018" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -103,7 +103,7 @@
     <Rule Id="CA1703" Action="Warning" />
     <Rule Id="CA1704" Action="Warning" />
     <Rule Id="CA1707" Action="Warning" />
-    <Rule Id="CA1708" Action="Info" />
+    <Rule Id="CA1708" Action="Warning" />
     <Rule Id="CA1709" Action="Warning" />
     <Rule Id="CA1710" Action="Warning" />
     <Rule Id="CA1711" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -242,6 +242,6 @@
     <Rule Id="RS0018" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="XmlDocumentationComments.Analyzers" RuleNamespace="XmlDocumentationComments.Analyzers">
-    <Rule Id="RS0010" Action="Info" />
+    <Rule Id="RS0010" Action="Warning" />
   </Rules>
 </RuleSet>

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -136,7 +136,7 @@
     <Rule Id="CA1819" Action="Warning" />
     <Rule Id="CA1820" Action="Warning" />
     <Rule Id="CA1821" Action="Warning" />
-    <Rule Id="CA1822" Action="Info" />
+    <Rule Id="CA1822" Action="Warning" />
     <Rule Id="CA1823" Action="Warning" />
     <Rule Id="CA1824" Action="Warning" />
     <Rule Id="CA1900" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -62,7 +62,7 @@
     <Rule Id="CA1062" Action="Warning" />
     <Rule Id="CA1063" Action="Warning" />
     <Rule Id="CA1064" Action="Warning" />
-    <Rule Id="CA1065" Action="Info" />
+    <Rule Id="CA1065" Action="Warning" />
     <Rule Id="CA1300" Action="Warning" />
     <Rule Id="CA1301" Action="Warning" />
     <Rule Id="CA1302" Action="Warning" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -236,7 +236,7 @@
     <Rule Id="CA5122" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
-    <Rule Id="CA1825" Action="Info" />
+    <Rule Id="CA1825" Action="None" />
   </Rules>
   <Rules AnalyzerId="System.Threading.Tasks.Analyzers" RuleNamespace="System.Threading.Tasks.Analyzers">
     <Rule Id="RS0018" Action="Info" />

--- a/Src/AutoFixture.ruleset
+++ b/Src/AutoFixture.ruleset
@@ -239,7 +239,7 @@
     <Rule Id="CA1825" Action="None" />
   </Rules>
   <Rules AnalyzerId="System.Threading.Tasks.Analyzers" RuleNamespace="System.Threading.Tasks.Analyzers">
-    <Rule Id="RS0018" Action="Info" />
+    <Rule Id="RS0018" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="XmlDocumentationComments.Analyzers" RuleNamespace="XmlDocumentationComments.Analyzers">
     <Rule Id="RS0010" Action="Info" />

--- a/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/FrozenAttribute.cs
@@ -21,7 +21,7 @@ namespace Ploeh.AutoFixture.Xunit
         /// <remarks>
         /// The <see cref="Matching"/> criteria used to determine
         /// which requests will be satisfied by the frozen parameter value
-        /// is <see cref="F:Matching.ExactType"/>.
+        /// is <see cref="Matching.ExactType"/>.
         /// </remarks>
         public FrozenAttribute()
             : this(Matching.ExactType)

--- a/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/FrozenAttribute.cs
@@ -21,7 +21,7 @@ namespace Ploeh.AutoFixture.Xunit2
         /// <remarks>
         /// The <see cref="Matching"/> criteria used to determine
         /// which requests will be satisfied by the frozen parameter value
-        /// is <see cref="F:Matching.ExactType"/>.
+        /// is <see cref="Matching.ExactType"/>.
         /// </remarks>
         public FrozenAttribute()
             : this(Matching.ExactType)

--- a/Src/AutoFixture/AutoPropertiesTarget.cs
+++ b/Src/AutoFixture/AutoPropertiesTarget.cs
@@ -89,7 +89,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         /// <seealso cref="GetEnumerator()" />

--- a/Src/AutoFixture/BehaviorRoot.cs
+++ b/Src/AutoFixture/BehaviorRoot.cs
@@ -89,7 +89,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         /// <seealso cref="GetEnumerator()" />

--- a/Src/AutoFixture/CurrentDateTimeCustomization.cs
+++ b/Src/AutoFixture/CurrentDateTimeCustomization.cs
@@ -3,12 +3,12 @@
 namespace Ploeh.AutoFixture
 {
     /// <summary>
-    /// A customization that enables DateTime specimens to be based on the current <see cref="P:DateTime.Now"/> value.
+    /// A customization that enables DateTime specimens to be based on the current <see cref="DateTime.Now"/> value.
     /// </summary>
     /// <remarks>
     /// <para>
     /// When this customization is added to an <see cref="IFixture"/> instance, requests for DateTime specimens
-    /// will be satisfied by returning the current <see cref="P:DateTime.Now"/> value.
+    /// will be satisfied by returning the current <see cref="DateTime.Now"/> value.
     /// </para>
     /// <para>
     /// This customization reproduces the generation strategy for DateTime specimens used in AutoFixture up to version 2.1.

--- a/Src/AutoFixture/CurrentDateTimeGenerator.cs
+++ b/Src/AutoFixture/CurrentDateTimeGenerator.cs
@@ -4,7 +4,7 @@ using Ploeh.AutoFixture.Kernel;
 namespace Ploeh.AutoFixture
 {
     /// <summary>
-    /// Creates new <see cref="DateTime"/> specimens based on the current <see cref="P:DateTime.Now"/> value.
+    /// Creates new <see cref="DateTime"/> specimens based on the current <see cref="DateTime.Now"/> value.
     /// </summary>
     public class CurrentDateTimeGenerator : ISpecimenBuilder
     {

--- a/Src/AutoFixture/CustomizationNode.cs
+++ b/Src/AutoFixture/CustomizationNode.cs
@@ -89,7 +89,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         /// <seealso cref="GetEnumerator()" />

--- a/Src/AutoFixture/DataAnnotations/BasicAutomata.cs
+++ b/Src/AutoFixture/DataAnnotations/BasicAutomata.cs
@@ -38,6 +38,12 @@ using System.Text;
 
 namespace Ploeh.AutoFixture.DataAnnotations
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider",
+        Justification = "This code has been copied from another project and is used as-is.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1309:Use ordinal stringcomparison",
+        Justification = "This code has been copied from another project and is used as-is.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison",
+        Justification = "This code has been copied from another project and is used as-is.")]
     internal static class BasicAutomata
     {
         /// <summary>

--- a/Src/AutoFixture/DataAnnotations/ListEqualityComparer.cs
+++ b/Src/AutoFixture/DataAnnotations/ListEqualityComparer.cs
@@ -67,7 +67,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is null.
         ///   </exception>
         public int GetHashCode(List<T> obj)
@@ -90,17 +90,17 @@ namespace Ploeh.AutoFixture.DataAnnotations
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="T:System.Object"/> is equal to the current
-        ///  <see cref="T:System.Object"/>.
+        /// Determines whether the specified <see cref="System.Object"/> is equal to the current
+        ///  <see cref="System.Object"/>.
         /// </summary>
         /// <returns>
-        /// true if the specified <see cref="T:System.Object"/> is equal to the current 
-        /// <see cref="T:System.Object"/>; otherwise, false.
+        /// true if the specified <see cref="System.Object"/> is equal to the current 
+        /// <see cref="System.Object"/>; otherwise, false.
         /// </returns>
-        /// <param name="obj">The <see cref="T:System.Object"/> to compare with the current 
-        /// <see cref="T:System.Object"/>. 
+        /// <param name="obj">The <see cref="System.Object"/> to compare with the current 
+        /// <see cref="System.Object"/>. 
         /// </param>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         /// </exception><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
@@ -127,7 +127,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// Serves as a hash function for a particular type. 
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// A hash code for the current <see cref="System.Object"/>.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()

--- a/Src/AutoFixture/DataAnnotations/RegExp.cs
+++ b/Src/AutoFixture/DataAnnotations/RegExp.cs
@@ -42,6 +42,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// <summary>
     /// Regular Expression extension to Automaton.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "This method has been ported as-is.")]
     internal sealed class RegExp
     {
         private readonly string b;

--- a/Src/AutoFixture/DataAnnotations/State.cs
+++ b/Src/AutoFixture/DataAnnotations/State.cs
@@ -41,6 +41,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
     /// <summary>
     /// <tt>Automaton</tt> state.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1036:Override methods on comparable types",
+        Justification = "This code has been copied from another project and is used as-is.")]
     internal sealed class State : IEquatable<State>, IComparable<State>
     {
         private static int nextId;

--- a/Src/AutoFixture/DataAnnotations/State.cs
+++ b/Src/AutoFixture/DataAnnotations/State.cs
@@ -104,16 +104,16 @@ namespace Ploeh.AutoFixture.DataAnnotations
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="T:System.Object"/> is equal to the current
-        ///  <see cref="T:System.Object"/>.
+        /// Determines whether the specified <see cref="System.Object"/> is equal to the current
+        ///  <see cref="System.Object"/>.
         /// </summary>
         /// <returns>
-        /// true if the specified <see cref="T:System.Object"/> is equal to the current
-        ///  <see cref="T:System.Object"/>; otherwise, false.
+        /// true if the specified <see cref="System.Object"/> is equal to the current
+        ///  <see cref="System.Object"/>; otherwise, false.
         /// </returns>
-        /// <param name="obj">The <see cref="T:System.Object"/> to compare with the current 
-        /// <see cref="T:System.Object"/>. 
-        ///                 </param><exception cref="T:System.NullReferenceException">
+        /// <param name="obj">The <see cref="System.Object"/> to compare with the current 
+        /// <see cref="System.Object"/>. 
+        ///                 </param><exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///                 </exception><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
@@ -140,7 +140,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// Serves as a hash function for a particular type. 
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// A hash code for the current <see cref="System.Object"/>.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()

--- a/Src/AutoFixture/DataAnnotations/StateEqualityComparer.cs
+++ b/Src/AutoFixture/DataAnnotations/StateEqualityComparer.cs
@@ -35,7 +35,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures
         /// like a hash table. 
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is null.
         ///   </exception>
         public int GetHashCode(State obj)

--- a/Src/AutoFixture/DataAnnotations/StatePair.cs
+++ b/Src/AutoFixture/DataAnnotations/StatePair.cs
@@ -133,16 +133,16 @@ namespace Ploeh.AutoFixture.DataAnnotations
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="T:System.Object"/> is equal to the current 
-        /// <see cref="T:System.Object"/>.
+        /// Determines whether the specified <see cref="System.Object"/> is equal to the current 
+        /// <see cref="System.Object"/>.
         /// </summary>
         /// <returns>
-        /// true if the specified <see cref="T:System.Object"/> is equal to the current
-        ///  <see cref="T:System.Object"/>; otherwise, false.
+        /// true if the specified <see cref="System.Object"/> is equal to the current
+        ///  <see cref="System.Object"/>; otherwise, false.
         /// </returns>
-        /// <param name="obj">The <see cref="T:System.Object"/> to compare with the current
-        ///  <see cref="T:System.Object"/>. 
-        ///                 </param><exception cref="T:System.NullReferenceException">The 
+        /// <param name="obj">The <see cref="System.Object"/> to compare with the current
+        ///  <see cref="System.Object"/>. 
+        ///                 </param><exception cref="System.NullReferenceException">The 
         /// <paramref name="obj"/> parameter is null.
         ///                 </exception><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
@@ -169,7 +169,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// Serves as a hash function for a particular type. 
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// A hash code for the current <see cref="System.Object"/>.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()

--- a/Src/AutoFixture/DataAnnotations/Transition.cs
+++ b/Src/AutoFixture/DataAnnotations/Transition.cs
@@ -43,6 +43,8 @@ namespace Ploeh.AutoFixture.DataAnnotations
     ///    and a destination state.
     ///  </p>
     ///</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Documentation", "RS0010: Avoid using cref tags with a prefix",
+        Justification = "This code has been copied from another project and is used as-is.")]
     internal sealed class Transition : IEquatable<Transition>
     {
         /// <summary>

--- a/Src/AutoFixture/DataAnnotations/TransitionComparer.cs
+++ b/Src/AutoFixture/DataAnnotations/TransitionComparer.cs
@@ -54,7 +54,7 @@ namespace Ploeh.AutoFixture.DataAnnotations
         /// <param name="t2">The second Transition.</param>
         /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", Justification = "This method has been ported as-is.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", Justification = "This method has been ported as-is.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "This code has been copied from another project and is used as-is.")]
         public int Compare(Transition t1, Transition t2)
         {
             if (this.toFirst)

--- a/Src/AutoFixture/DefaultEngineParts.cs
+++ b/Src/AutoFixture/DefaultEngineParts.cs
@@ -56,7 +56,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate
+        /// A <see cref="IEnumerator{T}"/> that can be used to iterate
         /// through the collection.
         /// </returns>
         public override IEnumerator<ISpecimenBuilder> GetEnumerator()

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -16,7 +16,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate
+        /// A <see cref="IEnumerator{T}"/> that can be used to iterate
         /// through the collection.
         /// </returns>
         public virtual IEnumerator<ISpecimenBuilder> GetEnumerator()
@@ -48,7 +48,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate
+        /// An <see cref="System.Collections.IEnumerator"/> object that can be used to iterate
         /// through the collection.
         /// </returns>
         IEnumerator IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/DefaultRelays.cs
+++ b/Src/AutoFixture/DefaultRelays.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using Ploeh.AutoFixture.DataAnnotations;
 using Ploeh.AutoFixture.Kernel;
 
 namespace Ploeh.AutoFixture
@@ -16,7 +15,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate
+        /// A <see cref="IEnumerator{T}"/> that can be used to iterate
         /// through the collection.
         /// </returns>
         public virtual IEnumerator<ISpecimenBuilder> GetEnumerator()
@@ -39,7 +38,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate
+        /// An <see cref="IEnumerator"/> object that can be used to iterate
         /// through the collection.
         /// </returns>
         IEnumerator IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/DictionaryFiller.cs
+++ b/Src/AutoFixture/DictionaryFiller.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Ploeh.AutoFixture.Kernel;
 using System.Linq;
 
@@ -61,6 +62,8 @@ namespace Ploeh.AutoFixture
             filler.Execute(specimen, context);
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+            Justification = "It's activated via reflection.")]
         private class Filler<TKey, TValue> : ISpecimenCommand
         {
             public void Execute(object specimen, ISpecimenContext context)

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -45,7 +45,7 @@ namespace Ploeh.AutoFixture
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; 
         /// otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -54,7 +54,7 @@ namespace Ploeh.AutoFixture
 
             if (other != null)
             {
-                return this.Domain.Equals(other.Domain);
+                return this.Domain.Equals(other.Domain, StringComparison.Ordinal);
             }
             return base.Equals(obj);
         }

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -443,7 +443,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -480,7 +480,7 @@ namespace Ploeh.AutoFixture.Dsl
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/EmailAddressLocalPart.cs
+++ b/Src/AutoFixture/EmailAddressLocalPart.cs
@@ -55,7 +55,7 @@ namespace Ploeh.AutoFixture
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; 
         /// otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/EmailAddressLocalPart.cs
+++ b/Src/AutoFixture/EmailAddressLocalPart.cs
@@ -63,7 +63,7 @@ namespace Ploeh.AutoFixture
             var other = obj as EmailAddressLocalPart;
             if (other != null)
             {
-                return this.LocalPart.Equals(other.LocalPart);
+                return this.LocalPart.Equals(other.LocalPart, StringComparison.Ordinal);
             }
 
             return base.Equals(obj);

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -79,6 +79,8 @@ namespace Ploeh.AutoFixture
             return enumerator;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1010:Collections should implement generic interface", 
+            Justification = "This is not a usual enumerable and for our purpose generic interface is not required.")]
         private class RoundRobinEnumEnumerable : IEnumerable
         {
             private readonly IEnumerable<object> values;

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -399,7 +399,7 @@ namespace Ploeh.AutoFixture
 
         /// <summary>Returns an enumerator that iterates through a collection.</summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.
+        /// An <see cref="IEnumerator{T}" /> object that can be used to iterate through the collection.
         /// </returns>
         /// <seealso cref="GetEnumerator()" />
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -91,7 +91,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
+++ b/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
@@ -59,7 +59,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Ploeh.AutoFixture.Kernel
@@ -59,6 +60,8 @@ namespace Ploeh.AutoFixture.Kernel
                 .Invoke(new[] {enumerable});
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+            Justification = "It's activated via reflection.")]
         private class ConvertedEnumerable<T> : IEnumerable<T>
         {
             private readonly IEnumerable<object> enumerable;

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Ploeh.AutoFixture.Kernel
 {
@@ -54,6 +55,8 @@ namespace Ploeh.AutoFixture.Kernel
         }
     }
 
+    [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", 
+        Justification = "It's activated via reflection.")]
     internal class EnumeratorRelay<T> : ISpecimenBuilder
     {
         public object Create(object request, ISpecimenContext context)

--- a/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
@@ -41,7 +41,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <see langword="true"/> if the specified <see cref="Object"/> is equal to this instance;
         /// otherwise, <see langword="false"/>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         /// </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/Kernel/GenericMethod.cs
+++ b/Src/AutoFixture/Kernel/GenericMethod.cs
@@ -83,7 +83,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (methodInfo.ContainsGenericParameters)
             {
                 var typeMap = arguments.Zip(methodInfo.GetParameters(),
-                (argument, parameter) => ResolveGenericType(GetType(argument), parameter.ParameterType))
+                (argument, parameter) => ResolveGenericType(GetArgumentTypeOrObjectType(argument), parameter.ParameterType))
                 .SelectMany(x => x)
                 .ToLookup(x => x.Item1, x => x.Item2);
 
@@ -102,7 +102,7 @@ namespace Ploeh.AutoFixture.Kernel
             return methodInfo;
         }
 
-        private static Type GetType(object argument)
+        private static Type GetArgumentTypeOrObjectType(object argument)
         {
             return argument == null ? typeof(object) : argument.GetType();
         }

--- a/Src/AutoFixture/Kernel/IllegalRequestException.cs
+++ b/Src/AutoFixture/Kernel/IllegalRequestException.cs
@@ -55,18 +55,18 @@ namespace Ploeh.AutoFixture.Kernel
         /// Initializes a new instance of the <see cref="IllegalRequestException"/> class.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// The <paramref name="info"/> parameter is null.
         /// </exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">
-        /// The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).
+        /// <exception cref="System.Runtime.Serialization.SerializationException">
+        /// The class name is null or <see cref="System.Exception.HResult"/> is zero (0).
         /// </exception>
         protected IllegalRequestException(SerializationInfo info, StreamingContext context)
             : base(info, context)

--- a/Src/AutoFixture/Kernel/InstanceMethod.cs
+++ b/Src/AutoFixture/Kernel/InstanceMethod.cs
@@ -63,7 +63,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <see langword="true"/> if the specified <see cref="System.Object"/> is equal to this
         /// instance; otherwise, <see langword="false"/>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         /// </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
+++ b/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
@@ -58,7 +58,7 @@ namespace Ploeh.AutoFixture.Kernel
             }
 
             return MemberInfoEqualityComparer.AreTypesRelated(x.DeclaringType, y.DeclaringType)
-                && x.Name == y.Name;
+                && string.Equals(x.Name, y.Name, StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
+++ b/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
@@ -75,10 +75,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// </exception>
         public int GetHashCode(MemberInfo obj)
         {
-            if (obj == null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
+            if (obj == null) return 0;
 
             if (obj.DeclaringType == null)
             {

--- a/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
+++ b/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
@@ -69,7 +69,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// A hash code for the supplied instance, suitable for use in hashing algorithms and data
         /// structures like a hash table. 
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is
         /// null.
         /// </exception>

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
@@ -42,7 +42,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/Kernel/ParameterScore.cs
+++ b/Src/AutoFixture/Kernel/ParameterScore.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 
 namespace Ploeh.AutoFixture.Kernel
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1036:Override methods on comparable types",
+        Justification = "This type implements IComparable to be sortable. It's used in limited number of places, so operators overload is not needed.")]
     internal class ParameterScore : IComparable<ParameterScore>
     {
         private readonly int score;
@@ -35,6 +37,16 @@ namespace Ploeh.AutoFixture.Kernel
             }
 
             return this.score.CompareTo(other.score);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.CompareTo(obj as ParameterScore) == 0;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.score.GetHashCode();
         }
 
         private static int CalculateScore(Type parentType, Type targetType, IEnumerable<ParameterInfo> parameters)

--- a/Src/AutoFixture/Kernel/Postprocessor.cs
+++ b/Src/AutoFixture/Kernel/Postprocessor.cs
@@ -97,7 +97,9 @@ namespace Ploeh.AutoFixture.Kernel
         {
             var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
             var pp = new Postprocessor(composedBuilder, this.Command, this.Specification);
-            pp.action = this.action;
+#pragma warning disable 618
+            pp.Action = this.Action;
+#pragma warning restore 618
             return pp;
         }
     }
@@ -109,7 +111,7 @@ namespace Ploeh.AutoFixture.Kernel
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
     public class Postprocessor<T> : ISpecimenBuilderNode
     {
-        internal Action<T, ISpecimenContext> action;
+        private Action<T, ISpecimenContext> action;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Postprocessor{T}"/> class with the
@@ -223,7 +225,8 @@ namespace Ploeh.AutoFixture.Kernel
         [Obsolete("Use the Command property instead.")]
         public Action<T, ISpecimenContext> Action
         {
-            get { return this.action; }
+            get => this.action;
+            internal set => this.action = value;
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/RangedNumberRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedNumberRequest.cs
@@ -66,7 +66,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
+++ b/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
@@ -33,7 +33,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
+++ b/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
@@ -72,7 +72,7 @@ namespace Ploeh.AutoFixture.Kernel
                 return false;
             }
 
-            return this.Pattern == other.Pattern;
+            return string.Equals(this.Pattern, other.Pattern, StringComparison.Ordinal);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/StaticMethod.cs
+++ b/Src/AutoFixture/Kernel/StaticMethod.cs
@@ -62,7 +62,7 @@ namespace Ploeh.AutoFixture.Kernel
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -91,9 +91,9 @@ namespace Ploeh.AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(type));
 
             return from method in type.GetTypeInfo().GetMethods()
-                   where method.Name == Template.Name && (Owner != null || method.IsStatic)
+                   where string.Equals(method.Name, this.Template.Name, StringComparison.Ordinal) && (this.Owner != null || method.IsStatic)
                    let methodParameters = method.GetParameters()
-                   let templateParameters = Template.GetParameters()
+                   let templateParameters = this.Template.GetParameters()
                    where methodParameters.Length >= templateParameters.Length
                    let score = new LateBindingParameterScore(methodParameters, templateParameters)
                    orderby score descending
@@ -109,7 +109,7 @@ namespace Ploeh.AutoFixture.Kernel
             if (method.IsStatic)
                 return new MissingParametersSupplyingStaticMethodFactory();
 
-            return new MissingParametersSupplyingMethodFactory(Owner);
+            return new MissingParametersSupplyingMethodFactory(this.Owner);
         }
 
         private bool Compare(Type parameterType, Type templateParameterType)

--- a/Src/AutoFixture/LazyRelay.cs
+++ b/Src/AutoFixture/LazyRelay.cs
@@ -1,9 +1,7 @@
 ﻿using Ploeh.AutoFixture.Kernel;
 using System;
 using System.Reflection;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Ploeh.AutoFixture
 {
@@ -52,6 +50,8 @@ namespace Ploeh.AutoFixture
             return builder.Create(context);
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+            Justification = "It's activated via reflection.")]
         private class LazyBuilder<T> : ILazyBuilder
         {
             public object Create(ISpecimenContext context)

--- a/Src/AutoFixture/ResidueCollectorNode.cs
+++ b/Src/AutoFixture/ResidueCollectorNode.cs
@@ -89,7 +89,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         /// <seealso cref="GetEnumerator()" />

--- a/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
+++ b/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
@@ -176,7 +176,7 @@ namespace Ploeh.AutoFixture
             this.UpdateGraph();
         }
 
-        /// <summary>Raises the <see cref="E:GraphChanged" /> event.</summary>
+        /// <summary>Raises the <see cref="GraphChanged" /> event.</summary>
         /// <param name="e">
         /// The <see cref="SpecimenBuilderNodeEventArgs" /> instance containing
         /// the event data.

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -389,7 +389,7 @@ namespace Ploeh.AutoFixture
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator" /> object that can
+        /// An <see cref="System.Collections.IEnumerator" /> object that can
         /// be used to iterate through the collection.
         /// </returns>
         /// <remarks>
@@ -434,7 +434,7 @@ namespace Ploeh.AutoFixture
             }
         }
 
-        /// <summary>Raises the <see cref="E:GraphChanged" /> event.</summary>
+        /// <summary>Raises the <see cref="GraphChanged" /> event.</summary>
         /// <param name="e">
         /// The <see cref="SpecimenBuilderNodeEventArgs" /> instance containing
         /// the event data.

--- a/Src/AutoFixture/UriScheme.cs
+++ b/Src/AutoFixture/UriScheme.cs
@@ -59,7 +59,7 @@ namespace Ploeh.AutoFixture
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; 
         /// otherwise, <c>false</c>.
         /// </returns>
-        /// <exception cref="T:System.NullReferenceException">
+        /// <exception cref="System.NullReferenceException">
         /// The <paramref name="obj"/> parameter is null.
         ///   </exception>
         public override bool Equals(object obj)

--- a/Src/AutoFixture/UriScheme.cs
+++ b/Src/AutoFixture/UriScheme.cs
@@ -104,7 +104,7 @@ namespace Ploeh.AutoFixture
                 return false;
             }
 
-            return this.Scheme.Equals(other.Scheme, StringComparison.CurrentCulture);
+            return this.Scheme.Equals(other.Scheme, StringComparison.Ordinal);
         }
 
         private static bool IsValid(string scheme)

--- a/Src/AutoFixtureUnitTest/Kernel/MemberInfoEqualityComparerTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MemberInfoEqualityComparerTest.cs
@@ -204,13 +204,13 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void StronglyTypedGetHashCodeWithNullSutThrows()
+        public void StronglyTypedGetHashCodeWithNullShouldNotThrowAsExceptionIsNotExpectedThere()
         {
             // Fixture setup
             var sut = new MemberInfoEqualityComparer();
             // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                sut.GetHashCode(null));
+            Assert.Null(Record.Exception(() =>
+                sut.GetHashCode(null)));
             // Teardown
         }
     }

--- a/Src/AutoMoq/AutoMockPropertiesCommand.cs
+++ b/Src/AutoMoq/AutoMockPropertiesCommand.cs
@@ -50,7 +50,8 @@ namespace Ploeh.AutoFixture.AutoMoq
 
             private static bool IsProxyMember(FieldInfo fi)
             {
-                return fi.Name == "__interceptors" || fi.Name == "__target";
+                return string.Equals(fi.Name, "__interceptors", StringComparison.Ordinal) ||
+                       string.Equals(fi.Name, "__target", StringComparison.Ordinal);
             }
         }
     }

--- a/Src/AutoMoq/MockPostprocessor.cs
+++ b/Src/AutoMoq/MockPostprocessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Moq;
 using Ploeh.AutoFixture.Kernel;
 
@@ -76,6 +77,8 @@ namespace Ploeh.AutoFixture.AutoMoq
             return m;
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses",
+            Justification = "It's activated via reflection.")]
         private class MockConfigurator<T> : IMockConfigurator where T : class
         {
             public void Configure(Mock mock)

--- a/Src/AutoMoq/MockSealedPropertiesCommand.cs
+++ b/Src/AutoMoq/MockSealedPropertiesCommand.cs
@@ -62,7 +62,7 @@ namespace Ploeh.AutoFixture.AutoMoq
             /// </summary>
             private static bool IsDynamicProxyMember(FieldInfo fi)
             {
-                return fi.Name == "__interceptors";
+                return string.Equals(fi.Name, "__interceptors", StringComparison.Ordinal);
             }
         }
     }

--- a/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
+++ b/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using NSubstitute;
@@ -46,6 +47,8 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             }
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", 
+            Justification = "It's activated via reflection.")]
         private class SubstituteMethod<T> : IMethod where T : class
         {
             private readonly IEnumerable<ParameterInfo> parameterInfos;

--- a/Src/AutoNSubstitute/NSubstituteSealedPropertiesCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteSealedPropertiesCommand.cs
@@ -64,8 +64,8 @@ namespace Ploeh.AutoFixture.AutoNSubstitute
             /// </summary>
             private static bool IsDynamicProxyMember(FieldInfo fi)
             {
-                return fi.Name == "__interceptors" || 
-                    fi.Name == "__mixin_NSubstitute_Core_ICallRouter";
+                return string.Equals(fi.Name, "__interceptors", StringComparison.Ordinal) ||
+                       string.Equals(fi.Name, "__mixin_NSubstitute_Core_ICallRouter", StringComparison.Ordinal);
             }
         }
     }

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -55,6 +55,7 @@
         <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
         <Optimize>true</Optimize>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
       </PropertyGroup>
     </When>
   </Choose>

--- a/Src/Idioms/ConstructorInitializedMemberAssertion.cs
+++ b/Src/Idioms/ConstructorInitializedMemberAssertion.cs
@@ -417,7 +417,7 @@ namespace Ploeh.AutoFixture.Idioms
                 {
                     if (x == null) throw new ArgumentNullException("x");
                     if (y == null) throw new ArgumentNullException("y");
-                    return x.Name.Equals(y.Name, StringComparison.CurrentCultureIgnoreCase)
+                    return x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase)
                            && x.Type == y.Type;
                 }
 

--- a/Src/Idioms/ConstructorInitializedMemberException.cs
+++ b/Src/Idioms/ConstructorInitializedMemberException.cs
@@ -15,7 +15,9 @@ namespace Ploeh.AutoFixture.Idioms
     [Serializable]
     public class ConstructorInitializedMemberException : Exception
     {
+        [NonSerialized]
         private readonly MemberInfo memberInfo;
+        [NonSerialized]
         private readonly ParameterInfo missingParameter;
 
         /// <summary>

--- a/Src/Idioms/ConstructorInitializedMemberException.cs
+++ b/Src/Idioms/ConstructorInitializedMemberException.cs
@@ -146,11 +146,11 @@ namespace Ploeh.AutoFixture.Idioms
         /// serialized data.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         protected ConstructorInitializedMemberException(SerializationInfo info, StreamingContext context)
@@ -201,14 +201,14 @@ namespace Ploeh.AutoFixture.Idioms
 
         /// <summary>
         /// Adds <see cref="PropertyInfo" /> to a
-        /// <see cref="T:System.Runtime.Serialization.SerializationInfo"/>.
+        /// <see cref="System.Runtime.Serialization.SerializationInfo"/>.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         [SecurityCritical]

--- a/Src/Idioms/CopyAndUpdateException.cs
+++ b/Src/Idioms/CopyAndUpdateException.cs
@@ -92,11 +92,11 @@ namespace Ploeh.AutoFixture.Idioms
         /// Initializes a new instance of the <see cref="CopyAndUpdateException"/> class.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         protected CopyAndUpdateException(SerializationInfo info, StreamingContext context)
@@ -126,14 +126,14 @@ namespace Ploeh.AutoFixture.Idioms
 
         /// <summary>
         /// Adds <see cref="PropertyInfo" /> to a
-        /// <see cref="T:System.Runtime.Serialization.SerializationInfo"/>.
+        /// <see cref="System.Runtime.Serialization.SerializationInfo"/>.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         [SecurityCritical]

--- a/Src/Idioms/CopyAndUpdateException.cs
+++ b/Src/Idioms/CopyAndUpdateException.cs
@@ -13,6 +13,15 @@ namespace Ploeh.AutoFixture.Idioms
     [Serializable]
     public class CopyAndUpdateException : Exception
     {
+        [NonSerialized]
+        private readonly MethodInfo methodInfo;
+
+        [NonSerialized]
+        private readonly MemberInfo memberWithInvalidValue;
+
+        [NonSerialized]
+        private ParameterInfo argumentWithNoMatchingPublicMember;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyAndUpdateException"/> class.
         /// </summary>
@@ -29,7 +38,7 @@ namespace Ploeh.AutoFixture.Idioms
         public CopyAndUpdateException(string message, MethodInfo methodInfo)
             : this(message)
         {
-            this.MethodInfo = methodInfo;
+            this.methodInfo = methodInfo;
         }
 
         /// <summary>
@@ -40,7 +49,7 @@ namespace Ploeh.AutoFixture.Idioms
         public CopyAndUpdateException(MethodInfo methodInfo, MemberInfo memberWithInvalidValue)
             : this(FormatMessageForMethodAndMember(methodInfo, memberWithInvalidValue), methodInfo)
         {
-            this.MemberWithInvalidValue = memberWithInvalidValue;
+            this.memberWithInvalidValue = memberWithInvalidValue;
         }
 
         /// <summary>
@@ -98,18 +107,22 @@ namespace Ploeh.AutoFixture.Idioms
         /// <summary>
         /// Gets the 'copy and update' method which is ill-behaved.
         /// </summary>
-        public MethodInfo MethodInfo { get; private set; }
+        public MethodInfo MethodInfo => this.methodInfo;
 
         /// <summary>
         /// Gets the member which was found to have an incorrect value.
         /// </summary>
-        public MemberInfo MemberWithInvalidValue { get; private set; }
+        public MemberInfo MemberWithInvalidValue => this.memberWithInvalidValue;
 
         /// <summary>
         /// Gets the argument of the 'copy and update' method for which no matching public
         /// member could be found.
         /// </summary>
-        public ParameterInfo ArgumentWithNoMatchingPublicMember { get; set; }
+        public ParameterInfo ArgumentWithNoMatchingPublicMember
+        {
+            get { return this.argumentWithNoMatchingPublicMember; }
+            set { this.argumentWithNoMatchingPublicMember = value; }
+        }
 
         /// <summary>
         /// Adds <see cref="PropertyInfo" /> to a

--- a/Src/Idioms/EqualsOverrideException.cs
+++ b/Src/Idioms/EqualsOverrideException.cs
@@ -47,11 +47,11 @@ namespace Ploeh.AutoFixture.Idioms
         /// Initializes a new instance of the <see cref="EqualsOverrideException"/> class.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         protected EqualsOverrideException(SerializationInfo info, StreamingContext context)

--- a/Src/Idioms/GetHashCodeOverrideException.cs
+++ b/Src/Idioms/GetHashCodeOverrideException.cs
@@ -48,11 +48,11 @@ namespace Ploeh.AutoFixture.Idioms
         /// Initializes a new instance of the <see cref="GetHashCodeOverrideException"/> class.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         protected GetHashCodeOverrideException(SerializationInfo info, StreamingContext context)

--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -202,10 +202,10 @@ namespace Ploeh.AutoFixture.Idioms
 
         private static bool IsMatched(MethodBase resolved, MethodBase method, AutoGenericType autoGenericType)
         {
-            return resolved.Name == method.Name &&
-                resolved.GetParameters()
-                    .Select(pi => pi.ParameterType)
-                    .SequenceEqual(autoGenericType.ResolveUnclosedParameterTypes(method.GetParameters()));
+            return string.Equals(resolved.Name, method.Name, StringComparison.Ordinal) &&
+                   resolved.GetParameters()
+                       .Select(pi => pi.ParameterType)
+                       .SequenceEqual(autoGenericType.ResolveUnclosedParameterTypes(method.GetParameters()));
         }
 
         private IMethod CreateMethod(MethodInfo methodInfo)
@@ -335,7 +335,7 @@ namespace Ploeh.AutoFixture.Idioms
                 ? new AutoGenericType(this.Builder, propertyInfo.ReflectedType)
                     .Value
                     .GetProperties()
-                    .Single(pi => pi.Name == propertyInfo.Name)
+                    .Single(pi => string.Equals(pi.Name, propertyInfo.Name, StringComparison.Ordinal))
                 : propertyInfo;
         }
 

--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -99,7 +99,7 @@ namespace Ploeh.AutoFixture.Idioms
             constructorInfo = this.ResolveUnclosedGenericType(constructorInfo);
 
             var method = new ConstructorMethod(constructorInfo);
-            this.Verify(method, false, false);
+            this.DoVerify(method, false, false);
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Ploeh.AutoFixture.Idioms
             var isReturnValueTask =
                 typeof(System.Threading.Tasks.Task).IsAssignableFrom(methodInfo.ReturnType);
 
-            this.Verify(method, isReturnValueDeferable, isReturnValueTask);
+            this.DoVerify(method, isReturnValueDeferable, isReturnValueTask);
         }
 
         private static bool IsNonDeferredEnumerable(Type t)
@@ -244,7 +244,7 @@ namespace Ploeh.AutoFixture.Idioms
             }
         }
 
-        private void Verify(IMethod method, bool isReturnValueDeferable, bool isReturnValueTask)
+        private void DoVerify(IMethod method, bool isReturnValueDeferable, bool isReturnValueTask)
         {
             if (isReturnValueDeferable)
                 VerifyDeferrableIterator(method);

--- a/Src/Idioms/GuardClauseException.cs
+++ b/Src/Idioms/GuardClauseException.cs
@@ -46,11 +46,11 @@ namespace Ploeh.AutoFixture.Idioms
         /// Initializes a new instance of the <see cref="GuardClauseException"/> class.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         protected GuardClauseException(SerializationInfo info, StreamingContext context)

--- a/Src/Idioms/MethodInfoExtensions.cs
+++ b/Src/Idioms/MethodInfoExtensions.cs
@@ -7,28 +7,28 @@ namespace Ploeh.AutoFixture.Idioms
     {
         internal static bool IsEqualsMethod(this MethodInfo method)
         {
-            return method.Name == "Equals"
-                && method.GetParameters().Length == 1
-                && method.ReturnType == typeof(bool);
+            return string.Equals(method.Name, "Equals", StringComparison.Ordinal)
+                   && method.GetParameters().Length == 1
+                   && method.ReturnType == typeof(bool);
         }
 
         internal static bool IsGetHashCodeMethod(this MethodInfo method)
         {
-            return method.Name == "GetHashCode"
-                && method.GetParameters().Length == 0
-                && method.ReturnType == typeof(int);
+            return string.Equals(method.Name, "GetHashCode", StringComparison.Ordinal)
+                   && method.GetParameters().Length == 0
+                   && method.ReturnType == typeof(int);
         }
 
         internal static bool IsToString(this MethodInfo method)
         {
-            return method.Name == "ToString"
+            return string.Equals(method.Name, "ToString", StringComparison.Ordinal)
                    && method.GetParameters().Length == 0
                    && method.ReturnType == typeof(string);
         }
 
         internal static bool IsGetType(this MethodInfo method)
         {
-            return method.Name == "GetType"
+            return string.Equals(method.Name, "GetType", StringComparison.Ordinal)
                    && method.GetParameters().Length == 0
                    && method.ReturnType == typeof(Type);
         }

--- a/Src/Idioms/NameAndType.cs
+++ b/Src/Idioms/NameAndType.cs
@@ -9,6 +9,7 @@ namespace Ploeh.AutoFixture.Idioms
     internal class NameAndType
     {
         public string Name { get; private set; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721:Property names should not match get methods", Justification = "It's fine to have the 'Type' property and we cannot re-use the GetType() method intead.")]
         public Type Type { get; private set; }
 
         public NameAndType(string name, Type type)

--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -52,7 +52,7 @@ namespace Ploeh.AutoFixture.Idioms
             }
             catch (ArgumentNullException e)
             {
-                if (e.ParamName == command.RequestedParameterName)
+                if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
                     return;
                 throw command.CreateException("null", e);
             }

--- a/Src/Idioms/ReflectionVisitorElementComparer.cs
+++ b/Src/Idioms/ReflectionVisitorElementComparer.cs
@@ -12,7 +12,7 @@ namespace Ploeh.AutoFixture.Idioms
     /// then comparing them using
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class ReflectionVisitorElementComparer<T> : IEqualityComparer<IReflectionElement>
+    internal abstract class ReflectionVisitorElementComparer<T> : IEqualityComparer<IReflectionElement>
     {
         private readonly IReflectionVisitor<IEnumerable<T>> visitor;
         private readonly IEqualityComparer<T> comparer;

--- a/Src/Idioms/WritablePropertyException.cs
+++ b/Src/Idioms/WritablePropertyException.cs
@@ -15,6 +15,7 @@ namespace Ploeh.AutoFixture.Idioms
     [Serializable]
     public class WritablePropertyException : Exception
     {
+        [NonSerialized]
         private readonly PropertyInfo propertyInfo;
 
         /// <summary>

--- a/Src/Idioms/WritablePropertyException.cs
+++ b/Src/Idioms/WritablePropertyException.cs
@@ -61,11 +61,11 @@ namespace Ploeh.AutoFixture.Idioms
         /// serialized data.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         protected WritablePropertyException(SerializationInfo info, StreamingContext context)
@@ -84,14 +84,14 @@ namespace Ploeh.AutoFixture.Idioms
 
         /// <summary>
         /// Adds <see cref="PropertyInfo" /> to a
-        /// <see cref="T:System.Runtime.Serialization.SerializationInfo"/>.
+        /// <see cref="System.Runtime.Serialization.SerializationInfo"/>.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
         [SecurityCritical]

--- a/Src/SemanticComparison/LikenessException.cs
+++ b/Src/SemanticComparison/LikenessException.cs
@@ -43,18 +43,18 @@ namespace Ploeh.SemanticComparison
         /// Initializes a new instance of the <see cref="LikenessException"/> class.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// The <paramref name="info"/> parameter is null.
         /// </exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">
-        /// The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).
+        /// <exception cref="System.Runtime.Serialization.SerializationException">
+        /// The class name is null or <see cref="Exception.HResult"/> is zero (0).
         /// </exception>
         protected LikenessException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             : base(info, context)

--- a/Src/SemanticComparison/MemberInfoNameComparer.cs
+++ b/Src/SemanticComparison/MemberInfoNameComparer.cs
@@ -33,10 +33,7 @@ namespace Ploeh.SemanticComparison
         /// </returns>
         public int GetHashCode(MemberInfo obj)
         {
-            if (obj == null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
+            if (obj == null) return 0;
 
             return obj.Name.GetHashCode();
         }

--- a/Src/SemanticComparison/ProxyCreationException.cs
+++ b/Src/SemanticComparison/ProxyCreationException.cs
@@ -41,18 +41,18 @@ namespace Ploeh.SemanticComparison
         /// Initializes a new instance of the <see cref="Ploeh.SemanticComparison.ProxyCreationException"/> class.
         /// </summary>
         /// <param name="info">
-        /// The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
         /// serialized object data about the exception being thrown.
         /// </param>
         /// <param name="context">
-        /// The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
         /// contextual information about the source or destination.
         /// </param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// The <paramref name="info"/> parameter is null.
         /// </exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">
-        /// The class name is null or <see cref="P:System.Exception.HResult"/> is zero (0).
+        /// <exception cref="System.Runtime.Serialization.SerializationException">
+        /// The class name is null or <see cref="Exception.HResult"/> is zero (0).
         /// </exception>
         protected ProxyCreationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             : base(info, context)

--- a/Src/SemanticComparison/ProxyGenerator.cs
+++ b/Src/SemanticComparison/ProxyGenerator.cs
@@ -485,6 +485,7 @@ namespace Ploeh.SemanticComparison
                 this.Value = value;
             }
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721:Property names should not match get methods", Justification = "It's fine to have the 'Type' property and we cannot re-use the GetType() method intead.")]
             public Type Type { get; }
             public object Value { get; }
         }

--- a/Src/SemanticComparison/ProxyGenerator.cs
+++ b/Src/SemanticComparison/ProxyGenerator.cs
@@ -416,7 +416,7 @@ namespace Ploeh.SemanticComparison
             foreach (FieldInfo fi in matchedTargetFields)
             {
                 var sourceField = sourceFields
-                    .Where(s => s.Name.Equals(fi.Name))
+                    .Where(s => s.Name.Equals(fi.Name, StringComparison.Ordinal))
                         .Concat(sourceFields
                             .Where(s => s.Match(fi)))
                     .FirstOrDefault();

--- a/Src/SemanticComparison/SemanticComparer.cs
+++ b/Src/SemanticComparison/SemanticComparer.cs
@@ -89,7 +89,7 @@ namespace Ploeh.SemanticComparison
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures 
         /// like a hash table. 
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is null.
         ///   </exception>
         public int GetHashCode(object obj)
@@ -121,7 +121,7 @@ namespace Ploeh.SemanticComparison
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures 
         /// like a hash table. 
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is null.
         ///   </exception>
         int IEqualityComparer.GetHashCode(object obj)

--- a/Src/SemanticComparisonUnitTest/MemberInfoNameComparerTest.cs
+++ b/Src/SemanticComparisonUnitTest/MemberInfoNameComparerTest.cs
@@ -75,13 +75,13 @@ namespace Ploeh.SemanticComparison.UnitTest
         }
 
         [Fact]
-        public void GetHashCodeOfNullSutThrows()
+        public void GetHashCodeOfNullSutShouldNotThrowAsExceptionIsNotExpectedThere()
         {
             // Fixture setup
             var sut = new MemberInfoNameComparer();
             // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                sut.GetHashCode(null));
+            Assert.Null(Record.Exception(() =>
+                sut.GetHashCode(null)));
             // Teardown
         }
     }


### PR DESCRIPTION
Closes #797.

Reviewed all the previously suppressed warnings, fixed them and enabled. It was quite a long way though..

I've fixed and enabled almost all of the warnings and disabled only 3 ones:
- CA1825:Avoid zero-length array allocations - The API it suggests to use is only available since .NET 4.6.
- CA2243: Attribute string literals should parse correctly - It's a [false positive](https://connect.microsoft.com/VisualStudio/feedback/details/796535/the-ca2243-rule-attribute-string-literals-should-parse-correctly-should-not-be-applied-to-assemblyinformationalversionattrubute) and it prevents us from writing the arbitrary data to the `AssemblyInformationalVersion` attribute (sha of commit in our case) which is absolutely legal.
- CA1006: Do not nest generic types in member signatures - It was previously suppressed so I decided to not touch. It seems like a false positive in most cases as it mostly fails on `Expression<Func<T>>`. 

@adamchester @moodmosaic Please take a look 🐴I'd recommend to go commit by commit as it would be simpler to see what exactly I changed for which exact rule.