### PR TITLE
Depend on `xunit.extensibility.core` as it's suggested by xUnit docs

### DIFF
--- a/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
+++ b/Src/AutoFixture.xUnit.net2/AutoFixture.xUnit.net2.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.core" Version="[2.0.0,3.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
-    <PackageReference Include="xunit.core" Version="[2.2.0,3.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
+    <PackageReference Include="xunit.extensibility.core" Version="[2.0.0,3.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="xunit.extensibility.core" Version="[2.2.0,3.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #867.

Changing the dependency for xUnit 2 glue library to `xunit.extensibility.core`. See more detail in the referenced issue.

@moodmosaic @adamchester Please take a look. Decided that this not a housekeeping as I change the package dependency 😅