### PR TITLE
Relay ISet<> to HashSet<> by default

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -155,6 +155,9 @@ namespace AutoFixture
                                 new TypeRelay(
                                     typeof(IReadOnlyList<>),
                                     typeof(ReadOnlyCollection<>)),
+                                new TypeRelay(
+                                    typeof(ISet<>),
+                                    typeof(HashSet<>)),
                                 new EnumerableRelay(),
                                 new EnumeratorRelay())),
                         new FilteringSpecimenBuilder(

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5817,6 +5817,19 @@ namespace AutoFixtureUnitTest
             Assert.False(result is Dictionary<int, string>);
         }
 
+        [Fact]
+        public void ShouldResolveISetByDefault()
+        {
+            // Arrange
+            var sut = new Fixture();
+            
+            // Act
+            var result = sut.Create<ISet<string>>();
+            
+            // Assert
+            Assert.IsAssignableFrom<ISet<string>>(result);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
To close the story about basic .NET interfaces I added the `ISet<>` support as well, given that we already support `HashSet<>`.
After we merge this PR, it seems that AutoFixture supports all the basic .NET interfaces.

@moodmosaic Please take a look 🍷