### PR TITLE
Add null guards for request and context in fixture.Create()

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -381,6 +381,9 @@ namespace Ploeh.AutoFixture
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
+            if (request == null) throw new ArgumentNullException(nameof(request));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
             return this.graph.Create(request, context);
         }
 

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6108,6 +6108,32 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
+        [Fact]
+        public void Issue871_FailsWithArgumentExceptionForNullRequest()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            var specimenContext = new DelegatingSpecimenContext();
+
+            // Exercise system and Verify outcome
+            Assert.Throws<ArgumentNullException>(() => sut.Create(null, specimenContext));
+
+            // Teardown
+        }
+
+        [Fact]
+        public void Issue871_FailsWithArgumentExceptionForNullRequestContext()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            var request = new object();
+
+            // Exercise system and Verify outcome
+            Assert.Throws<ArgumentNullException>(() => sut.Create(request, null));
+
+            // Teardown
+        }
+
 #if SYSTEM_NET_MAIL
         [Fact]
         public void CreateAnonymousWithMailAddressReturnsValidResult()


### PR DESCRIPTION
Fixes #871.

Given that we failed in v3 as well, it seems that we don't support `null` for requests, so I added a guard for fast fail.

@adamchester @moodmosaic Please review 😉