### PR TITLE
Added StringBehaviorExpectation and tests

### DIFF
--- a/Src/Idioms/ArgumentNullOrEmptyException.cs
+++ b/Src/Idioms/ArgumentNullOrEmptyException.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Represents an error about a null or empty string.
+    /// </summary>
+    [Serializable]
+    public class ArgumentNullOrEmptyException : ArgumentException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class.
+        /// </summary>
+        /// <param name="name">
+        /// The parameter passed in to the exception.
+        /// </param>
+        public ArgumentNullOrEmptyException(string name)
+            : base("Value should not be null or empty.", name)
+        {
+
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class.
+        /// </summary>
+        public ArgumentNullOrEmptyException()
+            : base("An invariant was not correctly protected. Are you missing a Guard Clause?")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class.
+        /// </summary>
+        /// <param name="message">
+        /// The error message that explains the reason for the exception.
+        /// </param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception.
+        /// </param>
+        public ArgumentNullOrEmptyException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentNullOrEmptyException"/> class.
+        /// </summary>
+        /// <param name="serializationInfo">
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="streamingContext">
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
+        /// Contextual information about the source or destination.
+        /// </param>
+        protected ArgumentNullOrEmptyException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+            : base(serializationInfo, streamingContext)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -40,10 +40,10 @@ namespace AutoFixture.Idioms
             }
             catch (Exception e)
             {
-                throw command.CreateException("\"string.Empty\"", e);
+                throw command.CreateException("<empty string>", e);
             }
 
-            throw command.CreateException("\"string.Empty\"");
+            throw command.CreateException("<empty string>");
         }
     }
 }

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -34,7 +34,7 @@ namespace AutoFixture.Idioms
             {
                 command.Execute(string.Empty);
             }
-            catch (ArgumentException e)
+            catch (ArgumentNullOrEmptyException e)
             {
                 if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
                     return;

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Encapsulates the expected behavior when an <see cref="IGuardClauseCommand" /> (typically
+    /// representing a method or constructor) is invoked with a <see cref="string.Empty" /> argument.
+    /// </summary>
+    /// <seealso cref="Verify(IGuardClauseCommand)" />
+    public class EmptyStringBehaviorExpectation : IBehaviorExpectation
+    {
+        /// <summary>
+        /// Verifies that the command behaves correct when invoked with an empty string argument.
+        /// </summary>
+        /// <param name="command">The command whose behavior must be examined.</param>
+        /// <remarks>
+        /// <para>
+        /// This method encapsulates the behavior which is expected when a method or constructor is
+        /// invoked with <see cref="string.Empty" /> as one of the method arguments. In that case it's
+        /// expected that invoking <paramref name="command" /> with string.Empty throws an
+        /// <see cref="ArgumentException" />, causing the Verify method to succeed. If other
+        /// exceptions are thrown, or no exception is thrown when invoking the command, the Verify
+        /// method throws an exception.
+        /// </para>
+        /// </remarks>
+        public void Verify(IGuardClauseCommand command)
+        {
+            if (command == null) throw new ArgumentNullException(nameof(command));
+
+            if (command.RequestedType != typeof(string))
+                return;
+
+            try
+            {
+                command.Execute(string.Empty);
+            }
+            catch (ArgumentException)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                throw command.CreateException("\"string.Empty\"", e);
+            }
+
+            throw command.CreateException("\"string.Empty\"");
+        }
+    }
+}

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -34,9 +34,11 @@ namespace AutoFixture.Idioms
             {
                 command.Execute(string.Empty);
             }
-            catch (ArgumentException)
+            catch (ArgumentException e)
             {
-                return;
+                if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
+                    return;
+                throw command.CreateException("<empty string>", e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -32,7 +32,8 @@ namespace AutoFixture.Idioms
         public GuardClauseAssertion(ISpecimenBuilder builder)
             : this(builder, new CompositeBehaviorExpectation(
                 new NullReferenceBehaviorExpectation(),
-                new EmptyGuidBehaviorExpectation()))
+                new EmptyGuidBehaviorExpectation(),
+                new EmptyStringBehaviorExpectation()))
         {
         }
 

--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -32,8 +32,7 @@ namespace AutoFixture.Idioms
         public GuardClauseAssertion(ISpecimenBuilder builder)
             : this(builder, new CompositeBehaviorExpectation(
                 new NullReferenceBehaviorExpectation(),
-                new EmptyGuidBehaviorExpectation(),
-                new EmptyStringBehaviorExpectation()))
+                new EmptyGuidBehaviorExpectation()))
         {
         }
 

--- a/Src/IdiomsUnitTest/ArgumentNullOrEmptyExceptionTest.cs
+++ b/Src/IdiomsUnitTest/ArgumentNullOrEmptyExceptionTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using AutoFixture.Idioms;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class ArgumentNullOrEmptyExceptionTest
+    {
+        [Fact]
+        public void SutIsArgumentException()
+        {
+            //Arrange
+            string paramName;
+
+            //Act
+            var sut = new ArgumentNullOrEmptyException(nameof(paramName));
+
+            //Assert
+            Assert.IsAssignableFrom<ArgumentException>(sut);
+        }
+
+        [Fact]
+        public void MessageIsNotNull()
+        {
+            //Arrange
+            string paramName;
+
+            //Act
+            var sut = new ArgumentNullOrEmptyException(nameof(paramName));
+            var result = sut.Message;
+
+            //Assert
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void MessageIsCorrect()
+        {
+            //Arrange
+            string parmName;
+            var expectedMessage = "Value should not be null or empty." + Environment.NewLine + "Parameter name: " + nameof(parmName);
+
+            //Act
+            var sut = new ArgumentNullOrEmptyException(nameof(parmName));
+
+            //Assert
+            Assert.Equal(expectedMessage, sut.Message);
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
@@ -129,5 +129,20 @@ namespace AutoFixture.IdiomsUnitTest
                 sut.Verify(cmd));
             Assert.Equal(expected, result);
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("invalidParamName")]
+        public void VerifyThrowsWhenCommandThrowsArgumentNullExceptionWithInvalidParamName(string invalidParamName)
+        {
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => { throw new ArgumentException("Invalid parameter", invalidParamName); },
+                RequestedType = typeof(string)
+            };
+            var sut = new EmptyStringBehaviorExpectation();
+            Assert.Throws<Exception>(() =>
+                sut.Verify(cmd));
+        }
     }
 }

--- a/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using AutoFixture.Idioms;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EmptyStringBehaviorExpectationTest
+    {
+        [Fact]
+        public void SutIsBehaviorExpectation()
+        {
+            //Arrange
+            //Act
+            var sut = new EmptyStringBehaviorExpectation();
+
+            //Assert
+            Assert.IsAssignableFrom<IBehaviorExpectation>(sut);
+        }
+
+        [Fact]
+        public void VerifyNullCommandThrows()
+        {
+            // Arrange
+            var sut = new EmptyStringBehaviorExpectation();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify(null));
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(Guid))]
+        [InlineData(typeof(Version))]
+        [InlineData(typeof(int))]
+        public void VerifyDoesNothingWhenRequestedTypeIsNotString(Type type)
+        {
+            // Arrange
+            var executeInvoked = false;
+            var mockCommand = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => executeInvoked = true,
+                RequestedType = type
+            };
+
+            var sut = new EmptyStringBehaviorExpectation();
+
+            // Act
+            sut.Verify(mockCommand);
+
+            // Assert
+            Assert.False(executeInvoked);
+        }
+
+        [Fact]
+        public void VerifyCorrectlyInvokesExecuteWhenRequestedTypeIsString()
+        {
+            // Arrange
+            var mockVerified = false;
+            var mockCommand = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => mockVerified = string.Empty.Equals(v),
+                OnCreateException = v => new InvalidOperationException(),
+                RequestedType = typeof(string)
+            };
+
+            var sut = new EmptyStringBehaviorExpectation();
+
+            // Act
+            try
+            {
+                sut.Verify(mockCommand);
+            }
+            catch (InvalidOperationException) { }
+            // Assert
+            Assert.True(mockVerified);
+        }
+
+        [Fact]
+        public void VerifySuccedsWhenCommandThrowsCorrectException()
+        {
+            // Arrange
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => { throw new ArgumentException(); },
+                RequestedType = typeof(string)
+            };
+
+            var sut = new EmptyStringBehaviorExpectation();
+
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(cmd)));
+        }
+
+        [Fact]
+        public void VerifyThrowsWhenCommandThrowsUnexpectedException()
+        {
+            // Arrange
+            var expectedInner = new Exception();
+            var expected = new Exception();
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => { throw expectedInner; },
+                OnCreateExceptionWithInner = (v, e) => v == "\"string.Empty\"" && expectedInner.Equals(e) ? expected : new Exception(),
+                RequestedType = typeof(string)
+            };
+            var sut = new EmptyStringBehaviorExpectation();
+
+            // Act & Assert
+            var result = Assert.Throws<Exception>(() =>
+                sut.Verify(cmd));
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void VerifyThrowsWhenCommandDoesNotThrow()
+        {
+            // Arrange
+            var expected = new Exception();
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnCreateException = v => v == "\"string.Empty\"" ? expected : new Exception(),
+                RequestedType = typeof(string)
+            };
+            var sut = new EmptyStringBehaviorExpectation();
+
+            // Act & Assert
+            var result = Assert.Throws<Exception>(() =>
+                sut.Verify(cmd));
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
@@ -56,24 +56,23 @@ namespace AutoFixture.IdiomsUnitTest
         public void VerifyCorrectlyInvokesExecuteWhenRequestedTypeIsString()
         {
             // Arrange
-            var mockVerified = false;
+            var capturedValue = false;
+            var createdException = new Exception();
             var mockCommand = new DelegatingGuardClauseCommand
             {
-                OnExecute = v => mockVerified = string.Empty.Equals(v),
-                OnCreateException = v => new InvalidOperationException(),
+                OnExecute = v => capturedValue = string.Empty.Equals(v),
+                OnCreateException = v => createdException,
                 RequestedType = typeof(string)
             };
 
             var sut = new EmptyStringBehaviorExpectation();
 
-            // Act
-            try
-            {
-                sut.Verify(mockCommand);
-            }
-            catch (InvalidOperationException) { }
             // Assert
-            Assert.True(mockVerified);
+            var ex = Assert.Throws<Exception>(() => 
+                sut.Verify(mockCommand));
+
+            Assert.Same(createdException, ex);
+            Assert.True(capturedValue);
         }
 
         [Fact]
@@ -102,7 +101,7 @@ namespace AutoFixture.IdiomsUnitTest
             var cmd = new DelegatingGuardClauseCommand
             {
                 OnExecute = v => { throw expectedInner; },
-                OnCreateExceptionWithInner = (v, e) => v == "\"string.Empty\"" && expectedInner.Equals(e) ? expected : new Exception(),
+                OnCreateExceptionWithInner = (v, e) => v == "<empty string>" && expectedInner.Equals(e) ? expected : new Exception(),
                 RequestedType = typeof(string)
             };
             var sut = new EmptyStringBehaviorExpectation();
@@ -120,7 +119,7 @@ namespace AutoFixture.IdiomsUnitTest
             var expected = new Exception();
             var cmd = new DelegatingGuardClauseCommand
             {
-                OnCreateException = v => v == "\"string.Empty\"" ? expected : new Exception(),
+                OnCreateException = v => v == "<empty string>" ? expected : new Exception(),
                 RequestedType = typeof(string)
             };
             var sut = new EmptyStringBehaviorExpectation();

--- a/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/EmptyStringBehaviorExpectationTest.cs
@@ -76,13 +76,14 @@ namespace AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
-        public void VerifySuccedsWhenCommandThrowsCorrectException()
+        public void VerifySucceedsWhenCommandThrowsCorrectException()
         {
             // Arrange
             var cmd = new DelegatingGuardClauseCommand
             {
-                OnExecute = v => { throw new ArgumentException(); },
-                RequestedType = typeof(string)
+                OnExecute = v => { throw new ArgumentNullOrEmptyException(string.Empty); },
+                RequestedType = typeof(string),
+                RequestedParameterName = string.Empty
             };
 
             var sut = new EmptyStringBehaviorExpectation();
@@ -137,7 +138,7 @@ namespace AutoFixture.IdiomsUnitTest
         {
             var cmd = new DelegatingGuardClauseCommand
             {
-                OnExecute = v => { throw new ArgumentException("Invalid parameter", invalidParamName); },
+                OnExecute = v => { throw new ArgumentNullOrEmptyException(invalidParamName); },
                 RequestedType = typeof(string)
             };
             var sut = new EmptyStringBehaviorExpectation();

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -1838,5 +1838,44 @@ namespace AutoFixture.IdiomsUnitTest
         {
             public abstract void Method(object arg);
         }
+
+        [Fact]
+        public void ClassWithEmptyStringGuardClauseDoesNotThrow()
+        {
+            // Arrange
+            var sut = new GuardClauseAssertion(new Fixture(), new EmptyStringBehaviorExpectation());
+            // Act
+            var exception = Record.Exception(() => sut.Verify(typeof(ClassWithEmptyStringGuard).GetConstructors()));
+            // Assert
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ClassWithoutEmptyStringGuardThrows()
+        {
+            // Arrange
+            var sut = new GuardClauseAssertion(new Fixture(), new EmptyStringBehaviorExpectation());
+            // Act
+            var exception = Record.Exception(() => sut.Verify(typeof(ClassWihoutEmptyStringGuard).GetConstructors()));
+            // Assert
+            Assert.NotNull(exception);
+            Assert.IsType<GuardClauseException>(exception);
+        }
+
+        private class ClassWithEmptyStringGuard
+        {
+            public ClassWithEmptyStringGuard(string param)
+            {
+                if (param == string.Empty)
+                    throw new ArgumentNullOrEmptyException(nameof(param));
+            }
+        }
+
+        private class ClassWihoutEmptyStringGuard
+        {
+            public ClassWihoutEmptyStringGuard(string param)
+            {
+            }
+        }
     }
 }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -75,6 +75,7 @@ namespace AutoFixture.IdiomsUnitTest
             var composite = Assert.IsAssignableFrom<CompositeBehaviorExpectation>(result);
             Assert.True(composite.BehaviorExpectations.OfType<NullReferenceBehaviorExpectation>().Any());
             Assert.True(composite.BehaviorExpectations.OfType<EmptyGuidBehaviorExpectation>().Any());
+            Assert.True(composite.BehaviorExpectations.OfType<EmptyStringBehaviorExpectation>().Any());
         }
 
         [Fact]
@@ -1725,6 +1726,11 @@ namespace AutoFixture.IdiomsUnitTest
                 if (argument1 == null)
                 {
                     throw new ArgumentNullException(nameof(argument1));
+                }
+
+                if (argument1 == string.Empty)
+                {
+                    throw new ArgumentException(nameof(argument1));
                 }
 
                 argument2 = null;

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -75,7 +75,6 @@ namespace AutoFixture.IdiomsUnitTest
             var composite = Assert.IsAssignableFrom<CompositeBehaviorExpectation>(result);
             Assert.True(composite.BehaviorExpectations.OfType<NullReferenceBehaviorExpectation>().Any());
             Assert.True(composite.BehaviorExpectations.OfType<EmptyGuidBehaviorExpectation>().Any());
-            Assert.True(composite.BehaviorExpectations.OfType<EmptyStringBehaviorExpectation>().Any());
         }
 
         [Fact]
@@ -1726,11 +1725,6 @@ namespace AutoFixture.IdiomsUnitTest
                 if (argument1 == null)
                 {
                     throw new ArgumentNullException(nameof(argument1));
-                }
-
-                if (argument1 == string.Empty)
-                {
-                    throw new ArgumentException(nameof(argument1));
                 }
 
                 argument2 = null;


### PR DESCRIPTION
This is my first ever open source PR, so please go easy on me...  This is my attempt to add the `EmptyStringBehaviorExpectation` portion of Issue #896.  It appeared to me that the new `EmptyStringBehaviorExpectation` class was very similar to the `EmptyGuidBehaviorExpectation`class, so it will look similar.  I added it to `GuardClauseAssertion` as well, uncertain if there was a set goal to make this truly optional.  I appreciate any feedback.