### PR TITLE
Improve RangedRequest conversion and handle string range value for enum

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)'=='netstandard1.5' ">
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 using AutoFixture.Kernel;
 
@@ -23,10 +24,24 @@ namespace AutoFixture.DataAnnotations
                 return new NoSpecimen();
 
             var underlyingNumericType = rangedRequest.MemberType.GetTypeInfo().GetEnumUnderlyingType();
-            var minimum = rangedRequest.GetConvertedMinimum(underlyingNumericType);
-            var maximum = rangedRequest.GetConvertedMaximum(underlyingNumericType);
 
-            var numericValue = context.Resolve(new RangedNumberRequest(underlyingNumericType, minimum, maximum));
+            object numericMin;
+            object numericMax;
+            if (rangedRequest.Minimum.GetType().IsNumberType())
+            {
+                numericMin = rangedRequest.GetConvertedMinimum(underlyingNumericType);
+                numericMax = rangedRequest.GetConvertedMaximum(underlyingNumericType);
+            }
+            else
+            {
+                var enumMin = rangedRequest.GetConvertedMinimum(rangedRequest.MemberType);
+                var enumMax = rangedRequest.GetConvertedMaximum(rangedRequest.MemberType);
+
+                numericMin = Convert.ChangeType(enumMin, underlyingNumericType, CultureInfo.CurrentCulture);
+                numericMax = Convert.ChangeType(enumMax, underlyingNumericType, CultureInfo.CurrentCulture);
+            }
+
+            var numericValue = context.Resolve(new RangedNumberRequest(underlyingNumericType, numericMin, numericMax));
             if (numericValue is NoSpecimen)
                 return new NoSpecimen();
 

--- a/Src/AutoFixtureUnitTest/DataAnnotations/EnumRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/EnumRangedRequestRelayTest.cs
@@ -147,7 +147,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             int minimum = 5;
             int maximum = 10;
 
-            var requst = new RangedRequest(typeof(EnumType), typeof(int), minimum, maximum);
+            var request = new RangedRequest(typeof(EnumType), typeof(int), minimum, maximum);
             RangedNumberRequest capturedNumericRequest = null;
             var context = new DelegatingSpecimenContext
             {
@@ -159,12 +159,32 @@ namespace AutoFixtureUnitTest.DataAnnotations
             };
 
             // Act
-            sut.Create(requst, context);
+            sut.Create(request, context);
 
             // Assert
             Assert.NotNull(capturedNumericRequest);
             Assert.Equal(minimum, capturedNumericRequest.Minimum);
             Assert.Equal(maximum, capturedNumericRequest.Maximum);
+        }
+
+        [Fact]
+        public void ShouldSupportRangeForLiteralBoundaries()
+        {
+            // Arrange
+            var sut = new EnumRangedRequestRelay();
+            var request
+                = new RangedRequest(typeof(EnumType), typeof(EnumType), nameof(EnumType.First), nameof(EnumType.Third));
+            var result = (int)EnumType.Second;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r => r is RangedNumberRequest ? (object)result : new NoSpecimen()
+            };
+
+            // Act
+            var actualResult = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(EnumType.Second, actualResult);
         }
 
         private enum ShortEnumType : short

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangedRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangedRequestTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using AutoFixture.DataAnnotations;
+using TestTypeFoundation;
 using Xunit;
 
 namespace AutoFixtureUnitTest.DataAnnotations
@@ -283,6 +284,22 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 sut.GetConvertedMaximum(typeof(long)));
             Assert.Contains("To solve the issue", actualEx.Message);
             // Teardown
+        }
+
+        [Fact]
+        public void ShouldConvertLiteralEnumValues()
+        {
+            // Arrange
+            var sut = new RangedRequest(
+                typeof(EnumType), typeof(string), nameof(EnumType.First), nameof(EnumType.Third));
+
+            // Act
+            var convertedMin = sut.GetConvertedMinimum(typeof(EnumType));
+            var convertedMax = sut.GetConvertedMaximum(typeof(EnumType));
+
+            // Assert
+            Assert.Equal(EnumType.First, convertedMin);
+            Assert.Equal(EnumType.Third, convertedMax);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6228,6 +6228,12 @@ namespace AutoFixtureUnitTest
             [Range(1, 3)]
             public EnumType RangedEnumProperty { get; set; }
 
+            [Range(typeof(EnumType), nameof(EnumType.First), nameof(EnumType.Third))]
+            public EnumType LiteralRangedEnumProperty { get; set; }
+
+            [Range(typeof(EnumType), "1", "3")]
+            public EnumType NumericRangedEnumProperty { get; set; }
+
             [Range(2, 2)]
             public EnumType Equal2EnumProperty { get; set; }
 
@@ -6248,6 +6254,8 @@ namespace AutoFixtureUnitTest
             var result = sut.Create<TypeWithRangedEnumProperties>();
             // Assert
             Assert.InRange(result.RangedEnumProperty, EnumType.First, EnumType.Third);
+            Assert.InRange(result.LiteralRangedEnumProperty, EnumType.First, EnumType.Third);
+            Assert.InRange(result.NumericRangedEnumProperty, EnumType.First, EnumType.Third);
             Assert.Equal(EnumType.Second, result.Equal2EnumProperty);
         }
 


### PR DESCRIPTION
Previously `RangedRequest` handled only numeric value conversion, while there are much more types supporting ranges (e.g. `TimeSpan`, `DateTime`). In this PR I improve the conversion approach to mimic the [`RangedAttribute`](https://github.com/Microsoft/referencesource/blob/b31308b03e8bd5bf779fb80fda71f31eb959fe0b/System.ComponentModel.DataAnnotations/DataAnnotations/RangeAttribute.cs#L140) logic. Additionally, I still use the `Convert.ChangeType()` fallback, as it appeared that type converters don't handle some primitive value conversions (e.g. `int -> decimal`).

Also I've improved `EnumRelay` to handle string specified ranges.

@moodmosaic Your review is welcome 🍷