### PR TITLE
Introduce RangedRequest to support non-number types

### DIFF
--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Reflection;
 using AutoFixture.Kernel;
 
 namespace AutoFixture.DataAnnotations
 {
     /// <summary>
-    /// Relays a request for a range number to a <see cref="RangedNumberRequest"/>.
+    /// Relays a request for a ranged request to a <see cref="RangedRequest"/>.
     /// </summary>
     public class RangeAttributeRelay : ISpecimenBuilder
     {
@@ -18,8 +17,8 @@ namespace AutoFixture.DataAnnotations
         /// <param name="request">The request that describes what to create.</param>
         /// <param name="context">A container that can be used to create other specimens.</param>
         /// <returns>
-        /// A specimen created from a <see cref="RangedNumberRequest"/> encapsulating the operand
-        /// type, the minimum and the maximum of the requested number, if possible; otherwise,
+        /// A specimen created from a <see cref="RangedRequest"/> encapsulating the operand
+        /// type, the minimum and the maximum of the requested value, if possible; otherwise,
         /// a <see cref="NoSpecimen"/> instance.
         /// </returns>
         public object Create(object request, ISpecimenContext context)
@@ -40,12 +39,20 @@ namespace AutoFixture.DataAnnotations
                 return new NoSpecimen();
             }
 
-            return context.Resolve(Create(rangeAttribute, request));
+            var memberType = GetMemberType(rangeAttribute, request);
+            var rangedRequest =
+                new RangedRequest(
+                    memberType,
+                    rangeAttribute.OperandType,
+                    rangeAttribute.Minimum,
+                    rangeAttribute.Maximum);
+
+            return context.Resolve(rangedRequest);
         }
 
         [SuppressMessage("Performance", "CA1801:Review unused parameters",
             Justification = "False positive - request property is used. Bug: https://github.com/dotnet/roslyn-analyzers/issues/1294")]
-        private static RangedNumberRequest Create(RangeAttribute rangeAttribute, object request)
+        private static Type GetMemberType(RangeAttribute rangeAttribute, object request)
         {
             Type conversionType;
             switch (request)
@@ -56,6 +63,10 @@ namespace AutoFixture.DataAnnotations
 
                 case FieldInfo fi:
                     conversionType = fi.FieldType;
+                    break;
+
+                case ParameterInfo pi:
+                    conversionType = pi.ParameterType;
                     break;
 
                 default:
@@ -69,52 +80,7 @@ namespace AutoFixture.DataAnnotations
                 conversionType = underlyingType;
             }
 
-            return new RangedNumberRequest(
-                conversionType,
-                GetConvertedRangeBoundary(rangeAttribute.Minimum, conversionType),
-                GetConvertedRangeBoundary(rangeAttribute.Maximum, conversionType)
-            );
-        }
-
-        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "RangeAttribute",
-            Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
-        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "OverflowException",
-            Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
-        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "typeof",
-            Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
-        private static object GetConvertedRangeBoundary(object attributeValue, Type conversionType)
-        {
-            try
-            {
-                return Convert.ChangeType(attributeValue, conversionType, CultureInfo.CurrentCulture);
-            }
-            catch (OverflowException ex)
-            {
-                throw new OverflowException(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Conversion of RangeAttribute boundary value of {1} type to {2} type caused the overflow " +
-                        "exception. Notice, the RangeAttribute type contains the following constructors taking two " +
-                        "arguments only:{0}" +
-                        "RangeAttribute(int, int){0}" +
-                        "RangeAttribute(double, double){0}" +
-                        "{0}" +
-                        "When you pass a value of other type (e.g. long, decimal), it is converted to either int or " +
-                        "double depending on the type. Some conversion (e.g. long to double) could lead to the value " +
-                        "distortion due to the double type precision and conversion back to the original type might " +
-                        "fail with OverflowException.{0}" +
-                        "{0}" +
-                        "To solve the issue rather specify the range value that could be safely converted to double " +
-                        "and back without overflow or use the constructor overload taking value as a string.{0}" +
-                        "{0}" +
-                        "Example:{0}" +
-                        "RangeAttribute(typeof(long), \"0\", \"9223372036854775807\")",
-                        Environment.NewLine,
-                        attributeValue.GetType().FullName,
-                        conversionType.FullName
-                    ),
-                    ex);
-            }
+            return conversionType;
         }
     }
 }

--- a/Src/AutoFixture/DefaultRelays.cs
+++ b/Src/AutoFixture/DefaultRelays.cs
@@ -28,6 +28,7 @@ namespace AutoFixture
             yield return new FieldRequestRelay();
             yield return new FiniteSequenceRelay();
             yield return new SeedIgnoringRelay();
+            yield return new NumericRangedRequestRelay();
             yield return new MethodInvoker(
                 new CompositeMethodQuery(
                     new ModestConstructorQuery(),

--- a/Src/AutoFixture/Kernel/RangedRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedRequest.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace AutoFixture.Kernel
+{
+    /// <summary>
+    /// Encapsulates a request of a specified type within the specified range.
+    /// </summary>
+    public class RangedRequest : IEquatable<RangedRequest>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RangedRequest"/> class.
+        /// </summary>
+        /// <param name="memberType">Type of the member the range is specified for</param>
+        /// <param name="operandType">Type of the operand.</param>
+        /// <param name="minimum">The minimum.</param>
+        /// <param name="maximum">The maximum.</param>
+        public RangedRequest(Type memberType, Type operandType, object minimum, object maximum)
+        {
+            this.MemberType = memberType ?? throw new ArgumentNullException(nameof(memberType));
+            this.OperandType = operandType ?? throw new ArgumentNullException(nameof(operandType));
+            this.Minimum = minimum ?? throw new ArgumentNullException(nameof(minimum));
+            this.Maximum = maximum ?? throw new ArgumentNullException(nameof(maximum));
+        }
+
+        /// <summary>
+        /// Gets the type of the member the range is specified for.
+        /// This property defines the expected type of the result.
+        /// Refer to the <see cref="OperandType"/> for additional hints about the actual range value type.
+        /// </summary>
+        public Type MemberType { get; }
+
+        /// <summary>
+        /// Gets the specified type of the operand the range is specified for.
+        /// This property might not correspond to the actual type of a member for which the Range is specified.
+        /// Refer to the <see cref="MemberType"/> property to get the actual member type.
+        /// </summary>
+        public Type OperandType { get; }
+
+        /// <summary>
+        /// Gets the minimum value.
+        /// </summary>
+        public object Minimum { get; }
+
+        /// <summary>
+        /// Gets the maximum value.
+        /// </summary>
+        public object Maximum { get; }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (obj is RangedRequest other)
+            {
+                return this.Equals(other);
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(RangedRequest other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return this.MemberType == other.MemberType &&
+                   this.OperandType == other.OperandType &&
+                   Equals(this.Minimum, other.Minimum) &&
+                   Equals(this.Maximum, other.Maximum);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = this.MemberType.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.OperandType.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Minimum.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.Maximum.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Gets minimum value converted to the specified type using the <see cref="Convert"/> helper.
+        /// </summary>
+        public object GetConvertedMinimum(Type typeToConvert)
+        {
+            if (typeToConvert == null) throw new ArgumentNullException(nameof(typeToConvert));
+
+            return GetConvertedRangeBoundary(this.Minimum, typeToConvert);
+        }
+
+        /// <summary>
+        /// Gets maximum value converted to the specified type using the <see cref="Convert"/> helper.
+        /// </summary>
+        public object GetConvertedMaximum(Type typeToConvert)
+        {
+            if (typeToConvert == null) throw new ArgumentNullException(nameof(typeToConvert));
+
+            return GetConvertedRangeBoundary(this.Maximum, typeToConvert);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "RangedRequest (MemberType: {0}, OperandType: {1} Minimum: [{2}] {3}, Maximum: [{4}] {5})",
+                this.MemberType.FullName,
+                this.OperandType.FullName,
+                this.Minimum.GetType().Name,
+                this.Minimum,
+                this.Maximum.GetType().Name,
+                this.Maximum);
+        }
+
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly",
+            MessageId = "RangeAttribute",
+            Justification =
+                "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly",
+            MessageId = "OverflowException",
+            Justification =
+                "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "typeof",
+            Justification =
+                "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
+        private static object GetConvertedRangeBoundary(object attributeValue, Type conversionType)
+        {
+            try
+            {
+                return Convert.ChangeType(attributeValue, conversionType, CultureInfo.CurrentCulture);
+            }
+            catch (OverflowException ex)
+            {
+                throw new OverflowException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Conversion of RangeAttribute boundary value of {1} type to {2} type caused the overflow " +
+                        "exception. Notice, the RangeAttribute type contains the following constructors taking two " +
+                        "arguments only:{0}" +
+                        "RangeAttribute(int, int){0}" +
+                        "RangeAttribute(double, double){0}" +
+                        "{0}" +
+                        "When you pass a value of other type (e.g. long, decimal), it is converted to either int or " +
+                        "double depending on the type. Some conversion (e.g. long to double) could lead to the value " +
+                        "distortion due to the double type precision and conversion back to the original type might " +
+                        "fail with OverflowException.{0}" +
+                        "{0}" +
+                        "To solve the issue rather specify the range value that could be safely converted to double " +
+                        "and back without overflow or use the constructor overload taking value as a string.{0}" +
+                        "{0}" +
+                        "Example:{0}" +
+                        "RangeAttribute(typeof(long), \"0\", \"9223372036854775807\")",
+                        Environment.NewLine,
+                        attributeValue.GetType().FullName,
+                        conversionType.FullName
+                    ),
+                    ex);
+            }
+        }
+    }
+}

--- a/Src/AutoFixture/Kernel/TypeEnvy.cs
+++ b/Src/AutoFixture/Kernel/TypeEnvy.cs
@@ -66,5 +66,30 @@ namespace AutoFixture.Kernel
         {
             return type.GetTypeInfo().IsValueType;
         }
+        
+        public static bool IsNumberType(this Type type)
+        {
+            if(type.IsEnum()) return false;
+
+            var typeCode = Type.GetTypeCode(type);
+            switch (typeCode)
+            {
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.UInt16:
+                case TypeCode.Int32:
+                case TypeCode.UInt32:
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                case TypeCode.Decimal:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/Src/AutoFixture/NumericRangedRequestRelay.cs
+++ b/Src/AutoFixture/NumericRangedRequestRelay.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using AutoFixture.Kernel;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// Handles the <see cref="RangedRequest"/> for the number type by forwarding it 
+    /// to the <see cref="RangedNumberRequest"/>.
+    /// </summary>
+    public class NumericRangedRequestRelay : ISpecimenBuilder
+    {
+        /// <inheritdoc />
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var rangedRequest = request as RangedRequest;
+            if (rangedRequest == null)
+                return new NoSpecimen();
+
+            if (!rangedRequest.MemberType.IsNumberType())
+                return new NoSpecimen();
+
+            var convertedMinimum = rangedRequest.GetConvertedMinimum(rangedRequest.MemberType);
+            var convertedMaximum = rangedRequest.GetConvertedMaximum(rangedRequest.MemberType);
+
+            var rangedNumberRequest = new RangedNumberRequest(
+                rangedRequest.MemberType,
+                convertedMinimum,
+                convertedMaximum);
+
+            return context.Resolve(rangedNumberRequest);
+        }
+    }
+}

--- a/Src/AutoFixture/RandomRangedNumberGenerator.cs
+++ b/Src/AutoFixture/RandomRangedNumberGenerator.cs
@@ -63,33 +63,10 @@ namespace AutoFixture
             return this.generatorMap.GetOrAdd(request, CreateRandomGenerator);
         }
 
-        private static bool IsNumericType(object value)
-        {
-            var typeCode = Convert.GetTypeCode(value);
-            switch (typeCode)
-            {
-                case TypeCode.Byte:
-                case TypeCode.SByte:
-                case TypeCode.Int16:
-                case TypeCode.UInt16:
-                case TypeCode.Int32:
-                case TypeCode.UInt32:
-                case TypeCode.Int64:
-                case TypeCode.UInt64:
-                case TypeCode.Single:
-                case TypeCode.Double:
-                case TypeCode.Decimal:
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
         private static ISpecimenBuilder CreateRandomGenerator(RangedNumberRequest request)
         {
             var typeCode = Type.GetTypeCode(request.OperandType);
-            if (!IsNumericType(request.Minimum) || !IsNumericType(request.Maximum))
+            if (!request.Minimum.GetType().IsNumberType() || !request.Maximum.GetType().IsNumberType())
             {
                 throw new ArgumentException("Limit values should be of numeric type.", nameof(request));
             }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedType.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeValidatedType.cs
@@ -66,5 +66,9 @@ namespace AutoFixtureUnitTest.DataAnnotations
 
         [Range(Minimum, float.MaxValue)]
         public float PropertyWithMaximumFloatMaxValue { get; set; }
+
+        public void MethodWithRangedParameter([Range(Minimum, Maximum)] decimal argument){ }
+
+        public void MethodWithRangedNullableParameter([Range(Minimum, Maximum)] decimal? argument){ }
     }
 }

--- a/Src/AutoFixtureUnitTest/DefaultRelaysTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultRelaysTest.cs
@@ -34,6 +34,7 @@ namespace AutoFixtureUnitTest
                 typeof(FieldRequestRelay),
                 typeof(FiniteSequenceRelay),
                 typeof(SeedIgnoringRelay),
+                typeof(NumericRangedRequestRelay),
                 typeof(MethodInvoker)
             };
             // Exercise system

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6011,11 +6011,11 @@ namespace AutoFixtureUnitTest
         public void Issue453_RangeAttributeShouldFailWithMeaningfulException()
         {
             // Fixture setup
-            var fixture = new Fixture();
+            var sut = new Fixture();
 
             // Exercise system and verify outcome
             var actualEx = Assert.ThrowsAny<ObjectCreationException>(
-                () => fixture.Create<Issue453_AnnotationWithOverflow>());
+                () => sut.Create<Issue453_AnnotationWithOverflow>());
 
             Assert.IsType<OverflowException>(actualEx.InnerException);
             Assert.Contains("To solve the issue", actualEx.InnerException.Message);
@@ -6027,6 +6027,30 @@ namespace AutoFixtureUnitTest
         {
             [Range(short.MinValue, long.MaxValue, ErrorMessage = "Id is not in range")]
             public long CustomerId { get; set; }
+        }
+
+        private class RangeAnnotationWithLargeStringBoundaries
+        {
+            [Range(typeof(long), "1", /* long.MaxValue */ "9223372036854775807")]
+            public long PropertyWithStringValueRange1 { get; set; }
+
+            [Range(typeof(long), /* long.MinValue */ "-9223372036854775808", "-1")]
+            public long PropertyWithStringValueRange2 { get; set; }
+        }
+
+        [Fact]
+        public void RangeAttributeWithLargeStringRangeShouldWork()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+
+            // Exercise system
+            var result = sut.Create<RangeAnnotationWithLargeStringBoundaries>();
+            
+            // Verify outcome
+            Assert.NotEqual(0, result.PropertyWithStringValueRange1);
+            Assert.NotEqual(0, result.PropertyWithStringValueRange2);
+            // Teardown
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/RangedRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedRequestTest.cs
@@ -1,0 +1,306 @@
+﻿using System;
+using AutoFixture.Kernel;
+using Xunit;
+
+namespace AutoFixtureUnitTest.Kernel
+{
+    public class RangedRequestTest
+    {
+        [Theory]
+        [InlineData(null, typeof(int), 1, 2)]
+        [InlineData(typeof(int), null, 1, 2)]
+        [InlineData(typeof(int), typeof(int), null, 2)]
+        [InlineData(typeof(int), typeof(int), 1, null)]
+        public void ShouldFailWithArgumentExceptionForNullArguments(Type memberType, Type operandType, object min, object max)
+        {
+            // Exercise system and Verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                new RangedRequest(memberType, operandType, min, max));
+
+            // Teardown
+        }
+
+        [Fact]
+        public void PropertiesShouldReturnPassedToConstructorValues()
+        {
+            // Fixture setup
+            var memberType = typeof(object);
+            var operandType = typeof(int);
+            var min = 42;
+            var max = 100;
+
+            // Exercise system
+            var sut = new RangedRequest(memberType, operandType, min, max);
+
+            // Verify outcome
+            Assert.Equal(memberType, sut.MemberType);
+            Assert.Equal(operandType, sut.OperandType);
+            Assert.Equal(min, sut.Minimum);
+            Assert.Equal(max, sut.Maximum);
+
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsEquatable()
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(int), typeof(int), 1, 2);
+
+            // Exercise system and Verify outcome
+            Assert.IsAssignableFrom<IEquatable<RangedRequest>>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsNotEqualNullObject()
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(int), typeof(int), 1, 2);
+            object nullObj = null;
+
+            // Exercise system
+            var areEqual = sut.Equals(nullObj);
+
+            // Verify outcome
+            Assert.False(areEqual);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsNotEqualNullSut()
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(int), typeof(int), 1, 2);
+            RangedRequest nullSut = null;
+
+            // Exercise system
+            var areEqual = sut.Equals(nullSut);
+
+            // Verify outcome
+            Assert.False(areEqual);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsNotEqualOtherTypeObject()
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(int), typeof(int), 1, 2);
+            var otherType = new object();
+
+            // Exercise system
+            var areEqual = sut.Equals(otherType);
+
+            // Verify outcome
+            Assert.False(areEqual);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(int), typeof(int), 1, 3)]
+        [InlineData(typeof(long), typeof(long), 1, 3)]
+        [InlineData(typeof(long), typeof(int), 2, 3)]
+        [InlineData(typeof(long), typeof(int), 1, 4)]
+        public void SutIsNotEqualOtherSutWhenAnyMemberDiffers(Type memberType, Type operandType, object min, object max)
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(long), typeof(int), 1, 3);
+            RangedRequest other = new RangedRequest(memberType, operandType, min, max);
+
+            // Exercise system
+            bool areEqual = sut.Equals(other);
+            // Verify outcome
+            Assert.False(areEqual);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(int), typeof(int), 1, 3)]
+        [InlineData(typeof(long), typeof(long), 1, 3)]
+        [InlineData(typeof(long), typeof(int), 2, 3)]
+        [InlineData(typeof(long), typeof(int), 1, 4)]
+        public void SutIsNotEqualOtherObjectWhenAnyMemberDiffers(Type memberType, Type operandType, object min, object max)
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(long), typeof(int), 1, 3);
+            object other = new RangedRequest(memberType, operandType, min, max);
+
+            // Exercise system
+            bool areEqual = sut.Equals(other);
+            // Verify outcome
+            Assert.False(areEqual);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsEqualOtherSutIfAllMembersEqual()
+        {
+            // Fixture setup
+            var memberType = typeof(decimal);
+            var operandType = typeof(int);
+            var min = 1;
+            var max = 3;
+
+            var sut = new RangedRequest(memberType, operandType, min, max);
+            RangedRequest other = new RangedRequest(memberType, operandType, min, max);
+
+            // Exercise system
+            bool areEqual = sut.Equals(other);
+
+            // Verify outcome
+            Assert.True(areEqual);
+            // Teardown
+        }
+
+        [Fact]
+        public void SutIsEqualOtherObjectIfAllMembersEqual()
+        {
+            // Fixture setup
+            var memberType = typeof(decimal);
+            var operandType = typeof(int);
+            var min = 1;
+            var max = 3;
+
+            var sut = new RangedRequest(memberType, operandType, min, max);
+            object other = new RangedRequest(memberType, operandType, min, max);
+
+            // Exercise system
+            bool areEqual = sut.Equals(other);
+
+            // Verify outcome
+            Assert.True(areEqual);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(int), typeof(int), 1, 3)]
+        [InlineData(typeof(long), typeof(long), 1, 3)]
+        [InlineData(typeof(long), typeof(int), 2, 3)]
+        [InlineData(typeof(long), typeof(int), 1, 4)]
+        public void HashCodeIsDifferentWhenAnyMemberChanges(Type memberType, Type operandType, object min, object max)
+        {
+            // Fixture setup
+            var etalonHashCode = new RangedRequest(typeof(long), typeof(int), 1, 3).GetHashCode();
+            var sut = new RangedRequest(memberType, operandType, min, max);
+
+            // Exercise system
+            var newHashCode = sut.GetHashCode();
+
+            // Verify outcome
+            Assert.NotEqual(etalonHashCode, newHashCode);
+            // Teardown
+        }
+
+        [Fact]
+        public void HashCodeIsSameWhenAllMembersAreSame()
+        {
+            // Fixture setup
+            var memberType = typeof(decimal);
+            var operandType = typeof(int);
+            var min = 1;
+            var max = 3;
+
+            var sut1 = new RangedRequest(memberType, operandType, min, max);
+            var sut2 = new RangedRequest(memberType, operandType, min, max);
+
+            // Exercise system
+            var hash1 = sut1.GetHashCode();
+            var hash2 = sut2.GetHashCode();
+
+            // Verify outcome
+            Assert.Equal(hash1, hash2);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData((int)42)]
+        [InlineData((uint)42)]
+        [InlineData((long)42)]
+        [InlineData((ulong)42)]
+        [InlineData((double)42.0)]
+        [InlineData((float)42.0f)]
+        [InlineData("42")]
+        public void ShouldCorrectlyConvertMinimum(object bounaryValue)
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(int), typeof(int), bounaryValue, int.MaxValue);
+
+            // Exercise system
+            var convertedValue = sut.GetConvertedMinimum(typeof(int));
+
+            // Verify outcome
+            Assert.Equal(42, convertedValue);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData((int)42)]
+        [InlineData((uint)42)]
+        [InlineData((long)42)]
+        [InlineData((ulong)42)]
+        [InlineData((double)42.0)]
+        [InlineData((float)42.0f)]
+        [InlineData("42")]
+        public void ShouldCorrectlyConvertMaximum(object bounaryValue)
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(int), typeof(int), 0, bounaryValue);
+
+            // Exercise system
+            var convertedValue = sut.GetConvertedMaximum(typeof(int));
+
+            // Verify outcome
+            Assert.Equal(42, convertedValue);
+            // Teardown
+        }
+
+        [Fact]
+        public void FailsWithMeaningfulExceptionWhenMinimumCannotBeConvertedWithoutOverflow()
+        {
+            // Fixture setup
+            double valueWithOverflow = (double)long.MaxValue;
+
+            var sut = new RangedRequest(typeof(long), typeof(double), valueWithOverflow, double.MaxValue);
+
+            // Exercise system and verify outcome
+            var actualEx = Assert.Throws<OverflowException>(() =>
+                sut.GetConvertedMinimum(typeof(long)));
+            Assert.Contains("To solve the issue", actualEx.Message);
+            // Teardown
+        }
+
+        [Fact]
+        public void FailsWithMeaningfulExceptionWhenMaximumCannotBeConvertedWithoutOverflow()
+        {
+            // Fixture setup
+            double valueWithOverflow = (double)long.MaxValue;
+
+            var sut = new RangedRequest(typeof(long), typeof(double), 0, valueWithOverflow);
+
+            // Exercise system and verify outcome
+            var actualEx = Assert.Throws<OverflowException>(() =>
+                sut.GetConvertedMaximum(typeof(long)));
+            Assert.Contains("To solve the issue", actualEx.Message);
+            // Teardown
+        }
+
+        [Fact]
+        public void ToStringShouldBeOverridden()
+        {
+            // Fixture setup
+            var sut = new RangedRequest(typeof(long), typeof(int), 42, 100);
+
+            // Exercise system
+            var stringResult = sut.ToString();
+
+            // Verify outcome
+            Assert.Contains("Int32", stringResult);
+            Assert.Contains("Int64", stringResult);
+            Assert.Contains("42", stringResult);
+            Assert.Contains("100", stringResult);
+
+            // Teardown
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/NumericRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/NumericRangedRequestRelayTest.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixtureUnitTest
+{
+    public class NumericRangedRequestRelayTest
+    {
+        [Fact]
+        public void SutShouldBeASpecimenBuilder()
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+
+            // Exercise system and Verify outcome
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldFailWithArgumentNullExceptionForNullContext()
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+            var request = new object();
+            ISpecimenContext nullContext = null;
+
+            // Exercise system and Verify outcome
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(request, nullContext));
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldReturnNoResultForNullRequest()
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+            object nullRequest = null;
+            var dummyContext = new DelegatingSpecimenContext();
+
+            // Exercise system
+            var result = sut.Create(nullRequest, dummyContext);
+
+            // Verify outcome
+            Assert.IsType<NoSpecimen>(result);
+            // Teardown
+        }
+
+        public static TheoryData<object> NonSupportedRequests => new TheoryData<object>
+        {
+            new object(),
+            typeof(object),
+            typeof(int),
+            typeof(string),
+            new RangedNumberRequest(typeof(int), 0, 42)
+        };
+
+        [Theory, MemberData(nameof(NonSupportedRequests))]
+        public void ShouldReturnNoResultForNonSupportedRequests(object request)
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+            var context = new DelegatingSpecimenContext();
+
+            // Exercise system
+            var result = sut.Create(request, context);
+
+            // Verify outcome
+            Assert.IsType<NoSpecimen>(result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(ConcreteType))]
+        [InlineData(typeof(StringComparison))]
+        public void ShouldReturnNoResultIfRangedRequestIsOfNonNumericMemberType(Type memberType)
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+            var request = new RangedRequest(memberType, typeof(int), 0, 42);
+            var context = new DelegatingSpecimenContext();
+
+            // Exercise system
+            var result = sut.Create(request, context);
+
+            // Verify outcome
+            Assert.IsType<NoSpecimen>(result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(sbyte))]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(uint))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(ulong))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(decimal))]
+        public void ShouldRelayForRangedRequestsOfNumericMemberType(Type requestType)
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+
+            var request = new RangedRequest(requestType, requestType, 0, 42);
+            var expectedResult = new object();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve =
+                    r => r is RangedNumberRequest rr && rr.OperandType == requestType
+                        ? expectedResult
+                        : new NoSpecimen()
+            };
+
+            // Exercise system
+            var result = sut.Create(request, context);
+
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(typeof(long), 10L, 42L)]
+        [InlineData(typeof(ushort), (ushort)10, (ushort)42)]
+        [InlineData(typeof(double), 10.0, 42.0)]
+        [InlineData(typeof(float), 10.0F, 42.0F)]
+        public void ShouldConvertBoundaryToMemberType(Type memberType, object castedMin, object castedMax)
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+
+            var request = new RangedRequest(memberType, typeof(int), 10, 42);
+            var expectedResult = new object();
+            var expectedNestedRequest = new RangedNumberRequest(memberType, castedMin, castedMax);
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve =
+                    r => r.Equals(expectedNestedRequest)
+                        ? expectedResult
+                        : new NoSpecimen()
+            };
+
+            // Exercise system
+            var result = sut.Create(request, context);
+
+            // Verify outcome
+            Assert.Equal(expectedResult, result);
+            // Teardown
+        }
+
+        [Fact]
+        public void ShouldFailWithMeaningfulExceptionIfUnableToCastWithoutOverflow()
+        {
+            // Fixture setup
+            var sut = new NumericRangedRequestRelay();
+
+            double overflowedValue = long.MaxValue;
+            var request = new RangedRequest(typeof(long), typeof(double), 0, overflowedValue);
+            var context = new DelegatingSpecimenContext();
+
+            // Exercise system and Verify outcome
+            var ex = Assert.Throws<OverflowException>(() =>
+                sut.Create(request, context));
+            Assert.Contains("To solve the issue", ex.Message);
+            // Teardown
+        }
+    }
+}


### PR DESCRIPTION
This is a precursor to fix issue #722 and potentially #919 (if we decide).

Currently the `RangeAttributeRelay` builder assumes that the `Range` attribute is applied to the members of the number types only. However, as you might see in the referenced issues, that is not always so. 

To fix this issue in a general way, I've introduced the `RangedRequest` type in addition to the `RangedNumberRequest` we have. Currently if any member is marked by the `Range` attribute, the chain is following:
- `RangeAttributeRelay` relays request to `RangedRequest`.
- If type is a number, `RangedRequestToRangedNumberRequestRelay` relays request to `RangedNumberRequest`.

Later we could add more `RangedRequest` handlers to cover enum and string requests.

This PR contains some changes in logic as now `RangeAttributeRelay` creates requests of other type. However, we are still working on major release, so such changes are fine (also no breaking changes in API).

@moodmosaic @adamchester Please review and share your feedback 😉