### PR TITLE
[NUnit3] Make `FixedNameTestMethodBuilder` the default strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ Notice how we can reduce unit tests to state only the relevant parts of the test
 
 Using AutoFixture is as easy as referencing the library and creating a new instance of the Fixture class!
 
-#### NUnit3 Known Issue
-You might need to change the test name strategy for compatibility with specific test runners. Read more about that [on our wiki](https://github.com/AutoFixture/AutoFixture/wiki/Known-Issues#test-name-strategies-for-nunit3).
-
 ## .NET platforms compatibility table
 
 | Product            | .NET Framework            | .NET Standard            |

--- a/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesTest.cs
@@ -17,7 +17,7 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
             var sut = new AutoDataAttribute();
             // Verify outcome
             Assert.That(sut.TestMethodBuilder,
-                Is.TypeOf<VolatileNameTestMethodBuilder>());
+                Is.TypeOf<FixedNameTestMethodBuilder>());
             // Teardown
         }
 
@@ -29,7 +29,7 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
             var sut = new InlineAutoDataAttribute();
             // Verify outcome
             Assert.That(sut.TestMethodBuilder,
-                Is.TypeOf<VolatileNameTestMethodBuilder>());
+                Is.TypeOf<FixedNameTestMethodBuilder>());
             // Teardown
         }
 

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.NUnit3
     {
         private readonly IFixture _fixture;
 
-        private ITestMethodBuilder _testMethodBuilder = new VolatileNameTestMethodBuilder();
+        private ITestMethodBuilder _testMethodBuilder = new FixedNameTestMethodBuilder();
         /// <summary>
         /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.
         /// </summary>

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -20,7 +20,7 @@ namespace Ploeh.AutoFixture.NUnit3
         private readonly object[] _existingParameterValues;
         private readonly IFixture _fixture;
 
-        private ITestMethodBuilder _testMethodBuilder = new VolatileNameTestMethodBuilder();
+        private ITestMethodBuilder _testMethodBuilder = new FixedNameTestMethodBuilder();
         
         /// <summary>
         /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.


### PR DESCRIPTION
Closes #862.

In this PR I make the `FixedNameTestMethodBuilder` strategy (recently introduced in #709) the default one. The reason behind that is to support the VS and NCrunch test runners out-of-the-box if user uses `AutoData` and `InlineAutoData` attributes and NUnit3.

The cons is that this strategy makes it a bit harder to troubleshoot if particular test failed:
Test name before: `SomeTest(42,"autogeneratedstring")`
Test name after: `SomeTest(auto<Int32>,auto<String>)`

Now we show the placeholders instead of actual values. If the particular test fails, you cannot look on the test input to understand why that happened. Rather, you need to rely on the [assertion methods output](https://github.com/AutoFixture/AutoFixture/issues/670#issuecomment-235198841), which not actually so bad..

I think that being able to work with all the runners by default is more important, than potentially decreased diagnostic opportunities. If user doesn't like how it works now, he could switch the name strategy back by following [the described approach](https://github.com/AutoFixture/AutoFixture/wiki/Known-Issues#test-name-strategies-for-nunit3).

@moodmosaic @adamchester Please let me know what you think about that.