### PR TITLE
Update ModestConstructorQuery.cs

### DIFF
--- a/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -26,6 +26,10 @@ namespace AutoFixture.Kernel
         /// one returned.
         /// </para>
         /// <para>
+        /// Extension added so that only constructors with multiple parameters are returned and 
+        /// none with the same type as the supplied one.
+        /// </para>
+        /// <para>
         /// In case of two constructors with an equal number of parameters, the ordering is
         /// unspecified.
         /// </para>
@@ -36,6 +40,7 @@ namespace AutoFixture.Kernel
 
             return from ci in type.GetTypeInfo().GetConstructors()
                    let parameters = ci.GetParameters()
+                   where (parameters.Length > 1 && parameters.All(p => p.ParameterType != type))
                    orderby parameters.Length ascending
                    select new ConstructorMethod(ci) as IMethod;
         }


### PR DESCRIPTION
extended the query with a where clause so that only constructors with multiple parameters are returned and none with the same type as the supplied one