### PR TITLE
Clean up TypeEnvy helpers and create extension for generic argument extraction

### DIFF
--- a/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
@@ -20,7 +20,7 @@ namespace AutoFixture.DataAnnotations
             if (rangedRequest == null)
                 return new NoSpecimen();
 
-            if (!rangedRequest.MemberType.IsEnum())
+            if (!rangedRequest.MemberType.GetTypeInfo().IsEnum)
                 return new NoSpecimen();
 
             var underlyingNumericType = rangedRequest.MemberType.GetTypeInfo().GetEnumUnderlyingType();

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using AutoFixture.Kernel;
 
 namespace AutoFixture
@@ -44,21 +45,17 @@ namespace AutoFixture
         /// </remarks>
         public object Create(object request, ISpecimenContext context)
         {
-            var t = request as Type;
-            if (!EnumGenerator.IsEnumType(t))
-            {
+            var type = request as Type;
+            if(type == null)
                 return new NoSpecimen();
-            }
+
+            if (!type.GetTypeInfo().IsEnum)
+                return new NoSpecimen();
 
             lock (this.syncRoot)
             {
-                return this.CreateValue(t);
+                return this.CreateValue(type);
             }
-        }
-
-        private static bool IsEnumType(Type t)
-        {
-            return (t != null) && t.IsEnum();
         }
 
         private object CreateValue(Type t)

--- a/Src/AutoFixture/Kernel/AbstractTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/AbstractTypeSpecification.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace AutoFixture.Kernel
 {
@@ -19,7 +20,7 @@ namespace AutoFixture.Kernel
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
 
-            return request is Type type && type.IsAbstract();
+            return request is Type type && type.GetTypeInfo().IsAbstract;
         }
     }
 }

--- a/Src/AutoFixture/Kernel/CollectionSpecification.cs
+++ b/Src/AutoFixture/Kernel/CollectionSpecification.cs
@@ -23,8 +23,7 @@ namespace AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             return request is Type type &&
-                   type.IsGenericType() &&
-                   type.GetGenericTypeDefinition() == typeof(Collection<>);
+                   type.TryGetSingleGenericTypeArgument(typeof(Collection<>), out var _);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ConstructorMethod.cs
+++ b/Src/AutoFixture/Kernel/ConstructorMethod.cs
@@ -75,7 +75,7 @@ namespace AutoFixture.Kernel
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "tinyurl", Justification = "Workaround for a bug in CA: https://connect.microsoft.com/VisualStudio/feedback/details/521030/")]
         public object Invoke(IEnumerable<object> parameters)
         {
-            if (this.Constructor.DeclaringType.IsAbstract() && this.Constructor.IsPublic)
+            if (this.Constructor.DeclaringType.GetTypeInfo().IsAbstract && this.Constructor.IsPublic)
             {
                 throw new ObjectCreationException(
                                 string.Format(

--- a/Src/AutoFixture/Kernel/DictionarySpecification.cs
+++ b/Src/AutoFixture/Kernel/DictionarySpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace AutoFixture.Kernel
 {
@@ -21,7 +22,7 @@ namespace AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             return request is Type type &&
-                       type.IsGenericType() &&
+                       type.GetTypeInfo().IsGenericType &&
                        type.GetGenericTypeDefinition() == typeof(Dictionary<,>);
         }
     }

--- a/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace AutoFixture.Kernel
 {
@@ -63,7 +64,7 @@ namespace AutoFixture.Kernel
 
         private bool IsDirectBaseOfTargetType(object request)
         {
-            return (Type)request == this.TargetType.BaseType();
+            return (Type)request == this.TargetType.GetTypeInfo().BaseType;
         }
     }
 }

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 namespace AutoFixture.Kernel
 {
@@ -39,17 +38,15 @@ namespace AutoFixture.Kernel
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            var t = request as Type;
-            if (t == null)
+            var type = request as Type;
+            if (type == null)
                 return new NoSpecimen();
 
-            var typeArguments = t.GetTypeInfo().GetGenericArguments();
-            if (typeArguments.Length != 1 ||
-                typeof (IEnumerator<>) != t.GetGenericTypeDefinition())
+            if (!type.TryGetSingleGenericTypeArgument(typeof(IEnumerator<>), out Type enumeratorType))
                 return new NoSpecimen();
 
             var specimenBuilder = (ISpecimenBuilder) Activator.CreateInstance(
-                typeof (EnumeratorRelay<>).MakeGenericType(typeArguments));
+                typeof (EnumeratorRelay<>).MakeGenericType(enumeratorType));
             return specimenBuilder.Create(request, context);
         }
     }

--- a/Src/AutoFixture/Kernel/HashSetSpecification.cs
+++ b/Src/AutoFixture/Kernel/HashSetSpecification.cs
@@ -22,8 +22,7 @@ namespace AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             return request is Type type &&
-                   type.IsGenericType() &&
-                   typeof(HashSet<>) == type.GetGenericTypeDefinition();
+                   type.TryGetSingleGenericTypeArgument(typeof(HashSet<>), out var _);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ListSpecification.cs
+++ b/Src/AutoFixture/Kernel/ListSpecification.cs
@@ -22,8 +22,7 @@ namespace AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             return request is Type type &&
-                   type.IsGenericType() &&
-                   typeof(List<>) == type.GetGenericTypeDefinition();
+                   type.TryGetSingleGenericTypeArgument(typeof(List<>), out var _);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
@@ -94,7 +94,7 @@ namespace AutoFixture.Kernel
                 parameter.ParameterType.IsArray)
                 return Array.CreateInstance(parameter.ParameterType.GetElementType(), 0);
 
-            return parameter.ParameterType.IsValueType() ? 
+            return parameter.ParameterType.GetTypeInfo().IsValueType ?
                 Activator.CreateInstance(parameter.ParameterType) : 
                 null;
         }

--- a/Src/AutoFixture/Kernel/NullableEnumRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/NullableEnumRequestSpecification.cs
@@ -20,13 +20,14 @@ namespace AutoFixture.Kernel
         {
             // This is performance-sensitive code when used repeatedly over many requests.
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
-            var requestType = request as Type;
-            if (requestType == null) return false;
-            if (!requestType.IsGenericType()) return false;
-            var gtd = requestType.GetGenericTypeDefinition();
-            if (!typeof(Nullable<>).GetTypeInfo().IsAssignableFrom(gtd)) return false;
-            var ga = requestType.GetTypeInfo().GetGenericArguments();
-            return ga.Length == 1 && ga[0].IsEnum();
+            var typeRequest = request as Type;
+            if (typeRequest == null)
+                return false;
+
+            if (!typeRequest.TryGetSingleGenericTypeArgument(typeof(Nullable<>), out Type nullableType))
+                return false;
+
+            return nullableType.GetTypeInfo().IsEnum;
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ObservableCollectionSpecification.cs
+++ b/Src/AutoFixture/Kernel/ObservableCollectionSpecification.cs
@@ -22,8 +22,7 @@ namespace AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             return request is Type type &&
-                   type.IsGenericType() &&
-                   typeof(ObservableCollection<>) == type.GetGenericTypeDefinition();
+                   type.TryGetSingleGenericTypeArgument(typeof(ObservableCollection<>), out var _);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace AutoFixture.Kernel
 {
     /// <summary>
     /// Relays requests for enumerable parameters, and returns an empty array
-    /// if the object returned from the context is an
-    /// <see cref="OmitSpecimen" /> instance.
+    /// if the object returned from the context is an <see cref="OmitSpecimen" /> instance.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -60,10 +58,7 @@ namespace AutoFixture.Kernel
             if (pi == null)
                 return new NoSpecimen();
 
-            if (!pi.ParameterType.IsGenericType())
-                return new NoSpecimen();
-
-            if (IsNotEnumerable(pi))
+            if (!pi.ParameterType.TryGetSingleGenericTypeArgument(typeof(IEnumerable<>), out Type enumerableType))
                 return new NoSpecimen();
 
             var returnValue = context.Resolve(
@@ -72,17 +67,9 @@ namespace AutoFixture.Kernel
                     pi.Name));
 
             if (returnValue is OmitSpecimen)
-                return Array.CreateInstance(
-                    pi.ParameterType.GetTypeInfo().GetGenericArguments().Single(),
-                    0);
+                return Array.CreateInstance(enumerableType, 0);
 
             return returnValue;
-        }
-
-        private static bool IsNotEnumerable(ParameterInfo pi)
-        {
-            var openGenericType = pi.ParameterType.GetGenericTypeDefinition();
-            return openGenericType != typeof(IEnumerable<>);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/ParameterScore.cs
+++ b/Src/AutoFixture/Kernel/ParameterScore.cs
@@ -62,7 +62,7 @@ namespace AutoFixture.Kernel
 
         private static bool IsExactMatch(Type targetType, ParameterInfo p)
         {
-            if (!p.ParameterType.IsGenericType())
+            if (!p.ParameterType.GetTypeInfo().IsGenericType)
                 return false;
 
             var genericParameterTypes = p.ParameterType.GetTypeInfo().GetGenericArguments();

--- a/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedDictionarySpecification.cs
@@ -23,7 +23,7 @@ namespace AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             return request is Type type &&
-                   type.IsGenericType() &&
+                   type.GetTypeInfo().IsGenericType &&
                    type.GetTypeInfo().GetGenericTypeDefinition() == typeof(SortedDictionary<,>);
         }
     }

--- a/Src/AutoFixture/Kernel/SortedSetSpecification.cs
+++ b/Src/AutoFixture/Kernel/SortedSetSpecification.cs
@@ -23,8 +23,7 @@ namespace AutoFixture.Kernel
         public bool IsSatisfiedBy(object request)
         {
             return request is Type type &&
-                   type.IsGenericType() &&
-                   type.GetTypeInfo().GetGenericTypeDefinition() == typeof(SortedSet<>);
+                   type.TryGetSingleGenericTypeArgument(typeof(SortedSet<>), out var _);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -171,7 +171,7 @@ namespace AutoFixture.Kernel
 
                 var hierarchy = GetHierarchy(templateParameterType).ToList();
                 
-                var matches = methodParameterType.IsClass() ? 
+                var matches = methodParameterType.GetTypeInfo().IsClass ?
                     hierarchy.Count(t => t.GetTypeInfo().IsAssignableFrom(methodParameterType)) : 
                     hierarchy.Count(t => t.GetTypeInfo().GetInterfaces().Any(i => i.GetTypeInfo().IsAssignableFrom(methodParameterType)));
 
@@ -183,7 +183,7 @@ namespace AutoFixture.Kernel
                 score += CalculateScore(methodTypeArguments, templateTypeArguments) / 10;
                 score += 50 * -Math.Abs(methodTypeArguments.Length - templateTypeArguments.Length);
 
-                if (methodParameterType.IsClass())
+                if (methodParameterType.GetTypeInfo().IsClass)
                     score += 5;
                 
                 return score;
@@ -191,14 +191,14 @@ namespace AutoFixture.Kernel
 
             private static IEnumerable<Type> GetHierarchy(Type type)
             {
-                if (!type.IsClass())
+                if (!type.GetTypeInfo().IsClass)
                     foreach (var interfaceType in type.GetTypeInfo().GetInterfaces())
                         yield return interfaceType;
 
                 while (type != null)
                 {
                     yield return type;
-                    type = type.BaseType();
+                    type = type.GetTypeInfo().BaseType;
                 }
             }
         }

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 
@@ -103,7 +104,7 @@ namespace AutoFixture.Kernel
 
             var t = request as Type;
 
-            if (t != null && t.IsInterface())
+            if (t != null && t.GetTypeInfo().IsInterface)
                 return
                     "AutoFixture was unable to create an instance from {0} " +
                     "because it's an interface. There's no single, most " +
@@ -115,7 +116,7 @@ namespace AutoFixture.Kernel
                     "interface, you can map the interface to that class:" +
                     TypeMappingOptionsHelp;
 
-            if (t != null && t.IsAbstract())
+            if (t != null && t.GetTypeInfo().IsAbstract)
                 return
                     "AutoFixture was unable to create an instance from {0} " +
                     "because it's an abstract class. There's no single, " +

--- a/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
+++ b/Src/AutoFixture/Kernel/TypeArgumentsCannotBeInferredException.cs
@@ -93,7 +93,7 @@ namespace AutoFixture.Kernel
 
         private static string GetFriendlyName(Type type)
         {
-            if (type.IsGenericType())
+            if (type.GetTypeInfo().IsGenericType)
                 return string.Format(CultureInfo.CurrentCulture, 
                     "{0}<{1}>", 
                     type.Name.Split('`')[0], 

--- a/Src/AutoFixture/Kernel/TypeEnvy.cs
+++ b/Src/AutoFixture/Kernel/TypeEnvy.cs
@@ -42,45 +42,10 @@ namespace AutoFixture.Kernel
             argument = null;
             return false;
         }
-
-        public static Type BaseType(this Type type)
-        {
-            return type.GetTypeInfo().BaseType;
-        }
-
-        public static bool IsAbstract(this Type type)
-        {
-            return type.GetTypeInfo().IsAbstract;
-        }
-
-        public static bool IsClass(this Type type)
-        {
-            return type.GetTypeInfo().IsClass;
-        }
-
-        public static bool IsEnum(this Type type)
-        {
-            return type.GetTypeInfo().IsEnum;
-        }
-
-        public static bool IsInterface(this Type type)
-        {
-            return type.GetTypeInfo().IsInterface;
-        }
-
-        public static bool IsPrimitive(this Type type)
-        {
-            return type.GetTypeInfo().IsPrimitive;
-        }
-
-        public static bool IsValueType(this Type type)
-        {
-            return type.GetTypeInfo().IsValueType;
-        }
         
         public static bool IsNumberType(this Type type)
         {
-            if(type.IsEnum()) return false;
+            if(type.GetTypeInfo().IsEnum) return false;
 
             var typeCode = Type.GetTypeCode(type);
             switch (typeCode)

--- a/Src/AutoFixture/Kernel/TypeEnvy.cs
+++ b/Src/AutoFixture/Kernel/TypeEnvy.cs
@@ -22,6 +22,27 @@ namespace AutoFixture.Kernel
                 "Member '{0}' contains more than one attribute of type '{1}'", candidate, typeof(TAttribute)));
         }
 
+        public static bool TryGetSingleGenericTypeArgument(
+            this Type currentType, Type expectedGenericDefinition, out Type argument)
+        {
+            if (!expectedGenericDefinition.GetTypeInfo().IsGenericTypeDefinition)
+                throw new ArgumentException("Must be a generic type definition", nameof(expectedGenericDefinition));
+
+            var typeInfo = currentType.GetTypeInfo();
+            if (typeInfo.IsGenericType && currentType.GetGenericTypeDefinition() == expectedGenericDefinition)
+            {
+                var typeArguments = typeInfo.GenericTypeArguments;
+                if (typeArguments.Length == 1)
+                {
+                    argument = typeArguments[0];
+                    return true;
+                }
+            }
+
+            argument = null;
+            return false;
+        }
+
         public static Type BaseType(this Type type)
         {
             return type.GetTypeInfo().BaseType;
@@ -40,16 +61,6 @@ namespace AutoFixture.Kernel
         public static bool IsEnum(this Type type)
         {
             return type.GetTypeInfo().IsEnum;
-        }
-
-        public static bool IsGenericType(this Type type)
-        {
-            return type.GetTypeInfo().IsGenericType;
-        }
-
-        public static bool IsGenericTypeDefinition(this Type type)
-        {
-            return type.GetTypeInfo().IsGenericTypeDefinition;
         }
 
         public static bool IsInterface(this Type type)

--- a/Src/AutoFixture/Kernel/ValueTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/ValueTypeSpecification.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace AutoFixture.Kernel
 {
@@ -28,7 +29,8 @@ namespace AutoFixture.Kernel
         /// </summary>
         private static bool IsValueTypeButNotPrimitiveOrEnum(Type type)
         {
-            return type.IsValueType() && !type.IsEnum() && !type.IsPrimitive();
+            var ti = type.GetTypeInfo();
+            return ti.IsValueType && !ti.IsEnum && !ti.IsPrimitive;
         }
     }
 }

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -34,7 +34,7 @@ namespace AutoFixture
             if (requestType == null)
                 return new NoSpecimen();
 
-            if (requestType.BaseType() != typeof(LambdaExpression))
+            if (requestType.GetTypeInfo().BaseType != typeof(LambdaExpression))
                 return new NoSpecimen();
 
             var delegateType = requestType.GetTypeInfo().GetGenericArguments().Single();

--- a/Src/AutoFixture/LazyRelay.cs
+++ b/Src/AutoFixture/LazyRelay.cs
@@ -36,16 +36,16 @@ namespace AutoFixture
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            var t = request as Type;
-            if (t == null || !t.IsGenericType())
+            var type = request as Type;
+            if (type == null)
                 return new NoSpecimen();
 
-            if (t.GetGenericTypeDefinition() != typeof(Lazy<>))
+            if (!type.TryGetSingleGenericTypeArgument(typeof(Lazy<>), out Type lazyType))
                 return new NoSpecimen();
 
-            var builder = (ILazyBuilder)Activator
-                .CreateInstance(typeof(LazyBuilder<>)
-                .MakeGenericType(t.GetTypeInfo().GetGenericArguments()));
+            var lazyBuilderType = typeof(LazyBuilder<>).MakeGenericType(lazyType);
+            var builder = (ILazyBuilder)Activator.CreateInstance(lazyBuilderType);
+
             return builder.Create(context);
         }
 


### PR DESCRIPTION
Basically, did a few minor improvements to our code:
- Cleaned up all the `TypeEnvy` helpers related to the `TypeInfo()` usage, so that `TypeInfo()` extension is used directly instead. That was done for the consistency as part of our code already uses the `TypeInfo()` extension.
- Created the helper `TryGetSingleGenericTypeArgument()` extension method to quickly extract single generic type argument if type is generic and is equal to expected. This pattern is very common across the our code base, so it makes sense to unify the logic. Also this allows to see in future if this code is hot, so could be potentially cached.

@moodmosaic Please take a look and let me know if you have any concerns 🍰 