### PR TITLE
Make expression validation logic more robust

### DIFF
--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5903,5 +5903,33 @@ namespace AutoFixtureUnitTest
             // Assert
             Assert.NotEqual(-42, result.FixedValue);
         }
+
+        public interface IIssue970_ValueHolder
+        {
+            string Value { get; set; }
+        }
+
+        public class Issue970_ValueHolderImpl : IIssue970_ValueHolder
+        {
+            public string Value { get; set; }
+        }
+
+        [Fact]
+        public void Issue970_DoesNotFailWhenHelperExtensionMethodIsUsed()
+        {
+            // Arrange
+            var sut = new Fixture();
+            // Act
+            sut.Customize<Issue970_ValueHolderImpl>(c => ConfigurePropertyField(c));
+            var result = sut.Create<Issue970_ValueHolderImpl>();
+            // Assert
+            Assert.Equal("42", result.Value);
+
+            IPostprocessComposer<T> ConfigurePropertyField<T>(IPostprocessComposer<T> composer)
+                where T: IIssue970_ValueHolder
+            {
+                return composer.With(x => x.Value, "42");
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #970 

In v4 we added the fail-fast guard if somebody tries to configure the nested properties (see #724). However, it appeared that there is an advanced valid scenario which is not recognized by the guard and AutoFixture fails. In this PR I made logic more robust by handling the possible implicit argument conversion. Additionally, I refactored the helper method for better re-usability.

None of the existing functionality was affected.

@moodmosaic Please take a look 😉