### PR TITLE
Fixed Fare to follow namespace standards

### DIFF
--- a/Src/AutoFixture/Fare/Automaton.cs
+++ b/Src/AutoFixture/Fare/Automaton.cs
@@ -34,7 +34,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     /// <summary>
     /// Finite-state automaton with regular expression operations.

--- a/Src/AutoFixture/Fare/BasicAutomata.cs
+++ b/Src/AutoFixture/Fare/BasicAutomata.cs
@@ -36,7 +36,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider",
         Justification = "This code has been copied from another project and is used as-is.")]

--- a/Src/AutoFixture/Fare/BasicOperations.cs
+++ b/Src/AutoFixture/Fare/BasicOperations.cs
@@ -36,7 +36,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     internal static class BasicOperations
     {

--- a/Src/AutoFixture/Fare/LinkedListExtensions.cs
+++ b/Src/AutoFixture/Fare/LinkedListExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     internal static class LinkedListExtensions
     {

--- a/Src/AutoFixture/Fare/ListEqualityComparer.cs
+++ b/Src/AutoFixture/Fare/ListEqualityComparer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     internal sealed class ListEqualityComparer<T>  : IEqualityComparer<List<T>>, IEquatable<ListEqualityComparer<T>>
     {

--- a/Src/AutoFixture/Fare/MinimizationOperations.cs
+++ b/Src/AutoFixture/Fare/MinimizationOperations.cs
@@ -33,7 +33,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     internal static class MinimizationOperations
     {

--- a/Src/AutoFixture/Fare/RegExp.cs
+++ b/Src/AutoFixture/Fare/RegExp.cs
@@ -37,7 +37,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     /// <summary>
     /// Regular Expression extension to Automaton.

--- a/Src/AutoFixture/Fare/RegExpMatchingOptions.cs
+++ b/Src/AutoFixture/Fare/RegExpMatchingOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     internal static class RegExpMatchingOptions
     {

--- a/Src/AutoFixture/Fare/RegExpSyntaxOptions.cs
+++ b/Src/AutoFixture/Fare/RegExpSyntaxOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     [Flags]
     internal enum RegExpSyntaxOptions

--- a/Src/AutoFixture/Fare/SpecialOperations.cs
+++ b/Src/AutoFixture/Fare/SpecialOperations.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     /// <summary>
     /// Special automata operations.

--- a/Src/AutoFixture/Fare/State.cs
+++ b/Src/AutoFixture/Fare/State.cs
@@ -36,7 +36,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     /// <summary>
     /// <tt>Automaton</tt> state.

--- a/Src/AutoFixture/Fare/StateEqualityComparer.cs
+++ b/Src/AutoFixture/Fare/StateEqualityComparer.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     internal sealed class StateEqualityComparer : IEqualityComparer<State>
     {

--- a/Src/AutoFixture/Fare/StatePair.cs
+++ b/Src/AutoFixture/Fare/StatePair.cs
@@ -32,7 +32,7 @@
 
 using System;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     /// <summary>
     /// Pair of states.

--- a/Src/AutoFixture/Fare/Transition.cs
+++ b/Src/AutoFixture/Fare/Transition.cs
@@ -34,7 +34,7 @@ using System;
 using System.Globalization;
 using System.Text;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     ///<summary>
     ///  <tt>Automaton</tt> transition. 

--- a/Src/AutoFixture/Fare/TransitionComparer.cs
+++ b/Src/AutoFixture/Fare/TransitionComparer.cs
@@ -32,7 +32,7 @@
 
 using System.Collections.Generic;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     internal sealed class TransitionComparer : IComparer<Transition>
     {

--- a/Src/AutoFixture/Fare/Xeger.cs
+++ b/Src/AutoFixture/Fare/Xeger.cs
@@ -20,7 +20,7 @@
 using System;
 using System.Text;
 
-namespace Fare
+namespace AutoFixture.Fare
 {
     /// <summary>
     /// An object that will generate text from a regular expression. In a way, 

--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using AutoFixture.Fare;
 using AutoFixture.Kernel;
-using Fare;
 
 namespace AutoFixture
 {


### PR DESCRIPTION
This global namespacing issue is preventing us from updating to the latest version of AutoFixture.  Other folders such as Dsl and DataNAnnotations follow the common namespacing pattern. For some reason Fare's does not. For any consuming projects with a model named "Fare" for example this can be problematic.