### PR TITLE
Improve RangeAttributeRelay to show meaningful exception in case of overflow

### DIFF
--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -2,28 +2,22 @@
   <Import Project="..\Common.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
-
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
     <AssemblyTitle>AutoFixtureUnitTest</AssemblyTitle>
     <AssemblyName>AutoFixtureUnitTest</AssemblyName>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)'=='netcoreapp1.1' ">
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>
-

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
@@ -118,8 +118,8 @@ namespace AutoFixtureUnitTest.DataAnnotations
         }
 
         [Theory]
-        [InlineData("Property")]
-        [InlineData("NullableTypeProperty")]
+        [InlineData(nameof(RangeValidatedType.Property))]
+        [InlineData(nameof(RangeValidatedType.NullableTypeProperty))]
         public void CreateWithPropertyDecoratedWithRangeAttributeReturnsCorrectResult(string name)
         {
             // Fixture setup
@@ -147,8 +147,8 @@ namespace AutoFixtureUnitTest.DataAnnotations
         }
 
         [Theory]
-        [InlineData("Field")]
-        [InlineData("NullableTypeField")]
+        [InlineData(nameof(RangeValidatedType.Field))]
+        [InlineData(nameof(RangeValidatedType.NullableTypeField))]
         public void CreateWithFieldDecoratedWithRangeAttributeReturnsCorrectResult(string name)
         {
             // Fixture setup
@@ -174,5 +174,42 @@ namespace AutoFixtureUnitTest.DataAnnotations
             Assert.Equal(expectedResult, result);
             // Teardown
         }
+
+        [Range(0, long.MaxValue)]
+        public static long FieldWithOverflowedRange = 0;
+        
+        [Fact]
+        public void FailsWithMeaningfulExceptionWhenBoundaryCannotBeConvertedWithoutOverflow()
+        {
+            // Fixture setup
+            var request = typeof(RangeAttributeRelayTest).GetField(nameof(FieldWithOverflowedRange));
+            
+            var sut = new RangeAttributeRelay();
+            var dummyContext = new DelegatingSpecimenContext();
+
+            // Exercise system and verify outcome
+            var actualEx = Assert.Throws<OverflowException>(() => sut.Create(request, dummyContext));
+            Assert.Contains("To solve the issue", actualEx.Message);
+            // Teardown
+        }
+
+        [Range(typeof(long), /* long.MinValue */ "-9223372036854775808", /* long.MaxValue */ "9223372036854775807")]
+        public static long FieldWithStringValueRange = 0;
+
+        [Fact]
+        public void ShouldNotFailIfRangeIsSpecifiedAsString()
+        {
+            // Fixture setup
+            var request = typeof(RangeAttributeRelayTest).GetField(nameof(FieldWithStringValueRange));
+
+            var sut = new RangeAttributeRelay();
+            var dummyContext = new DelegatingSpecimenContext();
+
+            // Exercise system and verify outcome
+            Assert.Null(Record.Exception(() => sut.Create(request, dummyContext)));
+            
+            // Teardown
+        }
+
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -6003,5 +6004,27 @@ namespace AutoFixtureUnitTest
             // Teardown
         }
 #endif
+
+        [Fact]
+        public void Issue453_RangeAttributeShouldFailWithMeaningfulException()
+        {
+            // Fixture setup
+            var fixture = new Fixture();
+
+            // Exercise system and verify outcome
+            var actualEx = Assert.ThrowsAny<ObjectCreationException>(
+                () => fixture.Create<Issue453_AnnotationWithOverflow>());
+
+            Assert.IsType<OverflowException>(actualEx.InnerException);
+            Assert.Contains("To solve the issue", actualEx.InnerException.Message);
+
+            // Teardown
+        }
+
+        private class Issue453_AnnotationWithOverflow
+        {
+            [Range(short.MinValue, long.MaxValue, ErrorMessage = "Id is not in range")]
+            public long CustomerId { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Fixes #453.

Fix the issue by catching the `OverfowException` during the conversion and providing the advice:

```
System.OverflowException: Conversion of RangeAttribute boundary value of System.Double type to System.Int64 type caused the overflow exception. Notice, the RangeAttribute type contains the following constructors taking two arguments only:
RangeAttribute(int, int)
RangeAttribute(double, double)

When you pass a value of other type (e.g. long, decimal), it is converted to either int or double depending on the type. Some conversion (e.g. long to double) could lead to the value distortion due to the double type precision and conversion back to the original type might fail with OverflowException.

To solve the issue rather specify the range value that could be safely converted to double and back without overflow or use the constructor overload taking value as a string.

Example:
RangeAttribute(typeof(long), "0", "9223372036854775807")
```

Now we provide users with a ways how to solve the issue. That is the only thing we can do, unfortunately.

@moodmosaic @adamchester Please review the approach and provide your feedback.