### PR TITLE
Support TimeSpan type for the Range attribute (#930)

### DIFF
--- a/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Globalization;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.DataAnnotations
+{
+    /// <summary>
+    /// Handles <see cref="RangedRequest"/> of TimeSpan type by forwarding requests
+    /// to the <see cref="RangedNumberRequest"/> with min and max TimeSpan as milliseconds values.
+    /// </summary>
+    public class TimeSpanRangedRequestRelay : ISpecimenBuilder
+    {
+        /// <inheritdoc />   
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var rangedRequest = request as RangedRequest;
+
+            if (rangedRequest == null)
+                return new NoSpecimen();
+
+            if (rangedRequest.MemberType != typeof(TimeSpan))
+                return new NoSpecimen();
+
+            return CreateRangedTimeSpanSpecimen(rangedRequest, context);
+        }
+
+        private static object CreateRangedTimeSpanSpecimen(RangedRequest rangedRequest, ISpecimenContext context)
+        {
+            TimeSpanRange range;
+
+            if (rangedRequest.Minimum is string)
+            {
+                range = GetTimeSpanRangeFromStringValues(rangedRequest);
+            }
+            else if (rangedRequest.Minimum.GetType().IsNumberType())
+            {
+                range = GetTimeSpanRangeFromNumberValues(rangedRequest);
+            }
+            else
+            {
+                return new NoSpecimen();
+            }
+
+            return RandomizeTimeSpanInRange(range, context);
+        }
+
+        private static TimeSpanRange GetTimeSpanRangeFromStringValues(RangedRequest rangedRequest)
+        {
+            return new TimeSpanRange
+            {
+                MillisecondsMin = StringToMilliseconds((string)rangedRequest.Minimum),
+                MillisecondsMax = StringToMilliseconds((string)rangedRequest.Maximum)
+            };
+        }
+
+        private static double StringToMilliseconds(string serializedTimeSpan)
+        {
+            return TimeSpan.Parse(serializedTimeSpan, CultureInfo.CurrentCulture).TotalMilliseconds;
+        }
+
+        private static TimeSpanRange GetTimeSpanRangeFromNumberValues(RangedRequest rangedRequest)
+        {
+            return new TimeSpanRange
+            {
+                MillisecondsMin = (double)rangedRequest.GetConvertedMinimum(typeof(double)),
+                MillisecondsMax = (double)rangedRequest.GetConvertedMaximum(typeof(double))
+            };
+        }
+
+        private static object RandomizeTimeSpanInRange(TimeSpanRange range, ISpecimenContext context)
+        {
+            var millisecondsInRange = context.Resolve(
+                new RangedNumberRequest(typeof(double), range.MillisecondsMin, range.MillisecondsMax));
+
+            return millisecondsInRange is NoSpecimen
+                ? millisecondsInRange
+                : TimeSpan.FromMilliseconds((double)millisecondsInRange);
+        }
+
+        private class TimeSpanRange
+        {
+            public double MillisecondsMin { get; set; }
+            public double MillisecondsMax { get; set; }
+        }
+    }
+}

--- a/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
@@ -28,21 +28,9 @@ namespace AutoFixture.DataAnnotations
 
         private static object CreateRangedTimeSpanSpecimen(RangedRequest rangedRequest, ISpecimenContext context)
         {
-            TimeSpanRange range;
+            if (!(rangedRequest.Minimum is string) || !(rangedRequest.Maximum is string)) return new NoSpecimen();
 
-            if (rangedRequest.Minimum is string)
-            {
-                range = GetTimeSpanRangeFromStringValues(rangedRequest);
-            }
-            else if (rangedRequest.Minimum.GetType().IsNumberType())
-            {
-                range = GetTimeSpanRangeFromNumberValues(rangedRequest);
-            }
-            else
-            {
-                return new NoSpecimen();
-            }
-
+            var range = GetTimeSpanRangeFromStringValues(rangedRequest);
             return RandomizeTimeSpanInRange(range, context);
         }
 
@@ -58,15 +46,6 @@ namespace AutoFixture.DataAnnotations
         private static double StringToMilliseconds(string serializedTimeSpan)
         {
             return TimeSpan.Parse(serializedTimeSpan, CultureInfo.CurrentCulture).TotalMilliseconds;
-        }
-
-        private static TimeSpanRange GetTimeSpanRangeFromNumberValues(RangedRequest rangedRequest)
-        {
-            return new TimeSpanRange
-            {
-                MillisecondsMin = (double)rangedRequest.GetConvertedMinimum(typeof(double)),
-                MillisecondsMax = (double)rangedRequest.GetConvertedMaximum(typeof(double))
-            };
         }
 
         private static object RandomizeTimeSpanInRange(TimeSpanRange range, ISpecimenContext context)

--- a/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
@@ -28,40 +28,37 @@ namespace AutoFixture.DataAnnotations
 
         private static object CreateRangedTimeSpanSpecimen(RangedRequest rangedRequest, ISpecimenContext context)
         {
-            if (!(rangedRequest.Minimum is string) || !(rangedRequest.Maximum is string)) return new NoSpecimen();
+            if (!(rangedRequest.Minimum is string) || !(rangedRequest.Maximum is string))
+                return new NoSpecimen();
 
-            var range = GetTimeSpanRangeFromStringValues(rangedRequest);
+            var range = ParseTimeSpanRange(rangedRequest);
             return RandomizeTimeSpanInRange(range, context);
         }
 
-        private static TimeSpanRange GetTimeSpanRangeFromStringValues(RangedRequest rangedRequest)
+        private static TimeSpanRange ParseTimeSpanRange(RangedRequest rangedRequest)
         {
             return new TimeSpanRange
             {
-                MillisecondsMin = StringToMilliseconds((string)rangedRequest.Minimum),
-                MillisecondsMax = StringToMilliseconds((string)rangedRequest.Maximum)
+                Min = TimeSpan.Parse((string)rangedRequest.Minimum, CultureInfo.CurrentCulture),
+                Max = TimeSpan.Parse((string)rangedRequest.Maximum, CultureInfo.CurrentCulture)
             };
-        }
-
-        private static double StringToMilliseconds(string serializedTimeSpan)
-        {
-            return TimeSpan.Parse(serializedTimeSpan, CultureInfo.CurrentCulture).TotalMilliseconds;
         }
 
         private static object RandomizeTimeSpanInRange(TimeSpanRange range, ISpecimenContext context)
         {
             var millisecondsInRange = context.Resolve(
-                new RangedNumberRequest(typeof(double), range.MillisecondsMin, range.MillisecondsMax));
+                new RangedNumberRequest(typeof(double), range.Min.TotalMilliseconds, range.Max.TotalMilliseconds));
 
-            return millisecondsInRange is NoSpecimen
-                ? millisecondsInRange
-                : TimeSpan.FromMilliseconds((double)millisecondsInRange);
+            if (millisecondsInRange is NoSpecimen)
+                return new NoSpecimen();
+
+            return TimeSpan.FromMilliseconds((double)millisecondsInRange);
         }
 
-        private class TimeSpanRange
+        private struct TimeSpanRange
         {
-            public double MillisecondsMin { get; set; }
-            public double MillisecondsMax { get; set; }
+            public TimeSpan Min { get; set; }
+            public TimeSpan Max { get; set; }
         }
     }
 }

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -129,6 +129,7 @@ namespace AutoFixture
                                         new RangeAttributeRelay(),
                                         new NumericRangedRequestRelay(),
                                         new EnumRangedRequestRelay(),
+                                        new TimeSpanRangedRequestRelay(),
                                         new StringLengthAttributeRelay(),
                                         new RegularExpressionAttributeRelay())))),
                         new AutoPropertiesTarget(

--- a/Src/AutoFixtureUnitTest/DataAnnotations/TimeSpanRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/TimeSpanRangedRequestRelayTest.cs
@@ -89,18 +89,15 @@ namespace AutoFixtureUnitTest.DataAnnotations
             Assert.Equal(new NoSpecimen(), actualResult);
         }
 
-        [Theory]
-        [InlineData("00:00:00", "12:00:00", 0.0, 12 * 60 * 60 * 1000.0)]
-        [InlineData(1000, 2000, 1000.0, 2000.0)]
-        [InlineData(1000.5, 2000.5, 1000.5, 2000.5)]
-        public void ShouldCorrectPassMinimumAndMaximumAsMilliseconds(object minimum, object maximum,
-            double expectedMinimumMilliseconds, double expectedMaximumMilliseconds)
+        [Fact]
+        public void ShouldCorrectPassMinimumAndMaximumAsMilliseconds()
         {
             // Arrange
             var sut = new TimeSpanRangedRequestRelay();
 
-            var request = new RangedRequest(typeof(TimeSpan), typeof(TimeSpan), minimum, maximum);
+            var request = new RangedRequest(typeof(TimeSpan), typeof(TimeSpan), "00:00:00", "12:00:00");
             RangedNumberRequest capturedNumericRequest = null;
+
             var context = new DelegatingSpecimenContext
             {
                 OnResolve = r =>
@@ -115,8 +112,8 @@ namespace AutoFixtureUnitTest.DataAnnotations
 
             // Assert
             Assert.NotNull(capturedNumericRequest);
-            Assert.Equal(expectedMinimumMilliseconds, capturedNumericRequest.Minimum);
-            Assert.Equal(expectedMaximumMilliseconds, capturedNumericRequest.Maximum);
+            Assert.Equal(0.0, capturedNumericRequest.Minimum);
+            Assert.Equal(12 * 60 * 60 * 1000.0, capturedNumericRequest.Maximum);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/TimeSpanRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/TimeSpanRangedRequestRelayTest.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using AutoFixture.DataAnnotations;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace AutoFixtureUnitTest.DataAnnotations
+{
+    public class TimeSpanRangedRequestRelayTest
+    {
+        [Fact]
+        public void SutShouldBeASpecimenBuilder()
+        {
+            // Arrange
+            var sut = new TimeSpanRangedRequestRelay();
+
+            // Act & Assert
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+
+        [Fact]
+        public void ShouldFailForNullContext()
+        {
+            // Arrange
+            var sut = new TimeSpanRangedRequestRelay();
+            var request = new object();
+
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentNullException>(() =>
+                sut.Create(request, null));
+        }
+
+        [Fact]
+        public void ShouldNotHandleRequestIfMemberTypeIsNotTimeSpan()
+        {
+            // Arrange
+            var sut = new TimeSpanRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: typeof(object), operandType: typeof(object), minimum: 0, maximum: 1);
+            var context = new DelegatingSpecimenContext();
+
+            // Act
+            var result = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Fact]
+        public void ShouldHandleRequestOfTimeSpanType()
+        {
+            // Arrange
+            var sut = new TimeSpanRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: typeof(TimeSpan), operandType: typeof(TimeSpan), minimum: "00:00:00",
+                    maximum: "01:00:00");
+
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = _ => 30 * 60 * 1000.0 //30 (chosen randomly) minutes in miliseconds
+            };
+
+            // Act
+            var actualResult = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(TimeSpan.FromMinutes(30), actualResult);
+        }
+
+        [Fact]
+        public void ShouldReturnNoSpecimenIfUnableToSatisfyRangedRequest()
+        {
+            // Arrange
+            var sut = new TimeSpanRangedRequestRelay();
+            var request =
+                new RangedRequest(memberType: typeof(TimeSpan), operandType: typeof(TimeSpan), minimum: "00:00:00",
+                    maximum: "01:00:00");
+
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = _ => new NoSpecimen()
+            };
+
+            // Act
+            var actualResult = sut.Create(request, context);
+
+            // Assert
+            Assert.Equal(new NoSpecimen(), actualResult);
+        }
+
+        [Theory]
+        [InlineData("00:00:00", "12:00:00", 0.0, 12 * 60 * 60 * 1000.0)]
+        [InlineData(1000, 2000, 1000.0, 2000.0)]
+        [InlineData(1000.5, 2000.5, 1000.5, 2000.5)]
+        public void ShouldCorrectPassMinimumAndMaximumAsMilliseconds(object minimum, object maximum,
+            double expectedMinimumMilliseconds, double expectedMaximumMilliseconds)
+        {
+            // Arrange
+            var sut = new TimeSpanRangedRequestRelay();
+
+            var request = new RangedRequest(typeof(TimeSpan), typeof(TimeSpan), minimum, maximum);
+            RangedNumberRequest capturedNumericRequest = null;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    capturedNumericRequest = (RangedNumberRequest)r;
+                    return new NoSpecimen();
+                }
+            };
+
+            // Act
+            sut.Create(request, context);
+
+            // Assert
+            Assert.NotNull(capturedNumericRequest);
+            Assert.Equal(expectedMinimumMilliseconds, capturedNumericRequest.Minimum);
+            Assert.Equal(expectedMaximumMilliseconds, capturedNumericRequest.Maximum);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6001,7 +6001,7 @@ namespace AutoFixtureUnitTest
 
         private class TypeWithRangedTimeSpanProperty
         {
-            [Range(typeof(TimeSpan), "00:00:00", "12:00:00")]
+            [Range(typeof(TimeSpan), "02:00:00", "12:00:00")]
             public TimeSpan StringRangedTimeSpanProperty { get; set; }
         }
 
@@ -6015,7 +6015,7 @@ namespace AutoFixtureUnitTest
             var result = sut.Create<TypeWithRangedTimeSpanProperty>();
 
             // Assert
-            Assert.InRange(result.StringRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
+            Assert.InRange(result.StringRangedTimeSpanProperty, TimeSpan.FromHours(2), TimeSpan.FromHours(12));
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6003,12 +6003,6 @@ namespace AutoFixtureUnitTest
         {
             [Range(typeof(TimeSpan), "00:00:00", "12:00:00")]
             public TimeSpan StringRangedTimeSpanProperty { get; set; }
-
-            [Range(0, 12 * 60 * 60 * 1000)]
-            public TimeSpan IntRangedTimeSpanProperty { get; set; }
-
-            [Range(0.0, 12 * 60 * 60 * 1000.0)]
-            public TimeSpan DoubleRangedTimeSpanProperty { get; set; }
         }
 
         [Fact]
@@ -6022,8 +6016,6 @@ namespace AutoFixtureUnitTest
 
             // Assert
             Assert.InRange(result.StringRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
-            Assert.InRange(result.IntRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
-            Assert.InRange(result.DoubleRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5998,5 +5998,32 @@ namespace AutoFixtureUnitTest
                 return composer.With(x => x.Value, "42");
             }
         }
+
+        private class TypeWithRangedTimeSpanProperty
+        {
+            [Range(typeof(TimeSpan), "00:00:00", "12:00:00")]
+            public TimeSpan StringRangedTimeSpanProperty { get; set; }
+
+            [Range(0, 12 * 60 * 60 * 1000)]
+            public TimeSpan IntRangedTimeSpanProperty { get; set; }
+
+            [Range(0.0, 12 * 60 * 60 * 1000.0)]
+            public TimeSpan DoubleRangedTimeSpanProperty { get; set; }
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveTimeSpanPropertiesDecoratedWithRange()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithRangedTimeSpanProperty>();
+
+            // Assert
+            Assert.InRange(result.StringRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
+            Assert.InRange(result.IntRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
+            Assert.InRange(result.DoubleRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6017,5 +6017,18 @@ namespace AutoFixtureUnitTest
             // Assert
             Assert.InRange(result.StringRangedTimeSpanProperty, TimeSpan.Zero, TimeSpan.FromHours(12));
         }
+
+        [Fact]
+        public void TimeSpanDecoratedWithRangeCreatedByFixtureShouldPassValidation()
+        { 
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var timeSpan = sut.Create<TypeWithRangedTimeSpanProperty>();
+
+            // Assert
+            Validator.ValidateObject(timeSpan, new ValidationContext(timeSpan), true);
+        }
     }
 }


### PR DESCRIPTION
Hi, guys

I have added support for TimeSpan type in the Range attribute:

1. When the range is specified with strings, then they are simply parsed to TimeSpan (like "00:00:00" is TimeSpan.Zero and "12:00:00" is TimeSpan.FromHours(12))

2. When the range is specified with numbers, they are treated as milliseconds - I am not sure that it is desired behavior but it seemed very natural to me.

All remarks are highly appreciated! 

Closes #930