### PR TITLE
[Housekeeping] Use xunit console runner for all frameworks

### DIFF
--- a/Src/AutoFixtureUnitTest/Kernel/InstanceMethodTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/InstanceMethodTest.cs
@@ -111,7 +111,7 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         public void InvokeParameterlessMethodReturnsCorrectResult(object owner)
         {
             // Fixture setup
-            var method = owner.GetType().GetMethod("GetHashCode");
+            var method = owner.GetType().GetMethod("GetHashCode", Type.EmptyTypes);
             var sut = new InstanceMethod(method, owner);
             // Exercise system
             var result = sut.Invoke(Enumerable.Empty<object>());

--- a/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/LambdaExpressionGeneratorTest.cs
@@ -58,7 +58,7 @@
 
             var result = sut.Create(expressionRequest, dummyContainer);
 
-            Assert.IsType<Expression<Func<object>>>(result);
+            Assert.IsAssignableFrom<Expression<Func<object>>>(result);
         }
 
         [Theory]
@@ -77,7 +77,7 @@
 
             var result = sut.Create(expressionRequest, context);
 
-            Assert.IsType(expected, result);
+            Assert.IsAssignableFrom(expected, result);
         }
     }
 }

--- a/Src/AutoMoqUnitTest/StubPropertiesCommandTest.cs
+++ b/Src/AutoMoqUnitTest/StubPropertiesCommandTest.cs
@@ -57,7 +57,7 @@ namespace Ploeh.AutoFixture.AutoMoq.UnitTest
             var sut = new StubPropertiesCommand();
             // Exercise system
             var task = Task.Factory.StartNew(() => sut.Execute(request, context));
-            bool ranToCompletion = task.Wait(1000) && task.Status == TaskStatus.RanToCompletion;
+            bool ranToCompletion = task.Wait(5000) && task.Status == TaskStatus.RanToCompletion;
             // Verify outcome
             Assert.True(ranToCompletion);
         }

--- a/Src/AutoRhinoMockUnitTest/Properties/AssemblyInfo.cs
+++ b/Src/AutoRhinoMockUnitTest/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using Xunit;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1489ac72-1967-48b8-a302-79b2900acbe3")]
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/build.cmd
+++ b/build.cmd
@@ -22,5 +22,9 @@ IF NOT EXIST "%TOOLS_DIR%\NUnit.Runners.2.6.2\" (
   %NUGET_PATH% install "NUnit.Runners" -Version 2.6.2 -OutputDirectory %TOOLS_DIR% 
 )
 
+IF NOT EXIST "%TOOLS_DIR%\xunit.runner.console\" (
+  %NUGET_PATH% install "xunit.runner.console" -Version 2.3.0 -OutputDirectory %TOOLS_DIR% -ExcludeVersion 
+)
+
 echo Running FAKE Build...
 %TOOLS_DIR%\FAKE.Core\tools\Fake.exe build.fsx %* -BuildDir=%BUILD_DIR%


### PR DESCRIPTION
Switch to console runner as it provides much better performance - 45 secs for our tests instead of ~2min.