### PR TITLE
Create a standalone package with seed methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,26 +72,28 @@ Using AutoFixture is as easy as referencing the library and creating a new insta
 
 ## .NET platforms compatibility table
 
-| Product            | .NET Framework            | .NET Standard            |
-| ------------------ | ------------------------  | ------------------------ |
-| AutoFixture        | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoFixture.xUnit  | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| AutoFixture.xUnit2 | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoFixture.NUnit2 | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| AutoFixture.NUnit3 | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoFakeItEasy     | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.6   |
-| AutoFoq            | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| AutoMoq            | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoNSubstitute    | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoRhinoMock      | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| Idioms             | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0   |
-| Idioms.FsCheck     | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| Product                    | .NET Framework            | .NET Standard            |
+| -------------------------- | ------------------------  | ------------------------ |
+| AutoFixture                | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoFixture.SeedExtensions | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoFixture.xUnit          | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| AutoFixture.xUnit2         | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoFixture.NUnit2         | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| AutoFixture.NUnit3         | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoFakeItEasy             | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.6   |
+| AutoFoq                    | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| AutoMoq                    | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoNSubstitute            | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
+| AutoRhinoMock              | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| Idioms                     | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0   |
+| Idioms.FsCheck             | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
 
 ## Downloads
 
 AutoFixture is available via NuGet:
 
 * [AutoFixture](http://nuget.org/packages/AutoFixture)
+* [AutoFixture.SeedExtensions](http://nuget.org/packages/AutoFixture.SeedExtensions)
 * [AutoFixture.AutoMoq](http://nuget.org/packages/AutoFixture.AutoMoq)
 * [AutoFixture.AutoRhinoMocks](http://nuget.org/packages/AutoFixture.AutoRhinoMocks)
 * [AutoFixture.AutoFakeItEasy](http://nuget.org/packages/AutoFixture.AutoFakeItEasy)

--- a/Src/All.sln
+++ b/Src/All.sln
@@ -77,6 +77,10 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Idioms.FsCheck.FsCheck2Unit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoNSubstitute.NSubstitute3UnitTest", "AutoNSubstitute.NSubstitute3UnitTest\AutoNSubstitute.NSubstitute3UnitTest.csproj", "{C25EA45A-358C-43F7-9A61-8F68632730F3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.SeedExtensions", "AutoFixture.SeedExtensions\AutoFixture.SeedExtensions.csproj", "{F1FE2173-62BD-4D3A-92C1-A3ECB2117252}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.SeedExtensions.UnitTest", "AutoFixture.SeedExtensions.UnitTest\AutoFixture.SeedExtensions.UnitTest.csproj", "{0F3C467A-ED89-4348-9210-FC2D358E20C5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -282,6 +286,18 @@ Global
 		{C25EA45A-358C-43F7-9A61-8F68632730F3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C25EA45A-358C-43F7-9A61-8F68632730F3}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{C25EA45A-358C-43F7-9A61-8F68632730F3}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{F1FE2173-62BD-4D3A-92C1-A3ECB2117252}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1FE2173-62BD-4D3A-92C1-A3ECB2117252}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1FE2173-62BD-4D3A-92C1-A3ECB2117252}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1FE2173-62BD-4D3A-92C1-A3ECB2117252}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1FE2173-62BD-4D3A-92C1-A3ECB2117252}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{F1FE2173-62BD-4D3A-92C1-A3ECB2117252}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFixture.SeedExtensions.UnitTest/AutoFixture.SeedExtensions.UnitTest.csproj
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/AutoFixture.SeedExtensions.UnitTest.csproj
@@ -5,17 +5,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
-    <AssemblyTitle>AutoFixtureDocumentationTest</AssemblyTitle>
-    <AssemblyName>Ploeh.AutoFixtureDocumentationTest</AssemblyName>
-    <RootNamespace>Ploeh.AutoFixtureDocumentationTest</RootNamespace>
+    <AssemblyTitle>AutoFixture.SeedExtensions.UnitTest</AssemblyTitle>
+    <AssemblyName>AutoFixture.SeedExtensions.UnitTest</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\AutoFixture.SeedExtensions\AutoFixture.SeedExtensions.csproj" />
+    <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>
+

--- a/Src/AutoFixture.SeedExtensions.UnitTest/CreateSeedExtensionsTest.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/CreateSeedExtensionsTest.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace AutoFixture.SeedExtensions.UnitTest
+{
+    public class CreateSeedExtensionsTest
+    {
+        [Fact]
+        [Obsolete]
+        public void CreateSeededAnonymousOnContainerReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = TimeSpan.FromMinutes(8);
+            object expectedResult = TimeSpan.FromHours(2);
+            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : new NoSpecimen() };
+            // Exercise system
+            var result = container.CreateAnonymous(seed);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateManyOnNullSpecimenBuilderWithSeedThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CreateSeedExtensions.CreateMany<object>(
+                    (ISpecimenBuilder)null,
+                    dummySeed));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateSeededManyOnSpecimenBuilderComposerReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = TimeSpan.FromMinutes(48);
+            var expectedResult = Enumerable.Range(1, 8).Select(i => TimeSpan.FromHours(i));
+            var specimenBuilder = new DelegatingSpecimenBuilder();
+            specimenBuilder.OnCreate = (r, c) =>
+            {
+                Assert.NotNull(c);
+                Assert.Equal(new MultipleRequest(new SeededRequest(typeof(TimeSpan), seed)), r);
+                return expectedResult.Cast<object>();
+            };
+
+            //var composer = new DelegatingComposer { OnCreate = specimenBuilder.OnCreate };
+            // Exercise system
+            var result = specimenBuilder.CreateMany(seed);
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(result));
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateSeededManyOnSpecimenBuilderReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = TimeSpan.FromMinutes(21);
+            var expected =
+                Enumerable.Range(42, 7).Select(i => TimeSpan.FromHours(i));
+            var builder = new DelegatingSpecimenBuilder();
+            builder.OnCreate = (r, c) =>
+            {
+                Assert.NotNull(c);
+                Assert.Equal(
+                    new MultipleRequest(
+                        new SeededRequest(typeof(TimeSpan), seed)),
+                    r);
+                return expected.Cast<object>();
+            };
+            // Exercise system
+            IEnumerable<TimeSpan> actual = builder.CreateMany(seed);
+            // Verify outcome
+            Assert.True(
+                expected.SequenceEqual(actual),
+                "Sequences not equal.");
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateManyOnNullSpecimenContextWithSeedThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CreateSeedExtensions.CreateMany<object>((ISpecimenContext)null, dummySeed));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateSeededManyOnContainerReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = new Version(1, 1);
+            var expectedResult = Enumerable.Range(1, 5).Select(i => new Version(i, i));
+            var container = new DelegatingSpecimenContext
+            {
+                OnResolve = r => r.Equals(new MultipleRequest(new SeededRequest(typeof(Version), seed))) ?
+                    (object)expectedResult.Cast<object>() :
+                    new NoSpecimen()
+            };
+            // Exercise system
+            var result = container.CreateMany(seed);
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(result));
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateManyOnNullSpecimenBuilderWithSeedAndCountThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            var dummyCount = 8;
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CreateSeedExtensions.CreateMany<object>(
+                    (ISpecimenBuilder)null,
+                    dummySeed,
+                    dummyCount));
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateSeededAndCountedManyOnSpecimenBuilderComposerReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = TimeSpan.FromDays(3);
+            var count = 6;
+            var expectedResult = Enumerable.Range(1, count).Select(i => TimeSpan.FromHours(i));
+            var specimenBuilder = new DelegatingSpecimenBuilder();
+            specimenBuilder.OnCreate = (r, c) =>
+            {
+                Assert.NotNull(c);
+                Assert.Equal(new FiniteSequenceRequest(new SeededRequest(typeof(TimeSpan), seed), count), r);
+                return expectedResult.Cast<object>();
+            };
+
+            // Exercise system
+            var result = specimenBuilder.CreateMany(seed, count);
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(result));
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateSeededAndCountedManyOnSpecimenBuilderReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = TimeSpan.FromDays(4);
+            var count = 5;
+            var expected =
+                Enumerable.Range(1, count).Select(i => TimeSpan.FromHours(i));
+            var builder = new DelegatingSpecimenBuilder();
+            builder.OnCreate = (r, c) =>
+            {
+                Assert.NotNull(c);
+                Assert.Equal(
+                    new FiniteSequenceRequest(
+                        new SeededRequest(typeof(TimeSpan), seed), count),
+                    r);
+                return expected.Cast<object>();
+            };
+            // Exercise system
+            IEnumerable<TimeSpan> actual = builder.CreateMany(seed, count);
+            // Verify outcome
+            Assert.True(
+                expected.SequenceEqual(actual),
+                "Sequences not equal.");
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateManyOnNullSpecimenContextWithSeedAndCountThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            var dummyCount = 1;
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CreateSeedExtensions.CreateMany<object>((ISpecimenContext)null, dummySeed, dummyCount));
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateSeededAndCountedManyOnContainerReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = new Version(0, 9);
+            var count = 4;
+            var expectedResult = Enumerable.Range(1, count).Select(i => new Version(i, i));
+            var container = new DelegatingSpecimenContext
+            {
+                OnResolve = r => r.Equals(new FiniteSequenceRequest(new SeededRequest(typeof(Version), seed), count)) ?
+                    (object)expectedResult.Cast<object>() :
+                    new NoSpecimen()
+            };
+            // Exercise system
+            var result = container.CreateMany(seed, count);
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(result));
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateFromNullSpecimenBuilderWithSeedThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CreateSeedExtensions.Create<object>((ISpecimenBuilder)null, dummySeed));
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateaSeededAnonymousOnSpecimenBuilderComposerReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = new Version(1, 1);
+            var expectedResult = new Version(2, 0);
+            var specimenBuilder = new DelegatingSpecimenBuilder();
+            specimenBuilder.OnCreate = (r, c) =>
+            {
+                Assert.NotNull(c);
+                Assert.Equal(new SeededRequest(typeof(Version), seed), r);
+                return expectedResult;
+            };
+
+            // Exercise system
+            var result = specimenBuilder.Create(seed);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateWithSeedOnSpecimenBuilderReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = new Version(2, 15);
+            var expected = new Version(3, 0);
+            var builder = new DelegatingSpecimenBuilder();
+            builder.OnCreate = (r, c) =>
+            {
+                Assert.NotNull(c);
+                Assert.Equal(
+                    new SeededRequest(typeof(Version), seed),
+                    r);
+                return expected;
+            };
+            // Exercise system
+            Version actual = builder.Create<Version>(seed);
+            // Verify outcome
+            Assert.Equal(expected, actual);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateFromNullSpecimenContextWithSeedThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CreateSeedExtensions.Create<object>((ISpecimenContext)null, dummySeed));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateSeededOnContainerReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = TimeSpan.FromMinutes(8);
+            object expectedResult = TimeSpan.FromHours(2);
+            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : new NoSpecimen() };
+            // Exercise system
+            var result = container.Create(seed);
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenBuilder.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenBuilder.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Ploeh.AutoFixture.Kernel;
+
+namespace AutoFixture.SeedExtensions.UnitTest
+{
+    internal class DelegatingSpecimenBuilder : ISpecimenBuilder
+    {
+        public DelegatingSpecimenBuilder()
+        {
+            this.OnCreate = (r, c) => null;
+        }
+
+        public object Create(object request, ISpecimenContext container)
+        {
+            return this.OnCreate(request, container);
+        }
+
+        internal Func<object, ISpecimenContext, object> OnCreate { get; set; }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenContext.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenContext.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Ploeh.AutoFixture.Kernel;
+
+namespace AutoFixture.SeedExtensions.UnitTest
+{
+    internal class DelegatingSpecimenContext : ISpecimenContext
+    {
+        public DelegatingSpecimenContext()
+        {
+            this.OnResolve = r => null;
+        }
+
+        public object Resolve(object request)
+        {
+            return this.OnResolve(request);
+        }
+
+        internal Func<object, object> OnResolve { get; set; }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions.UnitTest/FreezeSeedExtensionsTest.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/FreezeSeedExtensionsTest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Ploeh.AutoFixture;
+using Xunit;
+
+namespace AutoFixture.SeedExtensions.UnitTest
+{
+    public class FreezeSeedExtensionsTest
+    {
+        [Fact]
+        public void FreezeSeededWithNullFixtureThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                FreezeSeedExtensions.Freeze<object>(null, dummySeed));
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/Scenario.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+using Xunit;
+
+namespace AutoFixture.SeedExtensions.UnitTest
+{
+    public class Scenario
+    {
+        [Fact]
+        public void FreezeWithSeedWillCauseFixtureToKeepReturningTheFrozenInstance()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            var expectedResult = sut.Freeze("Frozen");
+            // Exercise system
+            var result = sut.Create("Something else");
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Fact]
+        [Obsolete]
+        public void CreateAnonymousWithSeedReturnsCorrectResult()
+        {
+            // Fixture setup
+            var container = new SpecimenContext(new Fixture());
+            // Exercise system
+            var result = container.CreateAnonymous("Seed");
+            // Verify outcome
+            Assert.Contains("Seed", result);
+            // Teardown
+        }
+
+
+        [Fact]
+        [Obsolete]
+        public void CreateAnonymousFromNullSpecimenContextWithSeedThrows()
+        {
+            // Fixture setup
+            var dummySeed = new object();
+            // Exercise system and verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                CreateSeedExtensions.CreateAnonymous<object>((ISpecimenContext)null, dummySeed));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateManyWithSeedWillCreateManyCorrectItems()
+        {
+            // Fixture setup
+            string anonymousPrefix = "AnonymousPrefix";
+            var sut = new Fixture();
+            int expectedItemCount = sut.RepeatCount;
+            // Exercise system
+            IEnumerable<string> result = sut.CreateMany(anonymousPrefix);
+            // Verify outcome
+            int actualCount = (from s in result
+                where s.StartsWith(anonymousPrefix)
+                select s).Count();
+            Assert.Equal<int>(expectedItemCount, actualCount);
+            // Teardown
+        }
+
+        [Fact]
+        public void BuildAndCreateManyWithSeedWillCreateManyCorrectItems()
+        {
+            // Fixture setup
+            string anonymousPrefix = "AnonymousPrefix";
+            var sut = new Fixture();
+            var expectedItemCount = sut.RepeatCount;
+            // Exercise system
+            IEnumerable<string> result = sut.Build<string>()
+                .FromSeed(seed => seed + Guid.NewGuid())
+                .CreateMany(anonymousPrefix);
+            // Verify outcome
+            int actualCount = (from s in result
+                where s.StartsWith(anonymousPrefix)
+                select s).Count();
+            Assert.Equal<int>(expectedItemCount, actualCount);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateManyWithSeedReturnsCorrectResult()
+        {
+            // Fixture setup
+            var container = new Fixture();
+            // Exercise system
+            var result = container.CreateMany("Seed").ToList();
+            // Verify outcome
+            Assert.NotEmpty(result);
+            Assert.True(result.All(s => s.Contains("Seed")));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateManyWithSeedWillCreateCorrectNumberOfItems()
+        {
+            // Fixture setup
+            string anonymousPrefix = "Prefix";
+            int expectedItemCount = 73;
+            var sut = new Fixture();
+            // Exercise system
+            IEnumerable<string> result = sut.CreateMany(anonymousPrefix, expectedItemCount);
+            // Verify outcome
+            int actualCount = (from s in result
+                where s.StartsWith(anonymousPrefix)
+                select s).Count();
+            Assert.Equal<int>(expectedItemCount, actualCount);
+            // Teardown
+        }
+
+        [Fact]
+        public void BuildAndCreateManyWithSeedWillCreateCorrectNumberOfItems()
+        {
+            // Fixture setup
+            string anonymousPrefix = "Prefix";
+            int expectedItemCount = 29;
+            var sut = new Fixture();
+            sut.RepeatCount = expectedItemCount;
+            // Exercise system
+            IEnumerable<string> result = sut.Build<string>()
+                .FromSeed(seed => seed + Guid.NewGuid())
+                .CreateMany(anonymousPrefix, expectedItemCount);
+            // Verify outcome
+            int actualCount = (from s in result
+                where s.StartsWith(anonymousPrefix)
+                select s).Count();
+            Assert.Equal<int>(expectedItemCount, actualCount);
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateManyWithSeedAndCountReturnsCorrectResult()
+        {
+            // Fixture setup
+            var seed = "Seed";
+            var count = 2;
+            var container = new Fixture();
+            // Exercise system
+            var result = container.CreateMany(seed, count).ToList();
+            // Verify outcome
+            Assert.Equal(count, result.Count);
+            Assert.True(result.All(s => s.Contains(seed)));
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateAnonymousStringWillPrefixName()
+        {
+            // Fixture setup
+            string expectedText = "Anonymous text";
+            Fixture sut = new Fixture();
+            // Exercise system
+            string result = sut.Create(expectedText);
+            // Verify outcome
+            string actualText = new TextGuidRegex().GetText(result);
+            Assert.Equal(expectedText, actualText);
+            // Teardown
+        }
+
+        [Fact]
+        public void CreateAnonymousStringWillAppendGuid()
+        {
+            // Fixture setup
+            string anonymousText = "Anonymous text";
+            Fixture sut = new Fixture();
+            // Exercise system
+            string result = sut.Create(anonymousText);
+            // Verify outcome
+            string guidString = new TextGuidRegex().GetGuid(result);
+            Guid g = new Guid(guidString);
+            Assert.NotEqual<Guid>(Guid.Empty, g);
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CustomizeWithEchoInt32GeneratorWillReturnSeed()
+        {
+            // Fixture setup
+            int expectedValue = 4;
+            Fixture sut = new Fixture();
+            sut.Customize<int>(c => c.FromSeed(s => s));
+            // Exercise system
+            int result = sut.Create(expectedValue);
+            // Verify outcome
+            Assert.Equal<int>(expectedValue, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void BuildFromSeedWillCreateUsingCorrectSeed()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            var seed = new object();
+
+            var verified = false;
+            Func<object, object> mock = s => verified = seed.Equals(s);
+            // Exercise system
+            sut.Build<object>().FromSeed(mock).Create(seed);
+            // Verify outcome
+            Assert.True(verified, "Mock verified");
+            // Teardown
+        }
+
+
+        [Fact]
+        public void CreateWithSeedReturnsCorrectResult()
+        {
+            // Fixture setup
+            var container = new Fixture();
+            // Exercise system
+            var result = container.Create("Seed");
+            // Verify outcome
+            Assert.Contains("Seed", result);
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions.UnitTest/TextGuidRegex.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/TextGuidRegex.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.RegularExpressions;
+
+namespace AutoFixture.SeedExtensions.UnitTest
+{
+    internal class TextGuidRegex : Regex
+    {
+        internal TextGuidRegex()
+            : base("^(?<text>.*)(?<guid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$", RegexOptions.Compiled)
+        {
+        }
+
+        internal string GetGuid(string s)
+        {
+            return this.Match(s).Groups["guid"].Value;
+        }
+
+        internal string GetText(string s)
+        {
+            return this.Match(s).Groups["text"].Value;
+        }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions/AutoFixture.SeedExtensions.csproj
+++ b/Src/AutoFixture.SeedExtensions/AutoFixture.SeedExtensions.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\Common.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
+    <AssemblyTitle>AutoFixture.SeedExtensions</AssemblyTitle>
+    <AssemblyName>AutoFixture.SeedExtensions</AssemblyName>
+    <RootNamespace>AutoFixture</RootNamespace>
+
+    <!-- NuGet options -->
+    <PackageId>AutoFixture.SeedExtensions</PackageId>
+    <Title>AutoFixture.SeedExtensions</Title>
+    <Description>Extensions for the most common AutoFixture operations to provide overloads with a seed.</Description>
+    <Authors>AutoFixture</Authors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+  </ItemGroup>
+</Project>

--- a/Src/AutoFixture.SeedExtensions/CreateSeedExtensions.cs
+++ b/Src/AutoFixture.SeedExtensions/CreateSeedExtensions.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Kernel;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// Creates anonymous variables from <see cref="ISpecimenContext"/> or <see cref="ISpecimenBuilder"/> instances
+    /// using the passed seed instance.
+    /// </summary>
+    public static class CreateSeedExtensions
+    {
+
+        /// <summary>
+        /// Creates an anonymous object, potentially using the supplied seed as additional
+        /// information when creating the object.
+        /// </summary>
+        /// <typeparam name="T">The type of object to create.</typeparam>
+        /// <param name="seed">
+        /// Any data that adds additional information when creating the anonymous object.
+        /// </param>
+        /// <param name="context">The context used to resolve the type request.</param>
+        /// <returns>An anonymous object.</returns>
+        /// <remarks>Obsolete: Please move over to using <see cref="SpecimenFactory.Create{T}(Ploeh.AutoFixture.Kernel.ISpecimenContext)">Create{T}()</see> as this method will be removed in the next release</remarks>
+        [Obsolete("Please move over to using Create<T>() as this method will be removed in the next release", true)]
+        public static T CreateAnonymous<T>(this ISpecimenContext context, T seed)
+        {
+            return CreateSeedExtensions.Create<T>(context, seed);
+        }
+
+
+        /// <summary>Creates many anonymous objects.</summary>
+        /// <typeparam name="T">The type of objects to create.</typeparam>
+        /// <param name="builder">
+        /// The builder used to resolve the type request.
+        /// </param>
+        /// <param name="seed">
+        /// An initial value that may or may not be used as input for the
+        /// algorithm creating the return value.
+        /// </param>
+        /// <returns>
+        /// A sequence of anonymous object of type <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// The CreateMany implementation always returns a new instance of
+        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
+        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
+        /// or explicitly assigned with the
+        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
+        /// CreateMany method returns a new, independent instance of
+        /// IEnumerable&lt;T&gt;.
+        /// </para>
+        /// <para>
+        /// However, you can change this behavior, for example by applying the
+        /// <see cref="MapCreateManyToEnumerable" /> customization.
+        /// </para>
+        /// </remarks>
+        public static IEnumerable<T> CreateMany<T>(this ISpecimenBuilder builder, T seed)
+        {
+            return builder.CreateContext().CreateMany(seed);
+        }
+
+        private static ISpecimenContext CreateContext(this ISpecimenBuilder builder)
+        {
+            return new SpecimenContext(builder);
+        }
+
+
+        /// <summary>
+        /// Creates many anonymous objects.
+        /// </summary>
+        /// <typeparam name="T">The type of objects to create.</typeparam>
+        /// <param name="context">The context used to resolve the type request.</param>
+        /// <param name="seed">
+        /// An initial value that may or may not be used as input for the algorithm creating the
+        /// return value.
+        /// </param>
+        /// <returns>A sequence of anonymous object of type <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        /// <para>
+        /// The CreateMany implementation always returns a new instance of
+        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
+        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
+        /// or explicitly assigned with the
+        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
+        /// CreateMany method returns a new, independent instance of
+        /// IEnumerable&lt;T&gt;.
+        /// </para>
+        /// <para>
+        /// However, you can change this behavior, for example by applying the
+        /// <see cref="MapCreateManyToEnumerable" /> customization.
+        /// </para>
+        /// </remarks>
+        public static IEnumerable<T> CreateMany<T>(this ISpecimenContext context, T seed)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var rawResult = context.Resolve(new MultipleRequest(new SeededRequest(typeof(T), seed)));
+
+            return ((IEnumerable<object>)rawResult).Cast<T>();
+        }
+
+
+        /// <summary>Creates many anonymous objects.</summary>
+        /// <typeparam name="T">The type of objects to create.</typeparam>
+        /// <param name="builder">
+        /// The builder used to resolve the type request.
+        /// </param>
+        /// <param name="seed">
+        /// An initial value that may or may not be used as input for the
+        /// algorithm creating the return value.
+        /// </param>
+        /// <param name="count">The number of objects to create.</param>
+        /// <returns>
+        /// A sequence of anonymous objects of type <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// The CreateMany implementation always returns a new instance of
+        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
+        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
+        /// or explicitly assigned with the
+        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
+        /// CreateMany method returns a new, independent instance of
+        /// IEnumerable&lt;T&gt;.
+        /// </para>
+        /// <para>
+        /// However, you can change this behavior, for example by applying the
+        /// <see cref="MapCreateManyToEnumerable" /> customization.
+        /// </para>
+        /// </remarks>
+        public static IEnumerable<T> CreateMany<T>(this ISpecimenBuilder builder, T seed, int count)
+        {
+            return builder.CreateContext().CreateMany(seed, count);
+        }
+
+        /// <summary>
+        /// Creates many anonymous objects.
+        /// </summary>
+        /// <typeparam name="T">The type of objects to create.</typeparam>
+        /// <param name="context">The context used to resolve the type request.</param>
+        /// <param name="seed">
+        /// An initial value that may or may not be used as input for the algorithm creating the
+        /// return value.
+        /// </param>
+        /// <param name="count">The number of objects to create.</param>
+        /// <returns>A sequence of anonymous objects of type <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        /// <para>
+        /// The CreateMany implementation always returns a new instance of
+        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
+        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
+        /// or explicitly assigned with the
+        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
+        /// CreateMany method returns a new, independent instance of
+        /// IEnumerable&lt;T&gt;.
+        /// </para>
+        /// <para>
+        /// However, you can change this behavior, for example by applying the
+        /// <see cref="MapCreateManyToEnumerable" /> customization.
+        /// </para>
+        /// </remarks>
+        public static IEnumerable<T> CreateMany<T>(this ISpecimenContext context, T seed, int count)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var rawResult = context.Resolve(new FiniteSequenceRequest(new SeededRequest(typeof(T), seed), count));
+            return ((IEnumerable<object>)rawResult).Cast<T>();
+        }
+
+
+        /// <summary>
+        /// Creates an anonymous object, potentially using the supplied seed as
+        /// additional information when creating the object.
+        /// </summary>
+        /// <typeparam name="T">The type of object to create.</typeparam>
+        /// <param name="builder">
+        /// The builder used to resolve the type request.
+        /// </param>
+        /// <param name="seed">
+        /// Any data that adds additional information when creating the
+        /// anonymous object.
+        /// </param>
+        /// <returns>An anonymous object.</returns>
+        public static T Create<T>(this ISpecimenBuilder builder, T seed)
+        {
+            return builder.CreateContext().Create<T>(seed);
+        }
+
+        /// <summary>
+        /// Creates an anonymous object, potentially using the supplied seed as additional
+        /// information when creating the object.
+        /// </summary>
+        /// <typeparam name="T">The type of object to create.</typeparam>
+        /// <param name="seed">
+        /// Any data that adds additional information when creating the anonymous object.
+        /// </param>
+        /// <param name="context">The context used to resolve the type request.</param>
+        /// <returns>An anonymous object.</returns>
+        public static T Create<T>(this ISpecimenContext context, T seed)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return (T)context.Resolve(new SeededRequest(typeof(T), seed));
+        }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions/FreezeSeedExtensions.cs
+++ b/Src/AutoFixture.SeedExtensions/FreezeSeedExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.ComponentModel;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.Dsl;
+using Ploeh.AutoFixture.Kernel;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// Contains extension methods for freezing specimens in <see cref="IFixture"/> instances with a specified seed.
+    /// </summary>
+    public static class FreezeSeedExtensions
+    {
+        /// <summary>
+        /// Freezes the type to a single value.
+        /// </summary>
+        /// <typeparam name="T">The type to freeze.</typeparam>
+        /// <param name="fixture">The fixture.</param>
+        /// <param name="seed">
+        /// Any data that adds additional information when creating the
+        /// anonymous object. Hypothetically, this value might be the value
+        /// being frozen, but this is not likely.
+        /// </param>
+        /// <returns>
+        /// The value that will subsequently always be created for <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Freeze{T}(IFixture, T)"/> method freezes the type to always return the
+        /// same instance whenever an instance of the type is requested either directly, or
+        /// indirectly as a nested value of other types.
+        /// </para>
+        /// <para>
+        /// Please notice that the <paramref name="seed" /> isn't likely to be
+        /// used as the frozen value, unless you've customized
+        /// <paramref name="fixture" /> to do this. If you wish to inject a
+        /// specific value into the Fixture, you should use the
+        /// <see cref="FixtureRegistrar.Inject{T}" /> method instead.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="FixtureFreezer.Freeze{T}(IFixture)"/>
+        /// <seealso cref="FixtureFreezer.Freeze{T}(IFixture, Func{ICustomizationComposer{T}, ISpecimenBuilder})"/>
+        /// <seealso cref="FixtureRegistrar.Inject{T}" />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T Freeze<T>(this IFixture fixture, T seed)
+        {
+            if (fixture == null)
+            {
+                throw new ArgumentNullException(nameof(fixture));
+            }
+
+            var value = fixture.Create<T>(seed);
+            fixture.Inject(value);
+            return value;
+        }
+    }
+}

--- a/Src/AutoFixture.SeedExtensions/Properties/AssemblyInfo.cs
+++ b/Src/AutoFixture.SeedExtensions/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Resources;
+
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5dcd335f-c81b-4c42-8a86-5aaaca945ec4")]
+
+[assembly: CLSCompliant(true)]
+[assembly: NeutralResourcesLanguage("en")]

--- a/Src/AutoFixture.sln
+++ b/Src/AutoFixture.sln
@@ -11,6 +11,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixtureDocumentationTes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestTypeFoundation", "TestTypeFoundation\TestTypeFoundation.csproj", "{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.SeedExtensions", "AutoFixture.SeedExtensions\AutoFixture.SeedExtensions.csproj", "{6DE9882E-2F70-4890-9F87-0E17124FD677}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.SeedExtensions.UnitTest", "AutoFixture.SeedExtensions.UnitTest\AutoFixture.SeedExtensions.UnitTest.csproj", "{87AF9B70-8F59-44F3-90C2-EC41D93469EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +46,18 @@ Global
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{7FF65787-F462-4204-BB9D-60B0D1BB6CC1}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{6DE9882E-2F70-4890-9F87-0E17124FD677}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DE9882E-2F70-4890-9F87-0E17124FD677}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DE9882E-2F70-4890-9F87-0E17124FD677}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DE9882E-2F70-4890-9F87-0E17124FD677}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DE9882E-2F70-4890-9F87-0E17124FD677}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{6DE9882E-2F70-4890-9F87-0E17124FD677}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{87AF9B70-8F59-44F3-90C2-EC41D93469EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87AF9B70-8F59-44F3-90C2-EC41D93469EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87AF9B70-8F59-44F3-90C2-EC41D93469EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87AF9B70-8F59-44F3-90C2-EC41D93469EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87AF9B70-8F59-44F3-90C2-EC41D93469EA}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{87AF9B70-8F59-44F3-90C2-EC41D93469EA}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFixture/FixtureFreezer.cs
+++ b/Src/AutoFixture/FixtureFreezer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using Ploeh.AutoFixture.Dsl;
 using Ploeh.AutoFixture.Kernel;
 
@@ -20,12 +19,11 @@ namespace Ploeh.AutoFixture
         /// </returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="Freeze(IFixture)"/> method freezes the type to always return the same
+        /// The <see cref="Freeze{T}(Ploeh.AutoFixture.IFixture)"/> method freezes the type to always return the same
         /// instance whenever an instance of the type is requested either directly, or indirectly as a
         /// nested value of other types.
         /// </para>
         /// </remarks>
-        /// <seealso cref="Freeze{T}(IFixture, T)"/>
         /// <seealso cref="Freeze{T}(IFixture, Func{ICustomizationComposer{T}, ISpecimenBuilder})"/>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Although this CA warning should never be suppressed, this particular usage scenario has been discussed and accepted on the FxCop DL.")]
         public static T Freeze<T>(this IFixture fixture)
@@ -45,49 +43,6 @@ namespace Ploeh.AutoFixture
         /// </summary>
         /// <typeparam name="T">The type to freeze.</typeparam>
         /// <param name="fixture">The fixture.</param>
-        /// <param name="seed">
-        /// Any data that adds additional information when creating the
-        /// anonymous object. Hypothetically, this value might be the value
-        /// being frozen, but this is not likely.
-        /// </param>
-        /// <returns>
-        /// The value that will subsequently always be created for <typeparamref name="T"/>.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The <see cref="Freeze{T}(IFixture, T)"/> method freezes the type to always return the
-        /// same instance whenever an instance of the type is requested either directly, or
-        /// indirectly as a nested value of other types.
-        /// </para>
-        /// <para>
-        /// Please notice that the <paramref name="seed" /> isn't likely to be
-        /// used as the frozen value, unless you've customized
-        /// <paramref name="fixture" /> to do this. If you wish to inject a
-        /// specific value into the Fixture, you should use the
-        /// <see cref="FixtureRegistrar.Inject" /> method instead.
-        /// </para>
-        /// </remarks>
-        /// <seealso cref="Freeze{T}(IFixture)"/>
-        /// <seealso cref="Freeze{T}(IFixture, Func{ICustomizationComposer{T}, ISpecimenBuilder})"/>
-        /// <seealso cref="FixtureRegistrar.Inject" />
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static T Freeze<T>(this IFixture fixture, T seed)
-        {
-            if (fixture == null)
-            {
-                throw new ArgumentNullException(nameof(fixture));
-            }
-
-            var value = fixture.Create<T>(seed);
-            fixture.Inject(value);
-            return value;
-        }
-
-        /// <summary>
-        /// Freezes the type to a single value.
-        /// </summary>
-        /// <typeparam name="T">The type to freeze.</typeparam>
-        /// <param name="fixture">The fixture.</param>
         /// <param name="composerTransformation">
         /// A function that customizes a given <see cref="ICustomizationComposer{T}"/> and returns
         /// the modified composer.
@@ -97,7 +52,7 @@ namespace Ploeh.AutoFixture
         /// </returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="Freeze{T}(IFixture, T)"/> method freezes the type to always return the
+        /// This method freezes the type to always return the
         /// same instance whenever an instance of the type is requested either directly, or
         /// indirectly as a nested value of other types. The frozen instance is created by an
         /// <see cref="ISpecimenBuilder" /> that is the result of applying the
@@ -105,7 +60,6 @@ namespace Ploeh.AutoFixture
         /// </para>
         /// </remarks>
         /// <seealso cref="Freeze{T}(IFixture)"/>
-        /// <seealso cref="Freeze{T}(IFixture, T)"/>
         public static T Freeze<T>(this IFixture fixture, Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
         {
             if (fixture == null)

--- a/Src/AutoFixture/SpecimenFactory.cs
+++ b/Src/AutoFixture/SpecimenFactory.cs
@@ -26,7 +26,7 @@ namespace Ploeh.AutoFixture
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return (T)context.Create(default(T));
+            return (T)context.Resolve(new SeededRequest(typeof(T), default(T)));
         }
 
         /// <summary>
@@ -105,61 +105,6 @@ namespace Ploeh.AutoFixture
             return Create<T>(composer);
         }
 
-        /// <summary>
-        /// Creates an anonymous object, potentially using the supplied seed as additional
-        /// information when creating the object.
-        /// </summary>
-        /// <typeparam name="T">The type of object to create.</typeparam>
-        /// <param name="seed">
-        /// Any data that adds additional information when creating the anonymous object.
-        /// </param>
-        /// <param name="context">The context used to resolve the type request.</param>
-        /// <returns>An anonymous object.</returns>
-        public static T Create<T>(this ISpecimenContext context, T seed)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            return (T)context.Resolve(new SeededRequest(typeof(T), seed));
-        }
-
-        /// <summary>
-        /// Creates an anonymous object, potentially using the supplied seed as additional
-        /// information when creating the object.
-        /// </summary>
-        /// <typeparam name="T">The type of object to create.</typeparam>
-        /// <param name="seed">
-        /// Any data that adds additional information when creating the anonymous object.
-        /// </param>
-        /// <param name="context">The context used to resolve the type request.</param>
-        /// <returns>An anonymous object.</returns>
-        /// <remarks>Obsolete: Please move over to using <see cref="Create{T}(Ploeh.AutoFixture.Kernel.ISpecimenContext)">Create{T}()</see> as this method will be removed in the next release</remarks>
-        [Obsolete("Please move over to using Create<T>() as this method will be removed in the next release", true)]
-        public static T CreateAnonymous<T>(this ISpecimenContext context, T seed)
-        {
-            return Create<T>(context, seed);
-        }
-
-        /// <summary>
-        /// Creates an anonymous object, potentially using the supplied seed as
-        /// additional information when creating the object.
-        /// </summary>
-        /// <typeparam name="T">The type of object to create.</typeparam>
-        /// <param name="builder">
-        /// The builder used to resolve the type request.
-        /// </param>
-        /// <param name="seed">
-        /// Any data that adds additional information when creating the
-        /// anonymous object.
-        /// </param>
-        /// <returns>An anonymous object.</returns>
-        public static T Create<T>(this ISpecimenBuilder builder, T seed)
-        {
-            return builder.CreateContext().Create<T>(seed);
-        }
-
         /// <summary>Creates many anonymous objects.</summary>
         /// <typeparam name="T">The type of objects to create.</typeparam>
         /// <param name="builder">
@@ -172,7 +117,7 @@ namespace Ploeh.AutoFixture
         /// <para>
         /// The CreateMany implementation always returns a new instance of
         /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
-        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
+        /// Frozen by the <see cref="FixtureFreezer.Freeze{T}(IFixture)" /> method
         /// or explicitly assigned with the
         /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
         /// CreateMany method returns a new, independent instance of
@@ -183,8 +128,7 @@ namespace Ploeh.AutoFixture
         /// <see cref="MapCreateManyToEnumerable" /> customization.
         /// </para>
         /// </remarks>
-        public static IEnumerable<T> CreateMany<T>(
-            this ISpecimenBuilder builder)
+        public static IEnumerable<T> CreateMany<T>(this ISpecimenBuilder builder)
         {
             return builder.CreateContext().CreateMany<T>();
         }
@@ -213,7 +157,10 @@ namespace Ploeh.AutoFixture
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Although this CA warning should never be suppressed, this particular usage scenario has been discussed and accepted on the FxCop DL.")]
         public static IEnumerable<T> CreateMany<T>(this ISpecimenContext context)
         {
-            return context.CreateMany(default(T));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var rawResult = context.Resolve(new MultipleRequest(new SeededRequest(typeof(T), default(T))));
+            return ((IEnumerable<object>) rawResult).Cast<T>();
         }
 
         /// <summary>
@@ -226,7 +173,7 @@ namespace Ploeh.AutoFixture
         /// <para>
         /// The CreateMany implementation always returns a new instance of
         /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
-        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
+        /// Frozen by the <see cref="FixtureFreezer.Freeze{T}(IFixture)" /> method
         /// or explicitly assigned with the
         /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
         /// CreateMany method returns a new, independent instance of
@@ -244,76 +191,6 @@ namespace Ploeh.AutoFixture
         public static IEnumerable<T> CreateMany<T>(this IPostprocessComposer<T> composer)
         {
             return ((ISpecimenBuilder)composer).CreateMany<T>();
-        }
-
-        /// <summary>Creates many anonymous objects.</summary>
-        /// <typeparam name="T">The type of objects to create.</typeparam>
-        /// <param name="builder">
-        /// The builder used to resolve the type request.
-        /// </param>
-        /// <param name="seed">
-        /// An initial value that may or may not be used as input for the
-        /// algorithm creating the return value.
-        /// </param>
-        /// <returns>
-        /// A sequence of anonymous object of type <typeparamref name="T"/>.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The CreateMany implementation always returns a new instance of
-        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
-        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
-        /// or explicitly assigned with the
-        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
-        /// CreateMany method returns a new, independent instance of
-        /// IEnumerable&lt;T&gt;.
-        /// </para>
-        /// <para>
-        /// However, you can change this behavior, for example by applying the
-        /// <see cref="MapCreateManyToEnumerable" /> customization.
-        /// </para>
-        /// </remarks>
-        public static IEnumerable<T> CreateMany<T>(
-            this ISpecimenBuilder builder,
-            T seed)
-        {
-            return builder.CreateContext().CreateMany(seed);
-        }
-
-        /// <summary>
-        /// Creates many anonymous objects.
-        /// </summary>
-        /// <typeparam name="T">The type of objects to create.</typeparam>
-        /// <param name="context">The context used to resolve the type request.</param>
-        /// <param name="seed">
-        /// An initial value that may or may not be used as input for the algorithm creating the
-        /// return value.
-        /// </param>
-        /// <returns>A sequence of anonymous object of type <typeparamref name="T"/>.</returns>
-        /// <remarks>
-        /// <para>
-        /// The CreateMany implementation always returns a new instance of
-        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
-        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
-        /// or explicitly assigned with the
-        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
-        /// CreateMany method returns a new, independent instance of
-        /// IEnumerable&lt;T&gt;.
-        /// </para>
-        /// <para>
-        /// However, you can change this behavior, for example by applying the
-        /// <see cref="MapCreateManyToEnumerable" /> customization.
-        /// </para>
-        /// </remarks>
-        public static IEnumerable<T> CreateMany<T>(this ISpecimenContext context, T seed)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            return from s in (IEnumerable<object>)context.Resolve(new MultipleRequest(new SeededRequest(typeof(T), seed)))
-                   select (T)s;
         }
 
         /// <summary>Creates many anonymous objects.</summary>
@@ -340,9 +217,7 @@ namespace Ploeh.AutoFixture
         /// <see cref="MapCreateManyToEnumerable" /> customization.
         /// </para>
         /// </remarks>
-        public static IEnumerable<T> CreateMany<T>(
-            this ISpecimenBuilder builder,
-            int count)
+        public static IEnumerable<T> CreateMany<T>(this ISpecimenBuilder builder, int count)
         {
             return builder.CreateContext().CreateMany<T>(count);
         }
@@ -372,7 +247,10 @@ namespace Ploeh.AutoFixture
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Although this CA warning should never be suppressed, this particular usage scenario has been discussed and accepted on the FxCop DL.")]
         public static IEnumerable<T> CreateMany<T>(this ISpecimenContext context, int count)
         {
-            return context.CreateMany(default(T), count);
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var rawResult = context.Resolve(new FiniteSequenceRequest(new SeededRequest(typeof(T), default(T)), count));
+            return ((IEnumerable<object>) rawResult).Cast<T>();
         }
 
         /// <summary>
@@ -404,79 +282,6 @@ namespace Ploeh.AutoFixture
         public static IEnumerable<T> CreateMany<T>(this IPostprocessComposer<T> composer, int count)
         {
             return ((ISpecimenBuilder)composer).CreateMany<T>(count);
-        }
-
-        /// <summary>Creates many anonymous objects.</summary>
-        /// <typeparam name="T">The type of objects to create.</typeparam>
-        /// <param name="builder">
-        /// The builder used to resolve the type request.
-        /// </param>
-        /// <param name="seed">
-        /// An initial value that may or may not be used as input for the
-        /// algorithm creating the return value.
-        /// </param>
-        /// <param name="count">The number of objects to create.</param>
-        /// <returns>
-        /// A sequence of anonymous objects of type <typeparamref name="T"/>.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The CreateMany implementation always returns a new instance of
-        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
-        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
-        /// or explicitly assigned with the
-        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
-        /// CreateMany method returns a new, independent instance of
-        /// IEnumerable&lt;T&gt;.
-        /// </para>
-        /// <para>
-        /// However, you can change this behavior, for example by applying the
-        /// <see cref="MapCreateManyToEnumerable" /> customization.
-        /// </para>
-        /// </remarks>
-        public static IEnumerable<T> CreateMany<T>(
-            this ISpecimenBuilder builder,
-            T seed,
-            int count)
-        {
-            return builder.CreateContext().CreateMany(seed, count);
-        }
-
-        /// <summary>
-        /// Creates many anonymous objects.
-        /// </summary>
-        /// <typeparam name="T">The type of objects to create.</typeparam>
-        /// <param name="context">The context used to resolve the type request.</param>
-        /// <param name="seed">
-        /// An initial value that may or may not be used as input for the algorithm creating the
-        /// return value.
-        /// </param>
-        /// <param name="count">The number of objects to create.</param>
-        /// <returns>A sequence of anonymous objects of type <typeparamref name="T"/>.</returns>
-        /// <remarks>
-        /// <para>
-        /// The CreateMany implementation always returns a new instance of
-        /// <see cref="IEnumerable{T}" />. Even if IEnumerable&lt;T&gt; is
-        /// Frozen by the <see cref="FixtureFreezer.Freeze(IFixture)" /> method
-        /// or explicitly assigned with the
-        /// <see cref="FixtureRegistrar.Inject{T}(IFixture, T)" /> method, the
-        /// CreateMany method returns a new, independent instance of
-        /// IEnumerable&lt;T&gt;.
-        /// </para>
-        /// <para>
-        /// However, you can change this behavior, for example by applying the
-        /// <see cref="MapCreateManyToEnumerable" /> customization.
-        /// </para>
-        /// </remarks>
-        public static IEnumerable<T> CreateMany<T>(this ISpecimenContext context, T seed, int count)
-        {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            return from s in (IEnumerable<object>)context.Resolve(new FiniteSequenceRequest(new SeededRequest(typeof(T), seed), count))
-                   select (T)s;
         }
 
         internal static object Create(this ISpecimenBuilder composer, Type type)

--- a/Src/AutoFixtureDocumentationTest/Simple/DocumentationExample.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/DocumentationExample.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Ploeh.AutoFixture;
 using Xunit;
+using AutoFixture;
 
 namespace Ploeh.AutoFixtureDocumentationTest.Simple
 {

--- a/Src/AutoFixtureUnitTest/FixtureFreezerTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureFreezerTest.cs
@@ -25,17 +25,6 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void FreezeSeededWithNullFixtureThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                FixtureFreezer.Freeze<object>(null, dummySeed));
-            // Teardown
-        }
-
-        [Fact]
         public void FreezeCustomWithNullFixtureThrows()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -410,35 +410,6 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void CreateAnonymousStringWillPrefixName()
-        {
-            // Fixture setup
-            string expectedText = "Anonymous text";
-            Fixture sut = new Fixture();
-            // Exercise system
-            string result = sut.Create(expectedText);
-            // Verify outcome
-            string actualText = new TextGuidRegex().GetText(result);
-            Assert.Equal(expectedText, actualText);
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateAnonymousStringWillAppendGuid()
-        {
-            // Fixture setup
-            string anonymousText = "Anonymous text";
-            Fixture sut = new Fixture();
-            // Exercise system
-            string result = sut.Create(anonymousText);
-            // Verify outcome
-            string guidString = new TextGuidRegex().GetGuid(result);
-            Guid g = new Guid(guidString);
-            Assert.NotEqual<Guid>(Guid.Empty, g);
-            // Teardown
-        }
-
-        [Fact]
         public void CreateAnonymousWithStringPropertyWillAssignNonEmptyString()
         {
             // Fixture setup
@@ -2017,40 +1988,6 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void CreateManyWithSeedWillCreateManyCorrectItems()
-        {
-            // Fixture setup
-            string anonymousPrefix = "AnonymousPrefix";
-            var sut = new Fixture();
-            int expectedItemCount = sut.RepeatCount;
-            // Exercise system
-            IEnumerable<string> result = sut.CreateMany(anonymousPrefix);
-            // Verify outcome
-            int actualCount = (from s in result
-                               where s.StartsWith(anonymousPrefix)
-                               select s).Count();
-            Assert.Equal<int>(expectedItemCount, actualCount);
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateManyWithSeedWillCreateCorrectNumberOfItems()
-        {
-            // Fixture setup
-            string anonymousPrefix = "Prefix";
-            int expectedItemCount = 73;
-            var sut = new Fixture();
-            // Exercise system
-            IEnumerable<string> result = sut.CreateMany(anonymousPrefix, expectedItemCount);
-            // Verify outcome
-            int actualCount = (from s in result
-                               where s.StartsWith(anonymousPrefix)
-                               select s).Count();
-            Assert.Equal<int>(expectedItemCount, actualCount);
-            // Teardown
-        }
-
-        [Fact]
         public void CustomizeNullTransformationThrows()
         {
             // Fixture setup
@@ -2072,20 +2009,6 @@ namespace Ploeh.AutoFixtureUnitTest
             PropertyHolder<string> result = sut.Create<PropertyHolder<string>>();
             // Verify outcome
             Assert.Equal(expectedValue, result.Property);
-            // Teardown
-        }
-
-        [Fact]
-        public void CustomizeWithEchoInt32GeneratorWillReturnSeed()
-        {
-            // Fixture setup
-            int expectedValue = 4;
-            Fixture sut = new Fixture();
-            sut.Customize<int>(c => c.FromSeed(s => s));
-            // Exercise system
-            int result = sut.Create(expectedValue);
-            // Verify outcome
-            Assert.Equal<int>(expectedValue, result);
             // Teardown
         }
 
@@ -3008,18 +2931,7 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact]
-        public void FreezeWithSeedWillCauseFixtureToKeepReturningTheFrozenInstance()
-        {
-            // Fixture setup
-            var sut = new Fixture();
-            var expectedResult = sut.Freeze("Frozen");
-            // Exercise system
-            var result = sut.Create("Something else");
-            // Verify outcome
-            Assert.Equal(expectedResult, result);
-            // Teardown
-        }
+
 
         [Fact]
         public void FreezeWithNullTransformationThrows()
@@ -3498,22 +3410,6 @@ namespace Ploeh.AutoFixtureUnitTest
             var result = sut.Build<object>().FromSeed(s => expectedResult).Create();
             // Verify outcome
             Assert.Equal(expectedResult, result);
-            // Teardown
-        }
-
-        [Fact]
-        public void BuildFromSeedWillCreateUsingCorrectSeed()
-        {
-            // Fixture setup
-            var sut = new Fixture();
-            var seed = new object();
-
-            var verified = false;
-            Func<object, object> mock = s => verified = seed.Equals(s);
-            // Exercise system
-            sut.Build<object>().FromSeed(mock).Create(seed);
-            // Verify outcome
-            Assert.True(verified, "Mock verified");
             // Teardown
         }
 
@@ -4316,45 +4212,6 @@ namespace Ploeh.AutoFixtureUnitTest
             var uniqueItemCount = (from ph in result
                                    select ph.Property).Distinct().Count();
             Assert.Equal<int>(expectedCount, uniqueItemCount);
-            // Teardown
-        }
-
-        [Fact]
-        public void BuildAndCreateManyWithSeedWillCreateManyCorrectItems()
-        {
-            // Fixture setup
-            string anonymousPrefix = "AnonymousPrefix";
-            var sut = new Fixture();
-            var expectedItemCount = sut.RepeatCount;
-            // Exercise system
-            IEnumerable<string> result = sut.Build<string>()
-                .FromSeed(seed => seed + Guid.NewGuid())
-                .CreateMany(anonymousPrefix);
-            // Verify outcome
-            int actualCount = (from s in result
-                               where s.StartsWith(anonymousPrefix)
-                               select s).Count();
-            Assert.Equal<int>(expectedItemCount, actualCount);
-            // Teardown
-        }
-
-        [Fact]
-        public void BuildAndCreateManyWithSeedWillCreateCorrectNumberOfItems()
-        {
-            // Fixture setup
-            string anonymousPrefix = "Prefix";
-            int expectedItemCount = 29;
-            var sut = new Fixture();
-            sut.RepeatCount = expectedItemCount;
-            // Exercise system
-            IEnumerable<string> result = sut.Build<string>()
-                .FromSeed(seed => seed + Guid.NewGuid())
-                .CreateMany(anonymousPrefix, expectedItemCount);
-            // Verify outcome
-            int actualCount = (from s in result
-                               where s.StartsWith(anonymousPrefix)
-                               select s).Count();
-            Assert.Equal<int>(expectedItemCount, actualCount);
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
@@ -282,30 +282,6 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        [Fact][Obsolete]
-        public void CreateAnonymousWithSeedReturnsCorrectResult()
-        {
-            // Fixture setup
-            var container = Scenario.CreateContainer();
-            // Exercise system
-            var result = container.CreateAnonymous("Seed");
-            // Verify outcome
-            Assert.Contains("Seed", result);
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateWithSeedReturnsCorrectResult()
-        {
-            // Fixture setup
-            var container = Scenario.CreateContainer();
-            // Exercise system
-            var result = container.Create("Seed");
-            // Verify outcome
-            Assert.Contains("Seed", result);
-            // Teardown
-        }
-
         [Fact]
         public void CreateManyReturnsCorrectResult()
         {
@@ -319,19 +295,6 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void CreateManyWithSeedReturnsCorrectResult()
-        {
-            // Fixture setup
-            var container = Scenario.CreateContainer();
-            // Exercise system
-            var result = container.CreateMany("Seed").ToList();
-            // Verify outcome
-            Assert.NotEmpty(result);
-            Assert.True(result.All(s => s.Contains("Seed")));
-            // Teardown
-        }
-
-        [Fact]
         public void CreateManyWithCountReturnsCorrectResult()
         {
             // Fixture setup
@@ -341,21 +304,6 @@ namespace Ploeh.AutoFixtureUnitTest.Kernel
             var result = container.CreateMany<long>(count);
             // Verify outcome
             Assert.True(Enumerable.Range(1, count).Select(i => (long)i).SequenceEqual(result));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateManyWithSeedAndCountReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = "Seed";
-            var count = 2;
-            var container = Scenario.CreateContainer();
-            // Exercise system
-            var result = container.CreateMany(seed, count).ToList();
-            // Verify outcome
-            Assert.Equal(count, result.Count);
-            Assert.True(result.All(s => s.Contains(seed)));
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/SpecimenFactoryTest.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenFactoryTest.cs
@@ -28,17 +28,6 @@ namespace Ploeh.AutoFixtureUnitTest
                 SpecimenFactory.Create<object>((ISpecimenBuilder)null));
         }
 
-        [Fact][Obsolete]
-        public void CreateAnonymousFromNullSpecimenContextWithSeedThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                SpecimenFactory.CreateAnonymous<object>((ISpecimenContext)null, dummySeed));
-            // Teardown
-        }
-
         [Fact]
         public void CreateFromNullSpecimenContextThrows()
         {
@@ -46,29 +35,6 @@ namespace Ploeh.AutoFixtureUnitTest
             // Exercise system and verify outcome
             Assert.Throws<ArgumentNullException>(() =>
                 SpecimenFactory.Create<object>((ISpecimenContext)null));
-            // Teardown
-        }
-
-
-        [Fact]
-        public void CreateFromNullSpecimenContextWithSeedThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                SpecimenFactory.Create<object>((ISpecimenContext)null, dummySeed));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateFromNullSpecimenBuilderWithSeedThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                SpecimenFactory.Create<object>((ISpecimenBuilder)null, dummySeed));
             // Teardown
         }
 
@@ -182,107 +148,11 @@ namespace Ploeh.AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact][Obsolete]
-        public void CreateSeededAnonymousOnContainerReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = TimeSpan.FromMinutes(8);
-            object expectedResult = TimeSpan.FromHours(2);
-            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : new NoSpecimen() };
-            // Exercise system
-            var result = container.CreateAnonymous(seed);
-            // Verify outcome
-            Assert.Equal(expectedResult, result);
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateSeededOnContainerReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = TimeSpan.FromMinutes(8);
-            object expectedResult = TimeSpan.FromHours(2);
-            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : new NoSpecimen() };
-            // Exercise system
-            var result = container.Create(seed);
-            // Verify outcome
-            Assert.Equal(expectedResult, result);
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateaSeededAnonymousOnSpecimenBuilderComposerReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = new Version(1, 1);
-            var expectedResult = new Version(2, 0);
-            var specimenBuilder = new DelegatingSpecimenBuilder();
-            specimenBuilder.OnCreate = (r, c) =>
-                {
-                    Assert.NotNull(c);
-                    Assert.Equal(new SeededRequest(typeof(Version), seed), r);
-                    return expectedResult;
-                };
-
-            var composer = new DelegatingComposer { OnCreate = specimenBuilder.OnCreate };
-            // Exercise system
-            var result = composer.Create(seed);
-            // Verify outcome
-            Assert.Equal(expectedResult, result);
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateWithSeedOnSpecimenBuilderReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = new Version(2, 15);
-            var expected = new Version(3, 0);
-            var builder = new DelegatingSpecimenBuilder();
-            builder.OnCreate = (r, c) =>
-            {
-                Assert.NotNull(c);
-                Assert.Equal(
-                    new SeededRequest(typeof(Version), seed),
-                    r);
-                return expected;
-            };
-            // Exercise system
-            Version actual = builder.Create<Version>(seed);
-            // Verify outcome
-            Assert.Equal(expected, actual);
-            // Teardown
-        }
-
         [Fact]
         public void CreateManyOnNullSpecimenBuilderThrows()
         {
             Assert.Throws<ArgumentNullException>(() =>
                 SpecimenFactory.CreateMany<object>((ISpecimenBuilder)null));
-        }
-
-        [Fact]
-        public void CreateManyOnNullSpecimenContextWithSeedThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                SpecimenFactory.CreateMany<object>((ISpecimenContext)null, dummySeed));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateManyOnNullSpecimenBuilderWithSeedThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                SpecimenFactory.CreateMany<object>(
-                    (ISpecimenBuilder)null,
-                    dummySeed));
-            // Teardown
         }
 
         [Fact]
@@ -295,33 +165,6 @@ namespace Ploeh.AutoFixtureUnitTest
                 SpecimenFactory.CreateMany<string>(
                     (ISpecimenBuilder)null,
                     dummyCount));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateManyOnNullSpecimenBuilderWithSeedAndCountThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            var dummyCount = 8;
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                SpecimenFactory.CreateMany<object>(
-                    (ISpecimenBuilder)null,
-                    dummySeed,
-                    dummyCount));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateManyOnNullSpecimenContextWithSeedAndCountThrows()
-        {
-            // Fixture setup
-            var dummySeed = new object();
-            var dummyCount = 1;
-            // Exercise system and verify outcome
-            Assert.Throws<ArgumentNullException>(() =>
-                SpecimenFactory.CreateMany<object>((ISpecimenContext)null, dummySeed, dummyCount));
             // Teardown
         }
 
@@ -411,73 +254,6 @@ namespace Ploeh.AutoFixtureUnitTest
         }
 
         [Fact]
-        public void CreateSeededManyOnContainerReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = new Version(1, 1);
-            var expectedResult = Enumerable.Range(1, 5).Select(i => new Version(i, i));
-            var container = new DelegatingSpecimenContext
-            {
-                OnResolve = r => r.Equals(new MultipleRequest(new SeededRequest(typeof(Version), seed))) ?
-                    (object)expectedResult.Cast<object>() :
-                    new NoSpecimen()
-            };
-            // Exercise system
-            var result = container.CreateMany(seed);
-            // Verify outcome
-            Assert.True(expectedResult.SequenceEqual(result));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateSeededManyOnSpecimenBuilderComposerReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = TimeSpan.FromMinutes(48);
-            var expectedResult = Enumerable.Range(1, 8).Select(i => TimeSpan.FromHours(i));
-            var specimenBuilder = new DelegatingSpecimenBuilder();
-            specimenBuilder.OnCreate = (r, c) =>
-                {
-                    Assert.NotNull(c);
-                    Assert.Equal(new MultipleRequest(new SeededRequest(typeof(TimeSpan), seed)), r);
-                    return expectedResult.Cast<object>();
-                };
-
-            var composer = new DelegatingComposer { OnCreate = specimenBuilder.OnCreate };
-            // Exercise system
-            var result = composer.CreateMany(seed);
-            // Verify outcome
-            Assert.True(expectedResult.SequenceEqual(result));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateSeededManyOnSpecimenBuilderReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = TimeSpan.FromMinutes(21);
-            var expected = 
-                Enumerable.Range(42, 7).Select(i => TimeSpan.FromHours(i));
-            var builder = new DelegatingSpecimenBuilder();
-            builder.OnCreate = (r, c) =>
-            {
-                Assert.NotNull(c);
-                Assert.Equal(
-                    new MultipleRequest(
-                        new SeededRequest(typeof(TimeSpan), seed)),
-                    r);
-                return expected.Cast<object>();
-            };
-            // Exercise system
-            IEnumerable<TimeSpan> actual = builder.CreateMany(seed);
-            // Verify outcome
-            Assert.True(
-                expected.SequenceEqual(actual),
-                "Sequences not equal.");
-            // Teardown
-        }
-
-        [Fact]
         public void CreateCountedManyOnContainerReturnsCorrectResult()
         {
             // Fixture setup
@@ -563,76 +339,6 @@ namespace Ploeh.AutoFixtureUnitTest
             var result = composer.CreateMany(count);
             // Verify outcome
             Assert.True(expectedResult.SequenceEqual(result));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateSeededAndCountedManyOnContainerReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = new Version(0, 9);
-            var count = 4;
-            var expectedResult = Enumerable.Range(1, count).Select(i => new Version(i, i));
-            var container = new DelegatingSpecimenContext
-            {
-                OnResolve = r => r.Equals(new FiniteSequenceRequest(new SeededRequest(typeof(Version), seed), count)) ?
-                    (object)expectedResult.Cast<object>() :
-                    new NoSpecimen()
-            };
-            // Exercise system
-            var result = container.CreateMany(seed, count);
-            // Verify outcome
-            Assert.True(expectedResult.SequenceEqual(result));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateSeededAndCountedManyOnSpecimenBuilderComposerReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = TimeSpan.FromDays(3);
-            var count = 6;
-            var expectedResult = Enumerable.Range(1, count).Select(i => TimeSpan.FromHours(i));
-            var specimenBuilder = new DelegatingSpecimenBuilder();
-            specimenBuilder.OnCreate = (r, c) =>
-                {
-                    Assert.NotNull(c);
-                    Assert.Equal(new FiniteSequenceRequest(new SeededRequest(typeof(TimeSpan), seed), count), r);
-                    return expectedResult.Cast<object>();
-                };
-
-            var composer = new DelegatingComposer { OnCreate = specimenBuilder.OnCreate };
-            // Exercise system
-            var result = composer.CreateMany(seed, count);
-            // Verify outcome
-            Assert.True(expectedResult.SequenceEqual(result));
-            // Teardown
-        }
-
-        [Fact]
-        public void CreateSeededAndCountedManyOnSpecimenBuilderReturnsCorrectResult()
-        {
-            // Fixture setup
-            var seed = TimeSpan.FromDays(4);
-            var count = 5;
-            var expected =
-                Enumerable.Range(1, count).Select(i => TimeSpan.FromHours(i));
-            var builder = new DelegatingSpecimenBuilder();
-            builder.OnCreate = (r, c) =>
-            {
-                Assert.NotNull(c);
-                Assert.Equal(
-                    new FiniteSequenceRequest(
-                        new SeededRequest(typeof(TimeSpan), seed), count),
-                    r);
-                return expected.Cast<object>();
-            };
-            // Exercise system
-            IEnumerable<TimeSpan> actual = builder.CreateMany(seed, count);
-            // Verify outcome
-            Assert.True(
-                expected.SequenceEqual(actual),
-                "Sequences not equal.");
             // Teardown
         }
     }


### PR DESCRIPTION
Implements #151.

Extracted all the `fixture.Create()` and `fixture.Freeze()` overloads with a `seed` parameter to a standalone package. The reason is that those overloads are confusing for new (and old) guys and might be not widely needed.

With current approach people could decide whether they actually need those API.

I decided to proceed with `AutoFixture.SeedExtensions` name rather than `AutoFixture.SeededCreation`, because this library contains methods not for `Create` only, but for the `Freeze` as well. This will make package name more consistent.

After this PR is merged we'll need to adjust our documentation cases that use seed and add a remark that 
`AutoFixture.SeedExtensions` library should be installed for that.

@moodmosaic @adamchester Please take a look. This is the last issue in our v4 list for now. The only leftover is namespace adjustment only - will be done after this.