### PR TITLE
Extract request path formatting to the exception constructor

### DIFF
--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -60,13 +60,13 @@ namespace AutoFixture.Kernel
                 var result = this.Builder.Create(request, context);
                 if (result is NoSpecimen)
                 {
-                    throw new ObjectCreationExceptionWithPath(string.Format(
-                        CultureInfo.CurrentCulture,
-                        BuildCoreMessageTemplate(request, null),
-                        request,
-                        Environment.NewLine,
-                        BuildRequestPathText(this.SpecimenRequests),
-                        string.Empty));
+                    throw new ObjectCreationExceptionWithPath(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            BuildCoreMessageTemplate(request, null),
+                            request,
+                            Environment.NewLine),
+                        this.SpecimenRequests);
                 }
 
                 return result;
@@ -83,9 +83,8 @@ namespace AutoFixture.Kernel
                         CultureInfo.CurrentCulture,
                         BuildCoreMessageTemplate(request, ex),
                         request,
-                        Environment.NewLine,
-                        BuildRequestPathText(this.SpecimenRequests),
-                        BuildInnerExceptionMessages(ex)),
+                        Environment.NewLine),
+                    this.SpecimenRequests,
                     ex);
             }
             finally
@@ -100,14 +99,7 @@ namespace AutoFixture.Kernel
                 return
                     "AutoFixture was unable to create an instance from {0} " +
                     "because creation unexpectedly failed with exception. " +
-                    "Please refer to the inner exception to investigate the root cause of the failure." +
-                    "{1}" +
-                    "{1}" +
-                    "Request path:{1}{2}" +
-                    "{1}" +
-                    "{1}" +
-                    "Inner exception messages:{1}{3}" +
-                    "{1}";
+                    "Please refer to the inner exception to investigate the root cause of the failure.";
 
             var t = request as Type;
 
@@ -121,10 +113,7 @@ namespace AutoFixture.Kernel
                     "{1}" +
                     "If you have a concrete class implementing the " +
                     "interface, you can map the interface to that class:" +
-                    TypeMappingOptionsHelp +
-                    "{1}" +
-                    "{1}" +
-                    "Request path:{1}{2}{1}";
+                    TypeMappingOptionsHelp;
 
             if (t != null && t.IsAbstract())
                 return
@@ -137,15 +126,12 @@ namespace AutoFixture.Kernel
                     "If you have a concrete class deriving from the abstract " +
                     "class, you can map the abstract class to that derived " + 
                     "class:" +
-                    TypeMappingOptionsHelp +
-                    "{1}" +
-                    "{1}" +
-                    "Request path:{1}{2}{1}";
+                    TypeMappingOptionsHelp;
 
             return
                 "AutoFixture was unable to create an instance from {0}, " +
                 "most likely because it has no public constructor, is an " +
-                "abstract or non-public type.{1}{1}Request path:{1}{2}";
+                "abstract or non-public type.";
         }
 
         private const string TypeMappingOptionsHelp =
@@ -168,33 +154,6 @@ namespace AutoFixture.Kernel
             "{1}" +
             "See http://blog.ploeh.dk/2010/08/19/AutoFixtureasanauto-mockingcontainer " +
             "for more details.";
-
-        private static string BuildRequestPathText(IEnumerable<object> recordedRequests)
-        {
-            var thisAssembly = typeof(TerminatingWithPathSpecimenBuilder).Assembly();
-            return recordedRequests
-                .Where(r => r.GetType().Assembly() != thisAssembly)
-                .Select((r, i) => string.Format(CultureInfo.CurrentCulture, "\t{0} {1}", " ".PadLeft(i+1), r))
-                .Aggregate((s1, s2) => s1 + " --> " + Environment.NewLine + s2);
-        }
-
-        private static string BuildInnerExceptionMessages(Exception ex)
-        {
-            var messages = new StringBuilder();
-           
-            var level = 2;
-            while (ex != null)
-            {
-                messages.AppendFormat(
-                    CultureInfo.InvariantCulture, "{0}{1}: {2}", " ".PadLeft(level), ex.GetType().FullName, ex.Message);
-                messages.AppendLine();
-
-                level += 2;
-                ex = ex.InnerException;
-            }
-
-            return messages.ToString();
-        }
 
         /// <summary>Composes the supplied builders.</summary>
         /// <param name="builders">The builders to compose.</param>

--- a/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 
 namespace AutoFixture.Kernel
 {
@@ -48,17 +47,16 @@ namespace AutoFixture.Kernel
         public override object HandleRecursiveRequest(object request)
         {
             throw new ObjectCreationExceptionWithPath(string.Format(
-                CultureInfo.InvariantCulture,
-                @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
+                    CultureInfo.InvariantCulture,
+                    @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
 
 fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
     .ForEach(b => fixture.Behaviors.Remove(b));
 fixture.Behaviors.Add(new OmitOnRecursionBehavior());
 
-                " + "{2}\tPath:{2}{1}",
-                this.RecordedRequests.Cast<object>().First().GetType(),
-                this.GetFlattenedRequests(request),
-                Environment.NewLine));
+                ",
+                    this.RecordedRequests.Cast<object>().First().GetType()),
+                this.RecordedRequests.Cast<object>());
         }
 
         /// <summary>Composes the supplied builders.</summary>
@@ -71,26 +69,6 @@ fixture.Behaviors.Add(new OmitOnRecursionBehavior());
         {
             var builder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
             return new ThrowingRecursionGuard(builder, this.Comparer);
-        }
-
-        private string GetFlattenedRequests(object finalRequest)
-        {
-            var requestInfos = new StringBuilder();
-            foreach (object request in this.RecordedRequests)
-            {
-                Type type = request.GetType();
-                if (type.Assembly() != typeof(RecursionGuard).Assembly())
-                {
-                    requestInfos.Append("\t\t");
-                    requestInfos.Append(request);
-                    requestInfos.AppendLine(" --> ");
-                }
-            }
-
-            requestInfos.Append("\t\t");
-            requestInfos.AppendLine(finalRequest.ToString());
-
-            return requestInfos.ToString();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionHandler.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 
 namespace AutoFixture.Kernel
 {
@@ -47,40 +45,18 @@ namespace AutoFixture.Kernel
             object request,
             IEnumerable<object> recordedRequests)
         {
-            throw new ObjectCreationExceptionWithPath(string.Format(
-                CultureInfo.InvariantCulture,
-                @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
+            throw new ObjectCreationExceptionWithPath(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    @"AutoFixture was unable to create an instance of type {0} because the traversed object graph contains a circular reference. Information about the circular path follows below. This is the correct behavior when a Fixture is equipped with a ThrowingRecursionBehavior, which is the default. This ensures that you are being made aware of circular references in your code. Your first reaction should be to redesign your API in order to get rid of all circular references. However, if this is not possible (most likely because parts or all of the API is delivered by a third party), you can replace this default behavior with a different behavior: on the Fixture instance, remove the ThrowingRecursionBehavior from Fixture.Behaviors, and instead add an instance of OmitOnRecursionBehavior:
 
 fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
     .ForEach(b => fixture.Behaviors.Remove(b));
 fixture.Behaviors.Add(new OmitOnRecursionBehavior());
 
-                " + "{2}\tPath:{2}{1}",
-                recordedRequests.Cast<object>().First().GetType(),
-                GetFlattenedRequests(request, recordedRequests),
-                Environment.NewLine));
-        }
-
-        private static string GetFlattenedRequests(
-            object request,
-            IEnumerable<object> recordedRequests)
-        {
-            var requestInfos = new StringBuilder();
-            foreach (object r in recordedRequests)
-            {
-                Type type = r.GetType();
-                if (type.Assembly() != typeof(RecursionGuard).Assembly())
-                {
-                    requestInfos.Append("\t\t");
-                    requestInfos.Append(r);
-                    requestInfos.AppendLine(" --> ");
-                }
-            }
-
-            requestInfos.Append("\t\t");
-            requestInfos.AppendLine(request.ToString());
-
-            return requestInfos.ToString();
+                ",
+                    recordedRequests.First().GetType()),
+                recordedRequests);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/TypeEnvy.cs
+++ b/Src/AutoFixture/Kernel/TypeEnvy.cs
@@ -22,11 +22,6 @@ namespace AutoFixture.Kernel
                 "Member '{0}' contains more than one attribute of type '{1}'", candidate, typeof(TAttribute)));
         }
 
-        public static Assembly Assembly(this Type type)
-        {
-            return type.GetTypeInfo().Assembly;
-        }
-
         public static Type BaseType(this Type type)
         {
             return type.GetTypeInfo().BaseType;

--- a/Src/AutoFixture/ObjectCreationExceptionWithPath.cs
+++ b/Src/AutoFixture/ObjectCreationExceptionWithPath.cs
@@ -1,8 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using AutoFixture.Kernel;
 
 namespace AutoFixture
 {
-
     /// <summary>
     /// The exception that is thrown when AutoFixture is unable to create an object.
     /// This exception is supposed to contain the full request path.
@@ -10,18 +15,29 @@ namespace AutoFixture
 #if SYSTEM_RUNTIME_SERIALIZATION
     [Serializable]
 #endif
-    internal class ObjectCreationExceptionWithPath: ObjectCreationException
+    internal class ObjectCreationExceptionWithPath : ObjectCreationException
     {
         public ObjectCreationExceptionWithPath()
         {
-        }       
-        
+        }
+
         public ObjectCreationExceptionWithPath(string message) : base(message)
         {
         }
 
+        public ObjectCreationExceptionWithPath(string message, IEnumerable<object> requests)
+            : base(message + FormatRequestsPath(requests))
+        {
+        }
+
         public ObjectCreationExceptionWithPath(string message, Exception innerException)
-            : base(message, innerException)
+            : base(message + FormatInnerExceptionMessages(innerException), innerException)
+        {
+        }
+
+        public ObjectCreationExceptionWithPath(string message, IEnumerable<object> requests, Exception innerException)
+            : base(message + FormatRequestsPath(requests) + FormatInnerExceptionMessages(innerException),
+                innerException)
         {
         }
 
@@ -33,5 +49,49 @@ namespace AutoFixture
         {
         }
 #endif
+
+        private static string FormatRequestsPath(IEnumerable<object> requests)
+        {
+            var prefix = string.Format(CultureInfo.InvariantCulture, "{0}{0}Request path:{0}", Environment.NewLine);
+
+            var paddedRequests = requests
+                .Where(ShouldDisplayRequestInPath)
+                .Select((req, level) => string.Format(CultureInfo.CurrentCulture, "\t{0}{1}", Indent(level), req));
+
+            return prefix + string.Join(Environment.NewLine, paddedRequests) + Environment.NewLine;
+        }
+
+        private static bool ShouldDisplayRequestInPath(object request)
+        {
+            var autoFixtureAssembly = typeof(ObjectCreationExceptionWithPath).GetTypeInfo().Assembly;
+            if (request.GetType().GetTypeInfo().Assembly.Equals(autoFixtureAssembly))
+                return false;
+
+            return true;
+        }
+
+        private static string FormatInnerExceptionMessages(Exception ex)
+        {
+            var messages = new StringBuilder();
+            messages.AppendLine();
+            messages.AppendLine("Inner exception messages:");
+
+            var level = 0;
+            while (ex != null)
+            {
+                messages.AppendFormat(
+                    CultureInfo.InvariantCulture, "\t{0}{1}: {2}", Indent(level), ex.GetType().FullName, ex.Message);
+                messages.AppendLine();
+
+                level++;
+                ex = ex.InnerException;
+            }
+
+            messages.AppendLine();
+
+            return messages.ToString();
+        }
+
+        private static string Indent(int level) => "".PadLeft(level * 2);
     }
 }


### PR DESCRIPTION
Normalize formatting of the request path and inner exception by moving logic to the `ObjectCreationExceptionWithPath` constructor exception. It makes API and exception messages more consistent.