### PR TITLE
[Housekeeping] Improve test reporting

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -396,13 +396,19 @@ Target "AppVeyor_SetVNextVersion" (fun _ ->
 
 Target "AppVeyor_UploadTestReports" (fun _ ->
     let uploadResults pattern format =
-        !! pattern
-        |> SetBaseDir testResultsFolder
-        |> Seq.iter (fun file -> AppVeyor.UploadTestResultsFile format file)
+        async {
+            !! pattern
+            |> SetBaseDir testResultsFolder
+            |> Seq.iter (fun file -> AppVeyor.UploadTestResultsFile format file)
+        }
 
-    uploadResults "xunit-*" Xunit
-    uploadResults "NUnit2TestResult.xml" NUnit
-    uploadResults "*.trx" MsTest
+    [ uploadResults "xunit-desktop.xml" Xunit;
+      uploadResults "xunit-netcore.xml" Xunit;
+      uploadResults "NUnit2TestResult.xml" NUnit;
+      uploadResults "*.trx" MsTest ]
+    |> Async.Parallel
+    |> Async.RunSynchronously
+    |> ignore
 )
 
 Target "AppVeyor" (fun _ ->

--- a/Build.fsx
+++ b/Build.fsx
@@ -252,6 +252,7 @@ Target "TestOnly" (fun _ ->
     nUnit2TestProjects
     |> getTestAssemblies "*"
     |> NUnitSequential.NUnit (fun p -> { p with StopOnError = false
+                                                ShowLabels = false
                                                 OutputFile  = testResultsFolder </> "NUnit2TestResult.xml"
                                                 ToolPath = buildToolsDir </> "NUnit.Runners.2.6.2" </> "tools" })
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,16 +18,7 @@ build_script:
 - ps: |
     & .\build.cmd AppVeyor NuGetPublicKey="$($Env:NUGET_API_KEY)" NuGetPrivateKey="$($Env:MYGET_API_KEY)" BuildVersion=git BuildNumber=$($Env:APPVEYOR_BUILD_NUMBER)
 
-test_script:
-- ps: |
-    function Publish-TestResults ($testRunner, $testResultsPath)
-    {
-        $client = New-Object System.Net.WebClient
-        $client.UploadFile("https://ci.appveyor.com/api/testresults/$testRunner/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsPath))
-    }
-
-    Publish-TestResults nunit "build\\TestResults\\NUnit2TestResult.xml"
-    Get-ChildItem "build\\TestResults" -Filter *.trx | Foreach-Object { Publish-TestResults mstest $_.FullName }
+test: off
 
 artifacts:
 - path: build\NuGetPackages\*.nupkg


### PR DESCRIPTION
Disable automatic reporters for xUnit and upload results manually to AppVeyor. That allows to win about 1-2 mins of build time.

Also disabled labels for NUnit 2 tests to align with other frameworks.