### PR TITLE
Improve terminating with path builder

### DIFF
--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading;
 
 namespace AutoFixture.Kernel
@@ -64,7 +65,8 @@ namespace AutoFixture.Kernel
                         BuildCoreMessageTemplate(request, null),
                         request,
                         Environment.NewLine,
-                        BuildRequestPathText(this.SpecimenRequests)));
+                        BuildRequestPathText(this.SpecimenRequests),
+                        string.Empty));
                 }
 
                 return result;
@@ -82,7 +84,8 @@ namespace AutoFixture.Kernel
                         BuildCoreMessageTemplate(request, ex),
                         request,
                         Environment.NewLine,
-                        BuildRequestPathText(this.SpecimenRequests)),
+                        BuildRequestPathText(this.SpecimenRequests),
+                        BuildInnerExceptionMessages(ex)),
                     ex);
             }
             finally
@@ -100,7 +103,11 @@ namespace AutoFixture.Kernel
                     "Please refer to the inner exception to investigate the root cause of the failure." +
                     "{1}" +
                     "{1}" +
-                    "Request path:{1}{2}{1}{1}";
+                    "Request path:{1}{2}" +
+                    "{1}" +
+                    "{1}" +
+                    "Inner exception messages:{1}{3}" +
+                    "{1}";
 
             var t = request as Type;
 
@@ -169,6 +176,24 @@ namespace AutoFixture.Kernel
                 .Where(r => r.GetType().Assembly() != thisAssembly)
                 .Select((r, i) => string.Format(CultureInfo.CurrentCulture, "\t{0} {1}", " ".PadLeft(i+1), r))
                 .Aggregate((s1, s2) => s1 + " --> " + Environment.NewLine + s2);
+        }
+
+        private static string BuildInnerExceptionMessages(Exception ex)
+        {
+            var messages = new StringBuilder();
+           
+            var level = 2;
+            while (ex != null)
+            {
+                messages.AppendFormat(
+                    CultureInfo.InvariantCulture, "{0}{1}: {2}", " ".PadLeft(level), ex.GetType().FullName, ex.Message);
+                messages.AppendLine();
+
+                level += 2;
+                ex = ex.InnerException;
+            }
+
+            return messages.ToString();
         }
 
         /// <summary>Composes the supplied builders.</summary>

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -59,7 +59,7 @@ namespace AutoFixture.Kernel
                 var result = this.Builder.Create(request, context);
                 if (result is NoSpecimen)
                 {
-                    throw new ObjectCreationException(string.Format(
+                    throw new ObjectCreationExceptionWithPath(string.Format(
                         CultureInfo.CurrentCulture,
                         BuildCoreMessageTemplate(request, null),
                         request,
@@ -69,14 +69,14 @@ namespace AutoFixture.Kernel
 
                 return result;
             }
-            catch (ObjectCreationException)
+            catch (ObjectCreationExceptionWithPath)
             {
                 // Do not modify exception thrown before as it already contains the full requests path. 
                 throw;
             }
             catch (Exception ex)
             {
-                throw new ObjectCreationException(
+                throw new ObjectCreationExceptionWithPath(
                     string.Format(
                         CultureInfo.CurrentCulture,
                         BuildCoreMessageTemplate(request, ex),

--- a/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
@@ -47,7 +47,7 @@ namespace AutoFixture.Kernel
         [Obsolete("This class will be removed in a future version of AutoFixture. Instead, use an instance of RecursionGuard, composed with an instance of ThrowingRecursionHandler.", true)]
         public override object HandleRecursiveRequest(object request)
         {
-            throw new ObjectCreationException(string.Format(
+            throw new ObjectCreationExceptionWithPath(string.Format(
                 CultureInfo.InvariantCulture,
                 @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
 

--- a/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
@@ -47,7 +47,7 @@ namespace AutoFixture.Kernel
             object request,
             IEnumerable<object> recordedRequests)
         {
-            throw new ObjectCreationException(string.Format(
+            throw new ObjectCreationExceptionWithPath(string.Format(
                 CultureInfo.InvariantCulture,
                 @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
 

--- a/Src/AutoFixture/ObjectCreationExceptionWithPath.cs
+++ b/Src/AutoFixture/ObjectCreationExceptionWithPath.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace AutoFixture
+{
+
+    /// <summary>
+    /// The exception that is thrown when AutoFixture is unable to create an object.
+    /// This exception is supposed to contain the full request path.
+    /// </summary>
+#if SYSTEM_RUNTIME_SERIALIZATION
+    [Serializable]
+#endif
+    internal class ObjectCreationExceptionWithPath: ObjectCreationException
+    {
+        public ObjectCreationExceptionWithPath()
+        {
+        }       
+        
+        public ObjectCreationExceptionWithPath(string message) : base(message)
+        {
+        }
+
+        public ObjectCreationExceptionWithPath(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if SYSTEM_RUNTIME_SERIALIZATION
+        protected ObjectCreationExceptionWithPath(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/Src/AutoFixtureDocumentationTest/Contact/Parsing/ContactTest.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/Parsing/ContactTest.cs
@@ -15,7 +15,7 @@ namespace AutoFixtureDocumentationTest.Contact.Parsing
             // Fixture setup
             Fixture fixture = new Fixture();
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<Contact>());
             // Teardown
         }

--- a/Src/AutoFixtureDocumentationTest/Simple/DocumentationExample.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/DocumentationExample.cs
@@ -337,7 +337,7 @@ namespace AutoFixtureDocumentationTest.Simple
             var fixture = new Fixture();
             fixture.Customizations.Add(new NumericSequenceGenerator());
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(()=>
+            Assert.ThrowsAny<ObjectCreationException>(()=>
                 fixture.Create<Filter>());
             // Teardown
         }
@@ -390,7 +390,7 @@ namespace AutoFixtureDocumentationTest.Simple
             // Fixture setup
             var fixture = new Fixture();
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<SomeImp>());
             // Teardown
         }

--- a/Src/AutoFixtureDocumentationTest/Simple/MyViewModelTest.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/MyViewModelTest.cs
@@ -45,7 +45,7 @@ namespace AutoFixtureDocumentationTest.Simple
             var fixture = new Fixture();
             // Exercise system
             // Verify outcome (expected exception)
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<MyViewModel>());
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/CreatingAbstractClassWithPublicConstructorTests.cs
+++ b/Src/AutoFixtureUnitTest/CreatingAbstractClassWithPublicConstructorTests.cs
@@ -13,7 +13,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 sut.Create<AbstractClassWithPublicConstructor>());
         }
 

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture;
@@ -6025,6 +6026,23 @@ namespace AutoFixtureUnitTest
         {
             [Range(short.MinValue, long.MaxValue, ErrorMessage = "Id is not in range")]
             public long CustomerId { get; set; }
+        }
+
+        [Fact]
+        public void ShouldNotDuplicateRequestPathTwiceInCaseOfRecursionGuardException()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            var requestToLookFor = typeof(RecursiveArrayNode).GetConstructors().Single().GetParameters().Single();
+
+            // Exercise system and verify outcome
+            var actualEx = Assert.ThrowsAny<ObjectCreationException>(() => sut.Create<RecursiveArrayNode>());
+            int numberOfRequestOccurence =
+                new Regex(Regex.Escape(requestToLookFor.ToString())).Matches(actualEx.Message).Count;
+
+            Assert.Equal(1, numberOfRequestOccurence);
+
+            // Teardown
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -257,7 +257,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             Fixture sut = new Fixture();
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 sut.Create<AbstractType>());
             // Teardown
         }
@@ -3082,7 +3082,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 sut.Create<RecursionTestObjectWithReferenceOutA>());
         }
 
@@ -3092,7 +3092,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 sut.Create<RecursionTestObjectWithConstructorReferenceOutA>());
         }
 
@@ -3103,7 +3103,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 new SpecimenContext(
                     new ThrowingRecursionGuard(
                         sut.Build<RecursionTestObjectWithReferenceOutA>()
@@ -3117,7 +3117,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 new SpecimenContext(
                     new RecursionGuard(
                         sut.Build<RecursionTestObjectWithReferenceOutA>(),
@@ -3133,7 +3133,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 new SpecimenContext(
                     new ThrowingRecursionGuard(
                         sut.Build<RecursionTestObjectWithConstructorReferenceOutA>()
@@ -3147,7 +3147,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 new SpecimenContext(
                     new RecursionGuard(
                         sut.Build<RecursionTestObjectWithConstructorReferenceOutA>(),
@@ -4706,7 +4706,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var sut = new Fixture();
             // Exercise system and verify outcome
-           var creationEx = Assert.Throws<ObjectCreationException>(() =>
+           var creationEx = Assert.ThrowsAny<ObjectCreationException>(() =>
                 sut.Create<IntPtr>());
             Assert.IsAssignableFrom<IllegalRequestException>(creationEx.InnerException);
             // Teardown
@@ -5142,7 +5142,7 @@ namespace AutoFixtureUnitTest
             // Fixture setup
             var fixture = new Fixture();
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() => fixture.Create<MutableValueTypeWithoutConstructor>());
+            Assert.ThrowsAny<ObjectCreationException>(() => fixture.Create<MutableValueTypeWithoutConstructor>());
             // Teardown
         }
 
@@ -5197,13 +5197,13 @@ namespace AutoFixtureUnitTest
             var fixture = new Fixture();
 
             // Exercise system and verify outcome
-            var ocex1 = Assert.Throws<ObjectCreationException>(() =>
+            var ocex1 = Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<AbstractType>>());
 
-            var ocex2 = Assert.Throws<ObjectCreationException>(() =>
+            var ocex2 = Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<AbstractType>>());
 
-            var ocex3 = Assert.Throws<ObjectCreationException>(() =>
+            var ocex3 = Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<AbstractType>>());
 
             Assert.Equal(ocex1.Message, ocex2.Message);
@@ -5218,13 +5218,13 @@ namespace AutoFixtureUnitTest
             var fixture = new Fixture();
 
             // Exercise system and verify outcome
-            var ocex1 = Assert.Throws<ObjectCreationException>(() =>
+            var ocex1 = Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<RecursionTestObjectWithReferenceOutA>>());
 
-            var ocex2 = Assert.Throws<ObjectCreationException>(() =>
+            var ocex2 = Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<RecursionTestObjectWithReferenceOutA>>());
 
-            var ocex3 = Assert.Throws<ObjectCreationException>(() =>
+            var ocex3 = Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<RecursionTestObjectWithReferenceOutA>>());
 
             Assert.Equal(ocex1.Message, ocex2.Message);
@@ -5241,13 +5241,13 @@ namespace AutoFixtureUnitTest
             fixture.Behaviors.Add(new TracingBehavior(outputWriter));
 
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<RecursionTestObjectWithReferenceOutA>>());
 
             var traceOutput1 = outputWriter.ToString();
             outputWriter.GetStringBuilder().Clear();
 
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<PropertyHolder<RecursionTestObjectWithReferenceOutA>>());
 
             var traceOutput2 = outputWriter.ToString();
@@ -5854,7 +5854,7 @@ namespace AutoFixtureUnitTest
             var fixture = new Fixture();
 
             // Exercise system and verify outcome
-            var ex = Assert.Throws<ObjectCreationException>(() =>
+            var ex = Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<TypeWithCastOperatorsWithoutPublicConstructor>());
 
             Assert.Contains("most likely because it has no public constructor", ex.Message);

--- a/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
@@ -448,5 +448,29 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.Equal(expectedInnerException, actualEx.InnerException);
             // Teardown
         }
+        
+        [Fact]
+        public void ThrownExceptionIncludesInnerExceptionMessages()
+        {
+            // Fixture setup
+            var innerInnerException = new InvalidOperationException("INNER_INNER_EXCEPTION");
+            var innerException = new InvalidOperationException("WRAPPED_INNER_EXCEPTION", innerInnerException);
+
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => throw innerException
+            };
+
+            var request = new object();
+            var context = new DelegatingSpecimenContext();
+            var sut = new TerminatingWithPathSpecimenBuilder(builder);
+
+            // Exercise system and verify outcome
+            var actualEx = Assert.ThrowsAny<ObjectCreationException>(() => sut.Create(request, context));
+            Assert.Contains("WRAPPED_INNER_EXCEPTION", actualEx.Message);
+            Assert.Contains("INNER_INNER_EXCEPTION", actualEx.Message);
+
+            // Teardown
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/ThrowingRecursionGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ThrowingRecursionGuardTest.cs
@@ -44,7 +44,7 @@ namespace AutoFixtureUnitTest.Kernel
             container.OnResolve = r => sut.Create(r, container); // Provoke recursion
 
             // Exercise system
-            Assert.Throws<ObjectCreationException>(() => sut.Create(Guid.NewGuid(), container));
+            Assert.ThrowsAny<ObjectCreationException>(() => sut.Create(Guid.NewGuid(), container));
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/ThrowingRecursionHandlerTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ThrowingRecursionHandlerTests.cs
@@ -23,7 +23,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Fixture setup
             var sut = new ThrowingRecursionHandler();
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(
+            Assert.ThrowsAny<ObjectCreationException>(
                 () => sut.HandleRecursiveRequest(
                     new object(),
                     new[] { new object() }));

--- a/Src/AutoFixtureUnitTest/StaticFactoryWithClosureOfOperationsBugRepro.cs
+++ b/Src/AutoFixtureUnitTest/StaticFactoryWithClosureOfOperationsBugRepro.cs
@@ -19,7 +19,7 @@ namespace AutoFixtureUnitTest
                 .ForEach(b => fixture.Behaviors.Remove(b));
             fixture.Behaviors.Add(new OmitOnRecursionBehavior());
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() =>
+            Assert.ThrowsAny<ObjectCreationException>(() =>
                 fixture.Create<ClosureOfOperationsHost>());
             // Teardown
         }

--- a/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
@@ -308,7 +308,7 @@ namespace AutoFixture.AutoMoq.UnitTest
             // Fixture setup
             var fixture = new Fixture().Customize(new AutoConfiguredMoqCustomization());
             // Exercise system and verify outcome
-            Assert.Throws<ObjectCreationException>(() => fixture.Create<IInterfaceWithPropertyWithCircularDependency>());
+            Assert.ThrowsAny<ObjectCreationException>(() => fixture.Create<IInterfaceWithPropertyWithCircularDependency>());
         }
     }
 }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -682,12 +682,12 @@ namespace AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
 
             var e =
-                Assert.Throws<GuardClauseException>(
+                Assert.ThrowsAny<GuardClauseException>(
                     () => sut.Verify(typeof(TypeWithMethodWithParameterWithoutImplementers)));
             Assert.Contains("parameter", e.Message, StringComparison.CurrentCultureIgnoreCase);
             Assert.Contains("TypeWithMethodWithParameterWithoutImplementers", e.Message);
             Assert.Contains("MethodWithParameterWithoutImplementers", e.Message);
-            Assert.IsType<ObjectCreationException>(e.InnerException);
+            Assert.IsAssignableFrom<ObjectCreationException>(e.InnerException);
         }
 
         [Fact]
@@ -696,10 +696,10 @@ namespace AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
 
             var e =
-                Assert.Throws<GuardClauseException>(
+                Assert.ThrowsAny<GuardClauseException>(
                     () => sut.Verify(typeof(TypeWithPropertyOfTypeWithoutImplementers)));
             Assert.Contains("TypeWithPropertyOfTypeWithoutImplementers", e.Message);
-            Assert.IsType<ObjectCreationException>(e.InnerException);
+            Assert.IsAssignableFrom<ObjectCreationException>(e.InnerException);
         }
 
         [Fact]
@@ -708,7 +708,7 @@ namespace AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
 
             var e =
-                Assert.Throws<GuardClauseException>(
+                Assert.ThrowsAny<GuardClauseException>(
                     () =>
                     sut.Verify(
                         typeof(
@@ -716,7 +716,7 @@ namespace AutoFixture.IdiomsUnitTest
                         .GetMethod("Method")));
             Assert.Contains(
                 "TypeWithPropertyOfTypeWithoutImplementersAndMethod", e.Message);
-            Assert.IsType<ObjectCreationException>(e.InnerException);
+            Assert.IsAssignableFrom<ObjectCreationException>(e.InnerException);
         }
 
         [Fact]
@@ -725,7 +725,7 @@ namespace AutoFixture.IdiomsUnitTest
             var sut = new GuardClauseAssertion(new Fixture());
 
             var e =
-                Assert.Throws<GuardClauseException>(
+                Assert.ThrowsAny<GuardClauseException>(
                     () =>
                     sut.Verify(
                         typeof(
@@ -733,7 +733,7 @@ namespace AutoFixture.IdiomsUnitTest
                         .GetProperty("Property")));
             Assert.Contains(
                 "TypeWithPropertyOfTypeWithoutImplementersAndMethod", e.Message);
-            Assert.IsType<ObjectCreationException>(e.InnerException);
+            Assert.IsAssignableFrom<ObjectCreationException>(e.InnerException);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #892.

In v4 RC1 [we started](https://github.com/AutoFixture/AutoFixture/issues/694) to wrap failed creation requests to show the full request path. That is an awesome feature as now it's much easier to troubleshoot failures.

However, I've found a couple more things that should be improved:
- Currently we check whether the thrown exception is `ObjectCreationException` and if so - we don't wrap it. It appeared that this type of exception might be thrown by other builders and in that case the diagnostic path is not displayed as exception is not wrapped. I improved that by introducing the internal `ObjectCreationExceptionWithPath` exception derived from `ObjectCreationException`. Now we still wrap the `ObjectCreationException`, but don't wrap the `ObjectCreationExceptionWithPath`. Users (an other libs) still can catch that exception using the `ObjectCreationException` filter.
- The creation path might be very deep. The full exception output becomes a mix of stack trace and inner exception messages, so it's hard to find the original failure cause. I improved that by including the inner exception messages directly to the top exception message. See demo below.

**Before:**
<details>
 <summary>click to expand</summary>

```
AutoFixture.ObjectCreationException: AutoFixture was unable to create an instance from AutoFixturePlayground.Playground+TypeWithThrowingCtor because creation unexpectedly failed with exception. Please refer to the inner exception to investigate the root cause of the failure.

Request path:
	  AutoFixturePlayground.Playground+PropertyHolder`1[AutoFixturePlayground.Playground+FieldHolder`1[AutoFixturePlayground.Playground+TypeWithThrowingCtor[]]] --> 
	   FieldHolder`1 Property --> 
	    AutoFixturePlayground.Playground+FieldHolder`1[AutoFixturePlayground.Playground+TypeWithThrowingCtor[]] --> 
	     TypeWithThrowingCtor[] Field --> 
	      AutoFixturePlayground.Playground+TypeWithThrowingCtor[] --> 
	       AutoFixturePlayground.Playground+TypeWithThrowingCtor


   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.StableFiniteSequenceRelay.<>c__DisplayClass0_0.<Create>b__0(Object req)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at AutoFixture.Kernel.StableFiniteSequenceRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.CustomizationNode.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.MultipleRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.ArrayRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.FieldRequestRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.PropertyRequestRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.SpecimenFactory.Create[T](ISpecimenContext context)
   at AutoFixture.SpecimenFactory.Create[T](ISpecimenBuilder builder)
   at AutoFixturePlayground.Playground.ExceptionMessageDemo()
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at AutoFixture.Kernel.ConstructorMethod.Invoke(IEnumerable`1 parameters)
   at AutoFixture.Kernel.MethodInvoker.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
System.ArgumentOutOfRangeException: Value should be 42.
Parameter name: value
   at AutoFixturePlayground.Playground.TypeWithThrowingCtor..ctor(Int32 value)
```
</details>


**After:**
<details>
 <summary>click to expand</summary>

```
AutoFixture.ObjectCreationExceptionWithPath: AutoFixture was unable to create an instance from AutoFixturePlayground.Playground+TypeWithThrowingCtor because creation unexpectedly failed with exception. Please refer to the inner exception to investigate the root cause of the failure.

Request path:
	  AutoFixturePlayground.Playground+PropertyHolder`1[AutoFixturePlayground.Playground+FieldHolder`1[AutoFixturePlayground.Playground+TypeWithThrowingCtor[]]] --> 
	   FieldHolder`1 Property --> 
	    AutoFixturePlayground.Playground+FieldHolder`1[AutoFixturePlayground.Playground+TypeWithThrowingCtor[]] --> 
	     TypeWithThrowingCtor[] Field --> 
	      AutoFixturePlayground.Playground+TypeWithThrowingCtor[] --> 
	       AutoFixturePlayground.Playground+TypeWithThrowingCtor

Inner exception messages:
  System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
    System.ArgumentOutOfRangeException: Value should be 42.
Parameter name: value


   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.StableFiniteSequenceRelay.<>c__DisplayClass0_0.<Create>b__0(Object req)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at AutoFixture.Kernel.StableFiniteSequenceRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.CustomizationNode.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.MultipleRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.ArrayRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.FieldRequestRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.PropertyRequestRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.AutoPropertiesCommand`1.Execute(Object specimen, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.Kernel.SeedIgnoringRelay.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.BehaviorRoot.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.RecursionGuard.Create(Object request, ISpecimenContext context)
   at AutoFixture.Fixture.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.SpecimenContext.Resolve(Object request)
   at AutoFixture.SpecimenFactory.Create[T](ISpecimenContext context)
   at AutoFixture.SpecimenFactory.Create[T](ISpecimenBuilder builder)
   at AutoFixturePlayground.Playground.ExceptionMessageDemo()
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at AutoFixture.Kernel.ConstructorMethod.Invoke(IEnumerable`1 parameters)
   at AutoFixture.Kernel.MethodInvoker.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.AutoPropertiesTarget.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.Postprocessor`1.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.CompositeSpecimenBuilder.Create(Object request, ISpecimenContext context)
   at AutoFixture.Kernel.TerminatingWithPathSpecimenBuilder.Create(Object request, ISpecimenContext context)
System.ArgumentOutOfRangeException: Value should be 42.
Parameter name: value
   at AutoFixturePlayground.Playground.TypeWithThrowingCtor..ctor(Int32 value)
```
</details>


Now exception message contains all the necessary information to quickly troubleshoot the issue. It allows to stay more focused and quickly see that issue is with parameter guard in the constructor.

Most of the changes in PR are related to tuned assertions as they expected exactly `ObjectCreationException` type without any reason. Now they are fine with derived exception types as well. User code will not be affected by this change as `catch(ObjectCreationException)` captures the derived types.

@moodmosaic @adamchester Please take a look. If you wish we could vote to allow me to perform such minor improvements without review 😉
