### PR TITLE
Improve Fixture.OmitAutoProperties internal approach

### DIFF
--- a/Src/AutoFixture/Kernel/SpecimenBuilderNode.cs
+++ b/Src/AutoFixture/Kernel/SpecimenBuilderNode.cs
@@ -158,24 +158,6 @@ namespace AutoFixture.Kernel
             return graph.Compose(nodes);
         }
 
-        internal static IEnumerable<ISpecimenBuilderNode> Parents(
-            this ISpecimenBuilderNode graph,
-            Func<ISpecimenBuilder, bool> predicate)
-        {
-            foreach (var b in graph)
-            {
-                if (predicate(b))
-                    yield return graph;
-
-                var n = b as ISpecimenBuilderNode;
-                if (n != null)
-                {
-                    foreach (var n1 in n.Parents(predicate))
-                        yield return n1;
-                }
-            }
-        }
-
         /// <summary>
         /// Finds the first node in the passed graph that matches the specified predicate.
         /// If nothing is found - null is returned.

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6091,5 +6091,47 @@ namespace AutoFixtureUnitTest
             Assert.NotNull(result);
             // Teardown
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void OmitAutoProperitesIsChangedAfterAssignment(bool value)
+        {
+            // Fixture setup
+            var sut = new Fixture
+            {
+                OmitAutoProperties = !value
+            };
+
+            // Exercise system
+            sut.OmitAutoProperties = value;
+
+            // Verify outcome
+            Assert.Equal(value, sut.OmitAutoProperties);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Optimization_GraphIsNotMutatedWhenActualOmitAutoPropertiesValueIsNotChanged(bool initialValue)
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            sut.OmitAutoProperties = initialValue;
+
+            var oldBehaviors = sut.Behaviors;
+            var oldCustomizations = sut.Customizations;
+            var oldResidueCollectors = sut.ResidueCollectors;
+
+            // Exercise system
+            sut.OmitAutoProperties = initialValue;
+            
+            // Verify outcome
+            Assert.Same(oldBehaviors, sut.Behaviors);
+            Assert.Same(oldCustomizations, sut.Customizations);
+            Assert.Same(oldResidueCollectors, sut.ResidueCollectors);
+            // Teardown
+        }
     }
 }


### PR DESCRIPTION
The previous approach was based on removal and insertion of the postprocessor node which fills up the properties. The new approach is to always keep the postprocessor, but instead enable/disable
it using the different specifications.

We follow the similar approach in the [NodeComposer.WithAutoProperties](https://github.com/AutoFixture/AutoFixture/blob/a3334feb3159279960ab3595b47fc361d0ad23ba/Src/AutoFixture/Dsl/NodeComposer.cs#L363) and it seems to works fine.

This approach makes the code much simpler and provides better current value lookup performance (the `Parents` implementation created recursive "yield" state machines). Also we removed about 30 lines of code from codebase - a huge win for such a small feature 😄