### PR TITLE
netstandard2.0 added into <TargetFrameworks> for AutoFixture.csproj

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5;netstandard2.0</TargetFrameworks>
     <AssemblyTitle>AutoFixture</AssemblyTitle>
     <AssemblyName>AutoFixture</AssemblyName>
     <RootNamespace>AutoFixture</RootNamespace>
@@ -18,7 +18,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' OR '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
It was not possible to use AutoFixture in test projects for netcoreapp2.0 applications.
