### PR TITLE
Return ISpecimenBuilderNode in ISpecimenBuilderTransformation

### DIFF
--- a/Src/AutoFixture/Kernel/DisposableTrackingBehavior.cs
+++ b/Src/AutoFixture/Kernel/DisposableTrackingBehavior.cs
@@ -43,7 +43,7 @@ namespace AutoFixture.Kernel
         /// <see cref="Trackers"/> property.
         /// </para>
         /// </remarks>
-        public ISpecimenBuilder Transform(ISpecimenBuilder builder)
+        public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
         {
             var tracker = new DisposableTracker(builder);
             this.trackers.Add(tracker);

--- a/Src/AutoFixture/Kernel/ISpecimenBuilderTransformation.cs
+++ b/Src/AutoFixture/Kernel/ISpecimenBuilderTransformation.cs
@@ -1,7 +1,7 @@
 ﻿namespace AutoFixture.Kernel
 {
     /// <summary>
-    /// Transforms one <see cref="ISpecimenBuilder"/> instance into another.
+    /// Transforms <see cref="ISpecimenBuilder"/> instance into <see cref="ISpecimenBuilderNode"/>.
     /// </summary>
     public interface ISpecimenBuilderTransformation
     {
@@ -10,7 +10,7 @@
         /// </summary>
         /// <param name="builder">The builder to transform.</param>
         /// <returns>
-        /// A new <see cref="ISpecimenBuilder"/> created from <paramref name="builder"/>.
+        /// A new <see cref="ISpecimenBuilderNode"/> created from <paramref name="builder"/>.
         /// </returns>
         /// <remarks>
         /// <para>
@@ -18,6 +18,6 @@
         /// behavior of <paramref name="builder"/>; usually by applying a Decorator.
         /// </para>
         /// </remarks>
-        ISpecimenBuilder Transform(ISpecimenBuilder builder);
+        ISpecimenBuilderNode Transform(ISpecimenBuilder builder);
     }
 }

--- a/Src/AutoFixture/NullRecursionBehavior.cs
+++ b/Src/AutoFixture/NullRecursionBehavior.cs
@@ -37,7 +37,7 @@ namespace AutoFixture
         /// <returns>
         /// <paramref name="builder"/> decorated with a <see cref="RecursionGuard"/>.
         /// </returns>
-        public ISpecimenBuilder Transform(ISpecimenBuilder builder)
+        public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
         {
             if (builder == null)
             {

--- a/Src/AutoFixture/OmitOnRecursionBehavior.cs
+++ b/Src/AutoFixture/OmitOnRecursionBehavior.cs
@@ -41,7 +41,7 @@ namespace AutoFixture
         /// <paramref name="builder" /> decorated with an
         /// <see cref="RecursionGuard" />.
         /// </returns>
-        public ISpecimenBuilder Transform(ISpecimenBuilder builder)
+        public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));

--- a/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
+++ b/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
@@ -189,14 +189,10 @@ namespace AutoFixture
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ISpecimenBuilderNode"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ISpecimenBuilderTransformation", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         private void UpdateGraph()
         {
-            ISpecimenBuilder g = this.Graph.FindFirstNode(this.isWrappedGraph);
-            var builder = this.Aggregate(g, (b, t) => t.Transform(b));
+            ISpecimenBuilderNode g = this.Graph.FindFirstNode(this.isWrappedGraph);
+            ISpecimenBuilderNode builder = this.Aggregate(g, (b, t) => t.Transform(b));
 
-            var node = builder as ISpecimenBuilderNode;
-            if (node == null)
-                throw new InvalidOperationException("An ISpecimenBuilderTransformation returned a result which cannot be converted to an ISpecimenBuilderNode. To be used in the current context, all ISpecimenBuilderTransformation Transform methods must return an ISpecimenBuilderNode instance.");
-
-            this.Graph = node;
+            this.Graph = builder;
 
             this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
         }

--- a/Src/AutoFixture/ThrowingRecursionBehavior.cs
+++ b/Src/AutoFixture/ThrowingRecursionBehavior.cs
@@ -16,7 +16,7 @@ namespace AutoFixture
         /// <returns>
         /// <paramref name="builder"/> decorated with a <see cref="RecursionGuard" />.
         /// </returns>
-        public ISpecimenBuilder Transform(ISpecimenBuilder builder)
+        public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
         {
             if (builder == null)
             {

--- a/Src/AutoFixture/TracingBehavior.cs
+++ b/Src/AutoFixture/TracingBehavior.cs
@@ -47,7 +47,7 @@ namespace AutoFixture
         /// A new <see cref="TraceWriter"/> that decorates <paramref name="builder"/> using
         /// <see cref="Writer"/>.
         /// </returns>
-        public ISpecimenBuilder Transform(ISpecimenBuilder builder)
+        public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
         {
             if (builder == null)
             {

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenBuilderTransformation.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenBuilderTransformation.cs
@@ -7,14 +7,14 @@ namespace AutoFixtureUnitTest.Kernel
     {
         public DelegatingSpecimenBuilderTransformation()
         {
-            this.OnTransform = b => b;
+            this.OnTransform = b => (ISpecimenBuilderNode)b;
         }
 
-        public ISpecimenBuilder Transform(ISpecimenBuilder builder)
+        public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
         {
             return this.OnTransform(builder);
         }
 
-        internal Func<ISpecimenBuilder, ISpecimenBuilder> OnTransform { get; set; }
+        internal Func<ISpecimenBuilder, ISpecimenBuilderNode> OnTransform { get; set; }
     }
 }

--- a/Src/AutoFixtureUnitTest/SingletonSpecimenBuilderNodeStackAdapterCollectionTest.cs
+++ b/Src/AutoFixtureUnitTest/SingletonSpecimenBuilderNodeStackAdapterCollectionTest.cs
@@ -314,14 +314,5 @@ namespace AutoFixtureUnitTest
                     null));
             // Teardown
         }
-
-        [Fact]
-        public void AddThrowsOnNonNode()
-        {
-            var nonNode = new DelegatingSpecimenBuilder();
-
-            Assert.Throws<InvalidOperationException>(() =>
-                this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = _ => nonNode }));
-        }
     }
 }


### PR DESCRIPTION
The current implementation of the `ISpecimenBuilderTransformation` used in `fixture.Behaviors` collection is following:
```c#
public interface ISpecimenBuilderTransformation
{
    ISpecimenBuilder Transform(ISpecimenBuilder builder);
}
```

While this interface looks cool, internally we implicitly expect that transformation returns an instance of `ISpecimenBuilderNode` rather than `ISpecimenBuilder`:
https://github.com/AutoFixture/AutoFixture/blob/6e1765747245d45c6659006f14e680568aec42e3/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs#L195-L197

and a test:

https://github.com/AutoFixture/AutoFixture/blob/6e1765747245d45c6659006f14e680568aec42e3/Src/AutoFixtureUnitTest/SingletonSpecimenBuilderNodeStackAdapterCollectionTest.cs#L318-L325


That point confused me each time I created my own behaviors because I got a feedback at run time only and needed to rework my code.

In this PR I'm changing the interface to transform `ISpecimenBuilder` to `ISpecimenBuilderNode`, so we have guarantee type safety at the compile time:

```c#
public interface ISpecimenBuilderTransformation
{
    ISpecimenBuilderNode Transform(ISpecimenBuilder builder);
}
```

This is a breaking change which will affect the existing user behaviors. Users will need to change the signature of the implementation in their code. However, that shouldn't be an issue as they returned `ISpecimenBuilderNode` instances in any case.

While it's a breaking change in API, I believe that it worth it as user experience will be much better.

We are totally fine to accept this breaking change as we are still working on the major version, so SemVer is not violated - we are still on the v3 -> v4 boundary.

@moodmosaic @adamchester What do you think about the suggested change? Let's discuss if you have objections.