### PR TITLE
Add support of delegate hook for NSubstitute

### DIFF
--- a/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AutoFixture.Kernel;
-using NSubstitute.Core;
 
 namespace AutoFixture.AutoNSubstitute
 {
@@ -8,48 +7,27 @@ namespace AutoFixture.AutoNSubstitute
     /// Enables auto-mocking and auto-setup with NSubstitute.
     /// Members of a substitute will be automatically setup to retrieve the return values from a fixture.
     /// </summary>
-    public class AutoConfiguredNSubstituteCustomization : ICustomization
+    [Obsolete("This customization is obsolete and will be removed in a future versions of product. " +
+              "Please use 'new AutoNSubstituteCustomization { ConfigureMembers = true }' customization instead.")]
+    public class AutoConfiguredNSubstituteCustomization : AutoNSubstituteCustomization
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoConfiguredNSubstituteCustomization"/> class.
         /// </summary>
         /// <remarks>Uses a new instance of <see cref="NSubstituteBuilder"/> as the builder.</remarks>
         public AutoConfiguredNSubstituteCustomization()
-            : this(new SubstituteRelay())
         {
+            this.ConfigureMembers = true;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutoConfiguredNSubstituteCustomization"/> class.
         /// </summary>
-        /// <param name="builder">The builder to use to create specimens for this customization.</param>
-        public AutoConfiguredNSubstituteCustomization(ISpecimenBuilder builder)
+        /// <param name="relay">The builder to use to create specimens for this customization.</param>
+        public AutoConfiguredNSubstituteCustomization(ISpecimenBuilder relay)
+            : base(relay)
         {
-            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        }
-
-        /// <summary>
-        /// Gets the builder that will be added to <see cref="IFixture.ResidueCollectors"/> when 
-        /// <see cref="Customize"/> is invoked.
-        /// </summary>
-        /// <seealso cref="AutoConfiguredNSubstituteCustomization(ISpecimenBuilder)"/>
-        public ISpecimenBuilder Builder { get; }
-
-        /// <summary>Customizes an <see cref="IFixture"/> to enable auto-mocking with NSubstitute.</summary>
-        /// <param name="fixture">The fixture upon which to enable auto-mocking.</param>
-        public void Customize(IFixture fixture)
-        {
-            if (fixture == null)
-                throw new ArgumentNullException(nameof(fixture));
-
-            fixture.Customizations.Insert(0,
-                new Postprocessor(
-                    new SubstituteRequestHandler(new MethodInvoker(new NSubstituteMethodQuery())),
-                    new CompositeSpecimenCommand(
-                        new NSubstituteRegisterCallHandlerCommand(SubstitutionContext.Current),
-                        new NSubstituteSealedPropertiesCommand())));
-            fixture.Customizations.Insert(0, new SubstituteAttributeRelay());
-            fixture.ResidueCollectors.Add(this.Builder);
+            this.ConfigureMembers = true;
         }
     }
 }

--- a/Src/AutoNSubstitute/AutoNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoNSubstituteCustomization.cs
@@ -52,6 +52,12 @@ namespace AutoFixture.AutoNSubstitute
         /// </summary>
         public bool ConfigureMembers { get; set; }
 
+        /// <summary>
+        /// If value is <c>true</c>, delegate requests are intercepted and created by NSubstitute.
+        /// Otherwise, if value is <c>false</c>, delegates are created by the AutoFixture kernel.
+        /// </summary>
+        public bool GenerateDelegates { get; set; }
+
         /// <summary>Customizes an <see cref="IFixture"/> to enable auto-mocking with NSubstitute.</summary>
         public void Customize(IFixture fixture)
         {
@@ -73,6 +79,11 @@ namespace AutoFixture.AutoNSubstitute
             fixture.Customizations.Insert(0, substituteBuilder);
             fixture.Customizations.Insert(0, new SubstituteAttributeRelay());
             fixture.ResidueCollectors.Add(this.Relay);
+
+            if (this.GenerateDelegates)
+            {
+                fixture.Customizations.Add(new SubstituteRelay(new DelegateSpecification()));
+            }
         }
     }
 }

--- a/Src/AutoNSubstitute/AutoNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoNSubstituteCustomization.cs
@@ -1,38 +1,78 @@
 ﻿using System;
 using AutoFixture.Kernel;
+using NSubstitute.Core;
 
 namespace AutoFixture.AutoNSubstitute
 {
     /// <summary>Enables auto-mocking with NSubstitute.</summary>
+    /// <remarks>
+    /// NOTICE! You can assign the customization properties to tweak the features you would like to enable. Example:
+    /// <br />
+    /// <code>new AutoNSubstituteCustomization { ConfigureMembers = true }</code>
+    /// </remarks>
     public class AutoNSubstituteCustomization : ICustomization
     {
-        /// <summary>Initializes a new instance of the <see cref="AutoNSubstituteCustomization"/> class.</summary>
-        /// <remarks>Uses a new instance of <see cref="NSubstituteBuilder"/> as the builder.</remarks>
+        private ISpecimenBuilder relay;
+
+        /// <summary>Initializes a new instance of the <see cref="AutoNSubstituteCustomization"/> class.
+        /// <para>
+        /// NOTICE! You can assign the customization properties to tweak the features you would like to enable. Example:
+        /// <br />
+        /// <code>new AutoNSubstituteCustomization { ConfigureMembers = true }</code>
+        /// </para>
+        /// </summary>
         public AutoNSubstituteCustomization()
+#pragma warning disable 618 // Type or member is obsolete
             : this(new SubstituteRelay())
+#pragma warning restore 618 // Type or member is obsolete
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="AutoNSubstituteCustomization"/> class.</summary>
-        /// <param name="builder">The builder to use to create specimens for this customization.</param>
-        public AutoNSubstituteCustomization(ISpecimenBuilder builder)
+        [Obsolete("This constructor is obsolete and will be removed in a future version of the product. " +
+                  "Please use the AutoNSubstituteCustomization() overload (without arguments) instead and set the Relay property.")]
+        public AutoNSubstituteCustomization(ISpecimenBuilder relay)
         {
-            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+            this.relay = relay ?? throw new ArgumentNullException(nameof(relay));
         }
 
         /// <summary>Gets the builder that will be added to <see cref="IFixture.ResidueCollectors"/> when <see cref="Customize"/> is invoked.</summary>
-        /// <seealso cref="AutoNSubstituteCustomization(ISpecimenBuilder)"/>
-        public ISpecimenBuilder Builder { get; }
+        [Obsolete("This property is obsolete - use the Relay property instead.")]
+        public ISpecimenBuilder Builder => this.relay;
+
+        /// <summary>Gets or sets the relay that will be added to <see cref="IFixture.ResidueCollectors"/> when <see cref="Customize"/> is invoked.</summary>
+        public ISpecimenBuilder Relay
+        {
+            get => this.relay;
+            set => this.relay = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Specifies whether members of a substitute will be automatically configured to retrieve the return values from a fixture.
+        /// </summary>
+        public bool ConfigureMembers { get; set; }
 
         /// <summary>Customizes an <see cref="IFixture"/> to enable auto-mocking with NSubstitute.</summary>
-        /// <param name="fixture">The fixture upon which to enable auto-mocking.</param>
         public void Customize(IFixture fixture)
         {
             if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-            fixture.Customizations.Insert(0, new SubstituteRequestHandler(new MethodInvoker(new NSubstituteMethodQuery())));
+            ISpecimenBuilder substituteBuilder = new SubstituteRequestHandler(
+                new MethodInvoker(
+                    new NSubstituteMethodQuery()));
+
+            if (this.ConfigureMembers)
+            {
+                substituteBuilder = new Postprocessor(
+                    substituteBuilder,
+                    new CompositeSpecimenCommand(
+                        new NSubstituteRegisterCallHandlerCommand(SubstitutionContext.Current),
+                        new NSubstituteSealedPropertiesCommand()));
+            }
+
+            fixture.Customizations.Insert(0, substituteBuilder);
             fixture.Customizations.Insert(0, new SubstituteAttributeRelay());
-            fixture.ResidueCollectors.Add(this.Builder);
+            fixture.ResidueCollectors.Add(this.Relay);
         }
     }
 }

--- a/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
+++ b/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
@@ -11,6 +11,8 @@ namespace AutoFixture.AutoNSubstitute
     /// <summary>Selects appropriate methods to create substitutes.</summary>
     public class NSubstituteMethodQuery : IMethodQuery
     {
+        private static readonly IRequestSpecification DelegateSpecification = new DelegateSpecification();
+
         /// <summary>Selects the methods for the supplied type.</summary>
         /// <param name="type">The type.</param>
         /// <returns>Methods for <paramref name="type"/>.</returns>
@@ -18,7 +20,7 @@ namespace AutoFixture.AutoNSubstitute
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            if (type.GetTypeInfo().IsInterface)
+            if (type.GetTypeInfo().IsInterface || DelegateSpecification.IsSatisfiedBy(type))
                 return new[] { SubstituteMethod.Create(type) };
 
             return from ci in type.GetPublicAndProtectedConstructors()

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace AutoFixture.AutoNSubstitute.UnitTest
 {
+    [Obsolete]
     public class AutoConfiguredFixtureIntegrationTest
     {
         [Fact]

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredNSubstituteCustomizationTest.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace AutoFixture.AutoNSubstitute.UnitTest
 {
+    [Obsolete]
     public class AutoConfiguredNSubstituteCustomizationTest
     {
         [Fact]

--- a/Src/AutoNSubstituteUnitTest/AutoNSubstituteCustomizationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoNSubstituteCustomizationTest.cs
@@ -29,6 +29,16 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             Assert.False(sut.ConfigureMembers);
         }
 
+        [Fact]
+        public void GenerateDelegatesIsDisabledByDefault()
+        {
+            // Arrange
+            // Act
+            var sut = new AutoNSubstituteCustomization();
+            // Assert
+            Assert.False(sut.GenerateDelegates);
+        }
+
         [Fact, Obsolete]
         public void InitializeWithNullBuilderThrows()
         {
@@ -180,6 +190,31 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             var compositeCommand = Assert.IsAssignableFrom<CompositeSpecimenCommand>(postprocessor.Command);
             Assert.True(compositeCommand.Commands.OfType<NSubstituteRegisterCallHandlerCommand>().Any());
             Assert.True(compositeCommand.Commands.OfType<NSubstituteSealedPropertiesCommand>().Any());
+        }
+
+        [Fact]
+        public void WithGenerateDelegates_CustomizeAddsRelayForDelegates()
+        {
+            // Arrange
+            var fixtureStub = new FixtureStub();
+            var sut = new AutoNSubstituteCustomization { GenerateDelegates = true };
+            // Act
+            sut.Customize(fixtureStub);
+            // Assert
+            var substituteRelay = fixtureStub.Customizations.OfType<SubstituteRelay>().Single();
+            Assert.IsType<DelegateSpecification>(substituteRelay.Specification);
+        }
+
+        [Fact]
+        public void WithoutGenerateDelegates_ShouldNotAddRelayForDelegates()
+        {
+            // Arrange
+            var fixtureStub = new FixtureStub();
+            var sut = new AutoNSubstituteCustomization { GenerateDelegates = false };
+            // Act
+            sut.Customize(fixtureStub);
+            // Assert
+            Assert.DoesNotContain(fixtureStub.Customizations, c => c is SubstituteRelay);
         }
     }
 }

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallHelper.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/CallHelper.cs
@@ -26,21 +26,28 @@ namespace AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
             call.GetReturnType().Returns(methodInfo.ReturnType);
             call.GetArguments().Returns(args.ToArray());
             call.GetOriginalArguments().Returns(args.ToArray());
+            call.Target().Returns(ResolveCallTarget(methodExpression.Object));
 
             return call;
         }
 
         public static ICall CreatePropertyGetterCallMock<T>(Expression<Func<T>> getProp)
         {
-            var propertyInfo = (PropertyInfo) ((MemberExpression) getProp.Body).Member;
+            var propertyExpression = (MemberExpression)getProp.Body;
+            var propertyInfo = (PropertyInfo)propertyExpression.Member;
 
             var call = Substitute.For<ICall>();
             call.GetMethodInfo().Returns(propertyInfo.GetMethod);
             call.GetReturnType().Returns(propertyInfo.PropertyType);
             call.GetArguments().Returns(new object[0]);
             call.GetOriginalArguments().Returns(new object[0]);
-
+            call.Target().Returns(ResolveCallTarget(propertyExpression.Expression));
             return call;
+        }
+
+        private static object ResolveCallTarget(Expression targetExpression)
+        {
+            return ((ConstantExpression)((MemberExpression)targetExpression).Expression).Value;
         }
     }
 }

--- a/Src/AutoNSubstituteUnitTest/FixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/FixtureIntegrationTest.cs
@@ -2,8 +2,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture.AutoNSubstitute.UnitTest.TestTypes;
 using AutoFixture.Kernel;
 using NSubstitute;
+using NSubstitute.ClearExtensions;
 using TestTypeFoundation;
 using Xunit;
 
@@ -128,6 +132,1000 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             var result = context.Resolve(new SeededRequest(collectionInterface, null));
             // Assert
             Assert.NotEmpty((IEnumerable)result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ParameterlessMethodsReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithParameterlessMethod>();
+            // Assert
+            Assert.Same(frozenString, result.Method());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_PropertiesReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithProperty>();
+            // Assert
+            Assert.Same(frozenString, result.Property);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_IndexersReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenInt = fixture.Freeze<int>();
+            // Act
+            var result = fixture.Create<IInterfaceWithIndexer>();
+            // Assert
+            Assert.Equal(frozenInt, result[2]);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VirtualMembersReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<TypeWithVirtualMembers>();
+            // Assert
+            Assert.Equal(frozenString, result.VirtualMethod());
+            Assert.Equal(frozenString, result.VirtualProperty);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_MethodsWithParametersReturnValuesFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<IInterfaceWithMethod>();
+            // Assert
+            Assert.Equal(frozenString, result.Method("hi"));
+        }
+
+        [Fact]
+        public void WithConfigureMembers_MethodsWithOutParametersReturnValuesFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenInt = fixture.Freeze<int>();
+            // Act
+            var result = fixture.Create<IInterfaceWithOutMethod>();
+            // Assert
+            result.Method(out var outResult);
+            Assert.Equal(frozenInt, outResult);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SealedSettablePropertiesAreSetUsingFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<TypeWithSealedMembers>();
+            // Assert
+            Assert.Equal(frozenString, result.ExplicitlySealedProperty);
+            Assert.Equal(frozenString, result.ImplicitlySealedProperty);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_FieldsAreSetUsingFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var result = fixture.Create<TypeWithPublicField>();
+            // Assert
+            Assert.Equal(frozenString, result.Field);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SealedMethodsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            var result = fixture.Create<TypeWithSealedMembers>();
+
+            Assert.NotEqual(frozenString, result.ImplicitlySealedMethod());
+            Assert.NotEqual(frozenString, result.ExplicitlySealedMethod());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_RefMethodsReturnValuesFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            var result = fixture.Create<IInterfaceWithRefMethod>();
+
+            string refResult = "";
+            string returnValue = result.Method(ref refResult);
+
+            Assert.Equal(frozenString, refResult);
+            Assert.Equal(frozenString, returnValue);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_GenericMethodsReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act
+            var obj = fixture.Create<IInterfaceWithGenericMethod>();
+            var result = obj.GenericMethod<string>();
+
+            // Assert
+            Assert.Equal(frozenString, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_StaticMethodsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithStaticMethod>()));
+            Assert.NotEqual(frozenString, TypeWithStaticMethod.StaticMethod());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_StaticPropertiesAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithStaticProperty>()));
+            Assert.NotEqual(frozenString, TypeWithStaticProperty.Property);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_PrivateFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            var result = fixture.Create<TypeWithPrivateField>();
+
+            Assert.NotEqual(frozenString, result.GetPrivateField());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ReadonlyFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            var result = fixture.Create<TypeWithReadonlyField>();
+
+            Assert.NotEqual(frozenString, result.ReadonlyField);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_LiteralFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithConstField>()));
+            Assert.NotEqual(frozenString, TypeWithConstField.ConstField);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_StaticFieldsAreIgnored()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<TypeWithStaticField>()));
+            Assert.NotEqual(frozenString, TypeWithStaticField.StaticField);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_CircularDependenciesAreAllowed()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            // Act & Assert
+            Assert.Null(Record.Exception(() => fixture.Create<IInterfaceWithCircularDependency>()));
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SubsequentCallsWithSameParameterReturnSameValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            var anonymousString = fixture.Create<string>();
+
+            // Act
+            var result1 = substitute.Method(anonymousString);
+            var result2 = substitute.Method(anonymousString);
+
+            // Assert
+            Assert.Equal(result1, result2);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SubsequentCallsWithoutParametersReturnSameValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            var anonymousString1 = fixture.Create<string>();
+            var anonymousString2 = fixture.Create<string>();
+
+            // Act
+            var result1 = substitute.Method(anonymousString1);
+            var result2 = substitute.Method(anonymousString2);
+
+            // Assert
+            Assert.NotEqual(result1, result2);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SetupCallsReturnValueFromSubstituteSetup()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            var anonymousString = fixture.Create<string>();
+            var expected = fixture.Create<string>();
+
+            substitute.Method(anonymousString).Returns(expected);
+
+            // Act
+            var result = substitute.Method(anonymousString);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SetupCallsOverrideValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            var anonymousString = fixture.Create<string>();
+            var result1 = substitute.Method(anonymousString);
+            var expected = fixture.Create<string>();
+
+            substitute.Method(anonymousString).Returns(expected);
+
+            // Act
+            var result2 = substitute.Method(anonymousString);
+
+            // Assert
+            Assert.NotEqual(result1, result2);
+            Assert.Equal(expected, result2);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SetupCallsReturningAbstractTypesAreOverridable()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithCircularDependency>();
+            var expected = fixture.Create<IInterfaceWithCircularDependency>();
+
+            substitute.Component.Returns(expected);
+
+            // Act
+            var result = substitute.Component;
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VoidMethodsWithOutParameterIsFilled()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenInt = fixture.Freeze<int>();
+            var substitute = fixture.Create<IInterfaceWithOutVoidMethod>();
+
+            // Act
+            substitute.Method(out var result);
+
+            // Assert
+            Assert.Equal(frozenInt, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VoidMethodsWithRefParameterIsFilled()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenInt = fixture.Freeze<int>();
+            var substitute = fixture.Create<IInterfaceWithRefVoidMethod>();
+
+            // Act
+            int result = 0;
+            substitute.Method(ref result);
+
+            // Assert
+            Assert.Equal(frozenInt, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VoidOutMethodsReturnValuesSetup()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithOutVoidMethod>();
+            var expected = fixture.Create<int>();
+            int result;
+
+            substitute
+                .When(x => x.Method(out result))
+                .Do(x => x[0] = expected);
+
+            // Act
+            substitute.Method(out result);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VoidRefMethodsReturnValuesSetup()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var subsitute = fixture.Create<IInterfaceWithRefVoidMethod>();
+            var expected = fixture.Create<int>();
+
+            int origIntValue = -42;
+            subsitute.When(x => x.Method(ref origIntValue)).Do(x => x[0] = expected);
+
+            // Act
+            int result = -42;
+            subsitute.Method(ref result);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ChainedSubstitutesAreVerifyable()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithCircularMethod>();
+            var anonymousObject = new object();
+
+            var anotherSubstitute = substitute.Method(anonymousObject);
+            var anotherAnonymousObject = new object();
+
+            // Act
+            anotherSubstitute.Method(anotherAnonymousObject);
+
+            // Assert
+            anotherSubstitute.Received().Method(anotherAnonymousObject);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ChainedSubstitutesReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenObject = fixture.Freeze<object>();
+            var substitute = fixture.Create<IInterfaceWithCircularMethod>();
+
+            var anonymousObject = new object();
+            IInterfaceWithCircularMethod anotherSubstitute = substitute.Method(anonymousObject);
+
+            // Act
+            var result = anotherSubstitute.AnotherMethod(new object());
+
+            // Assert
+            Assert.Equal(frozenObject, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SubstitutesCreatedFromNSubstituteDoNotReturnValueFromFixture()
+        {
+            // Arrange
+            var substitute = Substitute.For<IInterfaceWithMethod>();
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+
+            // Act
+            var result = substitute.Method(frozenString);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SubstitutesCountReceivedCallsCorrectly()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            var anonymousString1 = fixture.Create<string>();
+            var anonymousString2 = fixture.Create<string>();
+
+            // Act
+            substitute.Method(anonymousString1);
+            substitute.Method(anonymousString2);
+
+            // Assert
+            substitute.Received(1).Method(anonymousString1);
+            substitute.Received(1).Method(anonymousString2);
+            substitute.Received(2).Method(Arg.Any<string>());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_MethodsFromBaseInterfacesReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            var substitute = fixture.Create<IDerivedInterface>();
+            // Act
+            var result = substitute.Method();
+            // Assert
+            Assert.Same(frozenString, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_InterfaceNewMethodsReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithNewMethod>();
+            // Act
+            var result = substitute.Method(0);
+            // Assert
+            Assert.Same(frozenString, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_InterfaceShadowedMethodsReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithNewMethod>();
+            // Act
+            var shadowedInterface = (IInterfaceWithShadowedMethod)substitute;
+            var result = shadowedInterface.Method(0);
+            // Assert
+            Assert.Same(frozenString, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_InterfacesImplementingIEnumerableReturnFiniteSequence()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            fixture.Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var repeatCount = fixture.Create<int>();
+            fixture.RepeatCount = repeatCount;
+
+            var sut = fixture.Create<IDerivedFromEnumerableInterface<string>>();
+
+            // Act
+            var result = sut.Take(repeatCount + 1).Count();
+
+            // Assert
+            Assert.Equal(repeatCount, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_PropertiesOmittingSpecimenReturnsCorrectResult()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            fixture.Customizations.Add(
+                new Omitter(new PropertySpecification(typeof(string), nameof(IInterfaceWithProperty.Property))));
+            var sut = fixture.Create<IInterfaceWithProperty>();
+
+            // Act
+            var result = sut.Property;
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_MethodsOmittingSpecimenReturnsCorrectResult()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var anonymousString = fixture.Create<string>();
+            fixture.Customizations.Add(new Omitter(new ExactTypeSpecification(typeof(string))));
+            var sut = fixture.Create<IInterfaceWithMethod>();
+
+            // Act
+            var result = sut.Method(anonymousString);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_RefMethodsOmittingSpecimenReturnsCorrectResult()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var frozenString = fixture.Freeze<string>();
+            var intValue = fixture.Create<int>();
+            fixture.Customizations.Add(new Omitter(new ExactTypeSpecification(typeof(int))));
+
+            var sut = fixture.Create<IInterfaceWithRefIntMethod>();
+
+            // Act
+            var refResult = intValue;
+            var result = sut.Method(ref refResult);
+
+            // Assert
+            Assert.Equal(frozenString, result);
+            Assert.Equal(intValue, refResult);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_OutMethodsOmittingSpecimenReturnsCorrectResult()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var intValue = fixture.Create<int>();
+            fixture.Customizations.Add(new Omitter(new ExactTypeSpecification(typeof(int))));
+            var sut = fixture.Create<IInterfaceWithOutMethod>();
+
+            // Act
+            int refResult = intValue;
+            sut.Method(out refResult);
+
+            // Assert
+            Assert.Equal(intValue, refResult);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SetupCallsOverrideValueFromFixtureWithAnyArgumentMatcher()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            var anonymousString = fixture.Create<string>();
+            var expected = fixture.Create<string>();
+
+            substitute.Method(Arg.Any<string>()).Returns(expected);
+
+            // Act
+            var result = substitute.Method(anonymousString);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_SetupCallsOverrideValueFromFixtureWithIsArgumentMatcher()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            var anonymousString = fixture.Create<string>();
+            var expected = fixture.Create<string>();
+
+            substitute.Method(Arg.Is<string>(_ => true)).Returns(expected);
+
+            // Act
+            var result = substitute.Method(anonymousString);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_InterfaceImplementingAnotherReturnsValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var expected = fixture.Freeze<int>();
+            var sut = fixture.Create<IDerivedInterfaceWithOwnMethod>();
+
+            // Act
+            var result = sut.IntMethod();
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_GenericMethodsWithRefReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var expectedInt = fixture.Freeze<int>();
+            var expectedStr = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericRefMethod>();
+
+            // Act
+            string refValue = "dummy";
+            int retValue = substitute.GenericMethod<string>(ref refValue);
+
+            // Assert
+            Assert.Equal(expectedInt, retValue);
+            Assert.Equal(expectedStr, refValue);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_GenericMethodsWithOutReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var expectedInt = fixture.Freeze<int>();
+            var expectedStr = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericOutMethod>();
+
+            // Act
+            string outValue;
+            int retValue = substitute.GenericMethod<string>(out outValue);
+
+            // Assert
+            Assert.Equal(expectedInt, retValue);
+            Assert.Equal(expectedStr, outValue);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VoidGenericMethodsWithRefReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var expected = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericRefVoidMethod>();
+
+            // Act
+            string refValue = "dummy";
+            substitute.GenericMethod<string>(ref refValue);
+
+            // Assert
+            Assert.Equal(expected, refValue);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_VoidGenericMethodsWithOutReturnValueFromFixture()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var expected = fixture.Freeze<string>();
+            var substitute = fixture.Create<IInterfaceWithGenericOutVoidMethod>();
+
+            // Act
+            string outValue;
+            substitute.GenericMethod<string>(out outValue);
+
+            // Assert
+            Assert.Equal(expected, outValue);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ReturnValueIsSameForSameArgumentForGenerics()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithGenericParameterMethod>();
+
+            var inputValue = 42;
+
+            // Act
+            var result1 = substitute.GenericMethod<int>(inputValue);
+            var result2 = substitute.GenericMethod<int>(inputValue);
+
+            // Assert
+            Assert.Equal(result1, result2);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ReturnValueIsDifferentForDifferentArgumentForGenerics()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithGenericParameterMethod>();
+
+            // Act
+            var result1 = substitute.GenericMethod<int>(42);
+            var result2 = substitute.GenericMethod<int>(24);
+
+            // Assert
+            Assert.NotEqual(result1, result2);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_ResultIsDifferentForDifferentGenericInstantiations()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithGenericMethod>();
+
+            // Act
+            var intResult = substitute.GenericMethod<int>();
+            var longResult = substitute.GenericMethod<long>();
+
+            // Assert
+            Assert.NotEqual(intResult, longResult);
+        }
+
+        [Fact]
+        public void WithConfigureMembers_CachedResultIsMatchedByOtherInterfaceSubstituteForGenerics()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithGenericParameterMethod>();
+            var arg = fixture.Create<IInterfaceWithMethod>();
+
+            // Act
+            int result1 = substitute.GenericMethod<IInterfaceWithMethod>(arg);
+            int result2 = substitute.GenericMethod<IInterfaceWithMethod>(arg);
+
+            // Assert
+            Assert.Equal(result1, result2);
+        }
+
+        /// <summary>
+        /// Subsitute clear is used to reset manually configured user returns.
+        /// The values configured by AutoFixture are not being manually-configured.
+        ///
+        /// If user needs that, it could easily override the auto-generated value using the
+        /// substitute.Method(...).Returns(...);
+        /// </summary>
+        [Theory]
+        [InlineData(ClearOptions.CallActions)]
+        [InlineData(ClearOptions.ReceivedCalls)]
+        [InlineData(ClearOptions.ReturnValues)]
+        [InlineData(ClearOptions.All)]
+        public void WithConfigureMembers_ShouldNotResetCachedValuesOnSubsituteClear(ClearOptions options)
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethod>();
+            string arg = "argValue";
+
+            // Act
+            var resultBefore = substitute.Method(arg);
+            substitute.ClearSubstitute(options);
+            var resultAfter = substitute.Method(arg);
+
+            // Assert
+            Assert.Equal(resultBefore, resultAfter);
+        }
+
+        /// <summary>
+        /// Current implementation of NSubsitute doesn't call custom handlers for the Received.InOrder() scope (which
+        /// we use for our integration with NSubstitute). That shouldn't cause any usability issues for users.
+        ///
+        /// Asserting that behavior via test to get a notification when that behavior changes, so we can make a decision
+        /// whether we need to alter something in AF or not to respect that change.
+        /// </summary>
+        [Fact]
+        public void WithConfigureMembers_IsNotExpectedToReturnValueInReceivedInOrderBlock()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethodReturningOtherInterface>();
+
+            var actualResult = substitute.Method();
+
+            // Act
+            IInterfaceWithMethod capturedResult = null;
+            Received.InOrder(() => { capturedResult = substitute.Method(); });
+
+            // Assert
+            Assert.NotEqual(actualResult, capturedResult);
+        }
+
+        private class Issue630_TryingAlwaysSatisfyInlineTaskScheduler : TaskScheduler
+        {
+            private const int DELAY_MSEC = 100;
+            private readonly object syncRoot = new object();
+            private HashSet<Task> Tasks { get; } = new HashSet<Task>();
+
+            protected override void QueueTask(Task task)
+            {
+                lock (this.syncRoot)
+                {
+                    this.Tasks.Add(task);
+                }
+
+                ThreadPool.QueueUserWorkItem(delegate
+                {
+                    Thread.Sleep(DELAY_MSEC);
+
+                    // If task cannot be dequeued - it was already executed.
+                    if (this.TryDequeue(task))
+                    {
+                        this.TryExecuteTask(task);
+                    }
+                });
+            }
+
+            protected override bool TryDequeue(Task task)
+            {
+                lock (this.syncRoot)
+                {
+                    return this.Tasks.Remove(task);
+                }
+            }
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+            {
+                // If was queued, try to remove from queue before inlining. Ignore otherwise - it's already executed.
+                if (taskWasPreviouslyQueued && !this.TryDequeue(task))
+                {
+                    return false;
+                }
+
+                this.TryExecuteTask(task);
+                return true;
+            }
+
+            protected override IEnumerable<Task> GetScheduledTasks()
+            {
+                lock (this.syncRoot)
+                {
+                    // Create copy to ensure that it's not modified during enumeration
+                    return this.Tasks.ToArray();
+                }
+            }
+        }
+
+        [Fact]
+        public void Issue630_DontFailIfAllTasksAreInlinedInInlinePhase()
+        {
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var interfaceSource = fixture.Create<IInterfaceWithMethodReturningOtherInterface>();
+
+            var scheduler = new Issue630_TryingAlwaysSatisfyInlineTaskScheduler();
+
+            /*
+             * Simulate situation when tasks are always inlined on current thread.
+             * To do that we implement our custom scheduler which put some delay before running task.
+             * That gives a chance for task to be inlined.
+             *
+             * Schedulers are propagated to the nested tasks, so we are resolving IInterfaceWithMethod inside the task.
+             * All the tasks created during that resolve will be inlined, if that is possible.
+             */
+            var task = new Task<IInterfaceWithMethod>(() => interfaceSource.Method());
+            task.Start(scheduler);
+
+            var instance = task.Result;
+
+            //This test should not fail. Assertion is dummy and to specify that we use instance.
+            Assert.NotNull(instance);
+        }
+
+        private class InlineOnQueueTaskScheduler : TaskScheduler
+        {
+            protected override void QueueTask(Task task)
+            {
+                this.TryExecuteTask(task);
+            }
+
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+            {
+                throw new NotSupportedException("This method should be never reached.");
+            }
+
+            protected override IEnumerable<Task> GetScheduledTasks() => Enumerable.Empty<Task>();
+        }
+
+        [Fact]
+        public void WithConfigureMembers_DontFailIfAllTasksInlinedOnQueueByCurrentScheduler()
+        {
+            var task = new Task(() =>
+            {
+                //arrange
+                var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+                var interfaceSource = fixture.Create<IInterfaceWithMethodReturningOtherInterface>();
+
+                //act & assert not throw
+                var result = interfaceSource.Method();
+            });
+            task.Start(new InlineOnQueueTaskScheduler());
+
+            task.Wait();
+        }
+
+        [Fact]
+        public void Issue653_ResolvesPropertyValueViaPropertyRequest()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var subsitute = fixture.Create<IInterfaceWithProperty>();
+
+            var expected = fixture.Create<string>();
+            fixture.Customizations.Insert(0,
+                new FilteringSpecimenBuilder(
+                    new FixedBuilder(expected),
+                    new PropertySpecification(typeof(string), nameof(IInterfaceWithProperty.Property))
+                ));
+
+            // Act
+            var result = subsitute.Property;
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Issue707_CanConfigureOutMethodParameters()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithParameterAndOutMethod>();
+
+            var parameter = fixture.Create<string>();
+            var result = fixture.Create<int>();
+
+            // Act
+            substitute.Method(parameter, out int dummy).Returns(c =>
+            {
+                c[1] = result;
+                return true;
+            });
+
+            int actualResult;
+            substitute.Method(parameter, out actualResult);
+
+            // Assert
+            Assert.Equal(result, actualResult);
+        }
+
+        [Theory]
+        [InlineData(32), InlineData(64), InlineData(128), InlineData(256)]
+        public async Task Issue592_ShouldNotFailForConcurrency(int degreeOfParallelism)
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+            var substitute = fixture.Create<IInterfaceWithMethodReturningOtherInterface>();
+
+            var start = new SemaphoreSlim(0, degreeOfParallelism);
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            var tasks = Enumerable
+                .Repeat(0, degreeOfParallelism)
+                .Select(_ => Task.Run(() =>
+                    {
+                        start.Wait(cts.Token);
+                        substitute.Method();
+                    },
+                    cts.Token));
+
+
+            // Act
+            start.Release(degreeOfParallelism);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            // Assert
+            substitute.Received(degreeOfParallelism).Method();
         }
     }
 }

--- a/Src/AutoNSubstituteUnitTest/FixtureStub.cs
+++ b/Src/AutoNSubstituteUnitTest/FixtureStub.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using AutoFixture.Dsl;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.AutoNSubstitute.UnitTest
+{
+    public class FixtureStub : IFixture
+    {
+        public IList<ISpecimenBuilderTransformation> Behaviors { get; } = new List<ISpecimenBuilderTransformation>();
+        public IList<ISpecimenBuilder> Customizations { get; } = new List<ISpecimenBuilder>();
+        public bool OmitAutoProperties { get; set; }
+        public int RepeatCount { get; set; }
+        public IList<ISpecimenBuilder> ResidueCollectors { get; } = new List<ISpecimenBuilder>();
+
+        object ISpecimenBuilder.Create(object request, ISpecimenContext context) =>
+            throw new NotSupportedException();
+
+        ICustomizationComposer<T> IFixture.Build<T>() =>
+            throw new NotSupportedException();
+
+        IFixture IFixture.Customize(ICustomization customization) =>
+            throw new NotSupportedException();
+
+        void IFixture.Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation) =>
+            throw new NotSupportedException();
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/NSubstituteMethodQueryTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteMethodQueryTest.cs
@@ -80,7 +80,31 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             var result = sut.SelectMethods(type);
             // Assert
-            Assert.Empty(result.First().Parameters);
+            Assert.Empty(result.Single().Parameters);
+        }
+
+        [Fact]
+        public void SelectMethodReturnsMethodForDelegate()
+        {
+            // Arrange
+            var type = typeof(Action);
+            var sut = new NSubstituteMethodQuery();
+            // Act
+            var result = sut.SelectMethods(type);
+            // Assert
+            Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        public void SelectMethodReturnsMethodWithoutParametersForDelegate()
+        {
+            // Arrange
+            var type = typeof(Func<int>);
+            var sut = new NSubstituteMethodQuery();
+            // Act
+            var result = sut.SelectMethods(type);
+            // Assert
+            Assert.Empty(result.Single().Parameters);
         }
 
         [Fact]

--- a/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
@@ -15,8 +15,30 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
         {
             // Arrange
             // Act
+            var sut = new SubstituteRelay();
             // Assert
-            Assert.True(typeof(ISpecimenBuilder).IsAssignableFrom(typeof(SubstituteRelay)));
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void DefaultSpecificationShouldBeValid()
+        {
+            // Arrange
+            // Act
+            var sut = new SubstituteRelay();
+            // Assert
+            Assert.IsType<AbstractTypeSpecification>(sut.Specification);
+        }
+
+        [Fact]
+        public void CustomSpecificationIsPreserved()
+        {
+            // Arrange
+            var specification = new TrueRequestSpecification();
+            // Act
+            var sut = new SubstituteRelay(specification);
+            // Assert
+            Assert.Same(specification, sut.Specification);
         }
 
         [Fact]
@@ -91,6 +113,21 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             Assert.Contains(request.FullName, e.Message);
             Assert.Contains(typeof(SubstituteRequestHandler).FullName, e.Message); 
             Assert.IsType<NotASubstituteException>(e.InnerException);
+        }
+
+        [Fact]
+        public void ShouldNotRelayRequestIfSpecificationDoesNotMatch()
+        {
+            // Arrange
+            var falseSpecification = new FalseRequestSpecification();
+            var sut = new SubstituteRelay(falseSpecification);
+            var request = typeof(IInterface);
+            var context = Substitute.For<ISpecimenContext>();
+
+            // Act
+            var result = sut.Create(request, context);
+            // Assert
+            Assert.IsType<NoSpecimen>(result);
         }
     }
 }


### PR DESCRIPTION
Perform the similar refactoring to AutoMoq and enable delegate generation support for the NSubstitute. I've obsoleted the `AutoConfiguredNSubsituteCustomization` in favor of `AutoNSubstituteCustomization`. Also enabled the delegate generation via NSubsitute (`GenerateDelegates` option).

@moodmosaic Please take a look 😉 I'll publish a new version of AutoFixture after this PR is merged.