### PR TITLE
[xUnit/xUnit2] Loosen up InlineAutoDataAttribute constructor to take DataAttribute argument

### DIFF
--- a/Src/AutoFixture.xUnit.net.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net.UnitTest/InlineAutoDataAttributeTest.cs
@@ -105,9 +105,10 @@ namespace AutoFixture.Xunit.UnitTest
             // Fixture setup
             var sut = new InlineAutoDataAttribute();
             // Exercise system
-            AutoDataAttribute result = sut.AutoDataAttribute;
+            DataAttribute result = sut.AutoDataAttribute;
             // Verify outcome
             Assert.NotNull(result);
+            Assert.IsType<AutoDataAttribute>(result);
             // Teardown
         }
 
@@ -146,7 +147,7 @@ namespace AutoFixture.Xunit.UnitTest
         private class DerivedInlineAutoDataAttribute : InlineAutoDataAttribute
         {
             public DerivedInlineAutoDataAttribute(
-                AutoDataAttribute autoDataAttribute,
+                DataAttribute autoDataAttribute,
                 params object[] values)
                 : base(autoDataAttribute, values)
             {

--- a/Src/AutoFixture.xUnit.net/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net/InlineAutoDataAttribute.cs
@@ -10,11 +10,19 @@ namespace AutoFixture.Xunit
     /// </summary>    
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     [CLSCompliant(false)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes",
+        Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class InlineAutoDataAttribute : CompositeDataAttribute
     {
-        private readonly AutoDataAttribute autoDataAttribute;
-        private readonly IEnumerable<object> values;
+        /// <summary>
+        /// Gets the attribute used to automatically generate the remaining theory parameters, which are not fixed.
+        /// </summary>
+        public DataAttribute AutoDataAttribute { get; }
+
+        /// <summary>
+        /// Gets the data values to pass to the theory.
+        /// </summary>
+        public IEnumerable<object> Values { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineAutoDataAttribute"/> class.
@@ -28,12 +36,12 @@ namespace AutoFixture.Xunit
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineAutoDataAttribute"/> class.
         /// </summary>
-        /// <param name="autoDataAttribute">An <see cref="AutoDataAttribute"/>.</param>
+        /// <param name="autoDataAttribute">An <see cref="DataAttribute"/>.</param>
         /// <param name="values">The data values to pass to the theory.</param>
         /// <remarks>
         /// <para>
         /// This constructor overload exists to enable a derived attribute to
-        /// supply a custom <see cref="AutoDataAttribute" /> that again may
+        /// supply a custom <see cref="DataAttribute" /> that again may
         /// contain custom behavior.
         /// </para>
         /// </remarks>
@@ -80,34 +88,11 @@ namespace AutoFixture.Xunit
         /// }
         /// </code>
         /// </example>
-        protected InlineAutoDataAttribute(AutoDataAttribute autoDataAttribute, params object[] values)
-            : base(new DataAttribute[] { new InlineDataAttribute(values), autoDataAttribute })
+        protected InlineAutoDataAttribute(DataAttribute autoDataAttribute, params object[] values)
+            : base(new InlineDataAttribute(values), autoDataAttribute)
         {
-            this.autoDataAttribute = autoDataAttribute;
-            this.values = values;
-        }
-
-        /// <summary>
-        /// Gets the data values to pass to the theory.
-        /// </summary>
-        public IEnumerable<object> Values
-        {
-            get { return this.values; }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="AutoDataAttribute"/> encapsulated by this instance.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// If the constructor overload wich takes an explicit instance of
-        /// <see cref="AutoDataAttribute" /> is used, this property exposes that instance.
-        /// </para>
-        /// </remarks>
-        /// <seealso cref="InlineAutoDataAttribute(AutoDataAttribute, object[])"/>
-        public AutoDataAttribute AutoDataAttribute
-        {
-            get { return this.autoDataAttribute; }
+            this.AutoDataAttribute = autoDataAttribute;
+            this.Values = values;
         }
     }
 }

--- a/Src/AutoFixture.xUnit.net2.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit.net2.UnitTest/InlineAutoDataAttributeTest.cs
@@ -106,9 +106,10 @@ namespace AutoFixture.Xunit2.UnitTest
             // Fixture setup
             var sut = new InlineAutoDataAttribute();
             // Exercise system
-            AutoDataAttribute result = sut.AutoDataAttribute;
+            DataAttribute result = sut.AutoDataAttribute;
             // Verify outcome
             Assert.NotNull(result);
+            Assert.IsType<AutoDataAttribute>(result);
             // Teardown
         }
 
@@ -168,11 +169,11 @@ namespace AutoFixture.Xunit2.UnitTest
 
             // Teardown
         }
-
+        
         private class DerivedInlineAutoDataAttribute : InlineAutoDataAttribute
         {
             public DerivedInlineAutoDataAttribute(
-                AutoDataAttribute autoDataAttribute,
+                DataAttribute autoDataAttribute,
                 params object[] values)
                 : base(autoDataAttribute, values)
             {

--- a/Src/AutoFixture.xUnit.net2/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.net2/InlineAutoDataAttribute.cs
@@ -14,12 +14,20 @@ namespace AutoFixture.Xunit2
         assemblyName: "AutoFixture.Xunit2")]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     [CLSCompliant(false)]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", 
+        Justification = "This attribute is the root of a potential attribute hierarchy.")]
     public class InlineAutoDataAttribute : CompositeDataAttribute
     {
-        private readonly AutoDataAttribute autoDataAttribute;
-        private readonly IEnumerable<object> values;
-
+        /// <summary>
+        /// Gets the attribute used to automatically generate the remaining theory parameters, which are not fixed.
+        /// </summary>
+        public DataAttribute AutoDataAttribute { get; }
+        
+        /// <summary>
+        /// Gets the data values to pass to the theory.
+        /// </summary>
+        public IEnumerable<object> Values { get; }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineAutoDataAttribute"/> class.
         /// </summary>
@@ -32,12 +40,12 @@ namespace AutoFixture.Xunit2
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineAutoDataAttribute"/> class.
         /// </summary>
-        /// <param name="autoDataAttribute">An <see cref="AutoDataAttribute"/>.</param>
+        /// <param name="autoDataAttribute">An <see cref="DataAttribute"/>.</param>
         /// <param name="values">The data values to pass to the theory.</param>
         /// <remarks>
         /// <para>
         /// This constructor overload exists to enable a derived attribute to
-        /// supply a custom <see cref="AutoDataAttribute" /> that again may
+        /// supply a custom <see cref="DataAttribute" /> that again may
         /// contain custom behavior.
         /// </para>
         /// </remarks>
@@ -84,34 +92,11 @@ namespace AutoFixture.Xunit2
         /// }
         /// </code>
         /// </example>
-        protected InlineAutoDataAttribute(AutoDataAttribute autoDataAttribute, params object[] values)
-            : base(new DataAttribute[] { new InlineDataAttribute(values), autoDataAttribute })
+        protected InlineAutoDataAttribute(DataAttribute autoDataAttribute, params object[] values)
+            : base(new InlineDataAttribute(values), autoDataAttribute)
         {
-            this.autoDataAttribute = autoDataAttribute;
-            this.values = values;
-        }
-
-        /// <summary>
-        /// Gets the data values to pass to the theory.
-        /// </summary>
-        public IEnumerable<object> Values
-        {
-            get { return this.values; }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="AutoDataAttribute"/> encapsulated by this instance.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// If the constructor overload wich takes an explicit instance of
-        /// <see cref="AutoDataAttribute" /> is used, this property exposes that instance.
-        /// </para>
-        /// </remarks>
-        /// <seealso cref="InlineAutoDataAttribute(AutoDataAttribute, object[])"/>
-        public AutoDataAttribute AutoDataAttribute
-        {
-            get { return this.autoDataAttribute; }
+            this.AutoDataAttribute = autoDataAttribute;
+            this.Values = values;
         }
     }
 }


### PR DESCRIPTION
Currently `InlineAutoData` attribute allows to pass a custom `autoDataAttribute` implementation as a constructor argument:
https://github.com/AutoFixture/AutoFixture/blob/7e864358be5b4822df0134dc412861777a5a8b49/Src/AutoFixture.xUnit.net2/InlineAutoDataAttribute.cs#L87-L88

The issue is that it requires instance of `AutoDataAttribute`, while internally it works with it like that is a `DataAttribute`.

In our projects we sometimes need to deeply customize the AutoData attribute, so we derive directly from the `DataAttribute`. In this case it's impossible to re-use the `InlineAutoDataAttribute` implementation as it doesn't allow to pass our own `DataAttribute` types to the constructor.

In this PR I'm changing signature to take `DataAttribute` as a parameter. That doesn't lead to the breaking changes as `AutoDataAttribute` is derived from the `DataAttribute` type. Also I believe that it shouldn't lead to the usability issues as this constructor is protected and is used only when you define your own inline data attributes.