### PR TITLE
[Housekeeping] Migrate to VS 2017 Update 5

### DIFF
--- a/Src/AutoFakeItEasy2/AutoFakeItEasyCustomization.cs
+++ b/Src/AutoFakeItEasy2/AutoFakeItEasyCustomization.cs
@@ -26,12 +26,7 @@ namespace AutoFixture.AutoFakeItEasy2
         /// <param name="relay">The relay.</param>
         public AutoFakeItEasyCustomization(ISpecimenBuilder relay)
         {
-            if (relay == null)
-            {
-                throw new ArgumentNullException("relay");
-            }
-
-            this.relay = relay;
+            this.relay = relay ?? throw new ArgumentNullException(nameof(relay));
         }
 
         /// <summary>
@@ -50,10 +45,7 @@ namespace AutoFixture.AutoFakeItEasy2
         /// <param name="fixture">The fixture upon which to enable auto-mocking.</param>
         public void Customize(IFixture fixture)
         {
-            if (fixture == null)
-            {
-                throw new ArgumentNullException("fixture");
-            }
+            if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
             fixture.Customizations.Add(
                 new FakeItEasyBuilder(

--- a/Src/AutoFakeItEasy2/FakeItEasyBuilder.cs
+++ b/Src/AutoFakeItEasy2/FakeItEasyBuilder.cs
@@ -26,12 +26,7 @@ namespace AutoFixture.AutoFakeItEasy2
         /// <seealso cref="Builder" />
         public FakeItEasyBuilder(ISpecimenBuilder builder)
         {
-            if (builder == null)
-            {
-                throw new ArgumentNullException("builder");
-            }
-
-            this.builder = builder;
+            this.builder = builder ?? throw new ArgumentNullException(nameof(builder));
         }
 
         /// <summary>

--- a/Src/AutoFakeItEasy2/FakeItEasyRelay.cs
+++ b/Src/AutoFakeItEasy2/FakeItEasyRelay.cs
@@ -30,10 +30,7 @@ namespace AutoFixture.AutoFakeItEasy2
         /// </param>
         public FakeItEasyRelay(IRequestSpecification fakeableSpecification)
         {
-            if (fakeableSpecification == null)
-                throw new ArgumentNullException("fakeableSpecification");
-
-            this.fakeableSpecification = fakeableSpecification;
+            this.fakeableSpecification = fakeableSpecification ?? throw new ArgumentNullException(nameof(fakeableSpecification));
         }
 
         /// <summary>
@@ -67,8 +64,7 @@ namespace AutoFixture.AutoFakeItEasy2
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (context == null)
-                throw new ArgumentNullException("context");
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             if (!this.fakeableSpecification.IsSatisfiedBy(request))
                 return new NoSpecimen();

--- a/Src/AutoFixture.NUnit2.UnitTest/ComposerWithoutADefaultConstructor.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/ComposerWithoutADefaultConstructor.cs
@@ -7,8 +7,7 @@ namespace AutoFixture.NUnit2.UnitTest
     {
         public ComposerWithoutADefaultConstructor(Func<ISpecimenBuilder> onCompose)
         {
-            if (onCompose == null)
-                throw new ArgumentNullException("onCompose");
+            if (onCompose == null) throw new ArgumentNullException(nameof(onCompose));
         }
     }
 }

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -20,9 +20,6 @@ namespace AutoFixture.NUnit3
     {
         private readonly Lazy<IFixture> fixtureLazy;
         private IFixture Fixture => this.fixtureLazy.Value;
-
-        [SuppressMessage("Performance", "CA1823:Avoid unused private fields",
-            Justification = "False positive - request property is used. Bug: https://github.com/dotnet/roslyn-analyzers/issues/1321")]
         private ITestMethodBuilder testMethodBuilder = new FixedNameTestMethodBuilder();
         /// <summary>
         /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -21,9 +21,6 @@ namespace AutoFixture.NUnit3
         private readonly object[] existingParameterValues;
         private readonly Lazy<IFixture> fixtureLazy;
         private IFixture Fixture => this.fixtureLazy.Value;
-
-        [SuppressMessage("Performance", "CA1823:Avoid unused private fields",
-            Justification = "False positive - request property is used. Bug: https://github.com/dotnet/roslyn-analyzers/issues/1321")]
         private ITestMethodBuilder testMethodBuilder = new FixedNameTestMethodBuilder();
         
         /// <summary>

--- a/Src/AutoFixture.xUnit.UnitTest/ComposerWithoutADefaultConstructor.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/ComposerWithoutADefaultConstructor.cs
@@ -7,8 +7,7 @@ namespace AutoFixture.Xunit.UnitTest
     {
         public ComposerWithoutADefaultConstructor(Func<ISpecimenBuilder> onCompose)
         {
-            if (onCompose == null)
-                throw new ArgumentNullException("onCompose");
+            if (onCompose == null) throw new ArgumentNullException(nameof(onCompose));
         }
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/ComposerWithoutADefaultConstructor.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/ComposerWithoutADefaultConstructor.cs
@@ -7,8 +7,7 @@ namespace AutoFixture.Xunit2.UnitTest
     {
         public ComposerWithoutADefaultConstructor(Func<ISpecimenBuilder> onCompose)
         {
-            if (onCompose == null)
-                throw new ArgumentNullException("onCompose");
+            if (onCompose == null) throw new ArgumentNullException(nameof(onCompose));
         }
     }
 }

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using AutoFixture.Kernel;
 
@@ -50,8 +49,6 @@ namespace AutoFixture.DataAnnotations
             return context.Resolve(rangedRequest);
         }
 
-        [SuppressMessage("Performance", "CA1801:Review unused parameters",
-            Justification = "False positive - request property is used. Bug: https://github.com/dotnet/roslyn-analyzers/issues/1294")]
         private static Type GetMemberType(RangeAttribute rangeAttribute, object request)
         {
             Type conversionType;

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
@@ -30,7 +30,6 @@
   <ItemGroup>
     <PackageReference Include="Foq" Version="[1.5.1,2.0.0)" />
     <PackageReference Include="FSharp.Core" Version="3.0.2" PrivateAssets="All" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
@@ -21,7 +21,6 @@
     <PackageReference Include="Unquote" Version="3.1.0" />
     <!-- AutoFoq targets FSharp.Core 3.0.2, but we require 3.1.2 as Unquote was compiled against it. -->
     <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoMoq/MockType.cs
+++ b/Src/AutoMoq/MockType.cs
@@ -28,8 +28,8 @@ namespace AutoFixture.AutoMoq
                                                                                 ISpecimenBuilder fixture)
             where TMock : class
         {
-            if (setup == null) throw new ArgumentNullException("setup");
-            if (fixture == null) throw new ArgumentNullException("fixture");
+            if (setup == null) throw new ArgumentNullException(nameof(setup));
+            if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
             return setup.ReturnsUsingContext(new SpecimenContext(fixture));
         }

--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -50,8 +50,8 @@ namespace AutoFixture.AutoNSubstitute
         /// <param name="context">The context of the specimen.</param>
         public void Execute(object specimen, ISpecimenContext context)
         {
-            if (specimen == null) throw new ArgumentNullException("specimen");
-            if (context == null) throw new ArgumentNullException("context");
+            if (specimen == null) throw new ArgumentNullException(nameof(specimen));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
             try
             {
@@ -143,14 +143,8 @@ namespace AutoFixture.AutoNSubstitute
 
             public SubstituteValueFactory(object substitute, ISpecimenContext context)
             {
-                if (substitute == null)
-                    throw new ArgumentNullException("substitute");
-
-                if (context == null)
-                    throw new ArgumentNullException("context");
-
-                this.substitute = substitute;
-                this.context = context;
+                this.substitute = substitute ?? throw new ArgumentNullException(nameof(substitute));
+                this.context = context ?? throw new ArgumentNullException(nameof(context));
             }
 
             public object Substitute

--- a/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
+++ b/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
@@ -12,13 +12,8 @@ namespace AutoFixture.AutoNSubstitute
 
         public NoSetupCallbackHandler(ISubstituteState state, Action action)
         {
-            if (state == null)
-                throw new ArgumentNullException("state");
-            if (action == null)
-                throw new ArgumentNullException("action");
-
-            this.state = state;
-            this.action = action;
+            this.state = state ?? throw new ArgumentNullException(nameof(state));
+            this.action = action ?? throw new ArgumentNullException(nameof(action));
         }
 
         public bool HasResultFor(ICall call)

--- a/Src/AutoNSubstitute/SubstituteAttributeRelay.cs
+++ b/Src/AutoNSubstitute/SubstituteAttributeRelay.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -43,8 +42,6 @@ namespace AutoFixture.AutoNSubstitute
             return context.Resolve(substituteRequest);
         }
 
-        [SuppressMessage("Performance", "CA1801:Review unused parameters",
-            Justification = "False positive - request property is used. Bug: https://github.com/dotnet/roslyn-analyzers/issues/1294")]
         private static object CreateSubstituteRequest(ICustomAttributeProvider request, SubstituteAttribute attribute)
         {
             switch (request)

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -73,11 +73,6 @@
     <SourceLinkNotInGit>error</SourceLinkNotInGit>
     <SourceLinkHashMismatch>error</SourceLinkHashMismatch>
     <SourceLinkNoAutoLF>true</SourceLinkNoAutoLF>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
-  <Target Name="IncludePDBsInPackage" Condition=" '$(IncludeBuildOutput)'!='false' ">
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib\$(TargetFramework)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -61,7 +61,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0-beta2" ExcludeAssets="all" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Src/Idioms/CopyAndUpdateException.cs
+++ b/Src/Idioms/CopyAndUpdateException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -20,8 +19,6 @@ namespace AutoFixture.Idioms
         [NonSerialized]
         private readonly MemberInfo memberWithInvalidValue;
 
-        [SuppressMessage("Performance", "CA1823:Avoid unused private fields",
-            Justification = "False positive - request property is used. Bug: https://github.com/dotnet/roslyn-analyzers/issues/1321")]
         [NonSerialized]
         private ParameterInfo argumentWithNoMatchingPublicMember;
 

--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -94,7 +94,7 @@ namespace AutoFixture.Idioms
         public override void Verify(ConstructorInfo constructorInfo)
         {
             if (constructorInfo == null)
-                throw new ArgumentNullException("constructorInfo");
+                throw new ArgumentNullException(nameof(constructorInfo));
 
             constructorInfo = this.ResolveUnclosedGenericType(constructorInfo);
 
@@ -115,7 +115,7 @@ namespace AutoFixture.Idioms
         public override void Verify(MethodInfo methodInfo)
         {
             if (methodInfo == null)
-                throw new ArgumentNullException("methodInfo");
+                throw new ArgumentNullException(nameof(methodInfo));
 
             if (methodInfo.IsEqualsMethod() ||
                 methodInfo.IsGetHashCodeMethod() ||
@@ -187,7 +187,7 @@ namespace AutoFixture.Idioms
         public override void Verify(PropertyInfo propertyInfo)
         {
             if (propertyInfo == null)
-                throw new ArgumentNullException("propertyInfo");
+                throw new ArgumentNullException(nameof(propertyInfo));
 
             if (propertyInfo.GetSetMethod() == null)
                 return;
@@ -578,10 +578,7 @@ See e.g. http://codeblog.jonskeet.uk/2008/03/02/c-4-idea-iterator-blocks-and-par
         {
             protected override string GetKeyForItem(AutoGenericArgument item)
             {
-                if (item == null)
-                {
-                    throw new ArgumentNullException("item");
-                }
+                if (item == null) throw new ArgumentNullException(nameof(item));
 
                 return item.GenericArgument.Name;
             }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -464,7 +464,7 @@ namespace AutoFixture.IdiomsUnitTest
             public IEnumerable<string> GetValues(string someString)
             {
                 if (someString == null)
-                    throw new ArgumentNullException("someString");
+                    throw new ArgumentNullException(nameof(someString));
 
                 yield return someString;
                 yield return someString;
@@ -479,7 +479,7 @@ namespace AutoFixture.IdiomsUnitTest
                 if (someGuid == null)
                     throw new ArgumentException(
                         "Guid.Empty not allowed.",
-                        "someGuid");
+                        nameof(someGuid));
 
                 yield return someGuid;
                 yield return someGuid;
@@ -494,7 +494,7 @@ namespace AutoFixture.IdiomsUnitTest
                 if (someGuid == null)
                     throw new ArgumentException(
                         "Guid.Empty not allowed.",
-                        "someGuid");
+                        nameof(someGuid));
 
                 yield return someGuid;
                 yield return someGuid;
@@ -780,7 +780,7 @@ namespace AutoFixture.IdiomsUnitTest
                 set
                 {
                     if(value == null)
-                        throw new ArgumentNullException("value");
+                        throw new ArgumentNullException(nameof(value));
                     this._propertyOfTypeWithoutImplementers = value;
                 }
             }
@@ -1093,7 +1093,7 @@ namespace AutoFixture.IdiomsUnitTest
             public System.Threading.Tasks.Task<string> TaskOfTWithCorrectGuardClause(object obj)
             {
                 if (obj == null)
-                    throw new ArgumentNullException("obj");
+                    throw new ArgumentNullException(nameof(obj));
 
                 return System.Threading.Tasks.Task.Factory.StartNew(() => obj.ToString());
             }
@@ -1101,7 +1101,7 @@ namespace AutoFixture.IdiomsUnitTest
             public System.Threading.Tasks.Task TaskWithCorrectGuardClause(object obj)
             {
                 if (obj == null)
-                    throw new ArgumentNullException("obj");
+                    throw new ArgumentNullException(nameof(obj));
 
                 return System.Threading.Tasks.Task.Factory.StartNew(() => obj.ToString());
             }
@@ -1111,7 +1111,7 @@ namespace AutoFixture.IdiomsUnitTest
                 return System.Threading.Tasks.Task.Factory.StartNew(() =>
                 {
                     if (obj == null)
-                        throw new ArgumentNullException("obj");
+                        throw new ArgumentNullException(nameof(obj));
 
                     return obj.ToString();
                 });
@@ -1122,7 +1122,7 @@ namespace AutoFixture.IdiomsUnitTest
                 return System.Threading.Tasks.Task.Factory.StartNew(() =>
                 {
                     if (obj == null)
-                        throw new ArgumentNullException("obj");
+                        throw new ArgumentNullException(nameof(obj));
 
                     return obj.ToString();
                 });
@@ -1530,7 +1530,7 @@ namespace AutoFixture.IdiomsUnitTest
             {
                 if (argument == null)
                 {
-                    throw new ArgumentNullException("argument");
+                    throw new ArgumentNullException(nameof(argument));
                 }
                 if (argument.Argument1 == null || argument.Argument2 == null)
                 {
@@ -1539,7 +1539,7 @@ namespace AutoFixture.IdiomsUnitTest
                 }
                 if (test == null)
                 {
-                    throw new ArgumentNullException("test");
+                    throw new ArgumentNullException(nameof(test));
                 }
             }
         }
@@ -1653,15 +1653,15 @@ namespace AutoFixture.IdiomsUnitTest
             {
                 if (argument1 == null)
                 {
-                    throw new ArgumentNullException("argument1");
+                    throw new ArgumentNullException(nameof(argument1));
                 }
                 if (argument3 == null)
                 {
-                    throw new ArgumentNullException("argument3");
+                    throw new ArgumentNullException(nameof(argument3));
                 }
                 if (argument5 == null)
                 {
-                    throw new ArgumentNullException("argument5");
+                    throw new ArgumentNullException(nameof(argument5));
                 }
             }
         }
@@ -1748,7 +1748,7 @@ namespace AutoFixture.IdiomsUnitTest
             {
                 if (argument1 == null)
                 {
-                    throw new ArgumentNullException("argument1");
+                    throw new ArgumentNullException(nameof(argument1));
                 }
 
                 argument2 = null;
@@ -1760,49 +1760,49 @@ namespace AutoFixture.IdiomsUnitTest
             public NestedGenericParameterTestType(IEnumerable<T1> arg)
             {
                 if (arg == null)
-                    throw new ArgumentNullException("arg");
+                    throw new ArgumentNullException(nameof(arg));
             }
 
             public NestedGenericParameterTestType(IEnumerable<IEnumerable<T2>> arg)
             {
                 if (arg == null)
-                    throw new ArgumentNullException("arg");
+                    throw new ArgumentNullException(nameof(arg));
             }
 
             public NestedGenericParameterTestType(T1 arg1, Func<T1, IEnumerable<T2>> arg2)
             {
                 if (arg2 == null)
-                    throw new ArgumentNullException("arg2");
+                    throw new ArgumentNullException(nameof(arg2));
             }
 
             public NestedGenericParameterTestType(T1[] arg)
             {
                 if (arg == null)
-                    throw new ArgumentNullException("arg");
+                    throw new ArgumentNullException(nameof(arg));
             }
 
             public NestedGenericParameterTestType(T1[,] arg)
             {
                 if (arg == null)
-                    throw new ArgumentNullException("arg");
+                    throw new ArgumentNullException(nameof(arg));
             }
 
             public NestedGenericParameterTestType(T1[][] arg)
             {
                 if (arg == null)
-                    throw new ArgumentNullException("arg");
+                    throw new ArgumentNullException(nameof(arg));
             }
 
             public NestedGenericParameterTestType(T1[,][][] arg)
             {
                 if (arg == null)
-                    throw new ArgumentNullException("arg");
+                    throw new ArgumentNullException(nameof(arg));
             }
 
             public NestedGenericParameterTestType(Func<T1, IEnumerable<IEnumerable<T2>>, T1[][]> arg1, T2 arg2)
             {
                 if (arg1 == null)
-                    throw new ArgumentNullException("arg1");
+                    throw new ArgumentNullException(nameof(arg1));
             }
         }
 

--- a/Src/IdiomsUnitTest/Scenario.cs
+++ b/Src/IdiomsUnitTest/Scenario.cs
@@ -206,7 +206,7 @@ namespace AutoFixture.IdiomsUnitTest
             public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
                 FieldInfoElement fieldInfoElement)
             {
-                if (fieldInfoElement == null) throw new ArgumentNullException("fieldInfoElement");
+                if (fieldInfoElement == null) throw new ArgumentNullException(nameof(fieldInfoElement));
                 var v = new NameAndType(
                     fieldInfoElement.FieldInfo.Name,
                     fieldInfoElement.FieldInfo.FieldType);
@@ -217,7 +217,7 @@ namespace AutoFixture.IdiomsUnitTest
             public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
                 ParameterInfoElement parameterInfoElement)
             {
-                if (parameterInfoElement == null) throw new ArgumentNullException("parameterInfoElement");
+                if (parameterInfoElement == null) throw new ArgumentNullException(nameof(parameterInfoElement));
                 var v = new NameAndType(
                     parameterInfoElement.ParameterInfo.Name,
                     parameterInfoElement.ParameterInfo.ParameterType);
@@ -228,7 +228,7 @@ namespace AutoFixture.IdiomsUnitTest
             public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
                 PropertyInfoElement propertyInfoElement)
             {
-                if (propertyInfoElement == null) throw new ArgumentNullException("propertyInfoElement");
+                if (propertyInfoElement == null) throw new ArgumentNullException(nameof(propertyInfoElement));
                 var v = new NameAndType(
                     propertyInfoElement.PropertyInfo.Name,
                     propertyInfoElement.PropertyInfo.PropertyType);
@@ -264,7 +264,7 @@ namespace AutoFixture.IdiomsUnitTest
 
             int IEqualityComparer<IReflectionElement>.GetHashCode(IReflectionElement obj)
             {
-                if (obj == null) throw new ArgumentNullException("obj");
+                if (obj == null) throw new ArgumentNullException(nameof(obj));
                 return obj
                     .Accept(this.visitor)
                     .Value


### PR DESCRIPTION
Update analyzers to support compilation and remove fixed warning suppression.

P.S. Should be merged after https://github.com/appveyor/ci/issues/1963 is closed.