### PR TITLE
Allow to relay open generic types via TypeRelay

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -77,7 +77,6 @@ namespace AutoFixture
                                         new ExactTypeSpecification(
                                             typeof(ISpecimenBuilder)))),
                                 new StableFiniteSequenceRelay(),
-                                new ReadOnlyCollectionRelay(),
                                 new FilteringSpecimenBuilder(
                                     new Postprocessor(
                                         new MethodInvoker(
@@ -137,9 +136,10 @@ namespace AutoFixture
                                 new AnyTypeSpecification())),
                         new ResidueCollectorNode(
                             new CompositeSpecimenBuilder(
-                                new DictionaryRelay(),
-                                new CollectionRelay(),
-                                new ListRelay(),
+                                new TypeRelay(typeof(IDictionary<,>), typeof(Dictionary<,>)),
+                                new TypeRelay(typeof(ICollection<>), typeof(List<>)),
+                                new TypeRelay(typeof(IList<>), typeof(List<>)),
+                                new TypeRelay(typeof(IReadOnlyCollection<>), typeof(List<>)),
                                 new EnumerableRelay(),
                                 new EnumeratorRelay())),
                         new FilteringSpecimenBuilder(

--- a/Src/AutoFixture/Kernel/CollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/CollectionRelay.cs
@@ -8,6 +8,7 @@ namespace AutoFixture.Kernel
     /// Relays a request for an <see cref="ICollection{T}" /> to a request for a
     /// <see cref="List{T}"/> and returns the result.
     /// </summary>
+    [Obsolete("This relay has been deprecated, use \"new TypeRelay(typeof(ICollection<>), typeof(List<>))\" instead.")]
     public class CollectionRelay : ISpecimenBuilder
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/DictionaryRelay.cs
+++ b/Src/AutoFixture/Kernel/DictionaryRelay.cs
@@ -8,6 +8,7 @@ namespace AutoFixture.Kernel
     /// Relays a request for an <see cref="IDictionary{TKey, TValue}" /> to a request for a
     /// <see cref="Dictionary{TKey, TValue}"/> and returns the result.
     /// </summary>
+    [Obsolete("This relay has been deprecated, use \"new TypeRelay(typeof(IDictionary<>), typeof(Dictionary<>))\" instead.")]
     public class DictionaryRelay : ISpecimenBuilder
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/ListRelay.cs
+++ b/Src/AutoFixture/Kernel/ListRelay.cs
@@ -8,6 +8,7 @@ namespace AutoFixture.Kernel
     /// Relays a request for an <see cref="IList{T}" /> to a request for a
     /// <see cref="List{T}"/> and returns the result.
     /// </summary>
+    [Obsolete("This relay has been deprecated, use \"new TypeRelay(typeof(IList<>), typeof(List<>))\" instead.")]
     public class ListRelay : ISpecimenBuilder
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
@@ -8,6 +8,7 @@ namespace AutoFixture.Kernel
     /// Relays a request for an <see cref="IReadOnlyCollection{T}" /> to a request for a
     /// <see cref="List{T}"/> and retuns the result.
     /// </summary>
+    [Obsolete("This relay has been deprecated, use \"new TypeRelay(typeof(IReadOnlyCollection<>), typeof(List<>))\" instead.")]
     public class ReadOnlyCollectionRelay : ISpecimenBuilder
     {
         /// <summary>

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5060,17 +5060,29 @@ namespace AutoFixtureUnitTest
         [Theory]
         [InlineData(typeof(EnumeratorRelay))]
         [InlineData(typeof(EnumerableRelay))]
-        [InlineData(typeof(ListRelay))]
-        [InlineData(typeof(CollectionRelay))]
-        [InlineData(typeof(DictionaryRelay))]
-        public void ResidueCollectorsContainMultipleRelaysByDefault(
+        public void ResidueCollectorsContainEnumerableRelayByDefault(
             Type relayType)
         {
             var sut = new Fixture();
-            Assert.True(
-                sut.ResidueCollectors.Any(b =>
-                    relayType.IsAssignableFrom(b.GetType())),
-                relayType.Name + " not found.");
+            Assert.Contains(
+                sut.ResidueCollectors,
+                b => relayType.IsInstanceOfType(b));
+        }
+
+        [Theory]
+        [InlineData(typeof(IList<>), typeof(List<>))]
+        [InlineData(typeof(ICollection<>), typeof(List<>))]
+        [InlineData(typeof(IReadOnlyCollection<>), typeof(List<>))]
+        [InlineData(typeof(IDictionary<,>), typeof(Dictionary<,>))]
+        public void ResidueCollectorsContainForwardsByDefault(Type from, Type to)
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            // Exercise system and Verify outcome
+            Assert.Contains(
+                sut.ResidueCollectors,
+                b => b is TypeRelay tr && tr.From == from && tr.To == to);
+            // Teardown
         }
 
         [Theory]

--- a/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest.Kernel
 {
+    [Obsolete]
     public class CollectionRelayTest
     {
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest.Kernel
 {
+    [Obsolete]
     public class DictionaryRelayTest
     {
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest.Kernel
 {
+    [Obsolete]
     public class ListRelayTest
     {
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/ReadOnlyCollectionRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ReadOnlyCollectionRelayTest.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest.Kernel
 {
+    [Obsolete]
     public class ReadOnlyCollectionRelayTest
     {
         [Fact]


### PR DESCRIPTION
In this PR I've extended the `TypeRelay` to allow relay using open generic type specifications. For instance, if you relay `IEnumerable<T> -> List<T>`, it will relay e.g. `IEnumerable<int>` to `List<int>`.

That allows to remove a few boilerplate relays and use the reusable `TypeRelay` instead. In future we could add more relays (like `IReadOnlyList<T> -> List<T>`) much more easier.

@moodmosaic It's exactly like #935, but for relay.