### PR TITLE
Issue #918 Change ConstructorQuery-classes to skip copy constructors

### DIFF
--- a/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
@@ -40,6 +40,7 @@ namespace AutoFixture.Kernel
 
             return from ci in type.GetTypeInfo().GetConstructors()
                    let score = new ArrayParameterScore(ci.GetParameters())
+                   where ci.GetParameters().All(p => p.ParameterType != type)
                    orderby score descending
                    select new ConstructorMethod(ci) as IMethod;
         }

--- a/Src/AutoFixture/Kernel/EnumerableFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/EnumerableFavoringConstructorQuery.cs
@@ -42,6 +42,7 @@ namespace AutoFixture.Kernel
 
             return from ci in type.GetTypeInfo().GetConstructors()
                    let score = new ParameterScore(type, typeof(IEnumerable<>), ci.GetParameters())
+                   where ci.GetParameters().All(p => p.ParameterType != type)
                    orderby score descending
                    select new ConstructorMethod(ci) as IMethod;
         }

--- a/Src/AutoFixture/Kernel/GreedyConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/GreedyConstructorQuery.cs
@@ -36,6 +36,7 @@ namespace AutoFixture.Kernel
 
             return from ci in type.GetTypeInfo().GetConstructors()
                    let parameters = ci.GetParameters()
+                   where parameters.All(p => p.ParameterType != type)
                    orderby parameters.Length descending
                    select new ConstructorMethod(ci) as IMethod;
         }

--- a/Src/AutoFixture/Kernel/ListFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ListFavoringConstructorQuery.cs
@@ -42,6 +42,7 @@ namespace AutoFixture.Kernel
 
             return from ci in type.GetTypeInfo().GetConstructors()
                    let score = new ParameterScore(type, typeof(IList<>), ci.GetParameters())
+                   where ci.GetParameters().All(p => p.ParameterType != type)
                    orderby score descending
                    select new ConstructorMethod(ci) as IMethod;
         }

--- a/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ModestConstructorQuery.cs
@@ -36,6 +36,7 @@ namespace AutoFixture.Kernel
 
             return from ci in type.GetTypeInfo().GetConstructors()
                    let parameters = ci.GetParameters()
+                   where parameters.All(p => p.ParameterType != type)
                    orderby parameters.Length ascending
                    select new ConstructorMethod(ci) as IMethod;
         }

--- a/Src/AutoFixtureUnitTest/Kernel/ArrayFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ArrayFavoringConstructorQueryTest.cs
@@ -100,5 +100,28 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.True(expectedConstructors.SequenceEqual(result));
             // Teardown
         }
+
+        [Fact]
+        public void DoesNotReturnConstructorsWithParametersOfEnclosingType()
+        {
+            // Fixture setup
+            var sut = new ArrayFavoringConstructorQuery();
+            // Exercise system
+            var result = sut.SelectMethods(typeof(TypeWithCopyConstructorsOnly));
+            // Verify outcome
+            Assert.Empty(result);
+            // Teardown
+        }
+
+        private class TypeWithCopyConstructorsOnly
+        {
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other)
+            {
+            }
+
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other, int[] nums)
+            {
+            }
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumerableFavoringConstructorQueryTest.cs
@@ -119,5 +119,29 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.Contains(result.First().Parameters, p => expected == p.ParameterType);
             // Teardown
         }
+
+        [Fact]
+        public void DoesNotReturnConstructorsWithParametersOfEnclosingType()
+        {
+            // Fixture setup
+            var sut = new EnumerableFavoringConstructorQuery();
+            // Exercise system
+            var result = sut.SelectMethods(typeof(TypeWithCopyConstructorsOnly));
+
+            // Verify outcome
+            Assert.Empty(result);
+            // Teardown
+        }
+
+        private class TypeWithCopyConstructorsOnly
+        {
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other)
+            {
+            }
+
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other, IEnumerable<int> nums)
+            {
+            }
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/GreedyConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/GreedyConstructorQueryTest.cs
@@ -63,5 +63,34 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.True(expectedConstructors.SequenceEqual(result));
             // Teardown
         }
+
+        [Fact]
+        public void DoesNotReturnConstructorsWithParametersOfEnclosingType()
+        {
+            // Fixture setup
+            var sut = new GreedyConstructorQuery();
+            // Exercise system
+            var result = sut.SelectMethods(typeof(TypeWithCopyConstructorsOnly));
+            // Verify outcome
+            Assert.Empty(result);
+            // Teardown
+        }
+
+
+        public class TypeWithCopyConstructorsOnly
+        {
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other)
+            {
+            }
+
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other, int num)
+            {
+            }
+
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other, string str)
+            {
+            }
+        }
+
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListFavoringConstructorQueryTest.cs
@@ -116,5 +116,28 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.Contains(result.First().Parameters, p => typeof(IList<object>) == p.ParameterType);
             // Teardown
         }
+
+        [Fact]
+        public void DoesNotReturnConstructorsWithParametersOfEnclosingType()
+        {
+            // Fixture setup
+            var sut = new ListFavoringConstructorQuery();
+            // Exercise system
+            var result = sut.SelectMethods(typeof(TypeWithCopyConstructorsOnly));
+            // Verify outcome
+            Assert.Empty(result);
+            // Teardown
+        }
+
+        public class TypeWithCopyConstructorsOnly
+        {
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other)
+            {
+            }
+
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other, List<int> nums)
+            {
+            }
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/ModestConstructorQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ModestConstructorQueryTest.cs
@@ -63,5 +63,32 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.True(expectedConstructors.SequenceEqual(result));
             // Teardown
         }
+
+        [Fact]
+        public void DoesNotReturnConstructorsWithParametersOfEnclosingType()
+        {
+            // Fixture setup
+            var sut = new ModestConstructorQuery();
+            // Exercise system
+            var result = sut.SelectMethods(typeof(TypeWithCopyConstructorsOnly));
+            // Verify outcome
+            Assert.Empty(result);
+            // Teardown
+        }
+
+        public class TypeWithCopyConstructorsOnly
+        {
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other)
+            {
+            }
+
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other, int num)
+            {
+            }
+
+            public TypeWithCopyConstructorsOnly(TypeWithCopyConstructorsOnly other, string str)
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #918.

Changed EnumerableFavoring-, Greedy-, ArrayFavoring-, ListFavoring- and ModestConstructorQuery behavior to skip copy constructors

Modified tests to reflect new logic
Added extra tests to test for new logic