### PR TITLE
Sort customization attributes for InlineAutoData for NUnit3

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
@@ -57,6 +57,38 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
             Assert.AreSame(expectedArguments, result);
             // Teardown
         }
+        
+        [TestCase("CreateWithFrozenAndFavorArrays")]
+        [TestCase("CreateWithFavorArraysAndFrozen")]
+        [TestCase("CreateWithFrozenAndFavorEnumerables")]
+        [TestCase("CreateWithFavorEnumerablesAndFrozen")]
+        [TestCase("CreateWithFrozenAndFavorLists")]
+        [TestCase("CreateWithFavorListsAndFrozen")]
+        [TestCase("CreateWithFrozenAndGreedy")]
+        [TestCase("CreateWithGreedyAndFrozen")]
+        [TestCase("CreateWithFrozenAndModest")]
+        [TestCase("CreateWithModestAndFrozen")]
+        [TestCase("CreateWithFrozenAndNoAutoProperties")]
+        [TestCase("CreateWithNoAutoPropertiesAndFrozen")]
+        public void GetDataOrdersCustomizationAttributes(string methodName)
+        {
+            // Fixture setup
+            var method = new MethodWrapper(typeof(TypeWithCustomizationAttributes), methodName);
+            var customizationLog = new List<ICustomization>();
+            var fixture = new DelegatingFixture();
+            fixture.OnCustomize = c =>
+            {
+                customizationLog.Add(c);
+                return fixture;
+            };
+            var sut = new InlineAutoDataAttributeStub(fixture);
+            // Exercise system
+            sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
+            // Verify outcome
+            Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
+            Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
+            // Teardown
+        }
 
         /// <summary>
         /// This is used in BuildFromYieldsParameterValues for building a unit test method

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -113,8 +113,9 @@ namespace Ploeh.AutoFixture.NUnit3
         private void CustomizeFixtureByParameter(IParameterInfo parameter)
         {
             var customizeAttributes = parameter.GetCustomAttributes<Attribute>(false)
-                .OfType<IParameterCustomizationSource>();
-            
+                .OfType<IParameterCustomizationSource>()
+                .OrderBy(x => x, new CustomizeAttributeComparer());
+
             foreach (var ca in customizeAttributes)
             {
                 var customization = ca.GetCustomization(parameter.ParameterInfo);


### PR DESCRIPTION
Fixes #854.

It seems that we simply overlooked this scenario as `InlineAutoData` differs between NUnit and xUnit integrations.

@moodmosaic @adamchester Please take a look 😉