### PR TITLE
[Performance] Avoid unnecessary enumerator creation in CompositeSpecimenBuilder

### DIFF
--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -84,7 +84,7 @@ namespace AutoFixture.Kernel
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
-            return this.composedBuilders.Cast<ISpecimenBuilder>().GetEnumerator();
+            return this.composedBuilders.AsEnumerable().GetEnumerator();
         }
 
         /// <summary>


### PR DESCRIPTION
It appeared that `Cast<>()` is not actually required and we can re-use the existing array enumerator. This method is very hot so we probably win something 😉I haven't measured as the suggested change is very minor and the resulting code looks much better, so it shouldn't be an issue to modify it.