### PR TITLE
Add .NET Standard 2.0 direct support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 indent_size = 4
 indent_style = space
 
-[*.{sln,csproj,fsproj,config,xml}]
+[*.{sln,csproj,fsproj,config,xml,props}]
 indent_size = 2
 indent_style = space
 

--- a/README.md
+++ b/README.md
@@ -77,21 +77,21 @@ Using AutoFixture is as easy as referencing the library and creating a new insta
 
 ## .NET platforms compatibility table
 
-| Product                    | .NET Framework            | .NET Standard            |
-| -------------------------- | ------------------------  | ------------------------ |
-| AutoFixture                | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoFixture.SeedExtensions | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoFixture.xUnit          | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| AutoFixture.xUnit2         | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoFixture.NUnit2         | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| AutoFixture.NUnit3         | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoFakeItEasy             | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.6   |
-| AutoFoq                    | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| AutoMoq                    | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoNSubstitute            | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5   |
-| AutoRhinoMock              | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:       |
-| Idioms                     | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0   |
-| Idioms.FsCheck             | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0   |
+| Product                    | .NET Framework            | .NET Standard               |
+| -------------------------- | ------------------------  | ------------------------    |
+| AutoFixture                | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5, 2.0 |
+| AutoFixture.SeedExtensions | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5      |
+| AutoFixture.xUnit          | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:          |
+| AutoFixture.xUnit2         | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5      |
+| AutoFixture.NUnit2         | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:          |
+| AutoFixture.NUnit3         | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5      |
+| AutoFakeItEasy             | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.6      |
+| AutoFoq                    | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:          |
+| AutoMoq                    | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5      |
+| AutoNSubstitute            | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 1.5      |
+| AutoRhinoMock              | :heavy_check_mark: 4.5.2  | :heavy_minus_sign:          |
+| Idioms                     | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0      |
+| Idioms.FsCheck             | :heavy_check_mark: 4.5.2  | :heavy_check_mark: 2.0      |
 
 ## Downloads
 

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.5;netstandard2.0</TargetFrameworks>
     <AssemblyTitle>AutoFixture</AssemblyTitle>
     <AssemblyName>AutoFixture</AssemblyName>
     <RootNamespace>AutoFixture</RootNamespace>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fare" Version="[2.1.1,3.0.0)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <Reference Include="System.ComponentModel.DataAnnotations" Condition=" '$(TargetFramework)'=='net452' " />
   </ItemGroup>

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -2,21 +2,20 @@
   <Import Project="..\Common.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
+
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <AssemblyTitle>AutoFixtureUnitTest</AssemblyTitle>
     <AssemblyName>AutoFixtureUnitTest</AssemblyName>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
+    <Reference Condition=" '$(TargetFramework)'=='net452' " Include="System.ComponentModel.DataAnnotations" />
+    <PackageReference Condition=" '$(TargetFramework)'=='netcoreapp1.1' " Include="System.Linq.Parallel" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)'=='netcoreapp1.1' ">
-    <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
-  </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -35,6 +35,9 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netcoreapp2.0' ">$(DefineConstants);SYSTEM_NET_MAIL</DefineConstants>
+  </PropertyGroup>
 
   <Choose>
     <When Condition=" '$(Configuration)'=='Release' ">


### PR DESCRIPTION
Closes #993 

Add .NET Standard 2.0 as one of the target frameworks to enable mail generation there, as API is available. Still keep the `netstandard1.5` support to be compatible with lower API versions.