### PR TITLE
Add read-only collection relay by default

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -76,6 +76,7 @@ namespace AutoFixture
                                         new ExactTypeSpecification(
                                             typeof(ISpecimenBuilder)))),
                                 new StableFiniteSequenceRelay(),
+                                new ReadOnlyCollectionRelay(),
                                 new FilteringSpecimenBuilder(
                                     new Postprocessor(
                                         new MethodInvoker(

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6077,5 +6077,19 @@ namespace AutoFixtureUnitTest
             Assert.Equal(expectedValue, result);
             // Teardown
         }
+
+        [Fact]
+        public void ShouldResolveReadOnlyCollectionByDefault()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+
+            // Exercise system
+            var result = sut.Create<IReadOnlyCollection<string>>();
+
+            // Verify outcome
+            Assert.NotNull(result);
+            // Teardown
+        }
     }
 }


### PR DESCRIPTION
We [have a message](https://github.com/AutoFixture/AutoFixture/wiki/v4.0-Release-Notes#%EF%B8%8F-autofixture-resolves-ireadonlycollectiont-now) in the release notes that we support `IReadOnlyCollection<>` out-of-the-box. I didn't test that as was under the impression that #257 adds this support.

However, it appeared that we simply implemented a builder, without registering it by default.

Given that this is quite popular interface and to correspond to our release notes, I'm registering a relay for this interface by default.