### PR TITLE
Make Fixture.cs class code neat and tidy

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -185,33 +185,36 @@ namespace AutoFixture
                 if (value == this.OmitAutoProperties)
                     return;
 
-                var g = this.graph;
+                var updatedGraph = this.graph;
                 if (value)
                 {
-                    foreach (var p in this.graph.Parents(b => b is AutoPropertiesTarget))
+                    foreach (var parent in this.graph.Parents(b => b is AutoPropertiesTarget))
                     {
-                        foreach (var b in p)
+                        foreach (var builder in parent)
                         {
-                            var aptn = b as AutoPropertiesTarget;
-                            if (aptn != null)
-                                g = g.ReplaceNodes(with: aptn, when: p.Equals);
+                            if (builder is AutoPropertiesTarget targetNode)
+                                updatedGraph = updatedGraph.ReplaceNodes(
+                                    with: targetNode,
+                                    when: parent.Equals);
                         }
                     }
                 }
                 else
                 {
-                    foreach (var p in this.graph.Parents(b => b is AutoPropertiesTarget))
+                    foreach (var parent in this.graph.Parents(b => b is AutoPropertiesTarget))
                     {
-                        var pps = p
+                        var decoratedParent = parent
                             .Select(b => new Postprocessor(
                                 b,
                                 new AutoPropertiesCommand(),
-                                new AnyTypeSpecification()))
-                            .Cast<ISpecimenBuilder>();
-                        g = g.ReplaceNodes(with: pps, when: p.Equals);
+                                new AnyTypeSpecification()));
+                        updatedGraph = updatedGraph.ReplaceNodes(
+                            with: decoratedParent, 
+                            when: parent.Equals);
                     }
                 }
-                this.OnGraphChanged(this, new SpecimenBuilderNodeEventArgs(g));
+                
+                this.OnGraphChanged(this, new SpecimenBuilderNodeEventArgs(updatedGraph));
             }
         }
 

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -11,10 +12,14 @@ using AutoFixture.Kernel;
 namespace AutoFixture
 {
     /// <summary>
-    /// Provides anonymous object creation services.
+    /// Provides object creation services.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Fixture is coupled to many other types, because it embodies rules for creating various well-known types from the base class library.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main purpose of Fixture isn't to be a collection of anything. That it implements IEnumerable is just a coincidental side effect of how graphs are implemented in AutoFixture. Besides, fixing this CA error would be a breaking change.")]
+    [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", 
+        Justification = "Fixture is coupled to many other types, because it embodies rules for creating various well-known types from the base class library.")]
+    [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix",
+        Justification = "The main purpose of Fixture isn't to be a collection of anything." +
+                        "That it implements IEnumerable is just a coincidental side effect of how graphs are implemented in AutoFixture. " +
+                        "Besides, fixing this CA error would be a breaking change.")]
     public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
     {
         private SingletonSpecimenBuilderNodeStackAdapterCollection behaviors;
@@ -36,7 +41,6 @@ namespace AutoFixture
         /// Initializes a new instance of the <see cref="Fixture"/> class with the supplied engine
         /// parts.
         /// </summary>
-        /// <param name="engineParts">The engine parts.</param>
         public Fixture(DefaultRelays engineParts)
             : this(new CompositeSpecimenBuilder(engineParts), new MultipleRelay())
         {
@@ -48,20 +52,12 @@ namespace AutoFixture
         /// </summary>
         /// <param name="engine">The engine.</param>
         /// <param name="multiple">The definition and implementation of 'many'.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "This is the Façade that binds everything else together, so being coupled to many other types must follow.")]
+        [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", 
+            Justification = "This is the Façade that binds everything else together, so being coupled to many other types must follow.")]
         public Fixture(ISpecimenBuilder engine, MultipleRelay multiple)
         {
-            if (engine == null)
-            {
-                throw new ArgumentNullException(nameof(engine));
-            }
-            if (multiple == null)
-            {
-                throw new ArgumentNullException(nameof(multiple));
-            }
-
-            this.Engine = engine;
-            this.multiple = multiple;
+            this.Engine = engine ?? throw new ArgumentNullException(nameof(engine));
+            this.multiple = multiple ?? throw new ArgumentNullException(nameof(multiple));
 
             this.graph =
                 new BehaviorRoot(
@@ -156,33 +152,11 @@ namespace AutoFixture
             this.behaviors.Add(new ThrowingRecursionBehavior());
         }
 
-        /// <summary>
-        /// Gets the behaviors that wrap around the rest of the graph.
-        /// </summary>
-        public IList<ISpecimenBuilderTransformation> Behaviors
-        {
-            get { return this.behaviors; }
-        }
+        /// <inheritdoc />
+        public IList<ISpecimenBuilderTransformation> Behaviors => this.behaviors;
 
-        /// <summary>
-        /// Gets the customizations that intercept the <see cref="Engine"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Any <see cref="ISpecimenBuilder"/> in this list are invoked before
-        /// <see cref="Engine"/>, giving them a chance to intercept a request and resolve it before
-        /// the Engine.
-        /// </para>
-        /// <para>
-        /// <see cref="Customize{T}"/> places resulting customizations in this list.
-        /// </para>
-        /// </remarks>
-        /// <seealso cref="Engine"/>
-        /// <seealso cref="ResidueCollectors"/>
-        public IList<ISpecimenBuilder> Customizations
-        {
-            get { return this.customizer; }
-        }
+        /// <inheritdoc />
+        public IList<ISpecimenBuilder> Customizations => this.customizer;
 
         /// <summary>
         /// Gets the core engine of the <see cref="Fixture"/> instance.
@@ -199,15 +173,7 @@ namespace AutoFixture
         /// <see cref="ResidueCollectors"/>
         public ISpecimenBuilder Engine { get; }
 
-        /// <summary>
-        /// Gets or sets if writable properties should generally be assigned a value when 
-        /// generating an anonymous object.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The default value is false.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public bool OmitAutoProperties
         {
             get
@@ -249,65 +215,23 @@ namespace AutoFixture
             }
         }
 
+        /// <inheritdoc />
         /// <summary>
         /// Gets or sets a number that controls how many objects are created when a
         /// <see cref="Fixture"/> creates more than one anonymous objects.
         /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The default value is 3.
-        /// </para>
-        /// </remarks>
-        /// <seealso cref="CollectionFiller.AddManyTo{T}(IFixture, ICollection{T})" />
-        /// <seealso cref="CollectionFiller.AddManyTo{T}(IFixture, ICollection{T}, Func{T})" />
-        /// <seealso cref="FixtureRepeater.Repeat"/>
         public int RepeatCount
         {
-            get { return this.multiple.Count; }
-            set { this.multiple.Count = value; }
+            get => this.multiple.Count;
+            set => this.multiple.Count = value;
         }
 
-        /// <summary>
-        /// Gets the residue collectors that can be used to handle requests that neither the
-        /// <see cref="Customizations"/> nor <see cref="Engine"/> could handle.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// These <see cref="ISpecimenBuilder"/> instances will be invoked if no previous builder
-        /// could resolve a request. This gives you the opportunity to define fallback strategies
-        /// to deal with unresolved requests.
-        /// </para>
-        /// </remarks>
-        public IList<ISpecimenBuilder> ResidueCollectors
-        {
-            get { return this.residueCollector; }
-        }
+        /// <inheritdoc />
+        public IList<ISpecimenBuilder> ResidueCollectors => this.residueCollector;
 
-        /// <summary>
-        /// Customizes the creation algorithm for a single object, effectively turning off all
-        /// Customizations on the <see cref="IFixture"/>.
-        /// </summary>
-        /// <typeparam name="T">
-        /// The type of object for which the algorithm should be customized.
-        /// </typeparam>
-        /// <returns>
-        /// A <see cref="ICustomizationComposer{T}"/> that can be used to customize the creation
-        /// algorithm before creating the object.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The Build method kicks off a Fluent API which is usually completed by invoking
-        /// <see cref="SpecimenFactory.Create{T}(IPostprocessComposer{T})"/> on the method
-        /// chain.
-        /// </para>
-        /// <para>
-        /// Note that the Build method chain is best understood as a one-off Customization. It
-        /// bypasses all Customizations on the <see cref="Fixture"/> instance. Instead, it allows
-        /// fine-grained control when building a specific specimen. However, in most cases, adding
-        /// a convention-based <see cref="ICustomization"/> is a better, more flexible option.
-        /// </para>
-        /// </remarks>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Although this CA warning should never be suppressed, this particular usage scenario has been discussed and accepted on the FxCop DL.")]
+        /// <inheritdoc />
+        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", 
+            Justification = "This method is required to be generic by design, so there is no way to refactor it.")]
         public ICustomizationComposer<T> Build<T>()
         {
             var g = this.graph.ReplaceNodes(
@@ -319,66 +243,25 @@ namespace AutoFixture
             return new CompositeNodeComposer<T>(g);
         }
 
-        /// <summary>
-        /// Applies a customization.
-        /// </summary>
-        /// <param name="customization">The customization to apply.</param>
-        /// <returns>
-        /// The current instance.
-        /// </returns>
+        /// <inheritdoc />
         public IFixture Customize(ICustomization customization)
         {
-            if (customization == null)
-            {
-                throw new ArgumentNullException(nameof(customization));
-            }
+            if (customization == null) throw new ArgumentNullException(nameof(customization));
 
             customization.Customize(this);
             return this;
         }
 
-        /// <summary>
-        /// Customizes the creation algorithm for all objects of a given type.
-        /// </summary>
-        /// <typeparam name="T">The type of object to customize.</typeparam>
-        /// <param name="composerTransformation">
-        /// A function that customizes a given <see cref="ICustomizationComposer{T}"/> and returns
-        /// the modified composer.
-        /// </param>
-        /// <remarks>
-        /// <para>
-        /// The resulting <see cref="ISpecimenBuilder"/> is added to <see cref="Customizations"/>.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public void Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
         {
-            if (composerTransformation == null)
-            {
-                throw new ArgumentNullException(nameof(composerTransformation));
-            }
+            if (composerTransformation == null) throw new ArgumentNullException(nameof(composerTransformation));
 
             var c = composerTransformation(SpecimenBuilderNodeFactory.CreateComposer<T>().WithAutoProperties(this.EnableAutoProperties));
             this.customizer.Insert(0, c);
         }
 
-        /// <summary>Creates a new specimen based on a request.</summary>
-        /// <param name="request">
-        /// The request that describes what to create.
-        /// </param>
-        /// <param name="context">
-        /// A context that can be used to create other specimens.
-        /// </param>
-        /// <returns>
-        /// The requested specimen if possible; otherwise an exception is
-        /// thrown.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The <paramref name="request" /> can be any object, but will often
-        /// be a <see cref="Type" /> or other
-        /// <see cref="System.Reflection.MemberInfo" /> instances.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public object Create(object request, ISpecimenContext context)
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
@@ -388,32 +271,20 @@ namespace AutoFixture
         }
 
         /// <summary>
-        /// Gets an enumerator over the internal specimen builders used to 
-        /// create objects.
+        /// Gets an enumerator over the internal specimen builders used to create objects.
         /// </summary>
         /// <returns>
-        /// An enumerator over the internal specimen builders used to create
-        /// objects.
+        /// An enumerator over the internal specimen builders used to create objects.
         /// </returns>
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
             yield return this.graph;
         }
 
-        /// <summary>Returns an enumerator that iterates through a collection.</summary>
-        /// <returns>
-        /// An <see cref="IEnumerator{T}" /> object that can be used to iterate through the collection.
-        /// </returns>
-        /// <seealso cref="GetEnumerator()" />
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        /// <inheritdoc />
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
 
-        private bool EnableAutoProperties
-        {
-            get { return !this.OmitAutoProperties; }
-        }
+        private bool EnableAutoProperties => !this.OmitAutoProperties;
 
         private void OnGraphChanged(object sender, SpecimenBuilderNodeEventArgs e)
         {
@@ -446,7 +317,11 @@ namespace AutoFixture
 
         private void UpdateBehaviors(ISpecimenBuilderTransformation[] transformations)
         {
-            this.behaviors = new SingletonSpecimenBuilderNodeStackAdapterCollection(this.graph, n => n is BehaviorRoot, transformations);
+            this.behaviors =
+                new SingletonSpecimenBuilderNodeStackAdapterCollection(
+                    this.graph,
+                    n => n is BehaviorRoot,
+                    transformations);
             this.behaviors.GraphChanged += this.OnGraphChanged;
         }
 

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -22,12 +22,13 @@ namespace AutoFixture
                         "Besides, fixing this CA error would be a breaking change.")]
     public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
     {
-        private SingletonSpecimenBuilderNodeStackAdapterCollection behaviors;
-        private SpecimenBuilderNodeAdapterCollection customizer;
-        private SpecimenBuilderNodeAdapterCollection residueCollector;
         private readonly MultipleRelay multiple;
 
         private ISpecimenBuilderNode graph;
+
+        private SingletonSpecimenBuilderNodeStackAdapterCollection behaviors;
+        private SpecimenBuilderNodeAdapterCollection customizer;
+        private SpecimenBuilderNodeAdapterCollection residueCollector;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Fixture"/> class.

--- a/Src/AutoFixture/IFixture.cs
+++ b/Src/AutoFixture/IFixture.cs
@@ -6,7 +6,7 @@ using AutoFixture.Kernel;
 namespace AutoFixture
 {
     /// <summary>
-    /// Provides anonymous object creation services.
+    /// Provides object creation services.
     /// </summary>
     public interface IFixture : ISpecimenBuilder
     {
@@ -18,8 +18,19 @@ namespace AutoFixture
         IList<ISpecimenBuilderTransformation> Behaviors { get; }
 
         /// <summary>
-        /// Gets customizations.
+        /// Gets the customizations that intercept the request handling by the core.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Any <see cref="ISpecimenBuilder"/> in this list are invoked before predefined builders
+        /// giving them a chance to intercept a request and resolve it.
+        /// </para>
+        /// <para>
+        /// <see cref="Customize{T}"/> places resulting customizations in this list.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="Behaviors"/>
+        /// <seealso cref="ResidueCollectors"/>
         IList<ISpecimenBuilder> Customizations { get; }
 
         /// <summary>
@@ -32,15 +43,20 @@ namespace AutoFixture
         /// Gets or sets a number that controls how many objects are created when a
         /// <see cref="Fixture"/> creates more than one anonymous objects.
         /// </summary>
+        ///  <seealso cref="CollectionFiller.AddManyTo{T}(IFixture, ICollection{T})" />
+        /// <seealso cref="CollectionFiller.AddManyTo{T}(IFixture, ICollection{T}, Func{T})" />
+        /// <seealso cref="FixtureRepeater.Repeat{T}"/>
         int RepeatCount { get; set; }
 
         /// <summary>
-        /// Gets the residue collectors.
+        /// Gets the residue collectors that can be used to handle requests that neither the
+        /// <see cref="Customizations"/> nor the predefined builders could handle.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// It is expected that residue collectors provide fallback mechanisms if no earlier
-        /// <see cref="ISpecimenBuilder"/> can handle a request.
+        /// These <see cref="ISpecimenBuilder"/> instances will be invoked if no previous builder
+        /// could resolve a request. This gives you the opportunity to define fallback strategies
+        /// to deal with unresolved requests.
         /// </para>
         /// </remarks>
         IList<ISpecimenBuilder> ResidueCollectors { get; }
@@ -61,6 +77,12 @@ namespace AutoFixture
         /// The Build method kicks off a Fluent API which is usually completed by invoking
         /// <see cref="SpecimenFactory.Create{T}(IPostprocessComposer{T})"/> on the method
         /// chain.
+        /// </para>
+        /// <para>
+        /// Note that the Build method chain is best understood as a one-off Customization. It
+        /// bypasses all Customizations on the <see cref="Fixture"/> instance. Instead, it allows
+        /// fine-grained control when building a specific specimen. However, in most cases, adding
+        /// a convention-based <see cref="ICustomization"/> is a better, more flexible option.
         /// </para>
         /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Although this CA warning should never be suppressed, this particular usage scenario has been discussed and accepted on the FxCop DL.")]
@@ -88,6 +110,11 @@ namespace AutoFixture
         /// A function that customizes a given <see cref="ICustomizationComposer{T}"/> and returns
         /// the modified composer.
         /// </param>
+        /// <remarks>
+        /// <para>
+        /// The resulting <see cref="ISpecimenBuilder"/> is added to <see cref="Customizations"/>.
+        /// </para>
+        /// </remarks>
         void Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation);
     }
 }


### PR DESCRIPTION
Refactored and cleaned-up the Fixture class a bit to enhance the code readability. The changes don't affect the logic somehow.

Changes:
- Use `<interitdoc />` to not duplicate `IFixture` documentation.
- Use more descriptive variable names.
- Rework the `OnGraphChanged` for better re-usability and usage experience.

Now it should be much simpler to read the class as I removed about 120 lines of code 😉