### PR TITLE
Do not skip range request from path

### DIFF
--- a/Src/AutoFixture/DataAnnotations/RangedRequest.cs
+++ b/Src/AutoFixture/DataAnnotations/RangedRequest.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using AutoFixture.Kernel;
 
 namespace AutoFixture.DataAnnotations
 {
     /// <summary>
     /// Encapsulates a request of a specified type within the specified range.
     /// </summary>
+    [PreserveInRequestPath]
     public class RangedRequest : IEquatable<RangedRequest>
     {
         /// <summary>

--- a/Src/AutoFixture/Kernel/PreserveInRequestPathAttribute.cs
+++ b/Src/AutoFixture/Kernel/PreserveInRequestPathAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace AutoFixture.Kernel
+{
+    /// <summary>
+    /// A marker to indicate that request of this type should not be skipped in the request path.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    internal sealed class PreserveInRequestPathAttribute : Attribute
+    {
+    }
+}

--- a/Src/AutoFixture/Kernel/RangedNumberRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedNumberRequest.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Globalization;
 
 namespace AutoFixture.Kernel
 {
     /// <summary>
     /// Encapsulates a range for values of a given type.
     /// </summary>
+    [PreserveInRequestPath]
     public class RangedNumberRequest : IEquatable<RangedNumberRequest>
     {
         /// <summary>
@@ -97,6 +99,20 @@ namespace AutoFixture.Kernel
             return this.OperandType == other.OperandType
                 && object.Equals(this.Minimum, other.Minimum)
                 && object.Equals(this.Maximum, other.Maximum);
+        }
+
+        /// <inheritdoc />
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "RangedNumberRequest (OperandType: {0}, Minimum: [{1}] {2}, Maximum: [{3}] {4})",
+                this.OperandType.FullName,
+                this.Minimum.GetType().Name,
+                this.Minimum,
+                this.Maximum.GetType().Name,
+                this.Maximum);
         }
     }
 }

--- a/Src/AutoFixture/ObjectCreationExceptionWithPath.cs
+++ b/Src/AutoFixture/ObjectCreationExceptionWithPath.cs
@@ -63,6 +63,9 @@ namespace AutoFixture
 
         private static bool ShouldDisplayRequestInPath(object request)
         {
+            if (request.GetType().GetTypeInfo().GetCustomAttribute<PreserveInRequestPathAttribute>() != null)
+                return true;
+
             var autoFixtureAssembly = typeof(ObjectCreationExceptionWithPath).GetTypeInfo().Assembly;
             if (request.GetType().GetTypeInfo().Assembly.Equals(autoFixtureAssembly))
                 return false;

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture;
+using AutoFixture.DataAnnotations;
 using AutoFixture.Dsl;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.DataAnnotations;
@@ -6168,6 +6169,42 @@ namespace AutoFixtureUnitTest
             Assert.Same(oldBehaviors, sut.Behaviors);
             Assert.Same(oldCustomizations, sut.Customizations);
             Assert.Same(oldResidueCollectors, sut.ResidueCollectors);
+            // Teardown
+        }
+
+        [Fact]
+        public void RangedRequestIsPresentInFailurePath()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            var request = new RangedRequest(typeof(ConcreteType), typeof(ConcreteType), 10, 42);
+            var context = new SpecimenContext(sut);
+
+            // Exercise system and verify outcome
+            var ex = Assert.ThrowsAny<ObjectCreationException>(() =>
+                sut.Create(request, context));
+
+            var requestPath = ex.Message.Substring(ex.Message.IndexOf("Request path:"));
+
+            Assert.Contains("RangedRequest", requestPath);
+            // Teardown
+        }
+
+        [Fact]
+        public void RangedNumberRequestIsPresentInFailurePath()
+        {
+            // Fixture setup
+            var sut = new Fixture();
+            var request = new RangedNumberRequest(typeof(ConcreteType), 10, 42);
+            var context = new SpecimenContext(sut);
+
+            // Exercise system and verify outcome
+            var ex = Assert.ThrowsAny<ObjectCreationException>(() =>
+                sut.Create(request, context));
+
+            var requestPath = ex.Message.Substring(ex.Message.IndexOf("Request path:"));
+
+            Assert.Contains("RangedNumberRequest", requestPath);
             // Teardown
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedNumberRequestTest.cs
@@ -301,5 +301,22 @@ namespace AutoFixtureUnitTest.Kernel
             Assert.Equal(expectedHashCode, result);
             // Teardown
         }
+
+        [Fact]
+        public void ToStringShouldBeOverridden()
+        {
+            // Fixture setup
+            var sut = new RangedNumberRequest(typeof(long), 42, 100);
+
+            // Exercise system
+            var stringResult = sut.ToString();
+
+            // Verify outcome
+            Assert.Contains("Int64", stringResult);
+            Assert.Contains("42", stringResult);
+            Assert.Contains("100", stringResult);
+
+            // Teardown
+        }
     }
 }


### PR DESCRIPTION
Currently we strip all the intermediate "system" requests from the request path (e.g. in case of exception):
https://github.com/AutoFixture/AutoFixture/blob/e9212dc4c527f7446418cefc0340b371bc4cea17/Src/AutoFixture/ObjectCreationExceptionWithPath.cs#L64-L71

If there are Range attributes, the processing path might be very non-obvious and it will be hard to troubleshoot why activation failed.

In this PR I preserve all the ranged related requests, so if it fails - it's clear what was the internal path.