### PR TITLE
Refactor DomainNameGenerator to re-use ElementsBuilder

### DIFF
--- a/Src/AutoFixture/DomainNameGenerator.cs
+++ b/Src/AutoFixture/DomainNameGenerator.cs
@@ -8,32 +8,25 @@ namespace AutoFixture
     /// </summary>
     public class DomainNameGenerator : ISpecimenBuilder
     {
-        private readonly string[] fictitiousDomains =
-        {
-            "example.com",
-            "example.net",
-            "example.org"
-        };
+        private readonly ElementsBuilder<string> fictitiousDomainBuilder = new ElementsBuilder<string>(
+                "example.com",
+                "example.net",
+                "example.org"
+            );
 
-        private readonly Random random = new Random();
-
-        /// <summary>
-        /// Creates a new specimen based on a request.
-        /// </summary>
-        /// <param name="request">The request that describes what to create</param>
-        /// <param name="context">A context that can be used to create other specimens.</param>
-        /// <returns>
-        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
-        /// </returns>
+        /// <inheritdoc />
         public object Create(object request, ISpecimenContext context)
         {
-            if (request == null || !typeof(DomainName).Equals(request))
-            {
-                return new NoSpecimen();
-            }
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
-            var index = this.random.Next(0, this.fictitiousDomains.Length);
-            return new DomainName(this.fictitiousDomains[index]);
+            if (request == null || !typeof(DomainName).Equals(request))
+                return new NoSpecimen();
+
+            var domainName = this.fictitiousDomainBuilder.Create(typeof(string), context) as string;
+            if (domainName == null)
+                return new NoSpecimen();
+
+            return new DomainName(domainName);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using AutoFixture;
 using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
 using Xunit;
 
 namespace AutoFixtureUnitTest
@@ -11,7 +13,6 @@ namespace AutoFixtureUnitTest
         public void SutIsSpecimenBuilder()
         {
             // Arrange
-
             // Act
             var sut = new DomainNameGenerator();
             // Assert
@@ -23,10 +24,22 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             var sut = new DomainNameGenerator();
+            var context = new DelegatingSpecimenContext();
             // Act
-            var result = sut.Create(null, null);
+            var result = sut.Create(null, context);
             // Assert
             Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrowsException()
+        {
+            // Arrange
+            var sut = new DomainNameGenerator();
+            var request = new object();
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(request, context: null));
         }
 
         [Fact]
@@ -34,9 +47,10 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             var nonDomainNameRequest = typeof(object);
+            var context = new DelegatingSpecimenContext();
             var sut = new DomainNameGenerator();
             // Act
-            var result = sut.Create(nonDomainNameRequest, null);
+            var result = sut.Create(nonDomainNameRequest, context);
             // Assert
             Assert.Equal(new NoSpecimen(), result);
         }
@@ -46,8 +60,9 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             var sut = new DomainNameGenerator();
+            var context = new DelegatingSpecimenContext();
             // Act
-            var result = sut.Create(typeof(DomainName), null);
+            var result = sut.Create(typeof(DomainName), context);
             // Assert
             var actualDomainName = Assert.IsAssignableFrom<DomainName>(result);
             Assert.Matches(@"example\.(com|org|net)", actualDomainName.Domain);
@@ -58,9 +73,10 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             var sut = new DomainNameGenerator();
-            var expectedDomains = new[] { "example.com", "example.net", "example.org" }.Select(x => new DomainName(x)).ToList();
+            var context = new DelegatingSpecimenContext();
+            var expectedDomains = new[] { "example.com", "example.net", "example.org" }.Select(x => new DomainName(x));
             // Act
-            var result = Enumerable.Range(0, 100).Select(x => sut.Create(typeof(DomainName), null)).ToList();
+            var result = Enumerable.Range(0, 100).Select(x => sut.Create(typeof(DomainName), context)).ToList();
             // Assert
             foreach (var expectedDomain in expectedDomains)
             {


### PR DESCRIPTION
I've found that currently `DomainNameGenerator` contains logic equivalent to `ElementsBuilder`. Therefore, refactored it to re-use the `ElementsBuilder` instead.

Additionally, tuned code to require non-null context.

@moodmosaic Please take a look 🚶 