### PR TITLE
[WIP]Wrap delegate

### DIFF
--- a/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy2UnitTest/AutoFakeItEasy.FakeItEasy2UnitTest.csproj
@@ -8,6 +8,7 @@
     <AssemblyTitle>AutoFakeItEasy.FakeItEasy2.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFakeItEasy.FakeItEasy2UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
+    <DefineConstants>$(DefineConstants);CAN_FAKE_DELEGATES</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
@@ -12,6 +12,8 @@
     <!--  Suppress warning about invalid dependency version in Castle.Core.
           That is FakeItEasy dependency and we cannot fix that somehow. -->
     <NoWarn>$(NoWarn);NU1603</NoWarn>
+
+    <DefineConstants>$(DefineConstants);CAN_FAKE_DELEGATES</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy4UnitTest/AutoFakeItEasy.FakeItEasy4UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy4UnitTest/AutoFakeItEasy.FakeItEasy4UnitTest.csproj
@@ -12,6 +12,8 @@
     <!--  Suppress warning about invalid dependency version in Castle.Core.
           That is FakeItEasy dependency and we cannot fix that somehow. -->
     <NoWarn>$(NoWarn);NU1603</NoWarn>
+
+    <DefineConstants>$(DefineConstants);CAN_FAKE_DELEGATES</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
@@ -13,6 +13,8 @@ namespace AutoFixture.AutoFakeItEasy
     /// </summary>
     public class FakeItEasyMethodQuery : IMethodQuery
     {
+        private static readonly DelegateSpecification delegateSpecification = new DelegateSpecification();
+
         /// <summary>
         /// Selects constructors for the supplied type.
         /// </summary>
@@ -34,7 +36,7 @@ namespace AutoFixture.AutoFakeItEasy
             }
 
             var fakeType = type.GetFakedType();
-            if (fakeType.GetTypeInfo().IsInterface)
+            if (fakeType.GetTypeInfo().IsInterface || delegateSpecification.IsSatisfiedBy(fakeType))
             {
                 return new[] { new ConstructorMethod(type.GetDefaultConstructor()) };
             }

--- a/Src/AutoFakeItEasy/WrapDelegateInFakeBuilder.cs
+++ b/Src/AutoFakeItEasy/WrapDelegateInFakeBuilder.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Reflection;
+using AutoFixture.Kernel;
+using FakeItEasy;
+
+namespace AutoFixture.AutoFakeItEasy
+{
+    internal class WrapDelegateInFakeBuilder : ISpecimenBuilder
+    {
+        private readonly IRequestSpecification fakeableSpecification;
+        private readonly ISpecimenBuilder builder;
+
+        public WrapDelegateInFakeBuilder(IRequestSpecification delegateSpecification, ISpecimenBuilder builder)
+        {
+            this.fakeableSpecification = delegateSpecification ?? throw new ArgumentNullException(nameof(delegateSpecification));
+            this.builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            var type = request as Type;
+            if (type.IsFake())
+            {
+                var fakedType = type.GetFakedType();
+                if (this.fakeableSpecification.IsSatisfiedBy(fakedType))
+                {
+                    var bareDelegate = builder.Create(fakedType, context);
+                    return Wrap(bareDelegate);
+                }
+            }
+
+            return builder.Create(request, context);
+        }
+
+        private static object Wrap(object specimen)
+        {
+            var genericFakeType = typeof(Fake<>).MakeGenericType(specimen.GetType());
+
+            foreach (var constructor in genericFakeType.GetConstructors())
+            {
+                var constructorParameterInfos = constructor.GetParameters();
+                if (constructorParameterInfos.Length != 1)
+                {
+                    continue;
+                }
+
+                var parameterType = constructorParameterInfos[0].ParameterType;
+                if (!parameterType.GetTypeInfo().IsGenericType ||
+                    parameterType.GetGenericTypeDefinition() != typeof(Action<>))
+                {
+                    continue;
+                }
+
+                // The parameter is an action of type
+                // Action<IFakeOptionsBuilder<T>> (FakeItEasy 1.x) or
+                // Action<IFakeOptions<T>> (FakeItEasy 2.0+).
+                // Each of the options-type interfaces contains a Wrapping method
+                // that we'll use to pass the wrapped item to the fake object's constructor.
+                var fakeOptionsType = parameterType.GetGenericArguments()[0];
+
+                var withArgumentsForConstructorMethod = fakeOptionsType.GetMethod(
+                    "Wrapping",
+                    new[] { specimen.GetType() });
+
+                if (withArgumentsForConstructorMethod == null)
+                {
+                    continue;
+                }
+
+                Action<object> addWrappingToOptionsAction =
+                    options => withArgumentsForConstructorMethod.Invoke(options, new[] { specimen });
+
+                return constructor.Invoke(new object[] { addWrappingToOptionsAction });
+            }
+
+            return null;
+        }
+    }
+}

--- a/Src/AutoFakeItEasyUnitTest/FixtureIntegrationTest.cs
+++ b/Src/AutoFakeItEasyUnitTest/FixtureIntegrationTest.cs
@@ -42,6 +42,60 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             Assert.NotEqual(0, result.Property);
         }
 
+#if CAN_FAKE_DELEGATES
+        [Fact]
+        public void FixtureCanCreateFakeOfDelegate()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization());
+            // Act
+            var result = fixture.Create<Fake<Func<int, int>>>();
+            // Assert
+            Assert.IsAssignableFrom<Fake<Func<int, int>>>(result);
+        }
+
+        [Fact]
+        public void FixtureCanCreateDelegateThatIsAFake()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization());
+            var frozenInt = fixture.Freeze<int>();
+            var expectedValue = frozenInt + 1;
+            // Act
+            var result = fixture.Create<Func<int, int>>();
+            // Assert
+            A.CallTo(() => result.Invoke(A<int>.Ignored)).Returns(expectedValue);
+            Assert.IsAssignableFrom<Func<int, int>>(result);
+            Assert.Equal(expectedValue, result.Invoke(0));
+        }
+
+        [Fact]
+        public void FixtureCanFreezeFakeOfDelegate()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization());
+            // Act
+            var frozen = fixture.Freeze<Fake<Func<int, int>>>();
+            var result = fixture.Create<Func<int, int>>();
+            // Assert
+            Assert.Same(frozen.FakedObject, result);
+        }
+#else
+        [Fact]
+        public void FixtureCanCreateNonFakedDelegateWhenFakeItEasyCannotFakeDelegates()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoFakeItEasyCustomization());
+            // Act
+            var result = fixture.Create<Func<int, int>>();
+            // Assert
+            Assert.IsAssignableFrom<Func<int, int>>(result);
+
+            var notAFakeException = Assert.Throws<ArgumentException>(() => Fake.GetFakeManager(result));
+            Assert.Contains("not recognized as a fake", notAFakeException.Message);
+        }
+#endif
+
         [Fact]
         public void FixtureCanCreateFake()
         {

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -12,6 +12,26 @@ namespace AutoFixture.Kernel
     public class DelegateGenerator : ISpecimenBuilder
     {
         /// <summary>
+        /// The specification used to verify that request is for the supported delegate type.
+        /// </summary>
+        public IRequestSpecification Specification { get; }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="DelegateGenerator"/> type.
+        /// </summary>
+        public DelegateGenerator() : this(new DelegateSpecification())
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="DelegateGenerator"/> type.
+        /// </summary>
+        public DelegateGenerator(IRequestSpecification delegateSpecification)
+        {
+            this.Specification = delegateSpecification ?? throw new ArgumentNullException(nameof(delegateSpecification));
+        }
+
+        /// <summary>
         /// Creates a new <see cref="Delegate"/> instance.
         /// </summary>
         /// <param name="request">The request that describes what to create.</param>
@@ -29,7 +49,7 @@ namespace AutoFixture.Kernel
             if (delegateType == null)
                 return new NoSpecimen();
 
-            if (!typeof(Delegate).GetTypeInfo().IsAssignableFrom(delegateType))
+            if(!this.Specification.IsSatisfiedBy(delegateType))
                 return new NoSpecimen();
 
             var delegateMethod = delegateType.GetTypeInfo().GetMethod("Invoke");

--- a/Src/AutoFixture/Kernel/DelegateSpecification.cs
+++ b/Src/AutoFixture/Kernel/DelegateSpecification.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Reflection;
+
+namespace AutoFixture.Kernel
+{
+    /// <summary>
+    /// A specification that evaluates specimen request to see if it's for the delegate type.
+    /// </summary>
+    public class DelegateSpecification : IRequestSpecification
+    {
+        /// <summary>
+        /// Evaluates a request for a specimen.
+        /// </summary>
+        /// <param name="request">The specimen request.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="request"/> is of a delegate type, otherwise <see langword="false"/>.
+        /// </returns>
+        public bool IsSatisfiedBy(object request)
+        {
+            // Test against MulticastDelegate instead of Delegate base class
+            // because Brad Abrams says that we "should pretend that [Delegate
+            // and MulticaseDelegate] are merged and that only MulticastDelegate exists."
+            // http://blogs.msdn.com/b/brada/archive/2004/02/05/68415.aspx
+            return request is Type type && type.GetTypeInfo().IsSubclassOf(typeof(MulticastDelegate));
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
@@ -17,6 +17,25 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        public void NullDelegateSpecificationThrowsException()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new DelegateGenerator(null));
+        }
+
+        [Fact]
+        public void DefaultDelegateSpecificationIsCorrect()
+        {
+            // Arrange
+            // Act
+            var sut = new DelegateGenerator();
+            // Assert
+            Assert.IsType<DelegateSpecification>(sut.Specification);
+        }
+
+        [Fact]
         public void CreateWithNullRequestReturnsNoSpecimen()
         {
             // Arrange
@@ -26,6 +45,17 @@ namespace AutoFixtureUnitTest.Kernel
             var result = sut.Create(null, dummyContainer);
             // Assert
             Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Fact]
+        public void CustomSpecificationIsPreserved()
+        {
+            // Arrange
+            var specification = new TrueRequestSpecification();
+            // Act
+            var sut = new DelegateGenerator(specification);
+            // Assert
+            Assert.Equal(specification, sut.Specification);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/DelegateSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegateSpecificationTest.cs
@@ -1,0 +1,40 @@
+﻿namespace AutoFixtureUnitTest.Kernel
+{
+    using System;
+    using AutoFixture.Kernel;
+    using Xunit;
+
+    public class DelegateSpecificationTest
+    {
+        public delegate string CustomDelegate(object o);
+
+        [Fact]
+        public void SutIsRequestSpecification()
+        {
+            // Arrange
+            // Act
+            var sut = new DelegateSpecification();
+            // Assert
+            Assert.IsAssignableFrom<IRequestSpecification>(sut);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("a string", false)]
+        [InlineData(typeof(object), false)]
+        [InlineData(typeof(string), false)]
+        [InlineData(typeof(int), false)]
+        [InlineData(typeof(Func<int>), true)]
+        [InlineData(typeof(Action<string, object>), true)]
+        [InlineData(typeof(CustomDelegate), true)]
+        public void IsSatisfiedByReturnsCorrectResult(object request, bool expectedResult)
+        {
+            // Arrange
+            var sut = new DelegateSpecification();
+            // Act
+            var result = sut.IsSatisfiedBy(request);
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}


### PR DESCRIPTION
An alternative PR that fixes #984.

@zvirja, @moodmosaic, this is the approach that I'd originally advocated in https://github.com/AutoFixture/AutoFixture/pull/986#issuecomment-368730314:

>  I believe we could return a faked delegate that by default returns the automatically generated value. Then users would never know that anything changed, unless they were examining the type of returned delegate (which seems silly), or they attempted to configure it as a Fake, in which case I'd think they'd be pleased with the result.

@zvirja has already indicated that this approach is not desirable, although I thought that the reasoning was mostly around a perceived clash with what's normally called "Configured" customizations where the faked (mocked/substituted/rhinoed) objects are configured to return values from AutoFixture. I still think that this approach doesn't conflict, since it's all about changing the abilities of specimens that would previously have been supplied by AutoFixture kernel, not by AutoFakeItEasy.

All that's a bit of an aside, as I'm mostly pushing this because for a long time I couldn't even figure out how to accomplish this effect, and now that I have, I was hoping for a critique or this approach and/or discussion of an alternative approach.

All the juicy changes are in my second commit; the first one just grabs DelegateSpecification as was created in #986. But in 291e3ee, the approach I took was to, when FakeItEasy supports faking of delegates, to introduce a `FakeItEasyRelay` into customizations that would relay delegate requests to `Fake<TDelegate>`, as well as a builder that would create a `Fake<TDelegate>` by using `DelegateGenerator` to produce a regular AutoFixture-supplied delegate specimen, and then wrapping that delegate in a Fake (so the behaviour still looks like the AutoFixture delegate until you configure it).
Explicitly referencing the `DelegateGenerator` felt a little dirty, but I couldn't otherwise figure out how to pass the request for the delegate along to the AutoFixture kernel without having be picked up by the FakeItEasyRelay (or falling prey to the recursion guards).

Would my approach be considered reasonable, or is there a more idiomatic approach that I'm missing?