### PR TITLE
Obsolete AutoDataAttribute.FixtureType property

### DIFF
--- a/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
@@ -74,6 +74,7 @@ namespace Ploeh.AutoFixture.NUnit2
         /// <summary>
         /// Gets the type of <see cref="Fixture"/>.
         /// </summary>
+        [Obsolete("This property is deprecated and will be removed in a future version of AutoFixture. Please use Fixture.GetType() instead.")]
         public Type FixtureType
         {
             get { return Fixture.GetType(); }

--- a/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/AutoDataAttribute.cs
@@ -74,6 +74,7 @@ namespace Ploeh.AutoFixture.Xunit
         /// <summary>
         /// Gets the type of <see cref="Fixture"/>.
         /// </summary>
+        [Obsolete("This property is deprecated and will be removed in a future version of AutoFixture. Please use Fixture.GetType() instead.")]
         public Type FixtureType
         {
             get { return this.Fixture.GetType(); }

--- a/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/AutoDataAttribute.cs
@@ -77,6 +77,7 @@ namespace Ploeh.AutoFixture.Xunit2
         /// <summary>
         /// Gets the type of <see cref="Fixture"/>.
         /// </summary>
+        [Obsolete("This property is deprecated and will be removed in a future version of AutoFixture. Please use Fixture.GetType() instead.")]
         public Type FixtureType
         {
             get { return this.Fixture.GetType(); }


### PR DESCRIPTION
Closes #873.

This property was created together with ctor overload that accepts fixture type. That overload has been totally deprecated, so this property should be deprecated as well.

@adamchester @moodmosaic Please take a look 🎠