### PR TITLE
Deprecate generic PostProcessor<T> and AutoPropertiesCommand<T> versions

### DIFF
--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -511,7 +511,7 @@ namespace AutoFixture.Dsl
                     {
                         new Postprocessor(
                             CompositeSpecimenBuilder.ComposeIfMultiple(n),
-                            new AutoPropertiesCommand<T>(),
+                            new AutoPropertiesCommand(typeof(T)),
                             new FalseRequestSpecification()),
                         new SeedIgnoringRelay()
                     }),
@@ -522,7 +522,7 @@ namespace AutoFixture.Dsl
         {
             return (Postprocessor) graph
                 .FindFirstNodeOrDefault(n => n is Postprocessor postprocessor &&
-                                             postprocessor.Command is AutoPropertiesCommand<T>);
+                                             postprocessor.Command is AutoPropertiesCommand);
         }
         
         /// <summary>
@@ -535,7 +535,7 @@ namespace AutoFixture.Dsl
             var autoPropertiesNode = FindAutoPropertiesNode(graph);
             if (autoPropertiesNode == null) return graph;
 
-            var currentSpecification = ((AutoPropertiesCommand<T>) autoPropertiesNode.Command).Specification;
+            var currentSpecification = ((AutoPropertiesCommand) autoPropertiesNode.Command).Specification;
             var newRule = new InverseRequestSpecification(
                 new EqualRequestSpecification(
                     member,
@@ -559,7 +559,7 @@ namespace AutoFixture.Dsl
             return graph.ReplaceNodes(
                 with: _ => new Postprocessor(
                     autoPropertiesNode.Builder,
-                    new AutoPropertiesCommand<T>(specification),
+                    new AutoPropertiesCommand(typeof(T), specification),
                     autoPropertiesNode.Specification),
                 when: autoPropertiesNode.Equals);
         }

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -238,7 +238,7 @@ namespace AutoFixture.Dsl
                 with: n => n.Compose(
                     new[]
                     {
-                        new Postprocessor<T>(
+                        new Postprocessor(
                             CompositeSpecimenBuilder.ComposeIfMultiple(n),
                             new ActionSpecimenCommand<T>(action))
                     }),
@@ -265,7 +265,7 @@ namespace AutoFixture.Dsl
             // (e.g. if user does smth like fixture.Build().Without(x => x.P).OmitAutoProperties().WithAutoProperties()
             // the information from "Without" should not be missed)
             return (NodeComposer<T>) this.ReplaceNodes(
-                with: n => new Postprocessor<T>(
+                with: n => new Postprocessor(
                     autoPropertiesNode.Builder,
                     autoPropertiesNode.Command,
                     new FalseRequestSpecification()),
@@ -296,7 +296,7 @@ namespace AutoFixture.Dsl
             var targetToDecorate = this.FindFirstNode(n => n is NoSpecimenOutputGuard);
 
             return (NodeComposer<T>)this.ReplaceNodes(
-                with: n => new Postprocessor<T>(
+                with: n => new Postprocessor(
                     n,
                     new BindingCommand<T, TProperty>(propertyPicker),
                     CreateSpecification()),
@@ -336,7 +336,7 @@ namespace AutoFixture.Dsl
                 with: n => n.Compose(
                     new ISpecimenBuilder[]
                     {
-                        new Postprocessor<T>(
+                        new Postprocessor(
                             CompositeSpecimenBuilder.ComposeIfMultiple(n),
                             new BindingCommand<T, TProperty>(propertyPicker, value),
                             CreateSpecification()),
@@ -361,7 +361,7 @@ namespace AutoFixture.Dsl
             var autoProperties = FindAutoPropertiesNode(g);
 
             return (NodeComposer<T>) g.ReplaceNodes(
-                with: n => new Postprocessor<T>(
+                with: n => new Postprocessor(
                     autoProperties.Builder,
                     autoProperties.Command,
                     new TrueRequestSpecification()),
@@ -509,7 +509,7 @@ namespace AutoFixture.Dsl
                 with: n => n.Compose(
                     new ISpecimenBuilder[]
                     {
-                        new Postprocessor<T>(
+                        new Postprocessor(
                             CompositeSpecimenBuilder.ComposeIfMultiple(n),
                             new AutoPropertiesCommand<T>(),
                             new FalseRequestSpecification()),
@@ -518,10 +518,10 @@ namespace AutoFixture.Dsl
                 when: filter.Equals);
         }
 
-        private static Postprocessor<T> FindAutoPropertiesNode(ISpecimenBuilderNode graph)
+        private static Postprocessor FindAutoPropertiesNode(ISpecimenBuilderNode graph)
         {
-            return (Postprocessor<T>) graph
-                .FindFirstNodeOrDefault(n => n is Postprocessor<T> postprocessor &&
+            return (Postprocessor) graph
+                .FindFirstNodeOrDefault(n => n is Postprocessor postprocessor &&
                                              postprocessor.Command is AutoPropertiesCommand<T>);
         }
         
@@ -557,7 +557,7 @@ namespace AutoFixture.Dsl
             }
 
             return graph.ReplaceNodes(
-                with: _ => new Postprocessor<T>(
+                with: _ => new Postprocessor(
                     autoPropertiesNode.Builder,
                     new AutoPropertiesCommand<T>(specification),
                     autoPropertiesNode.Specification),

--- a/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
+++ b/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
@@ -8,7 +8,9 @@ namespace AutoFixture.Kernel
     /// <summary>
     /// A command that assigns anonymous values to all writable properties and fields of a type.
     /// </summary>
+#pragma warning disable 618
     public class AutoPropertiesCommand : AutoPropertiesCommand<object>
+#pragma warning restore 618
     {
         /// <summary>
         /// The explicitly specified <see cref="Type"/> that should be used to resolve fields and properties 
@@ -98,9 +100,8 @@ namespace AutoFixture.Kernel
     /// A command that assigns anonymous values to all writable properties and fields of a type.
     /// </summary>
     /// <typeparam name="T">The specimen type on which properties are assigned.</typeparam>
-#pragma warning disable 618
+    [Obsolete("The generic version of the AutoPropertiesCommand is no longer used and will be removed in future versions. Please use the non-generic version of the AutoPropertiesCommand type.")]
     public class AutoPropertiesCommand<T> : ISpecimenCommand, ObsoletedMemberShims.ISpecifiedSpecimenCommand<T>
-#pragma warning restore 618
     {
         /// <summary>
         /// Specification that filters properties and files that should be populated.

--- a/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
+++ b/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
@@ -10,8 +10,18 @@ namespace AutoFixture.Kernel
     /// </summary>
     public class AutoPropertiesCommand : AutoPropertiesCommand<object>
     {
-        private readonly Func<object, Type> getSpecimenType;
-
+        /// <summary>
+        /// The explicitly specified <see cref="Type"/> that should be used to resolve fields and properties 
+        /// to populate for the specimen.
+        /// <remarks>
+        /// <para>
+        /// Property will return null if no explicit specimen type was specified during the command construction.
+        /// In this case command uses the runtime type of the generated specimen to resolve its fields and properties.
+        /// </para>
+        /// </remarks>
+        /// </summary>
+        public Type ExplicitSpecimenType { get; }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoPropertiesCommand"/> class.
         /// </summary>
@@ -23,7 +33,7 @@ namespace AutoFixture.Kernel
         /// </remarks>
         public AutoPropertiesCommand()
         {
-            this.getSpecimenType = s => s.GetType();
+            this.ExplicitSpecimenType = null;
         }
 
         /// <summary>
@@ -33,12 +43,7 @@ namespace AutoFixture.Kernel
         /// <param name="specimenType">The specimen type on which properties are assigned.</param>
         public AutoPropertiesCommand(Type specimenType)
         {
-            if (specimenType == null)
-            {
-                throw new ArgumentNullException(nameof(specimenType));
-            }
-
-            this.getSpecimenType = s => specimenType;
+            this.ExplicitSpecimenType = specimenType ?? throw new ArgumentNullException(nameof(specimenType));
         }
 
         /// <summary>
@@ -57,7 +62,7 @@ namespace AutoFixture.Kernel
         public AutoPropertiesCommand(IRequestSpecification specification)
             : base(specification)
         {
-            this.getSpecimenType = s => s.GetType();
+            this.ExplicitSpecimenType = null;
         }
 
         /// <summary>
@@ -77,21 +82,15 @@ namespace AutoFixture.Kernel
         public AutoPropertiesCommand(Type specimenType, IRequestSpecification specification)
             : base(specification)
         {
-            this.getSpecimenType = s => specimenType;
+            this.ExplicitSpecimenType = specimenType ?? throw new ArgumentNullException(nameof(specimenType));
         }
 
-        /// <summary>
-        /// Gets the type of the specimen.
-        /// </summary>
-        /// <param name="specimen">The specimen.</param>
-        /// <returns>The type of the specimen.</returns>
-        /// <remarks>
-        /// This implementation may ignore <paramref name="specimen"/> and instead return the type
-        /// passed to the <see cref="AutoPropertiesCommand"/> constructor.
-        /// </remarks>
+        /// <inheritdoc />
         protected override Type GetSpecimenType(object specimen)
         {
-            return this.getSpecimenType(specimen);
+            if (specimen == null) throw new ArgumentNullException(nameof(specimen));
+
+            return this.ExplicitSpecimenType ?? specimen.GetType();
         }
     }
 

--- a/Src/AutoFixture/Kernel/OmitSpecimen.cs
+++ b/Src/AutoFixture/Kernel/OmitSpecimen.cs
@@ -15,7 +15,7 @@ namespace AutoFixture.Kernel
     /// <see langword="null" />.
     /// </para>
     /// <para>
-    /// The OmitSpecimen type is explicitly understood by <see cref="AutoPropertiesCommand{T}" />,
+    /// The OmitSpecimen type is explicitly understood by <see cref="AutoPropertiesCommand" />,
     /// but can be returned by any ISpecimenBuilder.
     /// </para>
     /// </remarks>

--- a/Src/AutoFixture/Kernel/Postprocessor.cs
+++ b/Src/AutoFixture/Kernel/Postprocessor.cs
@@ -7,8 +7,11 @@ namespace AutoFixture.Kernel
     /// <summary>
     /// Performs post-processing on a created specimen.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", 
+        Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
+#pragma warning disable 618
     public class Postprocessor : Postprocessor<object>
+#pragma warning restore 618
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Postprocessor"/> class with the supplied
@@ -109,6 +112,7 @@ namespace AutoFixture.Kernel
     /// </summary>
     /// <typeparam name="T">The type of specimen.</typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
+    [Obsolete("The generic version of the Postprocessor is no longer used and will be removed in future versions. Please use the non-generic version of the Postprocessor type.")]
     public class Postprocessor<T> : ISpecimenBuilderNode
     {
         private Action<T, ISpecimenContext> action;

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -348,7 +348,7 @@ namespace AutoFixtureUnitTest.Dsl
                                 new InverseRequestSpecification(
                                     new SeedRequestSpecification(
                                         typeof(Version)))),
-                            new AutoPropertiesCommand<Version>(),
+                            new AutoPropertiesCommand(typeof(Version)),
                             new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
@@ -393,7 +393,7 @@ namespace AutoFixtureUnitTest.Dsl
                                 new InverseRequestSpecification(
                                     new SeedRequestSpecification(
                                         typeof(Version)))),
-                            new AutoPropertiesCommand<Version>(),
+                            new AutoPropertiesCommand(typeof(Version)),
                             new FalseRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
@@ -460,7 +460,8 @@ namespace AutoFixtureUnitTest.Dsl
                                     new InverseRequestSpecification(
                                         new SeedRequestSpecification(
                                             typeof(PropertyHolder<string>)))),
-                                new AutoPropertiesCommand<PropertyHolder<string>>(
+                                new AutoPropertiesCommand(
+                                    typeof(PropertyHolder<string>),
                                     new InverseRequestSpecification(
                                         new EqualRequestSpecification(
                                             pi,
@@ -512,7 +513,8 @@ namespace AutoFixtureUnitTest.Dsl
                                         new InverseRequestSpecification(
                                             new SeedRequestSpecification(
                                                 typeof(DoublePropertyHolder<string, int>)))),
-                                    new AutoPropertiesCommand<DoublePropertyHolder<string, int>>(
+                                    new AutoPropertiesCommand(
+                                        typeof(DoublePropertyHolder<string, int>),
                                         new AndRequestSpecification(
                                             new InverseRequestSpecification(
                                                 new EqualRequestSpecification(
@@ -560,7 +562,8 @@ namespace AutoFixtureUnitTest.Dsl
                                 new InverseRequestSpecification(
                                     new SeedRequestSpecification(
                                         typeof(FieldHolder<short>)))),
-                            new AutoPropertiesCommand<FieldHolder<short>>(
+                            new AutoPropertiesCommand(
+                                typeof(FieldHolder<short>),
                                 new InverseRequestSpecification(
                                     new EqualRequestSpecification(
                                         fi,
@@ -595,7 +598,7 @@ namespace AutoFixtureUnitTest.Dsl
                                 new InverseRequestSpecification(
                                     new SeedRequestSpecification(
                                         typeof(Version)))),
-                            new AutoPropertiesCommand<Version>(),
+                            new AutoPropertiesCommand(typeof(Version)),
                             new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
@@ -640,7 +643,7 @@ namespace AutoFixtureUnitTest.Dsl
                                 new InverseRequestSpecification(
                                     new SeedRequestSpecification(
                                         typeof(Version)))),
-                            new AutoPropertiesCommand<Version>(),
+                            new AutoPropertiesCommand(typeof(Version)),
                             new FalseRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
@@ -671,7 +674,7 @@ namespace AutoFixtureUnitTest.Dsl
                                 new InverseRequestSpecification(
                                     new SeedRequestSpecification(
                                         typeof(PropertyHolder<string>)))),
-                            new AutoPropertiesCommand<PropertyHolder<string>>(),
+                            new AutoPropertiesCommand(typeof(PropertyHolder<string>)),
                             new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(
@@ -704,7 +707,7 @@ namespace AutoFixtureUnitTest.Dsl
                                         new SeedRequestSpecification(
                                             typeof(PropertyHolder<int>)))),
                                 new ActionSpecimenCommand<PropertyHolder<int>>(a)),
-                            new AutoPropertiesCommand<PropertyHolder<int>>(),
+                            new AutoPropertiesCommand(typeof(PropertyHolder<int>)),
                             new TrueRequestSpecification()),
                         new SeedIgnoringRelay()),
                     new OrRequestSpecification(

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -279,7 +279,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<ConcreteType>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<ConcreteType>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
@@ -310,8 +310,8 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<PropertyHolder<string>>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<PropertyHolder<string>>(
-                            new Postprocessor<PropertyHolder<string>>(
+                        new Postprocessor(
+                            new Postprocessor(
                                 new NoSpecimenOutputGuard(
                                     new MethodInvoker(
                                         new ModestConstructorQuery()),
@@ -341,7 +341,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<Version>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<Version>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
@@ -386,7 +386,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<Version>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<Version>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
@@ -416,7 +416,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<PropertyHolder<int>>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<PropertyHolder<int>>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
@@ -452,8 +452,8 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<PropertyHolder<string>>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<PropertyHolder<string>>(
-                            new Postprocessor<PropertyHolder<string>>(
+                        new Postprocessor(
+                            new Postprocessor(
                                 new NoSpecimenOutputGuard(
                                     new MethodInvoker(
                                         new ModestConstructorQuery()),
@@ -503,9 +503,9 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<DoublePropertyHolder<string, int>>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<DoublePropertyHolder<string, int>>(
-                            new Postprocessor<DoublePropertyHolder<string, int>>(
-                                new Postprocessor<DoublePropertyHolder<string, int>>(
+                        new Postprocessor(
+                            new Postprocessor(
+                                new Postprocessor(
                                     new NoSpecimenOutputGuard(
                                         new MethodInvoker(
                                             new ModestConstructorQuery()),
@@ -553,7 +553,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<FieldHolder<short>>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<FieldHolder<short>>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
@@ -588,7 +588,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<Version>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<Version>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
@@ -633,7 +633,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<Version>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<Version>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new MethodInvoker(
                                     new ModestConstructorQuery()),
@@ -665,7 +665,7 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<PropertyHolder<string>>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<PropertyHolder<string>>(
+                        new Postprocessor(
                             new NoSpecimenOutputGuard(
                                 new SpecimenFactory<PropertyHolder<string>>(f),
                                 new InverseRequestSpecification(
@@ -695,8 +695,8 @@ namespace AutoFixtureUnitTest.Dsl
             var expected = new NodeComposer<PropertyHolder<int>>(
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
-                        new Postprocessor<PropertyHolder<int>>(
-                            new Postprocessor<PropertyHolder<int>>(
+                        new Postprocessor(
+                            new Postprocessor(
                                 new NoSpecimenOutputGuard(
                                     new MethodInvoker(
                                         new ModestConstructorQuery()),

--- a/Src/AutoFixtureUnitTest/Kernel/AutoPropertiesCommandTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/AutoPropertiesCommandTest.cs
@@ -21,6 +21,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWithNullSpecimenThrows()
         {
             // Fixture setup
@@ -32,6 +33,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWithNullContainerThrows()
         {
             // Fixture setup
@@ -43,6 +45,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWillAssignCorrectFieldValue()
         {
             // Fixture setup
@@ -60,6 +63,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWillAssignCorrectPropertyValue()
         {
             // Fixture setup
@@ -77,6 +81,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteDoesNotSetReadOnlyProperty()
         {
             // Fixture setup
@@ -92,6 +97,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteDoesNotThrowOnIndexedProperty()
         {
             // Fixture setup
@@ -105,6 +111,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteDoesNotSetStaticProperty()
         {
             // Fixture setup
@@ -119,7 +126,8 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void ExecuteDoesNotSetStaticField()
+        [Obsolete]
+        void ExecuteDoesNotSetStaticField()
         {
             // Fixture setup
             var sut = new AutoPropertiesCommand<StaticFieldHolder<object>>();
@@ -133,6 +141,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteDoesNotSetReadonlyField()
         {
             // Fixture setup
@@ -148,6 +157,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void InitializeWithNullSpecificationThrows()
         {
             // Fixture setup
@@ -157,6 +167,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteDoesNotAssignPropertyWhenSpecificationIsNotSatisfied()
         {
             // Fixture setup
@@ -172,6 +183,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWillQuerySpecificationWithCorrectPropertyInfo()
         {
             // Fixture setup
@@ -189,6 +201,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWillNotAssignPropertyWhenContextReturnsOmitSpecimen()
         {
             // Fixture setup
@@ -206,6 +219,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteDoesNotAssignFieldWhenSpecificationIsNotSatisfied()
         {
             // Fixture setup
@@ -221,6 +235,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWillQuerySpecificationWithCorrectFieldInfo()
         {
             // Fixture setup
@@ -238,6 +253,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void ExecuteWillNotAssignFieldWhenContextReturnsOmitSpecimen()
         {
             // Fixture setup
@@ -255,6 +271,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByNullThrows()
         {
             // Fixture setup
@@ -267,6 +284,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByAnonymousRequestReturnsCorrectResult()
         {
             // Fixture setup
@@ -282,6 +300,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByUnfilteredPropertyInfoReturnsCorrectResult()
         {
             // Fixture setup
@@ -297,6 +316,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByReadOnlyPropertyReturnsCorrectResult()
         {
             // Fixture setup
@@ -312,6 +332,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByIndexedPropertyReturnsCorrectResult()
         {
             // Fixture setup
@@ -327,6 +348,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByFilteredPropertyInfoReturnsCorrectResult()
         {
             // Fixture setup
@@ -343,6 +365,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByWillInvokeSpecificationWithCorrectPropertyInfo()
         {
             // Fixture setup
@@ -360,6 +383,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByUnfilteredFieldInfoReturnsCorrectResult()
         {
             // Fixture setup
@@ -375,6 +399,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByFilteredFieldInfoReturnsCorrectResult()
         {
             // Fixture setup
@@ -391,6 +416,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void IsSatisfiedByWillInvokeSpecificationWithCorrectFieldInfo()
         {
             // Fixture setup
@@ -408,6 +434,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void NonGenericSutIsCorrectGenericSut()
         {
             // Fixture setup
@@ -524,6 +551,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void SutIsSpecimenCommand()
         {
             var sut = new AutoPropertiesCommand<object>();

--- a/Src/AutoFixtureUnitTest/Kernel/AutoPropertiesCommandTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/AutoPropertiesCommandTest.cs
@@ -530,6 +530,99 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.IsAssignableFrom<ISpecimenCommand>(sut);
         }
 
+        [Fact]
+        public void NonTypedUsesExplicitlySpecifiedTypeForFieldsAndPropertiesResolve()
+        {
+            // Fixture setup
+            var sut = new AutoPropertiesCommand(typeof(object));
+            
+            var dummyPropertyValue = new object();
+            var context = new DelegatingSpecimenContext { OnResolve = r => dummyPropertyValue };
+            
+            var specimen = new PropertyHolder<object>();
+
+            // Exercise system
+            sut.Execute(specimen, context);
+            
+            // Verify outcome
+            Assert.NotEqual(dummyPropertyValue, specimen.Property);
+            // Teardown
+        }
+        
+        [Fact]
+        public void NonTypedWithSpecificationUsesExplicitlySpecifiedTypeForFieldsAndPropertiesResolve()
+        {
+            // Fixture setup
+            var trueSpec = new TrueRequestSpecification();
+            var sut = new AutoPropertiesCommand(typeof(object), trueSpec);
+            
+            var dummyPropertyValue = new object();
+            var context = new DelegatingSpecimenContext { OnResolve = r => dummyPropertyValue };
+            
+            var specimen = new PropertyHolder<object>();
+
+            // Exercise system
+            sut.Execute(specimen, context);
+            
+            // Verify outcome
+            Assert.NotEqual(dummyPropertyValue, specimen.Property);
+            // Teardown
+        }
+
+        [Fact]
+        public void NonTypedReturnsSpecimenTypeIfProvidedInCtor()
+        {
+            // Fixture setup
+            var type = typeof(string);
+
+            // Exercise system
+            var sut = new AutoPropertiesCommand(type);
+
+            // Verify outcome
+            Assert.Equal(type, sut.ExplicitSpecimenType);
+            // Teardown
+        }
+        
+        [Fact]
+        public void NonTypedWithSpecificationReturnsSpecimenTypeIfProvidedInCtor()
+        {
+            // Fixture setup
+            var type = typeof(string);
+            var spec = new TrueRequestSpecification();
+
+            // Exercise system
+            var sut = new AutoPropertiesCommand(type, spec);
+
+            // Verify outcome
+            Assert.Equal(type, sut.ExplicitSpecimenType);
+            // Teardown
+        }
+        
+        [Fact]
+        public void NonTypedReturnsNullSpecimenTypeIfNotProvided()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new AutoPropertiesCommand();
+
+            // Verify outcome
+            Assert.Null(sut.ExplicitSpecimenType);
+            // Teardown
+        }
+        
+        [Fact]
+        public void NonTypedWithSpecificationReturnsNullSpecimenTypeIfNotProvided()
+        {
+            // Fixture setup
+            // Exercise system
+            var sut = new AutoPropertiesCommand();
+
+            // Verify outcome
+            Assert.Null(sut.ExplicitSpecimenType);
+            // Teardown
+        }
+        
+
         public void Dispose()
         {
             StaticPropertyHolder<object>.Property = null;

--- a/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
@@ -167,7 +167,7 @@ namespace AutoFixtureUnitTest.Kernel
                     { typeof(SpecimenFactory<,,>), typeof(SpecimenFactoryEquatable<,,>) },
                     { typeof(SpecimenFactory<,,,>), typeof(SpecimenFactoryEquatable<,,,>) },
                     { typeof(SpecimenFactory<,,,,>), typeof(SpecimenFactoryEquatable<,,,,>) },
-                    { typeof(Postprocessor<>), typeof(PostprocessorEquatable<>) },
+                    { typeof(Postprocessor), typeof(PostprocessorEquatable) },
                     { typeof(NodeComposer<>), typeof(NodeComposerEquatable<>) },
                     { typeof(CompositeNodeComposer<>), typeof(CompositeNodeComposerEquatable<>) }
                 };
@@ -190,17 +190,17 @@ namespace AutoFixtureUnitTest.Kernel
             }
         }
 
-        private class PostprocessorEquatable<T> : GenericEquatable<Postprocessor<T>>
+        private class PostprocessorEquatable : GenericEquatable<Postprocessor>
         {
             private readonly IEqualityComparer<IRequestSpecification> specificationComparer;
 
-            public PostprocessorEquatable(Postprocessor<T> pp)
+            public PostprocessorEquatable(Postprocessor pp)
                 : base(pp)
             {
                 this.specificationComparer = new SpecificationComparer();
             }
 
-            protected override bool EqualsInstance(Postprocessor<T> other)
+            protected override bool EqualsInstance(Postprocessor other)
             {
                 return this.CommandsAreEqual(this.Item.Command, other.Command)
                     && this.specificationComparer.Equals(this.Item.Specification, other.Specification);                
@@ -208,8 +208,8 @@ namespace AutoFixtureUnitTest.Kernel
 
             private bool CommandsAreEqual(ISpecimenCommand x, ISpecimenCommand y)
             {
-                if (x is AutoPropertiesCommand<T> apx &&
-                    y is AutoPropertiesCommand<T> apy)
+                if (x is AutoPropertiesCommand apx &&
+                    y is AutoPropertiesCommand apy)
                 {
                     return this.specificationComparer.Equals(apx.Specification, apy.Specification);
                 }

--- a/Src/AutoFixtureUnitTest/Kernel/PostprocessorGenericTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/PostprocessorGenericTest.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest.Kernel
 {
+    [Obsolete]
     public class PostprocessorGenericTest
     {
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/PostprocessorTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/PostprocessorTest.cs
@@ -21,6 +21,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        [Obsolete]
         public void SutIsPostProcessor()
         {
             // Fixture setup
@@ -329,7 +330,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Exercise system
             var actual = sut.Compose(new ISpecimenBuilder[0]);
             // Verify outcome
-            var pp = Assert.IsAssignableFrom<Postprocessor<object>>(actual);
+            var pp = Assert.IsAssignableFrom<Postprocessor>(actual);
             Assert.Equal(expected, pp.Command);
             // Teardown
         }

--- a/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
@@ -216,7 +216,7 @@ namespace AutoFixtureUnitTest.Kernel
                 new Postprocessor(
                     new MethodInvoker(new ModestConstructorQuery()),
                     specifiedCommand),
-                new AutoPropertiesCommand<DoublePropertyHolder<string, int>>(reservedProperty),
+                new AutoPropertiesCommand(reservedProperty),
                 new AnyTypeSpecification());
 
             var builder = new CompositeSpecimenBuilder(

--- a/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
@@ -141,8 +141,8 @@ namespace AutoFixtureUnitTest.Kernel
             var ctorInvoker = new MethodInvoker(new ModestConstructorQuery());
             var strCmd = new BindingCommand<DoublePropertyHolder<string, int>, string>(ph => ph.Property1);
             var intCmd = new BindingCommand<DoublePropertyHolder<string, int>, int>(ph => ph.Property2);
-            var strPostprocessor = new Postprocessor<DoublePropertyHolder<string, int>>(ctorInvoker, strCmd);
-            var intPostprocessor = new Postprocessor<DoublePropertyHolder<string, int>>(strPostprocessor, intCmd);
+            var strPostprocessor = new Postprocessor(ctorInvoker, strCmd);
+            var intPostprocessor = new Postprocessor(strPostprocessor, intCmd);
 
             var builder = new CompositeSpecimenBuilder(
                 new FilteringSpecimenBuilder(intPostprocessor, new ExactTypeSpecification(typeof(DoublePropertyHolder<string, int>))),
@@ -212,8 +212,8 @@ namespace AutoFixtureUnitTest.Kernel
             var specifiedCommand = new BindingCommand<DoublePropertyHolder<string, int>, string>(ph => ph.Property1, expectedText);
             var reservedProperty = new InverseRequestSpecification(specifiedCommand);
 
-            var customizedBuilder = new Postprocessor<DoublePropertyHolder<string, int>>(
-                new Postprocessor<DoublePropertyHolder<string, int>>(
+            var customizedBuilder = new Postprocessor(
+                new Postprocessor(
                     new MethodInvoker(new ModestConstructorQuery()),
                     specifiedCommand),
                 new AutoPropertiesCommand<DoublePropertyHolder<string, int>>(reservedProperty),


### PR DESCRIPTION
Currently we have generic and non-generic pairs for the `PostProcessor<T>` and `AutoPropertiesCommand<T>` types. In most of the places the non-generic versions are used, so it makes a bit of confusion which version to use. Also it's a bit hard to read their implementation as non-generic ones are inherited from the generic ones with `T = object`.

I investigated that more and found that previously existence of two variants made sense, but now all the generic parts of the classes are deprecated and they became almost non-generic.

For instance, previously the `AutoPropertiesCommand<T>` implemented the `ISpecifiedSpecimenCommand<T>` interface which now is [totally deprecated](https://github.com/AutoFixture/AutoFixture/blob/a3334feb3159279960ab3595b47fc361d0ad23ba/Src/AutoFixture/Kernel/ISpecifiedSpecimenCommand.cs#L11). All the generic members of this class are deprecated. The similar story is with `PostProcessor<T>` - all the generic members are fully deprecated and will be removed in a future version of the product.

Therefore, to keep the code base more tidy I deprecated the generic variants and altered the remaining code to use the non-generic siblings. As you can see, no functional tests failed - only the structural inspection one where we asserted the exact object type.