### PR TITLE
[Housekeeping] Disable AutoFakeItEasy2 package pack and other minor build script improvements

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -15,8 +15,6 @@ let nuGetOutputFolder = buildDir </> "NuGetPackages"
 let nuGetPackages = !! (nuGetOutputFolder </> "*.nupkg" )
                     // Skip symbol packages because NuGet publish symbols automatically when package is published
                     -- (nuGetOutputFolder </> "*.symbols.nupkg")
-                    // Currently AutoFakeItEasy2 has been deprecated and is not being published to the feeds.
-                    -- (nuGetOutputFolder </> "AutoFixture.AutoFakeItEasy2.*" )
 let solutionToBuild = "Src/All.sln"
 let configuration = getBuildParamOrDefault "BuildConfiguration" "Release"
 let bakFileExt = ".orig"

--- a/Src/AutoFakeItEasy2/AutoFakeItEasy2.csproj
+++ b/Src/AutoFakeItEasy2/AutoFakeItEasy2.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>AutoFixture.AutoFakeItEasy2</RootNamespace>
 
     <!-- NuGet options -->
+    <!-- This package was completely deprecated, so we don't pack it more. -->
+    <IsPackable>false</IsPackable>
     <PackageId>AutoFixture.AutoFakeItEasy2</PackageId>
     <Title>AutoFixture with Auto Mocking using FakeItEasy 2.x</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by FakeItEasy 2.x. To use it, add the AutoFakeItEasyCustomization to your Fixture instance.</Description>


### PR DESCRIPTION
A few minor improvements to the project:

- Don't pack `AutoFakeItEasy2` package as we don't publish it anywhere. It's totally deprecated now.
- Refactor how origin URLs are hardcoded.
- Prettify comments.