### PR TITLE
Migrate Idioms.FsCheck to support .NET Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Using AutoFixture is as easy as referencing the library and creating a new insta
 | AutoNSubstitute            | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
 | AutoRhinoMock              | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
 | Idioms                     | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0   |
-| Idioms.FsCheck             | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
+| Idioms.FsCheck             | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0   |
 
 ## Downloads
 

--- a/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
@@ -18,10 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="[1.0.0]" />
-
-    <PackageReference Include="Unquote" Version="3.1.0" />
-    <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Unquote" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
@@ -18,10 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="[2.0.1]" />
-
-    <PackageReference Include="Unquote" Version="3.1.0" />
-    <PackageReference Include="FSharp.Core" Version="3.1.2.1" PrivateAssets="All" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Unquote" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck/FsCheckInvoker.fs
+++ b/Src/Idioms.FsCheck/FsCheckInvoker.fs
@@ -1,7 +1,6 @@
 ﻿namespace AutoFixture.Idioms.FsCheck
 
 open FsCheck
-open FsCheck.Fluent
 open System
 open System.Reflection
 

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AssemblyTitle>AutoFixture.Idioms.FsCheck</AssemblyTitle>
     <AssemblyName>AutoFixture.Idioms.FsCheck</AssemblyName>
     <RootNamespace>AutoFixture.Idioms.FsCheck</RootNamespace>
@@ -26,9 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsCheck" Version="[0.9.2,3.0.0)" />
-    <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="FsCheck" Version="[0.9.2,3.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="FSharp.Core" Version="3.1.2" Condition=" '$(TargetFramework)'=='net452' " PrivateAssets="All" />
+
+    <PackageReference Include="FsCheck" Version="[2.9.0,3.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />    
+    <PackageReference Include="FSharp.Core" Version="4.1.17" Condition=" '$(TargetFramework)'=='netstandard2.0' " PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
+++ b/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <AssemblyTitle>AutoFixture.Idioms.FsCheckUnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.Idioms.FsCheckUnitTest</AssemblyName>
     <RootNamespace>AutoFixture.Idioms.FsCheckUnitTest</RootNamespace>
@@ -14,12 +14,11 @@
     <Compile Include="TestDsl.fs" />
     <Compile Include="TestTypes.fs" />
     <Compile Include="ReturnValueMustNotBeNullAssertionTest.fs" />
+    <Compile Include="Program.fs" Condition=" '$(TargetFramework)'=='netcoreapp2.0' " />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unquote" Version="3.1.0" />
-    <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Unquote" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheckUnitTest/Program.fs
+++ b/Src/Idioms.FsCheckUnitTest/Program.fs
@@ -1,0 +1,1 @@
+﻿module Program = let [<EntryPoint>] main _ = 0


### PR DESCRIPTION
Closes #880.

Visual Studio 2017 Update 5 improved .NET Core support for F#, allowing to migrate the leftover FsCheck project to F#.

Nothing changed in the code, except added dependency.

@moodmosaic Please take a look 😉