### PR TITLE
Fix Ranged request fails if request has same min and max

### DIFF
--- a/Src/All.sln.DotSettings
+++ b/Src/All.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">15</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/Src/AutoFixture/Kernel/RangedNumberRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedNumberRequest.cs
@@ -30,9 +30,9 @@ namespace AutoFixture.Kernel
                 throw new ArgumentNullException(nameof(maximum));
             }
 
-            if (((IComparable)minimum).CompareTo((IComparable)maximum) >= 0)
+            if (((IComparable)minimum).CompareTo((IComparable)maximum) > 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be lower than Maximum.");
+                throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be lower or equal Maximum.");
             }
 
             this.OperandType = operandType;

--- a/Src/AutoFixture/RandomRangedNumberGenerator.cs
+++ b/Src/AutoFixture/RandomRangedNumberGenerator.cs
@@ -99,6 +99,11 @@ namespace AutoFixture
                 throw new ArgumentException("Limit values should be of numeric type.", nameof(request));
             }
 
+            if (request.Minimum.Equals(request.Maximum))
+            {
+                return new FixedBuilder(request.Minimum);
+            }
+
             switch (typeCode)
             {
                 // Can be safely converted to long without overflow.

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -48,6 +48,11 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+            if (range.Minimum.Equals(range.Maximum))
+            {
+                return range.Minimum;
+            }
+
             var value = context.Resolve(range.OperandType) as IComparable;
             if (value == null)
             {

--- a/Src/AutoFixtureUnitTest/FakeMemberInfo.cs
+++ b/Src/AutoFixtureUnitTest/FakeMemberInfo.cs
@@ -17,22 +17,32 @@ namespace AutoFixtureUnitTest
         public object[] GetCustomAttributes(bool inherit)
         {
             return (from p in this.providedAttributes
-                    where p.Inherited == inherit
+                    where MatchesInheritance(p, inherit)
                     select p.Attribute).ToArray();
         }
 
         public object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
             return (from p in this.providedAttributes
-                    where p.Attribute.GetType() == attributeType && p.Inherited == inherit
+                    where p.Attribute.GetType() == attributeType && MatchesInheritance(p, inherit)
                     select p.Attribute).ToArray();
         }
 
         public bool IsDefined(Type attributeType, bool inherit)
         {
             return (from p in this.providedAttributes
-                    where p.Attribute.GetType() == attributeType && p.Inherited == inherit
+                    where p.Attribute.GetType() == attributeType && MatchesInheritance(p, inherit)
                     select p.Attribute).Any();
+        }
+
+        private static bool MatchesInheritance(ProvidedAttribute attribute, bool inherit)
+        {
+            if (!inherit && attribute.Inherited)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -6042,6 +6043,38 @@ namespace AutoFixtureUnitTest
 
             Assert.Equal(1, numberOfRequestOccurence);
 
+            // Teardown
+        }
+        
+        [Theory]
+        [InlineData(typeof(byte))] 
+        [InlineData(typeof(sbyte))] 
+        [InlineData(typeof(short))]  
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]  
+        [InlineData(typeof(uint))]  
+        [InlineData(typeof(long))] 
+        [InlineData(typeof(ulong))] 
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(float))]  
+        [InlineData(typeof(double))]
+        public void Issue897_ShouldCorrectlyHandleRequestsWithSameMinimumAndMaximumValue(Type type)
+        {
+            // Fixture setup
+            var expectedValue = Convert.ChangeType(42, type, CultureInfo.InvariantCulture);
+            var fakeMember = new FakeMemberInfo(
+                new ProvidedAttribute(
+                    new RangeAttribute(type, "42", "42"),
+                    inherited: false
+                ));
+            
+            var sut = new Fixture();
+            
+            // Exercise system
+            var result = sut.Create(fakeMember, new SpecimenContext(sut));
+
+            // Verify outcome
+            Assert.Equal(expectedValue, result);
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
@@ -78,16 +78,12 @@ namespace AutoFixtureUnitTest.Kernel
 
         [Theory]
         [InlineData(typeof(int), 20, 10)]
-        [InlineData(typeof(int), 10, 10)]
         [InlineData(typeof(int), -1, -2)]
         [InlineData(typeof(decimal), 20, 10)]
-        [InlineData(typeof(decimal), 10, 10)]
         [InlineData(typeof(decimal), -1, -2)]
         [InlineData(typeof(double), 20, 10)]
-        [InlineData(typeof(double), 10, 10)]
         [InlineData(typeof(double), -1, -2)]
         [InlineData(typeof(long), 20, 10)]
-        [InlineData(typeof(long), 10, 10)]
         [InlineData(typeof(long), -1, -2)]
         public void CreateWithEqualOrBiggerMinimumThanMaximumWillThrow(Type type, object minimum, object maximum)
         {
@@ -95,6 +91,20 @@ namespace AutoFixtureUnitTest.Kernel
             // Exercise system and verify outcome
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new RangedNumberRequest(type, minimum, maximum));
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(int), 10, 10)]
+        [InlineData(typeof(decimal), 10, 10)]
+        [InlineData(typeof(double), 10, 10)]
+        [InlineData(typeof(long), 10, 10)]
+        public void CreateWithLowerEqualToMaximunDoesNotThrow(Type type, object minimum, object maximum)
+        {
+            // Exercise system
+            Assert.Null(Record.Exception(() =>
+                new RangedNumberRequest(type, minimum, maximum)));
+            // Verify outcome
             // Teardown
         }
 

--- a/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
@@ -332,30 +332,30 @@ namespace AutoFixtureUnitTest
         public static TheoryData<Type, IConvertible, IConvertible> RequestsWithLimitsToZeroRange =>
             new TheoryData<Type, IConvertible, IConvertible>
             {
-                { typeof(float), float.MinValue, (float) 0 },
-                { typeof(float), (float) 0, float.MaxValue },
+                { typeof(float), float.MinValue, (float)0 },
+                { typeof(float), (float)0, float.MaxValue },
 
-                { typeof(double), double.MinValue, (double) 0 },
-                { typeof(double), (double) 0, double.MaxValue },
+                { typeof(double), double.MinValue, (double)0 },
+                { typeof(double), (double)0, double.MaxValue },
 
-                { typeof(decimal), decimal.MinValue, (decimal) 0 },
-                { typeof(decimal), (decimal) 0, decimal.MaxValue },
+                { typeof(decimal), decimal.MinValue, (decimal)0 },
+                { typeof(decimal), (decimal)0, decimal.MaxValue },
 
-                { typeof(sbyte), sbyte.MinValue, (sbyte) 0 },
-                { typeof(sbyte), (sbyte) 0, sbyte.MaxValue },
-                { typeof(byte), (byte) 0, byte.MaxValue },
+                { typeof(sbyte), sbyte.MinValue, (sbyte)0 },
+                { typeof(sbyte), (sbyte)0, sbyte.MaxValue },
+                { typeof(byte), (byte)0, byte.MaxValue },
 
-                { typeof(short), short.MinValue, (short) 0 },
-                { typeof(short), (short) 0, short.MaxValue },
-                { typeof(ushort), (ushort) 0, ushort.MaxValue },
+                { typeof(short), short.MinValue, (short)0 },
+                { typeof(short), (short)0, short.MaxValue },
+                { typeof(ushort), (ushort)0, ushort.MaxValue },
 
-                { typeof(int), int.MinValue, (int) 0 },
-                { typeof(int), (int) 0, int.MaxValue },
-                { typeof(uint), (uint) 0, uint.MaxValue },
+                { typeof(int), int.MinValue, (int)0 },
+                { typeof(int), (int)0, int.MaxValue },
+                { typeof(uint), (uint)0, uint.MaxValue },
 
-                { typeof(long), long.MinValue, (long) 0 },
-                { typeof(long), (long) 0, long.MaxValue },
-                { typeof(ulong), (ulong) 0, ulong.MaxValue }
+                { typeof(long), long.MinValue, (long)0 },
+                { typeof(long), (long)0, long.MaxValue },
+                { typeof(ulong), (ulong)0, ulong.MaxValue }
             };
 
         public static TheoryData<Type, Type> PairsOfDifferentIntegerTypes =>

--- a/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AutoFixture;
 using AutoFixture.Kernel;
@@ -263,7 +264,7 @@ namespace AutoFixtureUnitTest
 
         [Theory]
         [MemberData(nameof(MinLimitToMaxLimitRequests))]
-        public void CreationOnFullRangeShouldntFail(Type type, object minimum, object maximum)
+        public void CreationOnFullRangeShouldNotFail(Type type, object minimum, object maximum)
         {
             // Fixture setup
             var request = new RangedNumberRequest(type, minimum, maximum);
@@ -312,6 +313,33 @@ namespace AutoFixtureUnitTest
             // Teardown
         }
 
+        [Theory]
+        [InlineData(typeof(byte))] 
+        [InlineData(typeof(sbyte))] 
+        [InlineData(typeof(short))]  
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]  
+        [InlineData(typeof(uint))]  
+        [InlineData(typeof(long))] 
+        [InlineData(typeof(ulong))] 
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(float))]  
+        [InlineData(typeof(double))]
+        public void ShouldCorrectlyHandleRequestsWithSameMinimumAndMaximumValue(Type type)
+        {
+            // Fixture setup
+            var range = Convert.ChangeType(42, type, CultureInfo.InvariantCulture);
+            var sut = new RandomRangedNumberGenerator();
+            var request = new RangedNumberRequest(type, range, range);
+            var dummyContext = new DelegatingSpecimenContext();
+            
+            // Exercise system
+            var result = sut.Create(request, dummyContext);
+
+            // Verify outcome
+            Assert.Equal(range, result);
+            // Teardown
+        }
 
         public static TheoryData<Type, IConvertible, IConvertible> MinLimitToMaxLimitRequests =>
             new TheoryData<Type, IConvertible, IConvertible>

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AutoFixture;
 using AutoFixture.Kernel;
@@ -164,6 +165,35 @@ namespace AutoFixtureUnitTest
             var loopTest = new LoopTest<RangedNumberGenerator, int>(sut => (int)sut.Create(request, context));
             // Exercise system and verify outcome
             loopTest.Execute(loopCount, expectedResult);
+            // Teardown
+        }
+        
+        [Theory]
+        [InlineData(typeof(byte))] 
+        [InlineData(typeof(sbyte))] 
+        [InlineData(typeof(short))]  
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]  
+        [InlineData(typeof(uint))]  
+        [InlineData(typeof(long))] 
+        [InlineData(typeof(ulong))] 
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(float))]  
+        [InlineData(typeof(double))]
+        public void ReturnsSameNumberWhenMinimumAndMaximumAreSame(Type requestType)
+        {
+            // Fixture setup
+            var range = Convert.ChangeType(42, requestType, CultureInfo.InvariantCulture);
+            var sut = new RangedNumberGenerator();
+            var request = new RangedNumberRequest(requestType, range, range);
+
+            var dummyContext = new DelegatingSpecimenContext();
+            
+            // Exercise system
+            var result = sut.Create(request, dummyContext);
+
+            // Verify outcome
+            Assert.Equal(range, result);
             // Teardown
         }
 


### PR DESCRIPTION
Fixes #897.

Support `RangedNumberRequest` with same min and max value by resolving the constant value.