### PR TITLE
Make fixture creation lazy in AutoData attributes

### DIFF
--- a/Src/AutoFixture.NUnit2.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoDataAttributeTest.cs
@@ -28,9 +28,27 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             // Fixture setup
             var sut = new AutoDataAttribute();
             // Exercise system
+#pragma warning disable 618
             IFixture result = sut.Fixture;
+#pragma warning restore 618
             // Verify outcome
             Assert.IsAssignableFrom<Fixture>(result);
+            // Teardown
+        }
+        
+        [Test]
+        public void InitializedWithFixtureFactoryConstrucorHasCorrectFixture()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+            
+            // Exercise system
+            var sut = new DerivedAutoDataAttribute(() => fixture);
+            
+            // Verify outcome
+#pragma warning disable 618
+            Assert.AreSame(fixture, sut.Fixture);
+#pragma warning restore 618
             // Teardown
         }
 
@@ -39,8 +57,39 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         {
             // Fixture setup
             // Exercise system and verify outcome
+#pragma warning disable 612
             Assert.Throws<ArgumentNullException>(() =>
                 new DerivedAutoDataAttribute((IFixture)null));
+#pragma warning restore 612
+            // Teardown
+        }
+        
+        [Test]
+        public void InitializeWithNullFixtureFactoryThrows()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new DerivedAutoDataAttribute((Func<IFixture>) null));
+            // Teardown
+        }
+
+        [Test]
+        public void FixtureFactoryIsNotInvokedImmediately()
+        {
+            // Fixture setup
+            bool wasInvoked = false;
+            Func<IFixture> fixtureFactory = () =>
+            {
+                wasInvoked = true;
+                return null;
+            };
+
+            // Exercise system
+            var sut = new DerivedAutoDataAttribute(fixtureFactory);
+            
+            // Verify outcome
+            Assert.False(wasInvoked);
             // Teardown
         }
 
@@ -49,9 +98,13 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
         {
             // Fixture setup
             var expectedComposer = new DelegatingFixture();
+#pragma warning disable 612
             var sut = new DerivedAutoDataAttribute(expectedComposer);
+#pragma warning restore 612
             // Exercise system
+#pragma warning disable 618
             var result = sut.Fixture;
+#pragma warning restore 618
             // Verify outcome
             Assert.AreEqual(expectedComposer, result);
             // Teardown
@@ -158,20 +211,12 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
             };
             var composer = new DelegatingFixture { OnCreate = builder.OnCreate };
 
-            var sut = new DerivedAutoDataAttribute(composer);
+            var sut = new DerivedAutoDataAttribute(() => composer);
             // Exercise system
             var result = sut.GetData(method);
             // Verify outcome
             Assert.True(new[] { expectedResult }.SequenceEqual(result.Single()));
             // Teardown
-        }
-
-        private class DerivedAutoDataAttribute : AutoDataAttribute
-        {
-            public DerivedAutoDataAttribute(IFixture fixture)
-               : base(fixture)
-            {
-            }
         }
 
         [TestCase("CreateWithFrozenAndFavorArrays")]
@@ -197,7 +242,7 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
                 customizationLog.Add(c);
                 return fixture;
             };
-            var sut = new DerivedAutoDataAttribute(fixture);
+            var sut = new DerivedAutoDataAttribute(() => fixture);
             // Exercise system
             sut.GetData(method);
             // Verify outcome
@@ -242,13 +287,27 @@ namespace Ploeh.AutoFixture.NUnit2.UnitTest
                 customizationLog.Add(c);
                 return fixture;
             };
-            var sut = new DerivedAutoDataAttribute(fixture);
+            var sut = new DerivedAutoDataAttribute(() => fixture);
             
             // Exercise system
             sut.GetData(method);
             // Verify outcome
             Assert.True(customizationLog[0] is TypeWithIParameterCustomizationSourceUsage.Customization);
             // Teardown
+        }
+        
+        private class DerivedAutoDataAttribute : AutoDataAttribute
+        {
+            [Obsolete]
+            public DerivedAutoDataAttribute(IFixture fixture)
+                : base(fixture)
+            {
+            }
+
+            public DerivedAutoDataAttribute(Func<IFixture> fixtureFactory)
+                : base(fixtureFactory)
+            {
+            }
         }
     }
 }

--- a/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Ploeh.AutoFixture.NUnit2.Addins;
 using Ploeh.AutoFixture.Kernel;
 
@@ -17,7 +18,7 @@ namespace Ploeh.AutoFixture.NUnit2
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class AutoDataAttribute : DataAttribute
     {
-        private readonly IFixture _fixture;
+        private readonly Lazy<IFixture> fixtureLazy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoDataAttribute"/> class.
@@ -29,7 +30,7 @@ namespace Ploeh.AutoFixture.NUnit2
         /// </para>
         /// </remarks>
         public AutoDataAttribute()
-            : this(new Fixture())
+            : this(() => new Fixture())
         {
         }
 
@@ -53,6 +54,8 @@ namespace Ploeh.AutoFixture.NUnit2
         /// supplied <see cref="IFixture"/>.
         /// </summary>
         /// <param name="fixture">The fixture.</param>
+        [Obsolete("This constructor overload is deprecated as it ins't performance efficient and will be removed in a future version. " +
+                  "Please use the AutoDataAttribute(Func<IFixture> fixtureFactory) overload, so fixture will be constructed only if needed.")]
         protected AutoDataAttribute(IFixture fixture)
         {
             if (fixture == null)
@@ -60,15 +63,30 @@ namespace Ploeh.AutoFixture.NUnit2
                 throw new ArgumentNullException("fixture");
             }
 
-            _fixture = fixture;
+            this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoDataAttribute"/> class
+        /// with the supplised <paramref name="fixtureFactory"/>. Fixture will be created
+        /// on demand using the provided factory.
+        /// </summary>
+        /// <param name="fixtureFactory">The fixture factory used to construct the fixture.</param>
+        protected AutoDataAttribute(Func<IFixture> fixtureFactory)
+        {
+            if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
+            
+            this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
         }
 
         /// <summary>
         /// Gets the fixture used by <see cref="GetData"/> to create specimens.
         /// </summary>
+        [Obsolete("Fixture is created lazily for the performance efficiency, so this property is deprecated as it activates the fixture immediately. " +
+                  "If you need to customize the fixture, do that in the factory method passed to the constructor.")]
         public IFixture Fixture
         {
-            get { return _fixture; }
+            get { return this.fixtureLazy.Value; }
         }
 
         /// <summary>
@@ -77,7 +95,9 @@ namespace Ploeh.AutoFixture.NUnit2
         [Obsolete("This property is deprecated and will be removed in a future version of AutoFixture. Please use Fixture.GetType() instead.")]
         public Type FixtureType
         {
-            get { return Fixture.GetType(); }
+#pragma warning disable 618
+            get { return this.Fixture.GetType(); }
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -113,13 +133,17 @@ namespace Ploeh.AutoFixture.NUnit2
             foreach (var ca in customizeAttributes)
             {
                 var c = ca.GetCustomization(p);
-                Fixture.Customize(c);
+#pragma warning disable 618
+                this.Fixture.Customize(c);
+#pragma warning restore 618
             }
         }
 
         private object Resolve(ParameterInfo p)
         {
-            var context = new SpecimenContext(Fixture);
+#pragma warning disable 618
+            var context = new SpecimenContext(this.Fixture);
+#pragma warning restore 618
             return context.Resolve(p);
         }
 

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoDataAttributeStub.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoDataAttributeStub.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ploeh.AutoFixture.NUnit3.UnitTest
 {
     /// <summary>
@@ -5,8 +7,14 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
     /// </summary>
     public class AutoDataAttributeStub : AutoDataAttribute
     {
+        [Obsolete]
         public AutoDataAttributeStub(IFixture fixture)
             : base(fixture)
+        {
+        }
+
+        public AutoDataAttributeStub(Func<IFixture> fixtureFactory)
+            : base(fixtureFactory)
         {
         }
     }

--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeStub.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeStub.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ploeh.AutoFixture.NUnit3.UnitTest
 {
     /// <summary>
@@ -5,8 +7,14 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
     /// </summary>
     public class InlineAutoDataAttributeStub : InlineAutoDataAttribute
     {
+        [Obsolete]
         public InlineAutoDataAttributeStub(IFixture fixture, params object[] arguments)
             : base(fixture, arguments)
+        {
+        }
+
+        public InlineAutoDataAttributeStub(Func<IFixture> fixtureFactory, params object[] arguments)
+            : base(fixtureFactory, arguments)
         {
         }
     }

--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
@@ -20,15 +20,47 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
         [Test]
         public void IfExtendedWithNullFixtureThenThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new InlineAutoDataAttributeStub(null));
+#pragma warning disable 612
+            Assert.Throws<ArgumentNullException>(() => new InlineAutoDataAttributeStub((IFixture)null));
+#pragma warning restore 612
         }
+        
+        [Test]
+        public void InitializeWithNullFixtureFactoryThrows()
+        {
+            // Fixture setup
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new AutoDataAttributeStub((Func<IFixture>) null));
+            // Teardown
+        }
+        
+        [Test]
+        public void FixtureFactoryIsNotInvokedImmediately()
+        {
+            // Fixture setup
+            bool wasInvoked = false;
+            Func<IFixture> fixtureFactory = () =>
+            {
+                wasInvoked = true;
+                return null;
+            };
+
+            // Exercise system
+            var sut = new AutoDataAttributeStub(fixtureFactory);
+            
+            // Verify outcome
+            Assert.False(wasInvoked);
+            // Teardown
+        }
+        
 
         [Test]
         public void IfCreateParametersThrowsExceptionThenReturnsNotRunnableTestMethodWithExceptionInfoAsSkipReason()
         {
             // Arrange
             // DummyFixture is set up to throw DummyException when invoked by AutoDataAttribute
-            var inlineAutoDataAttributeStub = new InlineAutoDataAttributeStub(new ThrowingStubFixture());
+            var inlineAutoDataAttributeStub = new InlineAutoDataAttributeStub(() => new ThrowingStubFixture());
 
             var fixtureType = this.GetType();
 
@@ -43,6 +75,30 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
 
             Assert.That(testMethod.Properties.Get(PropertyNames.SkipReason),
                 Is.EqualTo(ExceptionHelper.BuildMessage(new ThrowingStubFixture.DummyException())));
+        }
+        
+        [Test]
+        public void BuildFromDontActivateFixtureIfArgsValuesAreNotUsedByTestBuilder()
+        {
+            // Fixture setup
+            bool wasActivated = false;
+            
+            var sut = new AutoDataAttributeStub(() =>
+            {
+                wasActivated = true;
+                return null;
+            });
+            sut.TestMethodBuilder = new TestMethodBuilderWithoutParametersUsage();
+            
+            var methodWrapper = new MethodWrapper(this.GetType(), nameof(this.DummyTestMethod));
+            var testSuite = new TestSuite(this.GetType());
+            
+            // Excercise system
+            var dummy = sut.BuildFrom(methodWrapper, testSuite).ToArray();
+
+            // Verify outcome
+            Assert.IsFalse(wasActivated);
+            // Teardown
         }
 
         [Test]
@@ -81,7 +137,7 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
                 customizationLog.Add(c);
                 return fixture;
             };
-            var sut = new InlineAutoDataAttributeStub(fixture);
+            var sut = new InlineAutoDataAttributeStub(() => fixture);
             // Exercise system
             sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
             // Verify outcome
@@ -95,6 +151,15 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
         /// </summary>
         public void DummyTestMethod(int anyInt, double anyDouble)
         {
+        }
+        
+        private class TestMethodBuilderWithoutParametersUsage: ITestMethodBuilder
+        {
+            public TestMethod Build(
+                IMethodInfo method, Test suite, IEnumerable<object> parameterValues, int autoDataStartIndex)
+            {
+                return new TestMethod(method);
+            }
         }
 
         private class TypeWithIParameterCustomizationSourceUsage
@@ -134,7 +199,7 @@ namespace Ploeh.AutoFixture.NUnit3.UnitTest
                 customizationLog.Add(c);
                 return fixture;
             };
-            var sut = new InlineAutoDataAttributeStub(fixture, new[] {42});
+            var sut = new InlineAutoDataAttributeStub(() => fixture, new[] {42});
 
             // Exercise system
             sut.BuildFrom(method, new TestSuite(this.GetType())).ToArray();

--- a/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesFixture.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesFixture.cs
@@ -21,7 +21,7 @@
 
         public class AutoDataVolatileNameAttribute : AutoDataAttribute
         {
-            public AutoDataVolatileNameAttribute() : base(CreateFixtureWithInjectedValues())
+            public AutoDataVolatileNameAttribute() : base(CreateFixtureWithInjectedValues)
             {
                 TestMethodBuilder = new VolatileNameTestMethodBuilder();
             }
@@ -39,7 +39,7 @@
         public class InlineAutoDataVolatileNameAttribute : InlineAutoDataAttribute
         {
             public InlineAutoDataVolatileNameAttribute(params object[] arguments) 
-                : base(CreateFixtureWithInjectedValues(), arguments)
+                : base(CreateFixtureWithInjectedValues, arguments)
             {
                 TestMethodBuilder = new VolatileNameTestMethodBuilder();
             }

--- a/Src/AutoFixture.xUnit.net.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/InlineAutoDataAttributeTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Extensions;
@@ -123,12 +124,39 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
             // Teardown
         }
 
+        [Fact]
+        public void DoesntActivateFixtureImmediately()
+        {
+            // Fixture setup
+            bool wasInvoked = false;
+            var autoData = new DerivedAutoDataAttribute(() =>
+            {
+                wasInvoked = true;
+                return null;
+            });
+
+            // Exercise system
+            var sut = new DerivedInlineAutoDataAttribute(autoData);
+
+            // Verify outcome
+            Assert.False(wasInvoked);
+            // Teardown
+        }
+
         private class DerivedInlineAutoDataAttribute : InlineAutoDataAttribute
         {
             public DerivedInlineAutoDataAttribute(
                 AutoDataAttribute autoDataAttribute,
                 params object[] values)
                 : base(autoDataAttribute, values)
+            {
+            }
+        }
+
+        private class DerivedAutoDataAttribute : AutoDataAttribute
+        {
+            public DerivedAutoDataAttribute(Func<IFixture> fixtureFactory)
+                : base(fixtureFactory)
             {
             }
         }

--- a/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/Scenario.cs
@@ -92,7 +92,7 @@ namespace Ploeh.AutoFixture.Xunit.UnitTest
         private class MyCustomAutoDataAttribute : AutoDataAttribute
         {
             public MyCustomAutoDataAttribute() :
-                base(new Fixture().Customize(new TheAnswer()))
+                base(() => new Fixture().Customize(new TheAnswer()))
             {
             }
 

--- a/Src/AutoFixture.xUnit.net2.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/InlineAutoDataAttributeTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Sdk;
@@ -122,6 +123,26 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
             Assert.Equal(expected, result);
             // Teardown
         }
+        
+        
+        [Fact]
+        public void DoesntActivateFixtureImmediately()
+        {
+            // Fixture setup
+            bool wasInvoked = false;
+            var autoData = new DerivedAutoDataAttribute(() =>
+            {
+                wasInvoked = true;
+                return null;
+            });
+
+            // Exercise system
+            var sut = new DerivedInlineAutoDataAttribute(autoData);
+
+            // Verify outcome
+            Assert.False(wasInvoked);
+            // Teardown
+        }
 
         private class DerivedInlineAutoDataAttribute : InlineAutoDataAttribute
         {
@@ -129,6 +150,14 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
                 AutoDataAttribute autoDataAttribute,
                 params object[] values)
                 : base(autoDataAttribute, values)
+            {
+            }
+        }
+        
+        private class DerivedAutoDataAttribute : AutoDataAttribute
+        {
+            public DerivedAutoDataAttribute(Func<IFixture> fixtureFactory)
+                : base(fixtureFactory)
             {
             }
         }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/Scenario.cs
@@ -93,7 +93,7 @@ namespace Ploeh.AutoFixture.Xunit2.UnitTest
         private class MyCustomAutoDataAttribute : AutoDataAttribute
         {
             public MyCustomAutoDataAttribute() :
-                base(new Fixture().Customize(new TheAnswer()))
+                base(() => new Fixture().Customize(new TheAnswer()))
             {
             }
 

--- a/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Ploeh.AutoFixture.Kernel;
 using Xunit.Sdk;
 
@@ -20,7 +21,7 @@ namespace Ploeh.AutoFixture.Xunit2
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class AutoDataAttribute : DataAttribute
     {
-        private readonly IFixture fixture;
+        private readonly Lazy<IFixture> fixtureLazy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoDataAttribute"/> class.
@@ -32,7 +33,7 @@ namespace Ploeh.AutoFixture.Xunit2
         /// </para>
         /// </remarks>
         public AutoDataAttribute()
-            : this(new Fixture())
+            : this(() => new Fixture())
         {
         }
 
@@ -56,6 +57,8 @@ namespace Ploeh.AutoFixture.Xunit2
         /// supplied <see cref="IFixture"/>.
         /// </summary>
         /// <param name="fixture">The fixture.</param>
+        [Obsolete("This constructor overload is deprecated as it ins't performance efficient and will be removed in a future version. " +
+                  "Please use the AutoDataAttribute(Func<IFixture> fixtureFactory) overload, so fixture will be constructed only if needed.")]
         protected AutoDataAttribute(IFixture fixture)
         {
             if (fixture == null)
@@ -63,15 +66,30 @@ namespace Ploeh.AutoFixture.Xunit2
                 throw new ArgumentNullException("fixture");
             }
 
-            this.fixture = fixture;
+            this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutoDataAttribute"/> class
+        /// with the supplised <paramref name="fixtureFactory"/>. Fixture will be created
+        /// on demand using the provided factory.
+        /// </summary>
+        /// <param name="fixtureFactory">The fixture factory used to construct the fixture.</param>
+        protected AutoDataAttribute(Func<IFixture> fixtureFactory)
+        {
+            if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
+
+            this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
         }
 
         /// <summary>
         /// Gets the fixture used by <see cref="GetData"/> to create specimens.
         /// </summary>
+        [Obsolete("Fixture is created lazily for the performance efficiency, so this property is deprecated as it activates the fixture immediately. " +
+                  "If you need to customize the fixture, do that in the factory method passed to the constructor.")]
         public IFixture Fixture
         {
-            get { return this.fixture; }
+            get { return this.fixtureLazy.Value; }
         }
 
         /// <summary>
@@ -80,7 +98,9 @@ namespace Ploeh.AutoFixture.Xunit2
         [Obsolete("This property is deprecated and will be removed in a future version of AutoFixture. Please use Fixture.GetType() instead.")]
         public Type FixtureType
         {
+#pragma warning disable 618
             get { return this.Fixture.GetType(); }
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -116,13 +136,17 @@ namespace Ploeh.AutoFixture.Xunit2
             foreach (var ca in customizeAttributes)
             {
                 var c = ca.GetCustomization(p);
+#pragma warning disable 618
                 this.Fixture.Customize(c);
+#pragma warning restore 618
             }
         }
 
         private object Resolve(ParameterInfo p)
         {
+#pragma warning disable 618
             var context = new SpecimenContext(this.Fixture);
+#pragma warning restore 618
             return context.Resolve(p);
         }
 


### PR DESCRIPTION
Closes #843.

I've discovered that test frameworks might activate `AutoData` and `InlineAutoData` attributes, but actual argument values are being enumerated not for all the times. For instance, we have [disabled value pre-discovery](https://github.com/AutoFixture/AutoFixture/blob/54b1dec755a520080961afc42a0fa3ba9fe0b821/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs#L16) for xUnit 2 integration, meaning xUnit will not request values during the discovery phase.

By making the Fixture creation lazy we could save some time, as usually fixture is heavily customized and customization performance is not perfect (e.g. see #818 and #793 as examples of performance improvements).

On my real-world test project with 1.8k tests NCrunch test discovery decreated from 4.5 to 2.5 secs when I applied the fix from this PR.

Additionally I made the `AutoDataAttribute.Fixture` property obsoleted as it's usage leads to the immediate fixture instantiation. Rather, fixture should be customized in the factory method passed to constructor, so the property should not be needed.

@adamchester @moodmosaic Let me know if you need some benchmark results from me. I wanted to profile something, but wasn't able to find which exact scenario it's better to measure.

@adamchester Here is performance improvement, so you're welcome to review it as well 😉