### PR TITLE
Improve organization of the DataAnnotation related stuff

### DIFF
--- a/Src/AutoFixture/DataAnnotations/NumericRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/NumericRangedRequestRelay.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using AutoFixture.Kernel;
 
-namespace AutoFixture
+namespace AutoFixture.DataAnnotations
 {
     /// <summary>
     /// Handles the <see cref="RangedRequest"/> for the number type by forwarding it 

--- a/Src/AutoFixture/DataAnnotations/RangedRequest.cs
+++ b/Src/AutoFixture/DataAnnotations/RangedRequest.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
-namespace AutoFixture.Kernel
+namespace AutoFixture.DataAnnotations
 {
     /// <summary>
     /// Encapsulates a request of a specified type within the specified range.

--- a/Src/AutoFixture/DefaultRelays.cs
+++ b/Src/AutoFixture/DefaultRelays.cs
@@ -28,7 +28,6 @@ namespace AutoFixture
             yield return new FieldRequestRelay();
             yield return new FiniteSequenceRelay();
             yield return new SeedIgnoringRelay();
-            yield return new NumericRangedRequestRelay();
             yield return new MethodInvoker(
                 new CompositeMethodQuery(
                     new ModestConstructorQuery(),

--- a/Src/AutoFixture/Fare/Automaton.cs
+++ b/Src/AutoFixture/Fare/Automaton.cs
@@ -34,7 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     /// <summary>
     /// Finite-state automaton with regular expression operations.

--- a/Src/AutoFixture/Fare/BasicAutomata.cs
+++ b/Src/AutoFixture/Fare/BasicAutomata.cs
@@ -36,7 +36,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider",
         Justification = "This code has been copied from another project and is used as-is.")]

--- a/Src/AutoFixture/Fare/BasicOperations.cs
+++ b/Src/AutoFixture/Fare/BasicOperations.cs
@@ -36,7 +36,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     internal static class BasicOperations
     {

--- a/Src/AutoFixture/Fare/LinkedListExtensions.cs
+++ b/Src/AutoFixture/Fare/LinkedListExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     internal static class LinkedListExtensions
     {

--- a/Src/AutoFixture/Fare/ListEqualityComparer.cs
+++ b/Src/AutoFixture/Fare/ListEqualityComparer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     internal sealed class ListEqualityComparer<T>  : IEqualityComparer<List<T>>, IEquatable<ListEqualityComparer<T>>
     {

--- a/Src/AutoFixture/Fare/MinimizationOperations.cs
+++ b/Src/AutoFixture/Fare/MinimizationOperations.cs
@@ -33,7 +33,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     internal static class MinimizationOperations
     {

--- a/Src/AutoFixture/Fare/RegExp.cs
+++ b/Src/AutoFixture/Fare/RegExp.cs
@@ -37,7 +37,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     /// <summary>
     /// Regular Expression extension to Automaton.

--- a/Src/AutoFixture/Fare/RegExpMatchingOptions.cs
+++ b/Src/AutoFixture/Fare/RegExpMatchingOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     internal static class RegExpMatchingOptions
     {

--- a/Src/AutoFixture/Fare/RegExpSyntaxOptions.cs
+++ b/Src/AutoFixture/Fare/RegExpSyntaxOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     [Flags]
     internal enum RegExpSyntaxOptions

--- a/Src/AutoFixture/Fare/SpecialOperations.cs
+++ b/Src/AutoFixture/Fare/SpecialOperations.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     /// <summary>
     /// Special automata operations.

--- a/Src/AutoFixture/Fare/State.cs
+++ b/Src/AutoFixture/Fare/State.cs
@@ -36,7 +36,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     /// <summary>
     /// <tt>Automaton</tt> state.

--- a/Src/AutoFixture/Fare/StateEqualityComparer.cs
+++ b/Src/AutoFixture/Fare/StateEqualityComparer.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     internal sealed class StateEqualityComparer : IEqualityComparer<State>
     {

--- a/Src/AutoFixture/Fare/StatePair.cs
+++ b/Src/AutoFixture/Fare/StatePair.cs
@@ -32,7 +32,7 @@
 
 using System;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     /// <summary>
     /// Pair of states.

--- a/Src/AutoFixture/Fare/Transition.cs
+++ b/Src/AutoFixture/Fare/Transition.cs
@@ -34,7 +34,7 @@ using System;
 using System.Globalization;
 using System.Text;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     ///<summary>
     ///  <tt>Automaton</tt> transition. 

--- a/Src/AutoFixture/Fare/TransitionComparer.cs
+++ b/Src/AutoFixture/Fare/TransitionComparer.cs
@@ -32,7 +32,7 @@
 
 using System.Collections.Generic;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     internal sealed class TransitionComparer : IComparer<Transition>
     {

--- a/Src/AutoFixture/Fare/Xeger.cs
+++ b/Src/AutoFixture/Fare/Xeger.cs
@@ -20,7 +20,7 @@
 using System;
 using System.Text;
 
-namespace AutoFixture.DataAnnotations
+namespace Fare
 {
     /// <summary>
     /// An object that will generate text from a regular expression. In a way, 

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -119,14 +119,17 @@ namespace AutoFixture
                                     new MethodInvoker(
                                         new ModestConstructorQuery()),
                                     new NullableEnumRequestSpecification()),
-                                new RangeAttributeRelay(),
-                                new StringLengthAttributeRelay(),
-                                new RegularExpressionAttributeRelay(),
                                 new EnumGenerator(),
                                 new LambdaExpressionGenerator(),
                                 CreateDefaultValueBuilder(CultureInfo.InvariantCulture),
                                 CreateDefaultValueBuilder(Encoding.UTF8),
-                                CreateDefaultValueBuilder(IPAddress.Loopback))),
+                                CreateDefaultValueBuilder(IPAddress.Loopback),
+                        
+                                /* Data annotations */
+                                new RangeAttributeRelay(),
+                                new NumericRangedRequestRelay(),
+                                new StringLengthAttributeRelay(),
+                                new RegularExpressionAttributeRelay())),
                         new AutoPropertiesTarget(
                             new Postprocessor(
                                 new CompositeSpecimenBuilder(

--- a/Src/AutoFixture/NoDataAnnotationsCustomization.cs
+++ b/Src/AutoFixture/NoDataAnnotationsCustomization.cs
@@ -27,9 +27,10 @@ namespace AutoFixture
 
             var dataAnnotationsRelayTypes = new[]
             {
-                typeof (RangeAttributeRelay),
-                typeof (StringLengthAttributeRelay),
-                typeof (RegularExpressionAttributeRelay)
+                typeof(RangeAttributeRelay),
+                typeof(NumericRangedRequestRelay),
+                typeof(StringLengthAttributeRelay),
+                typeof(RegularExpressionAttributeRelay)
             };
 
             fixture

--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using AutoFixture.DataAnnotations;
 using AutoFixture.Kernel;
+using Fare;
 
 namespace AutoFixture
 {

--- a/Src/AutoFixtureUnitTest/DataAnnotations/NumericRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/NumericRangedRequestRelayTest.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using AutoFixture;
+using AutoFixture.DataAnnotations;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
 using TestTypeFoundation;
 using Xunit;
 
-namespace AutoFixtureUnitTest
+namespace AutoFixtureUnitTest.DataAnnotations
 {
     public class NumericRangedRequestRelayTest
     {

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangedRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangedRequestTest.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using AutoFixture.Kernel;
+using AutoFixture.DataAnnotations;
 using Xunit;
 
-namespace AutoFixtureUnitTest.Kernel
+namespace AutoFixtureUnitTest.DataAnnotations
 {
     public class RangedRequestTest
     {

--- a/Src/AutoFixtureUnitTest/DefaultRelaysTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultRelaysTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
+using AutoFixture.DataAnnotations;
 using AutoFixture.Kernel;
 using Xunit;
 
@@ -34,7 +35,6 @@ namespace AutoFixtureUnitTest
                 typeof(FieldRequestRelay),
                 typeof(FiniteSequenceRelay),
                 typeof(SeedIgnoringRelay),
-                typeof(NumericRangedRequestRelay),
                 typeof(MethodInvoker)
             };
             // Exercise system

--- a/Src/AutoFixtureUnitTest/NoDataAnnotationsCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/NoDataAnnotationsCustomizationTest.cs
@@ -33,6 +33,7 @@ namespace AutoFixtureUnitTest
         [InlineData(typeof(RangeAttributeRelay))]
         [InlineData(typeof(StringLengthAttributeRelay))]
         [InlineData(typeof(RegularExpressionAttributeRelay))]
+        [InlineData(typeof(NumericRangedRequestRelay))]
         public void CustomizeProperFixtureCorrectlyCustomizesIt(Type removedBuilderType)
         {
             // Fixture setup
@@ -41,10 +42,10 @@ namespace AutoFixtureUnitTest
             // Exercise system
             sut.Customize(fixture);
 
-            var results = fixture.Customizations
-                .SingleOrDefault(c => c.GetType() == removedBuilderType);
             // Verify outcome
-            Assert.Null(results);
+            Assert.DoesNotContain(
+                fixture.Customizations,
+                b => b.GetType() == removedBuilderType);
             // Teardown
         }
     }


### PR DESCRIPTION
In this commit I perform a bit of cleanup to make the code structure more clear and consistent:
- all the Xeger stuff was moved to its own namespace;
- all the data annotations specific stuff has been moved under the `DataAnnotations` namespace. While some of the changes are broken, we are fine as those files were introduced in non-released v4;
- moved `NumericRangedRequestRelay` to Customization section for consistency with other builders. Now all the builders are located nearby;
- extended the `NoDataAnnotationsCustomization` to remove all the related builders.

All those changes are minor, but now it's more clear which particular stuff is specific to DataAnnotations.