### PR TITLE
Add a few minor build script improvements

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -207,7 +207,7 @@ Target "EnableSourceLinkGeneration" (fun _ ->
     enableSourceLink <- true
 )
 
-Target "Verify" (fun _ -> rebuild "Verify")
+Target "VerifyOnly" (fun _ -> rebuild "Verify")
 
 Target "BuildOnly" (fun _ -> rebuild configuration)
 Target "TestOnly" (fun _ ->
@@ -266,8 +266,9 @@ Target "TestOnly" (fun _ ->
     )
 )
 
-Target "Build" DoNothing
-Target "Test"  DoNothing
+Target "Verify" DoNothing
+Target "Build"  DoNothing
+Target "Test"   DoNothing
 
 Target "CleanNuGetPackages" (fun _ ->
     CleanDir nuGetOutputFolder
@@ -326,6 +327,7 @@ Target "PublishNuGetAll" DoNothing
 "CleanAll"                   ==> "Verify"
 "RestoreNuGetPackages"       ==> "Verify"
 "EnableSourceLinkGeneration" ?=> "Verify"
+"VerifyOnly"                 ==> "Verify"
 
 "Verify"                             ==> "Build"
 "PatchAssemblyVersions"              ==> "Build"

--- a/Build.fsx
+++ b/Build.fsx
@@ -177,12 +177,8 @@ let runMsBuild target configuration properties =
                                 Targets = [ target ]
                                 Properties = properties })
 
-let cleanBuild configuration = runMsBuild "Clean" (Some configuration) []
 let rebuild configuration = runMsBuild "Rebuild" (Some configuration) []
 
-Target "CleanAll"               DoNothing 
-Target "CleanVerify"            (fun _ -> cleanBuild "Verify")
-Target "CleanRelease"           (fun _ -> cleanBuild configuration)
 Target "CleanTestResultsFolder" (fun _ -> CleanDir testResultsFolder)
 
 let restoreNugetPackages() = runMsBuild "Restore" None []
@@ -321,10 +317,6 @@ Target "PublishNuGetPrivate" (fun _ ->
 Target "CompleteBuild"   DoNothing
 Target "PublishNuGetAll" DoNothing
 
-"CleanVerify"  ==> "CleanAll"
-"CleanRelease" ==> "CleanAll"
-
-"CleanAll"                   ==> "Verify"
 "RestoreNuGetPackages"       ==> "Verify"
 "EnableSourceLinkGeneration" ?=> "Verify"
 "VerifyOnly"                 ==> "Verify"


### PR DESCRIPTION
A few build script improvements to boost the build time and make scripts more convenient to use:
- Remove the "Clean" build at the beginning as it's useless. See more detail in the commit message;
- Don't perform extra restore during the pack. Instead inspect the produced NuGet package and verify the actual dependency version.
- Add `VerifyOnly` target to run the verification build only.