### PR TITLE
Add tests and impl for a random DateTimeOffset generator

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Kernel\TypeRelay.cs" />
     <Compile Include="OmitOnRecursionBehavior.cs" />
     <Compile Include="RandomCharSequenceGenerator.cs" />
+    <Compile Include="RandomDateTimeOffsetSequenceGenerator.cs" />
     <Compile Include="RandomDateTimeSequenceGenerator.cs" />
     <Compile Include="RandomBooleanSequenceCustomization.cs" />
     <Compile Include="RandomNumericSequenceCustomization.cs" />

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -40,6 +40,7 @@ namespace Ploeh.AutoFixture
             yield return new MailAddressGenerator();
             yield return new EmailAddressLocalPartGenerator();
             yield return new DomainNameGenerator();
+            yield return new RandomDateTimeOffsetSequenceGenerator();
         }
 
         /// <summary>

--- a/Src/AutoFixture/RandomDateTimeOffsetSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateTimeOffsetSequenceGenerator.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Ploeh.AutoFixture.Kernel;
+
+namespace Ploeh.AutoFixture
+{
+    /// <summary>
+    /// Creates random <see cref="DateTimeOffset"/> specimens.
+    /// </summary>
+    /// <remarks>
+    /// The generated <see cref="DateTimeOffset"/> UTC values will be within
+    /// a range of ± two years from today's date,
+    /// unless a different range has been specified in the constructor.
+    /// </remarks>
+    public class RandomDateTimeOffsetSequenceGenerator : ISpecimenBuilder
+    {
+        private readonly RandomDateTimeSequenceGenerator _dateRandomizer;
+        private readonly RandomNumericSequenceGenerator _offsetRandomizer;
+
+        // Offsets have a maximum ± of 14hrs...
+        private static long MinutesInFourteenHours = 840L;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RandomDateTimeOffsetSequenceGenerator"/> class.
+        /// </summary>
+        public RandomDateTimeOffsetSequenceGenerator()
+            : this(DateTimeOffset.Now.AddYears(-2), DateTimeOffset.Now.AddYears(2))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RandomDateTimeOffsetSequenceGenerator"/> class
+        /// for a specific range of dates.
+        /// </summary>
+        /// <param name="minDate">The lower bound of the date range.</param>
+        /// <param name="maxDate">The upper bound of the date range.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="minDate"/> is greater than <paramref name="maxDate"/>.
+        /// </exception>
+        public RandomDateTimeOffsetSequenceGenerator(DateTimeOffset minDate, DateTimeOffset maxDate)
+        {
+            if (minDate >= maxDate)
+            {
+                throw new ArgumentException("The 'minDate' argument must be less than the 'maxDate'.");
+            }
+
+            _dateRandomizer = new RandomDateTimeSequenceGenerator(minDate.ToUniversalTime().DateTime, maxDate.ToUniversalTime().DateTime);
+            _offsetRandomizer = new RandomNumericSequenceGenerator(MinutesInFourteenHours * -1, MinutesInFourteenHours);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DateTimeOffset"/> specimen based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">Not used.</param>
+        /// <returns>
+        /// A new <see cref="DateTimeOffset"/> specimen, if <paramref name="request"/> is a request for a
+        /// <see cref="DateTimeOffset"/> value; otherwise, a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return IsNotDateTimeOffsetRequest(request)
+                ? new NoSpecimen()
+                : CreateRandomDate(context);
+        }
+
+        private static bool IsNotDateTimeOffsetRequest(object request)
+        {
+            return !typeof(DateTimeOffset).IsAssignableFrom(request as Type);
+        }
+
+        private object CreateRandomDate(ISpecimenContext context)
+        {
+            // This ensures that the date/time falls within the specified range
+            var utcDto = new DateTimeOffset(GetRandomNumberOfTicks(context), TimeSpan.Zero);
+            // This then applies a randomly generated offset
+            return utcDto.ToOffset(GetRandomOffset(context));
+        }
+
+        private TimeSpan GetRandomOffset(ISpecimenContext context)
+        {
+            return new TimeSpan((long)_offsetRandomizer.Create(typeof(long), context) * TimeSpan.TicksPerMinute);
+        }
+
+        private DateTime GetRandomNumberOfTicks(ISpecimenContext context)
+        {
+            return (DateTime)this._dateRandomizer.Create(typeof(DateTime), context);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -187,6 +187,7 @@
     <Compile Include="MarkerNode.cs" />
     <Compile Include="ProvidedAttribute.cs" />
     <Compile Include="RandomCharSequenceGeneratorTest.cs" />
+    <Compile Include="RandomDateTimeOffsetSequenceGeneratorTest.cs" />
     <Compile Include="RandomDateTimeSequenceGeneratorTest.cs" />
     <Compile Include="RandomBooleanSequenceCustomizationTest.cs" />
     <Compile Include="RandomNumericSequenceCustomizationTest.cs" />

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -45,7 +45,8 @@ namespace Ploeh.AutoFixtureUnitTest
                     typeof(IntPtrGuard),
                     typeof(MailAddressGenerator),
                     typeof(EmailAddressLocalPartGenerator),
-                    typeof(DomainNameGenerator)
+                    typeof(DomainNameGenerator),
+                    typeof(RandomDateTimeOffsetSequenceGenerator)
                  };
             // Exercise system
             var sut = new DefaultPrimitiveBuilders();

--- a/Src/AutoFixtureUnitTest/RandomDateTimeOffsetSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomDateTimeOffsetSequenceGeneratorTest.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Linq;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Ploeh.AutoFixtureUnitTest.Kernel;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Ploeh.AutoFixtureUnitTest
+{
+    public class RandomDateTimeOffsetSequenceGeneratorTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithInvertedDateRangeThrowsArgumentException()
+        {
+            // Fixture setup
+            var minDate = DateTimeOffset.Now;
+            var maxDate = minDate.AddDays(3);
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentException>(
+                () => new RandomDateTimeOffsetSequenceGenerator(maxDate, minDate));
+            // Teardown
+        }
+
+        [Fact]
+        public void InitializeWithEmptyDateRangeThrowsArgumentException()
+        {
+            // Fixture setup
+            var date = DateTimeOffset.Now;
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentException>(
+                () => new RandomDateTimeOffsetSequenceGenerator(date, date));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullRequestReturnsNoSpecimen()
+        {
+            // Fixture setup
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = sut.Create(null, dummyContainer);
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(), result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrowsArgumentNullException()
+        {
+            // Fixture setup
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(
+                () => sut.Create(typeof(DateTimeOffset), null));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(default(int))]
+        [InlineData(default(bool))]
+        public void CreateWithNonTypeRequestReturnsNoSpecimen(object request)
+        {
+            // Fixture setup
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = sut.Create(request, dummyContainer);
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(), result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(bool))]
+        public void CreateWithNonDateTimeTypeRequestReturnsNoSpecimen(Type request)
+        {
+            // Fixture setup
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = sut.Create(request, dummyContainer);
+            // Verify outcome
+            Assert.Equal(new NoSpecimen(), result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithDateTimeOffsetRequestReturnsDateTimeOffsetValue()
+        {
+            // Fixture setup
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = sut.Create(typeof(DateTimeOffset), dummyContainer);
+            // Verify outcome
+            Assert.IsAssignableFrom<DateTimeOffset>(result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithDateTimeOffsetRequestReturnsADateWithinARangeOfPlusMinusTwoYearsFromToday()
+        {
+            // Fixture setup
+            var twoYearsAgo = DateTimeOffset.UtcNow.AddYears(-2);
+            var twoYearsForward = DateTimeOffset.UtcNow.AddYears(2);
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = (DateTimeOffset)sut.Create(typeof(DateTimeOffset), dummyContainer);
+            // Verify outcome
+            Assert.InRange(result, twoYearsAgo, twoYearsForward);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithMultipleDateTimeOffsetRequestsReturnsDifferentDates()
+        {
+            // Fixture setup
+            const int requestCount = 10;
+            var times = Enumerable.Range(1, requestCount);
+            var sut = new RandomDateTimeOffsetSequenceGenerator();
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var results = times
+                .Select(t => sut.Create(typeof(DateTimeOffset), dummyContainer))
+                .Cast<DateTimeOffset>();
+            // Verify outcome
+            Assert.Equal(requestCount, results.Distinct().Count());
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateWithDateTimeOffsetRequestAndDateRangeReturnsDateWithinThatRange()
+        {
+            // Fixture setup
+            var minDate = DateTimeOffset.UtcNow;
+            var maxDate = minDate.AddDays(3);
+            var sut = new RandomDateTimeOffsetSequenceGenerator(minDate, maxDate);
+            // Exercise system
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = (DateTimeOffset)sut.Create(typeof(DateTimeOffset), dummyContainer);
+            // Verify outcome
+            Assert.InRange(result.ToUniversalTime(), minDate, maxDate);
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
This generator is based on the existing RandomDateTimeSequenceGenerator.
By randomly setting the offset you are able to ensure you are dealing
correctly with data from different time zones.

We (On The Beach) needed to generate DateTimeOffsets to test some of our
code. We have been using this generator for a while now, and in cleaning
up our code-base decided it was time to contribute this back.

Thanks for the great tool!