### PR TITLE
Skip inherited properties in MockVirtualMethodsCommand

### DIFF
--- a/Src/AutoMoq/Extensions/TypeExtensions.cs
+++ b/Src/AutoMoq/Extensions/TypeExtensions.cs
@@ -24,11 +24,11 @@ namespace AutoFixture.AutoMoq.Extensions
         /// </summary>
         /// <param name="type">An interface type.</param>
         /// <returns>A collection of all properties declared by the interface <paramref name="type"/> or any of its base interfaces.</returns>
-        internal static IEnumerable<PropertyInfo> GetInterfaceProperties(this Type type)
+        internal static IEnumerable<PropertyInfo> GetAllProperties(this Type type)
         {
             return type.GetProperties().Concat(
                 type.GetInterfaces()
                     .SelectMany(@interface => @interface.GetProperties()));
-        }
+        }        
     }
 }

--- a/Src/AutoMoq/Extensions/TypeExtensions.cs
+++ b/Src/AutoMoq/Extensions/TypeExtensions.cs
@@ -8,27 +8,31 @@ namespace AutoFixture.AutoMoq.Extensions
     internal static class TypeExtensions
     {
         /// <summary>
-        /// Gets a collection of all methods declared by the interface <paramref name="type"/> or any of its base interfaces.
+        /// Gets a collection of all methods declared by the type or any of its base interfaces.
         /// </summary>
-        /// <param name="type">An interface type.</param>
-        /// <returns>A collection of all methods declared by the interface <paramref name="type"/> or any of its base interfaces.</returns>
-        internal static IEnumerable<MethodInfo> GetInterfaceMethods(this Type type)
+        internal static IEnumerable<MethodInfo> GetAllMethods(this Type type)
         {
-            return type.GetMethods().Concat(
-                type.GetInterfaces()
-                    .SelectMany(@interface => @interface.GetMethods()));
+            IEnumerable<MethodInfo> result = type.GetMethods();
+            
+            // If "type" is an interface, "GetMethods" does not return methods declared on other interfaces extended by "type".
+            if (type.GetTypeInfo().IsInterface)
+                result = result.Concat(type.GetInterfaces().SelectMany(x => x.GetMethods()));
+
+            return result;
         }
 
         /// <summary>
-        /// Gets a collection of all properties declared by the interface <paramref name="type"/> or any of its base interfaces.
+        /// Gets a collection of all properties declared by the type or any of its base interfaces.
         /// </summary>
-        /// <param name="type">An interface type.</param>
-        /// <returns>A collection of all properties declared by the interface <paramref name="type"/> or any of its base interfaces.</returns>
         internal static IEnumerable<PropertyInfo> GetAllProperties(this Type type)
         {
-            return type.GetProperties().Concat(
-                type.GetInterfaces()
-                    .SelectMany(@interface => @interface.GetProperties()));
+            IEnumerable<PropertyInfo> result = type.GetProperties();
+            
+            // If "type" is an interface, "GetProperties" does not return methods declared on other interfaces extended by "type".
+            if (type.GetTypeInfo().IsInterface)
+                result = result.Concat(type.GetInterfaces().SelectMany(x => x.GetProperties()));
+
+            return result;
         }        
     }
 }

--- a/Src/AutoMoq/Extensions/TypeExtensions.cs
+++ b/Src/AutoMoq/Extensions/TypeExtensions.cs
@@ -18,5 +18,17 @@ namespace AutoFixture.AutoMoq.Extensions
                 type.GetInterfaces()
                     .SelectMany(@interface => @interface.GetMethods()));
         }
+
+        /// <summary>
+        /// Gets a collection of all properties declared by the interface <paramref name="type"/> or any of its base interfaces.
+        /// </summary>
+        /// <param name="type">An interface type.</param>
+        /// <returns>A collection of all properties declared by the interface <paramref name="type"/> or any of its base interfaces.</returns>
+        internal static IEnumerable<PropertyInfo> GetInterfaceProperties(this Type type)
+        {
+            return type.GetProperties().Concat(
+                type.GetInterfaces()
+                    .SelectMany(@interface => @interface.GetProperties()));
+        }
     }
 }

--- a/Src/AutoMoq/MockVirtualMethodsCommand.cs
+++ b/Src/AutoMoq/MockVirtualMethodsCommand.cs
@@ -126,29 +126,21 @@ namespace AutoFixture.AutoMoq
 
             // Skip properties that have both getters and setters to not interfere
             // with other post-processors in the chain that initialize them later.
-            methods = RemoveGetterSetterMethods(type, methods);
+            methods = SkipWritablePropertyGetters(type, methods);
 
             return methods.Where(CanBeConfigured);
         }
 
-        private static IEnumerable<MethodInfo> RemoveGetterSetterMethods(Type type, IEnumerable<MethodInfo> methods)
+        private static IEnumerable<MethodInfo> SkipWritablePropertyGetters(Type type, IEnumerable<MethodInfo> methods)
         {
-            var getterSetterMethods = GetProperties(type)
+            var getterSetterMethods = type.GetAllProperties()
                 .Where(p => p.GetGetMethod() != null &&
                             p.GetSetMethod() != null)
                 .Select(p => p.GetGetMethod());
             methods = methods.Except(getterSetterMethods);
             return methods;
         }
-
-        private static IEnumerable<PropertyInfo> GetProperties(Type type)
-        {
-            if (type.GetTypeInfo().IsInterface)
-                return type.GetInterfaceProperties();
-            
-            return type.GetProperties();
-        }
-
+        
         /// <summary>
         /// Determines whether a method can be mocked.
         /// </summary>

--- a/Src/AutoMoq/MockVirtualMethodsCommand.cs
+++ b/Src/AutoMoq/MockVirtualMethodsCommand.cs
@@ -112,17 +112,10 @@ namespace AutoFixture.AutoMoq
         /// <param name="type">The type being mocked and whose methods need to be configured.</param>
         private static IEnumerable<MethodInfo> GetConfigurableMethods(Type type)
         {
-            IEnumerable<MethodInfo> methods;
-           
-            if (DelegateSpecification.IsSatisfiedBy(type))
-                // If "type" is a delegate, return "Invoke" method only and skip the rest of the methods.
-                methods = new[] { type.GetTypeInfo().GetMethod("Invoke") };
-            else if (type.GetTypeInfo().IsInterface)
-                // If "type" is an interface, "GetMethods" does not return methods declared on other interfaces extended by "type".
-                // In these cases, we use the "GetInterfaceMethods" extension method instead.
-                methods = type.GetInterfaceMethods();
-            else
-                methods = type.GetMethods();
+            // If "type" is a delegate, return "Invoke" method only and skip the rest of the methods.
+            var methods = DelegateSpecification.IsSatisfiedBy(type)
+                ? new[] { type.GetTypeInfo().GetMethod("Invoke") }
+                : type.GetAllMethods();
 
             // Skip properties that have both getters and setters to not interfere
             // with other post-processors in the chain that initialize them later.
@@ -133,12 +126,12 @@ namespace AutoFixture.AutoMoq
 
         private static IEnumerable<MethodInfo> SkipWritablePropertyGetters(Type type, IEnumerable<MethodInfo> methods)
         {
-            var getterSetterMethods = type.GetAllProperties()
+            var getterMethods = type.GetAllProperties()
                 .Where(p => p.GetGetMethod() != null &&
                             p.GetSetMethod() != null)
                 .Select(p => p.GetGetMethod());
-            methods = methods.Except(getterSetterMethods);
-            return methods;
+            
+            return methods.Except(getterMethods);
         }
         
         /// <summary>

--- a/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoMoqCustomizationTest.cs
@@ -166,8 +166,22 @@ namespace AutoFixture.AutoMoq.UnitTest
             var frozenString = fixture.Freeze<string>();
             // Act
             var result = fixture.Create<IDerivedInterface>();
+            
             // Assert
             Assert.Same(frozenString, result.Method());
+        }
+
+        [Fact]
+        public void WithConfigureMembers_PropertiesFromBaseInterfacesIsSetupLikeRealProperty()
+        {
+            // Arrange
+            var fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            var expected = fixture.Create<string>();
+            // Act
+            var result = fixture.Create<IDerivedInterfaceOfDerivedInterfaceWithProperty>();
+            result.Property = expected;
+            // Assert
+            Assert.Same(expected, result.Property);
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoMoqCustomizationTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureIntegrationWithAutoMoqCustomizationTest.cs
@@ -166,7 +166,6 @@ namespace AutoFixture.AutoMoq.UnitTest
             var frozenString = fixture.Freeze<string>();
             // Act
             var result = fixture.Create<IDerivedInterface>();
-            
             // Assert
             Assert.Same(frozenString, result.Method());
         }
@@ -180,8 +179,10 @@ namespace AutoFixture.AutoMoq.UnitTest
             // Act
             var result = fixture.Create<IDerivedInterfaceOfDerivedInterfaceWithProperty>();
             result.Property = expected;
+            result.DerivedProperty = expected;
             // Assert
             Assert.Same(expected, result.Property);
+            Assert.Same(expected, result.DerivedProperty);
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
@@ -321,7 +321,7 @@ namespace AutoFixture.AutoMoq.UnitTest
         {
             // Arrange
             var fixture = new Fixture();
-            var mock = new Mock<IDerivedInterfaceWithProperty>();
+            var mock = new Mock<IDerivedInterfaceOfDerivedInterfaceWithProperty>();
 
             var sut = new MockVirtualMethodsCommand();
             // Act
@@ -329,7 +329,8 @@ namespace AutoFixture.AutoMoq.UnitTest
             // Assert
             var result = mock.Object;
             Assert.Null(result.Property);
-            Assert.Null(result.SecondProperty);
+            Assert.Null(result.DerivedProperty);
+            Assert.Null(result.DerivedDerivedProperty);
         }
 
         [Fact]

--- a/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
@@ -302,6 +302,22 @@ namespace AutoFixture.AutoMoq.UnitTest
         }
 
         [Fact]
+        public void IgnoresPropertiesWithGettersAndSettersFromInheritedInterface()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var mock = new Mock<IDerivedInterfaceWithProperty>();
+
+            var sut = new MockVirtualMethodsCommand();
+            // Act
+            sut.Execute(mock, new SpecimenContext(fixture));
+            // Assert
+            var result = mock.Object;
+            Assert.Null(result.Property);
+            Assert.Null(result.SecondProperty);
+        }
+
+        [Fact]
         public void IgnoresVirtualPropertiesWithGettersAndSetters()
         {
             // Arrange

--- a/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
+++ b/Src/AutoMoqUnitTest/MockVirtualMethodsCommandTest.cs
@@ -314,6 +314,21 @@ namespace AutoFixture.AutoMoq.UnitTest
             // Assert
             var result = mock.Object;
             Assert.Null(result.Property);
+        }
+
+        [Fact]
+        public void IgnoresPropertiesWithGettersAndSettersFromInheritedInterfaceOfInheritedInterface()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var mock = new Mock<IDerivedInterfaceWithProperty>();
+
+            var sut = new MockVirtualMethodsCommand();
+            // Act
+            sut.Execute(mock, new SpecimenContext(fixture));
+            // Assert
+            var result = mock.Object;
+            Assert.Null(result.Property);
             Assert.Null(result.SecondProperty);
         }
 

--- a/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceOfDerivedInterfaceWithProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceOfDerivedInterfaceWithProperty.cs
@@ -2,6 +2,6 @@
 {
     public interface IDerivedInterfaceOfDerivedInterfaceWithProperty : IDerivedInterfaceWithProperty
     {
-        string ThirdProperty { get; set; }
+        string DerivedDerivedProperty { get; set; }
     }
 }

--- a/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceOfDerivedInterfaceWithProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceOfDerivedInterfaceWithProperty.cs
@@ -1,0 +1,7 @@
+﻿namespace AutoFixture.AutoMoq.UnitTest.TestTypes
+{
+    public interface IDerivedInterfaceOfDerivedInterfaceWithProperty : IDerivedInterfaceWithProperty
+    {
+        string ThirdProperty { get; set; }
+    }
+}

--- a/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceWithProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceWithProperty.cs
@@ -2,6 +2,6 @@
 {
     public interface IDerivedInterfaceWithProperty : IInterfaceWithProperty
     {
-        string SecondProperty { get; set; }
+        string DerivedProperty { get; set; }
     }
 }

--- a/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceWithProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/IDerivedInterfaceWithProperty.cs
@@ -1,0 +1,7 @@
+﻿namespace AutoFixture.AutoMoq.UnitTest.TestTypes
+{
+    public interface IDerivedInterfaceWithProperty : IInterfaceWithProperty
+    {
+        string SecondProperty { get; set; }
+    }
+}


### PR DESCRIPTION
Not the same behavior with ConfigureMembers = True on inherited interface properties. Base props were returning fixture instead of being setup correctly by Moq.