### PR TITLE
[Housekeeping] Remove snk file path from build scripts as that's no longer needed

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -15,7 +15,6 @@ let nuGetPackages = !! (nuGetOutputFolder </> "*.nupkg" )
                     -- (nuGetOutputFolder </> "*.symbols.nupkg")
                     // Currently AutoFakeItEasy2 has been deprecated and is not being published to the feeds.
                     -- (nuGetOutputFolder </> "AutoFixture.AutoFakeItEasy2.*" )
-let signKeyPath = FullName "Src/AutoFixture.snk"
 let solutionToBuild = "Src/All.sln"
 let configuration = getBuildParamOrDefault "BuildConfiguration" "Release"
 let bakFileExt = ".orig"
@@ -166,8 +165,7 @@ let runMsBuild target configuration properties =
                                         | false -> "false"
 
     let properties = configProperty @ properties
-                     @ [ "AssemblyOriginatorKeyFile", signKeyPath
-                         "AssemblyVersion", buildVersion.assemblyVersion
+                     @ [ "AssemblyVersion", buildVersion.assemblyVersion
                          "FileVersion", buildVersion.fileVersion
                          "InformationalVersion", buildVersion.infoVersion
                          "PackageVersion", buildVersion.nugetVersion


### PR DESCRIPTION
Currently snk file path is specified in csproj files (via `Common.props`), so it's not required to pass it from the build scripts.