### PR TITLE
Obsolete non-uniform specimen.Create() method overloads

### DIFF
--- a/Src/AutoFixture/BooleanSwitch.cs
+++ b/Src/AutoFixture/BooleanSwitch.cs
@@ -27,6 +27,7 @@ namespace AutoFixture
         /// <see langword="true"/>, followed by <see langword="false"/> at the next invocation, and
         /// so on.
         /// </returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public bool Create()
         {
             lock (this.syncRoot)
@@ -69,7 +70,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/ByteSequenceGenerator.cs
+++ b/Src/AutoFixture/ByteSequenceGenerator.cs
@@ -23,6 +23,7 @@ namespace AutoFixture
         /// Creates an anonymous number.
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public byte Create()
         {
             lock (this.syncRoot)
@@ -58,7 +59,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/DecimalSequenceGenerator.cs
+++ b/Src/AutoFixture/DecimalSequenceGenerator.cs
@@ -23,6 +23,7 @@ namespace AutoFixture
         /// Creates an anonymous number.
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public decimal Create()
         {
             lock (this.syncRoot)
@@ -42,8 +43,6 @@ namespace AutoFixture
             return this.Create();
         }
 
-
-
         /// <summary>
         /// Creates an anonymous number.
         /// </summary>
@@ -60,7 +59,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/DoubleSequenceGenerator.cs
+++ b/Src/AutoFixture/DoubleSequenceGenerator.cs
@@ -23,6 +23,7 @@ namespace AutoFixture
         /// Creates an anonymous number.
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public double Create()
         {
             lock (this.syncRoot)
@@ -59,7 +60,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/GuidGenerator.cs
+++ b/Src/AutoFixture/GuidGenerator.cs
@@ -12,6 +12,7 @@ namespace AutoFixture
         /// Creates a new <see cref="Guid"/> instance.
         /// </summary>
         /// <returns>A new <see cref="Guid"/> instance.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public static Guid Create()
         {
             return Guid.NewGuid();
@@ -44,7 +45,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
-            return GuidGenerator.Create();
+#pragma warning disable 618
+            return Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/Int16SequenceGenerator.cs
+++ b/Src/AutoFixture/Int16SequenceGenerator.cs
@@ -23,6 +23,7 @@ namespace AutoFixture
         /// Creates an anonymous number.
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public short Create()
         {
             lock (this.syncRoot)
@@ -58,7 +59,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/Int32SequenceGenerator.cs
+++ b/Src/AutoFixture/Int32SequenceGenerator.cs
@@ -12,16 +12,10 @@ namespace AutoFixture
         private int i;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Int32SequenceGenerator"/> class.
-        /// </summary>
-        public Int32SequenceGenerator()
-        {
-        }
-
-        /// <summary>
         /// Creates an anonymous number.
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public int Create()
         {
             return Interlocked.Increment(ref this.i);
@@ -54,7 +48,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/Int64SequenceGenerator.cs
+++ b/Src/AutoFixture/Int64SequenceGenerator.cs
@@ -12,16 +12,10 @@ namespace AutoFixture
         private long l;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Int64SequenceGenerator"/> class.
-        /// </summary>
-        public Int64SequenceGenerator()
-        {
-        }
-
-        /// <summary>
         /// Creates an anonymous number.
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public long Create()
         {
             return Interlocked.Increment(ref this.l);
@@ -54,7 +48,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/SByteSequenceGenerator.cs
+++ b/Src/AutoFixture/SByteSequenceGenerator.cs
@@ -24,6 +24,7 @@ namespace AutoFixture
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
         [CLSCompliant(false)]
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public sbyte Create()
         {
             lock (this.syncRoot)
@@ -60,7 +61,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/SingleSequenceGenerator.cs
+++ b/Src/AutoFixture/SingleSequenceGenerator.cs
@@ -23,6 +23,7 @@ namespace AutoFixture
         /// Creates an anonymous number.
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
+        [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
         public float Create()
         {
             lock (this.syncRoot)
@@ -58,7 +59,9 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
+#pragma warning disable 618
             return this.Create();
+#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/UInt16SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt16SequenceGenerator.cs
@@ -24,12 +24,10 @@ namespace AutoFixture
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
         [CLSCompliant(false)]
+        [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
         public ushort CreateAnonymous()
         {
-            lock (this.syncRoot)
-            {
-                return ++this.u;
-            }
+            return (ushort)this.Create(typeof(ushort), null);
         }
 
         /// <summary>
@@ -47,8 +45,11 @@ namespace AutoFixture
             {
                 return new NoSpecimen();
             }
-
-            return this.CreateAnonymous();
+            
+            lock (this.syncRoot)
+            {
+                return ++this.u;
+            }
         }
     }
 }

--- a/Src/AutoFixture/UInt32SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt32SequenceGenerator.cs
@@ -24,12 +24,10 @@ namespace AutoFixture
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
         [CLSCompliant(false)]
+        [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
         public uint CreateAnonymous()
         {
-            lock (this.syncRoot)
-            {
-                return ++this.u;
-            }
+            return (uint)this.Create(typeof(uint), null);
         }
 
         /// <summary>
@@ -47,8 +45,11 @@ namespace AutoFixture
             {
                 return new NoSpecimen();
             }
-
-            return this.CreateAnonymous();
+            
+            lock (this.syncRoot)
+            {
+                return ++this.u;
+            }
         }
     }
 }

--- a/Src/AutoFixture/UInt64SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt64SequenceGenerator.cs
@@ -24,12 +24,10 @@ namespace AutoFixture
         /// </summary>
         /// <returns>The next number in a consecutive sequence.</returns>
         [CLSCompliant(false)]
+        [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
         public ulong CreateAnonymous()
         {
-            lock (this.syncRoot)
-            {
-                return ++this.u;
-            }
+            return (ulong)this.Create(typeof(ulong), null);
         }
 
         /// <summary>
@@ -47,8 +45,11 @@ namespace AutoFixture
             {
                 return new NoSpecimen();
             }
-
-            return this.CreateAnonymous();
+            
+            lock (this.syncRoot)
+            {
+                return ++this.u;
+            }
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
+++ b/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
@@ -8,7 +8,7 @@ namespace AutoFixtureUnitTest
 {
     public class BooleanSwitchTest
     {
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTrueOnFirstCall()
         {
             // Fixture setup
@@ -32,7 +32,7 @@ namespace AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnFalseOnSecondCall()
         {
             // Fixture setup
@@ -71,7 +71,7 @@ namespace AutoFixtureUnitTest
             Assert.True(result, "CreateAnonymous called an uneven number of times");
             // Teardown
         }
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTrueOnThirdCall()
         {
             // Fixture setup
@@ -99,7 +99,7 @@ namespace AutoFixtureUnitTest
             Assert.False(result, "CreateAnonymous called an even number of times");
             // Teardown
         }
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnFalseOnFourthCall()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<ByteSequenceGenerator, byte>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<ByteSequenceGenerator, byte>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<ByteSequenceGenerator, byte>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<ByteSequenceGenerator, byte>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<DecimalSequenceGenerator, decimal>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<DecimalSequenceGenerator, decimal>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<DecimalSequenceGenerator, decimal>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<DecimalSequenceGenerator, decimal>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<DoubleSequenceGenerator, double>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<DoubleSequenceGenerator, double>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<DoubleSequenceGenerator, double>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<DoubleSequenceGenerator, double>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
@@ -20,7 +20,7 @@ namespace AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnNonDefaultGuid()
         {
             // Fixture setup
@@ -44,7 +44,7 @@ namespace AutoFixtureUnitTest
             // Teardown
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateTwiceWillReturnDifferentValues()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<Int16SequenceGenerator, short>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<Int16SequenceGenerator, short>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<Int16SequenceGenerator, short>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<Int16SequenceGenerator, short>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<Int32SequenceGenerator, int>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<Int32SequenceGenerator, int>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<Int32SequenceGenerator, int>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<Int32SequenceGenerator, int>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<Int64SequenceGenerator, long>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<Int64SequenceGenerator, long>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<Int64SequenceGenerator, long>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<Int64SequenceGenerator, long>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
@@ -108,7 +108,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Teardown
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateDoubleMixedParameterizedTypeWithNumberBasedStringGenerator()
         {
             // Fixture setup

--- a/Src/AutoFixtureUnitTest/SByteSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/SByteSequenceGeneratorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<SByteSequenceGenerator, sbyte>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<SByteSequenceGenerator, sbyte>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<SByteSequenceGenerator, sbyte>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<SByteSequenceGenerator, sbyte>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/SingleSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/SingleSequenceGeneratorTest.cs
@@ -26,19 +26,19 @@ namespace AutoFixtureUnitTest
             new LoopTest<SingleSequenceGenerator, float>(sut => sut.CreateAnonymous()).Execute(10);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<SingleSequenceGenerator, float>(sut => sut.Create()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<SingleSequenceGenerator, float>(sut => sut.Create()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<SingleSequenceGenerator, float>(sut => sut.Create()).Execute(10);

--- a/Src/AutoFixtureUnitTest/UInt16SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt16SequenceGeneratorTest.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture;
+﻿using System;
+using AutoFixture;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
 using Xunit;
@@ -7,19 +8,19 @@ namespace AutoFixtureUnitTest
 {
     public class UInt16SequenceGeneratorTest
     {
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<UInt16SequenceGenerator, ushort>(sut => sut.CreateAnonymous()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<UInt16SequenceGenerator, ushort>(sut => sut.CreateAnonymous()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<UInt16SequenceGenerator, ushort>(sut => sut.CreateAnonymous()).Execute(10);

--- a/Src/AutoFixtureUnitTest/UInt32SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt32SequenceGeneratorTest.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture;
+﻿using System;
+using AutoFixture;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
 using Xunit;
@@ -7,19 +8,19 @@ namespace AutoFixtureUnitTest
 {
     public class UInt32SequenceGeneratorTest
     {
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<UInt32SequenceGenerator, uint>(sut => sut.CreateAnonymous()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<UInt32SequenceGenerator, uint>(sut => sut.CreateAnonymous()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<UInt32SequenceGenerator, uint>(sut => sut.CreateAnonymous()).Execute(10);

--- a/Src/AutoFixtureUnitTest/UInt64SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt64SequenceGeneratorTest.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture;
+﻿using System;
+using AutoFixture;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
 using Xunit;
@@ -7,19 +8,19 @@ namespace AutoFixtureUnitTest
 {
     public class UInt64SequenceGeneratorTest
     {
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnOneOnFirstCall()
         {
             new LoopTest<UInt64SequenceGenerator, ulong>(sut => sut.CreateAnonymous()).Execute(1);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTwoOnSecondCall()
         {
             new LoopTest<UInt64SequenceGenerator, ulong>(sut => sut.CreateAnonymous()).Execute(2);
         }
 
-        [Fact]
+        [Fact][Obsolete]
         public void CreateWillReturnTenOnTenthCall()
         {
             new LoopTest<UInt64SequenceGenerator, ulong>(sut => sut.CreateAnonymous()).Execute(10);


### PR DESCRIPTION
I've found that there are some builders with extra-overloads of the `Create()` method which are not being used. I've altered the code to deprecate them.

That allows to unify the code so that all the specimen builders looks the same unless that is required on purpose.

Notice, the overloads with the `Anonymous` word were deprecated completely to align with other builders - this API convention was removed since v3.