### PR TITLE
Obsolete RandomRangedNumberCustomization as it's no longer needed

### DIFF
--- a/Src/AutoFixture/RandomRangedNumberCustomization.cs
+++ b/Src/AutoFixture/RandomRangedNumberCustomization.cs
@@ -5,6 +5,7 @@ namespace AutoFixture
     /// <summary>
     /// A customization that enables numeric specimens to be random and unique per equivalence set of type and range limits.
     /// </summary>
+    [Obsolete("The RandomRangedNumberGenerator now is used by default, therefore this customization is no longer needed and will be removed in future versions of AutoFixture.")]
     public class RandomRangedNumberCustomization : ICustomization 
     {
         /// <summary>

--- a/Src/AutoFixtureUnitTest/RandomRangedNumberCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomRangedNumberCustomizationTest.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest
 {
+    [Obsolete]
     public class RandomRangedNumberCustomizationTest
     {
         [Fact]


### PR DESCRIPTION
Closes #899.

Starting from v4 we use `RandomRangedNumberGenerator` by default, therefore the `RandomRangedNumberCustomization` is no longer needed. Additionally, that will be hint for the existing users who don't  read release notes, so that they could stop to use the customization.