### PR TITLE
Support Range attribute for Enum members

### DIFF
--- a/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.DataAnnotations
+{
+    /// <summary>
+    /// Handles <see cref="RangedRequest"/> of enum type by forwarding requests
+    /// to the <see cref="RangedNumberRequest"/> of the underlying enum type.
+    /// </summary>
+    public class EnumRangedRequestRelay : ISpecimenBuilder
+    {
+        /// <inheritdoc />
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var rangedRequest = request as RangedRequest;
+            if (rangedRequest == null)
+                return new NoSpecimen();
+
+            if (!rangedRequest.MemberType.IsEnum())
+                return new NoSpecimen();
+
+            var underlyingNumericType = rangedRequest.MemberType.GetTypeInfo().GetEnumUnderlyingType();
+            var minimum = rangedRequest.GetConvertedMinimum(underlyingNumericType);
+            var maximum = rangedRequest.GetConvertedMaximum(underlyingNumericType);
+
+            var numericValue = context.Resolve(new RangedNumberRequest(underlyingNumericType, minimum, maximum));
+            if (numericValue is NoSpecimen)
+                return new NoSpecimen();
+
+            return Enum.ToObject(rangedRequest.MemberType, numericValue);
+        }
+    }
+}

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -128,6 +128,7 @@ namespace AutoFixture
                                 /* Data annotations */
                                 new RangeAttributeRelay(),
                                 new NumericRangedRequestRelay(),
+                                new EnumRangedRequestRelay(),
                                 new StringLengthAttributeRelay(),
                                 new RegularExpressionAttributeRelay())),
                         new AutoPropertiesTarget(

--- a/Src/AutoFixture/NoDataAnnotationsCustomization.cs
+++ b/Src/AutoFixture/NoDataAnnotationsCustomization.cs
@@ -29,6 +29,7 @@ namespace AutoFixture
             {
                 typeof(RangeAttributeRelay),
                 typeof(NumericRangedRequestRelay),
+                typeof(EnumRangedRequestRelay),
                 typeof(StringLengthAttributeRelay),
                 typeof(RegularExpressionAttributeRelay)
             };

--- a/Src/AutoFixtureUnitTest/DataAnnotations/EnumRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/EnumRangedRequestRelayTest.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using AutoFixture.DataAnnotations;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixtureUnitTest.DataAnnotations
+{
+    public class EnumRangedRequestRelayTest
+    {
+        [Fact]
+        public void SutShouldBeASpecimenBuilder()
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+
+            // Act & Assert
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void ShouldFailForNullContext()
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            var request = new object();
+
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentNullException>(() =>
+                sut.Create(request, null));
+        }
+
+        [Fact]
+        public void ShouldNotHandleRequestIfMemberTypeIsNotEnum()
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: typeof(object), operandType: typeof(EnumType), minimum: 0, maximum: 1);
+            var context = new DelegatingSpecimenContext();
+
+            // Act
+            var result = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Fact]
+        public void ShouldHandleRequestOfEnumType()
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: typeof(EnumType), operandType: typeof(int), minimum: 1, maximum: 2);
+            var result = (int)EnumType.Second;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = _ => result
+            };
+
+            // Act
+            var actualResult = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(EnumType.Second, actualResult);
+        }
+
+        [Theory]
+        [InlineData(EnumType.First, 1)]
+        [InlineData(EnumType.Second, 2)]
+        [InlineData(EnumType.Third, 3)]
+        public void ShouldCorrectlyConvertNumericValue(EnumType expectedResult, int numericValue)
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: typeof(EnumType), operandType: typeof(int), minimum: 1, maximum: 3);
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = _ => numericValue
+            };
+
+            // Act
+            var result = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void ShouldReturnNoSpecimenIfUnableToSatisfyRangedRequest()
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: typeof(EnumType), operandType: typeof(int), minimum: 1, maximum: 2);
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = _ => new NoSpecimen()
+            };
+
+            // Act
+            var result = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Theory]
+        [InlineData(typeof(ShortEnumType), typeof(short))]
+        [InlineData(typeof(ByteEnumType), typeof(byte))]
+        [InlineData(typeof(LongEnumType), typeof(long))]
+        public void ShouldRespectUnderlyingEnumType(Type enumType, Type underlyingType)
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: enumType, operandType: typeof(int), minimum: 1, maximum: 2);
+
+            RangedNumberRequest capturedNumericRequest = null;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    capturedNumericRequest = (RangedNumberRequest)r;
+                    return new NoSpecimen();
+                }
+            };
+
+            // Act
+            sut.Create(request, context);
+
+            // Assert
+            Assert.NotNull(capturedNumericRequest);
+            Assert.Equal(underlyingType, capturedNumericRequest.OperandType);
+            Assert.IsType(underlyingType, capturedNumericRequest.Minimum);
+            Assert.IsType(underlyingType, capturedNumericRequest.Maximum);
+        }
+
+        [Fact]
+        public void ShouldCorrectPassMinimumAndMaximum()
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            int minimum = 5;
+            int maximum = 10;
+
+            var requst = new RangedRequest(typeof(EnumType), typeof(int), minimum, maximum);
+            RangedNumberRequest capturedNumericRequest = null;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    capturedNumericRequest = (RangedNumberRequest)r;
+                    return new NoSpecimen();
+                }
+            };
+
+            // Act
+            sut.Create(requst, context);
+
+            // Assert
+            Assert.NotNull(capturedNumericRequest);
+            Assert.Equal(minimum, capturedNumericRequest.Minimum);
+            Assert.Equal(maximum, capturedNumericRequest.Maximum);
+        }
+
+        private enum ShortEnumType : short
+        {
+            First,
+            Second
+        }
+
+        private enum ByteEnumType : byte
+        {
+            First,
+            Second
+        }
+
+        private enum LongEnumType : long
+        {
+            First,
+            Second
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6222,5 +6222,45 @@ namespace AutoFixtureUnitTest
             Assert.Contains("RangedNumberRequest", requestPath);
             // Teardown
         }
+
+        private class TypeWithRangedEnumProperties
+        {
+            [Range(1, 3)]
+            public EnumType RangedEnumProperty { get; set; }
+
+            [Range(2, 2)]
+            public EnumType Equal2EnumProperty { get; set; }
+
+            [Range(10, 20)]
+            public EnumType OutOfRangeEnumProperty { get; set; }
+        }
+
+        /// <summary>
+        /// Scenario for: https://github.com/AutoFixture/AutoFixture/issues/722
+        /// </summary>
+        [Fact]
+        public void ShouldCorrectlyResolveEnumPropertiesDecoratedWithRange()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithRangedEnumProperties>();
+            // Assert
+            Assert.InRange(result.RangedEnumProperty, EnumType.First, EnumType.Third);
+            Assert.Equal(EnumType.Second, result.Equal2EnumProperty);
+        }
+
+        [Fact]
+        public void ShouldGenerateOutOfRangeValueIfRangeAttributeIsOutOfEnumRange()
+        {
+            // Arrange
+            var sut = new Fixture();
+            // Act
+            var result = sut.Create<TypeWithRangedEnumProperties>();
+            // Assert
+            var numericValue = (int)result.OutOfRangeEnumProperty;
+            Assert.InRange(numericValue, 10, 20);
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/NoDataAnnotationsCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/NoDataAnnotationsCustomizationTest.cs
@@ -34,6 +34,7 @@ namespace AutoFixtureUnitTest
         [InlineData(typeof(StringLengthAttributeRelay))]
         [InlineData(typeof(RegularExpressionAttributeRelay))]
         [InlineData(typeof(NumericRangedRequestRelay))]
+        [InlineData(typeof(EnumRangedRequestRelay))]
         public void CustomizeProperFixtureCorrectlyCustomizesIt(Type removedBuilderType)
         {
             // Fixture setup

--- a/Src/TestTypeFoundation/EnumType.cs
+++ b/Src/TestTypeFoundation/EnumType.cs
@@ -1,0 +1,9 @@
+﻿namespace TestTypeFoundation
+{
+    public enum EnumType
+    {
+        First = 1,
+        Second = 2,
+        Third = 3
+    }
+}


### PR DESCRIPTION
Closes #722.

If `Range` attribute is applied to a member of an enum type, generate a ranged value of the underlying numeric type and later convert that numeric value back to the enum type. If the specified range is out of enum options range, ignore that fact and still respect the specified range. Later we could improve that behavior if needed and we have a plan.

@moodmosaic Please take a look 😉