### PR TITLE
Add option to generate delegates via Moq

### DIFF
--- a/Src/AutoMoq/AutoConfiguredMoqCustomization.cs
+++ b/Src/AutoMoq/AutoConfiguredMoqCustomization.cs
@@ -7,15 +7,16 @@ namespace AutoFixture.AutoMoq
     /// Enables auto-mocking and auto-setup with Moq.
     /// Members of a mock will be automatically setup to retrieve the return values from a fixture.
     /// </summary>
-    public class AutoConfiguredMoqCustomization : ICustomization
+    [Obsolete("This customization is obsolete and will be removed in the future versions of product. " +
+              "Please use 'new AutoMoqCustomization { ConfigureMembers = true }' customization instead.")]
+    public class AutoConfiguredMoqCustomization : AutoMoqCustomization
     {
         /// <summary>
         /// Creates a new instance of <see cref="AutoConfiguredMoqCustomization"/>.
         /// </summary>
         public AutoConfiguredMoqCustomization()
-            : this(new MockRelay())
         {
-
+            this.ConfigureMembers = true;
         }
 
         /// <summary>
@@ -23,35 +24,9 @@ namespace AutoFixture.AutoMoq
         /// </summary>
         /// <param name="relay">A mock relay to be added to <see cref="IFixture.ResidueCollectors"/></param>
         public AutoConfiguredMoqCustomization(ISpecimenBuilder relay)
+            : base(relay)
         {
-            this.Relay = relay ?? throw new ArgumentNullException(nameof(relay));
-        }
-
-        /// <summary>
-        /// Gets the relay that will be added to <see cref="IFixture.ResidueCollectors"/> when <see cref="Customize"/> is invoked.
-        /// </summary>
-        public ISpecimenBuilder Relay { get; }
-
-        /// <summary>
-        /// Customizes a <see cref="IFixture"/> to enable auto-mocking and auto-setup with Moq.
-        /// Members of a mock will be automatically setup to retrieve the return values from <paramref name="fixture"/>.
-        /// </summary>
-        /// <param name="fixture">The fixture to customize.</param>
-        public void Customize(IFixture fixture)
-        {
-            if (fixture == null) throw new ArgumentNullException(nameof(fixture));
-
-            fixture.Customizations.Add(
-                new Postprocessor(
-                    builder: new MockPostprocessor(
-                                new MethodInvoker(
-                                    new MockConstructorQuery())),
-                    command: new CompositeSpecimenCommand(
-                                new StubPropertiesCommand(),
-                                new MockVirtualMethodsCommand(),
-                                new AutoMockPropertiesCommand())));
-
-            fixture.ResidueCollectors.Add(this.Relay);
+            this.ConfigureMembers = true;
         }
     }
 }

--- a/Src/AutoMoq/AutoMoqCustomization.cs
+++ b/Src/AutoMoq/AutoMoqCustomization.cs
@@ -48,6 +48,12 @@ namespace AutoFixture.AutoMoq
         public bool ConfigureMembers { get; set; }
 
         /// <summary>
+        /// If value is <c>true</c>, delegate requests are intercepted and created by Moq.
+        /// Otherwise, if value is <c>false</c>, delegates are created by the AutoFixture kernel.
+        /// </summary>
+        public bool GenerateDelegates { get; set; }
+
+        /// <summary>
         /// Gets or sets the relay that will be added to <see cref="IFixture.ResidueCollectors"/> when
         /// <see cref="Customize"/> is invoked.
         /// </summary>
@@ -82,6 +88,11 @@ namespace AutoFixture.AutoMoq
 
             fixture.Customizations.Add(mockBuilder);
             fixture.ResidueCollectors.Add(this.Relay);
+
+            if (this.GenerateDelegates)
+            {
+                fixture.Customizations.Add(new MockRelay(new DelegateSpecification()));
+            }
         }
     }
 }

--- a/Src/AutoMoq/AutoMoqCustomization.cs
+++ b/Src/AutoMoq/AutoMoqCustomization.cs
@@ -6,13 +6,27 @@ namespace AutoFixture.AutoMoq
     /// <summary>
     /// Enables auto-mocking with Moq.
     /// </summary>
+    /// <remarks>
+    /// NOTICE! You can assign the customization properties to tweak the features you would like to enable. Example:
+    /// <br />
+    /// <code>new AutoMoqCustomization { ConfigureMembers = true }</code>
+    /// </remarks>
     public class AutoMoqCustomization : ICustomization
     {
+        private ISpecimenBuilder relay;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoMoqCustomization"/> class.
+        /// <para>
+        /// NOTICE! You can assign the customization properties to tweak the features you would like to enable. Example:
+        /// <br />
+        /// <code>new AutoMoqCustomization { ConfigureMembers = true }</code>
+        /// </para>
         /// </summary>
         public AutoMoqCustomization()
+#pragma warning disable 618 // Type or member is obsolete
             : this(new MockRelay())
+#pragma warning restore 618 // Type or member is obsolete
         {
         }
 
@@ -21,30 +35,52 @@ namespace AutoFixture.AutoMoq
         /// <see cref="MockRelay"/>.
         /// </summary>
         /// <param name="relay">The relay.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future version of the product. " +
+                  "Please use the AutoMoqCustomization() overload (without arguments) instead and set the Relay property.")]
         public AutoMoqCustomization(ISpecimenBuilder relay)
         {
-            this.Relay = relay ?? throw new ArgumentNullException(nameof(relay));
+            this.relay = relay ?? throw new ArgumentNullException(nameof(relay));
         }
 
         /// <summary>
-        /// Gets the relay that will be added to <see cref="IFixture.ResidueCollectors"/> when
-        /// <see cref="Customize"/> is invoked.
+        /// Specifies whether members of a mock will be automatically setup to retrieve the return values from a fixture.
         /// </summary>
-        /// <seealso cref="AutoMoqCustomization(ISpecimenBuilder)"/>
-        public ISpecimenBuilder Relay { get; }
+        public bool ConfigureMembers { get; set; }
 
         /// <summary>
-        /// Customizes a <see cref="IFixture"/> to enable auto-mocking with Moq.
+        /// Gets or sets the relay that will be added to <see cref="IFixture.ResidueCollectors"/> when
+        /// <see cref="Customize"/> is invoked.
+        /// </summary>
+        public ISpecimenBuilder Relay
+        {
+            get => this.relay;
+            set => this.relay = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Customizes an <see cref="IFixture"/> to enable auto-mocking with Moq.
         /// </summary>
         /// <param name="fixture">The fixture upon which to enable auto-mocking.</param>
         public void Customize(IFixture fixture)
         {
             if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-            fixture.Customizations.Add(
-                new MockPostprocessor(
-                    new MethodInvoker(
-                        new MockConstructorQuery())));
+            ISpecimenBuilder mockBuilder = new MockPostprocessor(
+                                              new MethodInvoker(
+                                                 new MockConstructorQuery()));
+
+            // If members should be automatically configured, wrap the builder with members setup postprocessor.
+            if (this.ConfigureMembers)
+            {
+                mockBuilder = new Postprocessor(
+                    builder: mockBuilder,
+                    command: new CompositeSpecimenCommand(
+                                new StubPropertiesCommand(),
+                                new MockVirtualMethodsCommand(),
+                                new AutoMockPropertiesCommand()));
+            }
+
+            fixture.Customizations.Add(mockBuilder);
             fixture.ResidueCollectors.Add(this.Relay);
         }
     }

--- a/Src/AutoMoq/MockConstructorQuery.cs
+++ b/Src/AutoMoq/MockConstructorQuery.cs
@@ -11,6 +11,8 @@ namespace AutoFixture.AutoMoq
     /// </summary>
     public class MockConstructorQuery : IMethodQuery
     {
+        private static readonly DelegateSpecification DelegateSpecification = new DelegateSpecification();
+
         /// <summary>
         /// Selects constructors for the supplied <see cref="Moq.Mock{T}"/> type.
         /// </summary>
@@ -42,7 +44,7 @@ namespace AutoFixture.AutoMoq
             }
 
             var mockType = type.GetMockedType();
-            if (mockType.GetTypeInfo().IsInterface || mockType.IsDelegate())
+            if (mockType.GetTypeInfo().IsInterface || DelegateSpecification.IsSatisfiedBy(mockType))
             {
                 return new[] { new ConstructorMethod(type.GetDefaultConstructor()) };
             }

--- a/Src/AutoMoq/MockType.cs
+++ b/Src/AutoMoq/MockType.cs
@@ -42,16 +42,6 @@ namespace AutoFixture.AutoMoq
                 && !type.GetMockedType().IsGenericParameter);
         }
 
-        internal static bool IsDelegate(this Type type)
-        {
-            /* Test against MulticastDelegate instead of Delegate base class
-             * because Brad Abrams says that we "should pretend that [Delegate 
-             * and MulticaseDelegate] are merged and that only 
-             * MulticastDelegate exists."
-             * http://blogs.msdn.com/b/brada/archive/2004/02/05/68415.aspx */
-            return typeof(MulticastDelegate).IsAssignableFrom(type.GetTypeInfo().BaseType);
-        }
-
         internal static ConstructorInfo GetDefaultConstructor(this Type type)
         {
             return type.GetConstructor(Type.EmptyTypes);

--- a/Src/AutoMoqUnitTest/AutoConfiguredMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/AutoConfiguredMoqCustomizationTest.cs
@@ -7,8 +7,27 @@ using Xunit;
 
 namespace AutoFixture.AutoMoq.UnitTest
 {
+    [Obsolete]
     public class AutoConfiguredMoqCustomizationTest
     {
+        [Fact]
+        public void IsInheritedFromAutoMoqCustomization()
+        {
+            // Arrange
+            var sut = new AutoConfiguredMoqCustomization();
+            // Act & Assert
+            Assert.IsAssignableFrom<AutoMoqCustomization>(sut);
+        }
+
+        [Fact]
+        public void SetsConfigureMembersPropertyToTrue()
+        {
+            // Arrange
+            var sut = new AutoConfiguredMoqCustomization();
+            // Act & Assert
+            Assert.True(sut.ConfigureMembers);
+        }
+
         [Fact]
         public void CtorThrowsWhenRelayIsNull()
         {

--- a/Src/AutoMoqUnitTest/AutoMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/AutoMoqCustomizationTest.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using AutoFixture.Kernel;
-using Moq;
 using Xunit;
 
 namespace AutoFixture.AutoMoq.UnitTest
@@ -20,6 +18,16 @@ namespace AutoFixture.AutoMoq.UnitTest
         }
 
         [Fact]
+        public void ConfigureMembersIsDisabledByDefault()
+        {
+            // Arrange
+            // Act
+            var sut = new AutoMoqCustomization();
+            // Assert
+            Assert.False(sut.ConfigureMembers);
+        }
+
+        [Fact, Obsolete]
         public void InitializeWithNullRelayThrows()
         {
             // Arrange
@@ -29,6 +37,28 @@ namespace AutoFixture.AutoMoq.UnitTest
         }
 
         [Fact]
+        public void ThrowsIfNullRelayIsSet()
+        {
+            // Arrange
+            var sut = new AutoMoqCustomization();
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Relay = null);
+        }
+
+        [Fact]
+        public void ShouldPreserveTheSetRelay()
+        {
+            // Arrange
+            var sut = new AutoMoqCustomization();
+            var relay = new CompositeSpecimenBuilder();
+            // Act
+            sut.Relay = relay;
+            // Assert
+            Assert.Equal(relay, sut.Relay);
+        }
+
+        [Fact, Obsolete]
         public void SpecificationIsCorrectWhenInitializedWithRelay()
         {
             // Arrange
@@ -65,32 +95,58 @@ namespace AutoFixture.AutoMoq.UnitTest
         public void CustomizeAddsAppropriateResidueCollector()
         {
             // Arrange
-            var residueCollectors = new List<ISpecimenBuilder>();
-            var fixtureStub = new Mock<IFixture> { DefaultValue = DefaultValue.Mock };
-            fixtureStub.SetupGet(c => c.ResidueCollectors).Returns(residueCollectors);
+            var fixtureStub = new FixtureStub();
 
             var sut = new AutoMoqCustomization();
             // Act
-            sut.Customize(fixtureStub.Object);
+            sut.Customize(fixtureStub);
             // Assert
-            Assert.Contains(sut.Relay, residueCollectors);
+            Assert.Contains(sut.Relay, fixtureStub.ResidueCollectors);
         }
 
         [Fact]
         public void CustomizeAddsAppropriateCustomizations()
         {
             // Arrange
-            var customizations = new List<ISpecimenBuilder>();
-            var fixtureStub = new Mock<IFixture> { DefaultValue = DefaultValue.Mock };
-            fixtureStub.SetupGet(c => c.Customizations).Returns(customizations);
+            var fixtureStub = new FixtureStub();
 
             var sut = new AutoMoqCustomization();
             // Act
-            sut.Customize(fixtureStub.Object);
+            sut.Customize(fixtureStub);
             // Assert
-            var postprocessor = customizations.OfType<MockPostprocessor>().Single();
+            var postprocessor = fixtureStub.Customizations.OfType<MockPostprocessor>().Single();
             var ctorInvoker = Assert.IsAssignableFrom<MethodInvoker>(postprocessor.Builder);
             Assert.IsAssignableFrom<MockConstructorQuery>(ctorInvoker.Query);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_CustomizeAddsPostprocessorToCustomizations()
+        {
+            // Arrange
+            var fixtureStub = new FixtureStub();
+            var sut = new AutoMoqCustomization { ConfigureMembers = true };
+            // Act
+            sut.Customize(fixtureStub);
+            // Assert
+            Assert.Contains(fixtureStub.Customizations, builder => builder is Postprocessor);
+        }
+
+        [Theory]
+        [InlineData(typeof(MockVirtualMethodsCommand))]
+        [InlineData(typeof(StubPropertiesCommand))]
+        [InlineData(typeof(AutoMockPropertiesCommand))]
+        public void WithConfigureMembers_CustomizeAddsMockCommandsToPostprocessor(Type expectedCommandType)
+        {
+            // Arrange
+            var fixtureStub = new FixtureStub();
+            var sut = new AutoMoqCustomization { ConfigureMembers = true };
+            // Act
+            sut.Customize(fixtureStub);
+            // Assert
+            var postprocessor = (Postprocessor) fixtureStub.Customizations.Single(builder => builder is Postprocessor);
+            var compositeCommand = (CompositeSpecimenCommand) postprocessor.Command;
+
+            Assert.Contains(compositeCommand.Commands, command => command.GetType() == expectedCommandType);
         }
     }
 }

--- a/Src/AutoMoqUnitTest/AutoMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/AutoMoqCustomizationTest.cs
@@ -27,6 +27,16 @@ namespace AutoFixture.AutoMoq.UnitTest
             Assert.False(sut.ConfigureMembers);
         }
 
+        [Fact]
+        public void GenerateDelegatesIsDisabledByDefault()
+        {
+            // Arrange
+            // Act
+            var sut = new AutoMoqCustomization();
+            // Assert
+            Assert.False(sut.GenerateDelegates);
+        }
+
         [Fact, Obsolete]
         public void InitializeWithNullRelayThrows()
         {
@@ -147,6 +157,31 @@ namespace AutoFixture.AutoMoq.UnitTest
             var compositeCommand = (CompositeSpecimenCommand) postprocessor.Command;
 
             Assert.Contains(compositeCommand.Commands, command => command.GetType() == expectedCommandType);
+        }
+
+        [Fact]
+        public void WithGenerateDelegates_CustomizeAddsRelay()
+        {
+            // Arrange
+            var fixtureStub = new FixtureStub();
+            var sut = new AutoMoqCustomization { GenerateDelegates = true };
+            // Act
+            sut.Customize(fixtureStub);
+            // Assert
+            var mockRelay = (MockRelay)fixtureStub.Customizations.Single(c => c is MockRelay);
+            Assert.IsType<DelegateSpecification>(mockRelay.MockableSpecification);
+        }
+
+        [Fact]
+        public void WithoutGenerateDelegates_DoesNotAddMockRelayForDelegate()
+        {
+            // Arrange
+            var fixtureStub = new FixtureStub();
+            var sut = new AutoMoqCustomization { GenerateDelegates = false };
+            // Act
+            sut.Customize(fixtureStub);
+            // Assert
+            Assert.DoesNotContain(fixtureStub.Customizations, c => c is MockRelay);
         }
     }
 }

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -10,8 +10,11 @@
     <RootNamespace>AutoFixture.AutoMoq.UnitTest</RootNamespace>
 
     <!--  Suppress warning about invalid dependency version in Castle.Core.
-          That is Moq dependency and we cannot fix that somehow. -->
+          That is a Moq dependency and we cannot fix that somehow. -->
     <NoWarn>$(NoWarn);NU1603</NoWarn>
+
+    <!-- An issue with out parameters for delegates was fixed in the recent versions of Moq (consumed by .Net Core). -->
+    <DefineConstants Condition=" '$(TargetFramework)'=='netcoreapp1.1' ">$(DefineConstants);FIXED_DELEGATE_OUT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoConfiguredMoqCustomizationTest.cs
@@ -1,9 +1,11 @@
-﻿using AutoFixture.AutoMoq.UnitTest.TestTypes;
+﻿using System;
+using AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Moq;
 using Xunit;
 
 namespace AutoFixture.AutoMoq.UnitTest
 {
+    [Obsolete]
     public class FixtureIntegrationWithAutoConfiguredMoqCustomizationTest
     {
         [Fact]

--- a/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoMoqCustomizationTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using AutoFixture.AutoMoq.UnitTest.TestTypes;
 using Moq;
 using TestTypeFoundation;
 using Xunit;
@@ -137,19 +138,302 @@ namespace AutoFixture.AutoMoq.UnitTest
             mockOfDelegate.Setup(f => f(13, 37)).Returns(expected);
 
             // Act
-            var actual = mockOfDelegate.Object(13, 37);
+            var actual = mockOfDelegate.Object.Invoke(13, 37);
 
             // Assert
             Assert.Equal(expected, actual);
         }
 
-        public interface IFoo
+        [Fact]
+        public void WithConfigureMembers_ParameterlessMethodsReturnValueFromFixture()
         {
-            IBar Bar { get; set; }
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithParameterlessMethod>();
+            // Assert
+            Assert.Same(frozenString, result.Method());
         }
 
-        public interface IBar
+        [Fact]
+        public void WithConfigureMembers_MethodsFromBaseInterfacesReturnValueFromFixture()
         {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IDerivedInterface>();
+            // Assert
+            Assert.Same(frozenString, result.Method());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_InterfaceNewMethodsReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithNewMethod>();
+            // Assert
+            Assert.Same(frozenString, result.Method(0));
+        }
+
+        [Fact]
+        public void WithConfigureMembers_InterfaceShadowedMethodsReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithNewMethod>();
+            // Assert
+            Assert.Same(frozenString, ((IInterfaceWithShadowedMethod)result).Method(0));
+        }
+
+        [Fact]
+        public void WithConfigureMembers_PropertiesReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithProperty>();
+            // Assert
+            Assert.Same(frozenString, result.Property);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_GetOnlyPropertiesReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithGetOnlyProperty>();
+            // Assert
+            Assert.Same(frozenString, result.GetOnlyProperty);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_IndexersReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenInt = fixture.Freeze<int>();
+            // Act
+            var result = fixture.Create<IInterfaceWithIndexer>();
+            // Assert
+            Assert.Equal(frozenInt, result[42]);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VirtualMembersReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<Mock<TypeWithVirtualMembers>>();
+            // Assert
+            Assert.Equal(frozenString, result.Object.VirtualGetOnlyProperty);
+            Assert.Equal(frozenString, result.Object.VirtualMethod());
+            Assert.Equal(frozenString, result.Object.VirtualProperty);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_MethodsWithParametersReturnValuesFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithMethod>();
+            // Assert
+            Assert.Equal(frozenString, result.Method("hi"));
+        }
+
+        [Fact]
+        public void WithConfigureMembers_MethodsWithOutParametersReturnValuesFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenInt = fixture.Freeze<int>();
+            // Act
+            var result = fixture.Create<IInterfaceWithOutMethod>();
+            // Assert
+            result.Method(out int outResult);
+            Assert.Equal(frozenInt, outResult);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SealedSettablePropertiesAreSetUsingFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<Mock<TypeWithSealedMembers>>();
+            // Assert
+            Assert.Equal(frozenString, result.Object.ExplicitlySealedProperty);
+            Assert.Equal(frozenString, result.Object.ImplicitlySealedProperty);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_OverridablePropertiesAreSetUsingFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithProperty>();
+            // Assert
+            Assert.Equal(frozenString, result.Property);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_OverridablePropertiesAreStubbed()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            // Act
+            var result = fixture.Create<IInterfaceWithProperty>();
+            // Assert
+            result.Property = "a string";
+            Assert.Equal("a string", result.Property);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_FieldsAreSetUsingFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<Mock<TypeWithPublicField>>();
+            // Assert
+            Assert.Equal(frozenString, result.Object.Field);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SealedMethodsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Mock<TypeWithSealedMembers> result = null;
+            Assert.Null(Record.Exception(() => result = fixture.Create<Mock<TypeWithSealedMembers>>()));
+            Assert.NotEqual(frozenString, result.Object.ImplicitlySealedMethod());
+            Assert.NotEqual(frozenString, result.Object.ExplicitlySealedMethod());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_RefMethodsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            IInterfaceWithRefMethod result = null;
+            Assert.Null(Record.Exception(() => result = fixture.Create<IInterfaceWithRefMethod>()));
+
+            string refResult = "";
+            string returnValue = result.Method(ref refResult);
+            Assert.NotEqual(frozenString, refResult);
+            Assert.NotEqual(frozenString, returnValue);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_GenericMethodsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            IInterfaceWithGenericMethod result = null;
+            Assert.Null(Record.Exception(() => result = fixture.Create<IInterfaceWithGenericMethod>()));
+
+            Assert.NotEqual(frozenString, result.GenericMethod<string>());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_StaticMethodsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithStaticMethod>>()));
+        }
+
+        [Fact]
+        public void WithConfigureMembers_StaticPropertiesAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithStaticProperty>>()));
+            Assert.NotEqual(frozenString, TypeWithStaticProperty.Property);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_PrivateFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Mock<TypeWithPrivateField> result = null;
+            Assert.Null(Record.Exception(() => result = fixture.Create<Mock<TypeWithPrivateField>>()));
+
+            Assert.NotEqual(frozenString, result.Object.GetPrivateField());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ReadonlyFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Mock<TypeWithReadonlyField> result = null;
+            Assert.Null(Record.Exception(() => result = fixture.Create<Mock<TypeWithReadonlyField>>()));
+
+            Assert.NotEqual(frozenString, result.Object.ReadonlyField);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_LiteralFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithConstField>>()));
+            Assert.NotEqual(frozenString, TypeWithConstField.ConstField);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_StaticFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<Mock<TypeWithStaticField>>()));
+            Assert.NotEqual(frozenString, TypeWithStaticField.StaticField);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_PropertiesWithCircularDependenciesAreNotAllowed()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            // Act & Assert
+            Assert.ThrowsAny<ObjectCreationException>(() => fixture.Create<IInterfaceWithPropertyWithCircularDependency>());
         }
 
         public delegate string DBaz(short s, byte b);

--- a/Src/AutoMoqUnitTest/FixtureStub.cs
+++ b/Src/AutoMoqUnitTest/FixtureStub.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using AutoFixture.Dsl;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.AutoMoq.UnitTest
+{
+    public class FixtureStub : IFixture
+    {
+        public bool OmitAutoProperties { get; set; }
+        public int RepeatCount { get; set; }
+        public IList<ISpecimenBuilderTransformation> Behaviors { get; set; } = new List<ISpecimenBuilderTransformation>();
+        public IList<ISpecimenBuilder> Customizations { get; set; } = new List<ISpecimenBuilder>();
+        public IList<ISpecimenBuilder> ResidueCollectors { get; set; } = new List<ISpecimenBuilder>();
+
+        object ISpecimenBuilder.Create(object request, ISpecimenContext context) =>
+            throw new NotSupportedException();
+
+        ICustomizationComposer<T> IFixture.Build<T>() =>
+            throw new NotSupportedException();
+
+        IFixture IFixture.Customize(ICustomization customization) =>
+            throw new NotSupportedException();
+
+        void IFixture.Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation) =>
+            throw new NotSupportedException();
+    }
+}

--- a/Src/AutoMoqUnitTest/TestTypes/TypeWithSealedMembers.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/TypeWithSealedMembers.cs
@@ -8,10 +8,10 @@
 
     public class TypeWithSealedMembers : TypeWithSealedMembersTemp
     {
-        public override sealed string ExplicitlySealedProperty { get; set; }
+        public sealed override string ExplicitlySealedProperty { get; set; }
         public string ImplicitlySealedProperty { get; set; }
 
-        public override sealed string ExplicitlySealedMethod()
+        public sealed override string ExplicitlySealedMethod()
         {
             return "Awesome string";
         }


### PR DESCRIPTION
Fixes #742

The main goal of this PR is to add an option to allow generate delegates by Moq, rather than by AutoFixture kernel. That allows to later use Moq API to configure the result value for them. The final API looks like following:
```c#
var fixture = new Fixture().Customize(new AutoMoqCustomization
{
    GenerateDelegates = true, // Enable delegate generation via Moq
    ConfigureMembers = true // Enable configuration of Moq to return values from AutoFixture.
});
```
A few major changes were applied in this PR to achieve the desired goal.

### 1. Deprecated `AutoConfiguredMoqCustomization`
To make it consistent with #986, I've deprecated the `AutoConfiguredMoqCustomization` type. Instead, the `AutoMoqCustomization` and the `ConfigureMembers` property should be used to enable the feature:

```c#
var fixture = new Fixture().Customize(new AutoMoqCustomization
{
    ConfigureMembers = true
});
```

This change is required, as we added yet another configuration option - delegate interception. If we follow the old approach, we'll be required to have 4 different classes:
- `AutoMoqCustomization`
- `AutoMoqWithDelegatesCustomization`
- `AutoConfiguredMoqCustomization`
- `AutoConfiguredMoqWithDelegatesCustomization`.

Obviously, this approach isn't scalable and is an overkill. Therefore, the introduced approach with properties should work better.

Additional benefit is that now glue library has a single facade entry point with properties to configure each possible variants of customization.

### 2. Add option to generate interfaces via Moq

Now you can tune configuration to additionally intercept the delegate requests. It required some changes in the code to ensure that delegates work fine with `ConfigureMembers` feature, so that AutoFixture generate result values for them as well.

-----
@moodmosaic Please review the PR commit by commit, so it will be simpler to you to understand the applied changes.