### PR TITLE
Fail with better exception if guard is invalid

### DIFF
--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -376,20 +376,11 @@ See https://github.com/AutoFixture/AutoFixture/issues/268 for more details.";
                 this.command = command;
             }
 
-            public Type RequestedType
-            {
-                get { return this.command.RequestedType; }
-            }
+            public Type RequestedType => this.command.RequestedType;
 
-            public string RequestedParameterName
-            {
-                get { return this.command.RequestedParameterName; }
-            }
+            public string RequestedParameterName => this.command.RequestedParameterName;
 
-            public void Execute(object value)
-            {
-                this.command.Execute(value);
-            }
+            public void Execute(object value) => this.command.Execute(value);
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture",
                 Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
@@ -401,10 +392,23 @@ See https://github.com/AutoFixture/AutoFixture/issues/268 for more details.";
                 return new GuardClauseException(Message, e);
             }
 
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "github")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture",
+                Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "github",
+                Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
             public Exception CreateException(string value, Exception innerException)
             {
                 var e = this.command.CreateException(value, innerException);
+                return new GuardClauseException(Message, e);
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AutoFixture",
+                Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "github",
+                Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            public Exception CreateException(string value, string customError, Exception innerException)
+            {
+                var e = this.command.CreateException(value, customError, innerException);
                 return new GuardClauseException(Message, e);
             }
         }
@@ -421,24 +425,18 @@ See e.g. http://codeblog.jonskeet.uk/2008/03/02/c-4-idea-iterator-blocks-and-par
                 this.command = command;
             }
 
-            public Type RequestedType
-            {
-                get { return this.command.RequestedType; }
-            }
+            public Type RequestedType => this.command.RequestedType;
 
-            public string RequestedParameterName
-            {
-                get { return this.command.RequestedParameterName; }
-            }
+            public string RequestedParameterName => this.command.RequestedParameterName;
 
-            public void Execute(object value)
-            {
-                this.command.Execute(value);
-            }
+            public void Execute(object value) => this.command.Execute(value);
 
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "codeblog", Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "uk", Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "jonskeet", Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "codeblog",
+                Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "uk",
+                Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "jonskeet",
+                Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
             public Exception CreateException(string value)
             {
                 var e = this.command.CreateException(value);
@@ -451,6 +449,15 @@ See e.g. http://codeblog.jonskeet.uk/2008/03/02/c-4-idea-iterator-blocks-and-par
             public Exception CreateException(string value, Exception innerException)
             {
                 var e = this.command.CreateException(value, innerException);
+                return new GuardClauseException(Message, e);
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "codeblog", Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "uk", Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "jonskeet", Justification = "False Positive. Code Analysis really shouldn't attempt to spell check URLs.")]
+            public Exception CreateException(string value, string customError, Exception innerException)
+            {
+                var e = this.command.CreateException(value, customError, innerException);
                 return new GuardClauseException(Message, e);
             }
         }

--- a/Src/Idioms/IGuardClauseCommand.cs
+++ b/Src/Idioms/IGuardClauseCommand.cs
@@ -43,15 +43,13 @@ namespace AutoFixture.Idioms
         /// <remarks>
         /// <para>
         /// The <paramref name="value" /> is expected to be compatible with
-        /// <see cref="RequestedType" />. It should be possible to cast the value to the requested
-        /// type.
+        /// <see cref="RequestedType" />. It should be possible to cast the value to the requested type.
         /// </para>
         /// </remarks>
         void Execute(object value);
 
         /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
+        /// Creates an exception which communicates that an error occured for a specific input value.
         /// </summary>
         /// <param name="value">A string representation of the value.</param>
         /// <returns>An exception which communicates the cause of the error.</returns>
@@ -59,29 +57,41 @@ namespace AutoFixture.Idioms
         /// <para>
         /// The <paramref name="value" /> is a string representation of the value supplied to the
         /// <see cref="Execute" /> method. Together with the context contained within any
-        /// implementation of <see cref="IGuardClauseCommand" /> this value can be used to build an
-        /// exception message.
+        /// implementation of <see cref="IGuardClauseCommand" /> this value can be used to build an exception message.
         /// </para>
         /// </remarks>
         Exception CreateException(string value);
 
         /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
+        /// Creates an exception which communicates that an error occured for a specific input value.
         /// </summary>
         /// <param name="value">A string representation of the value.</param>
-        /// <param name="innerException">
-        /// The exception that is the cause of the current exception.
-        /// </param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
         /// <returns>An exception which communicates the cause of the error.</returns>
         /// <remarks>
         /// <para>
         /// The <paramref name="value" /> is a string representation of the value supplied to the
         /// <see cref="Execute" /> method. Together with the context contained within any
-        /// implementation of <see cref="IGuardClauseCommand" /> this value can be used to build an
-        /// exception message.
+        /// implementation of <see cref="IGuardClauseCommand" /> this value can be used to build an exception message.
         /// </para>
         /// </remarks>
         Exception CreateException(string value, Exception innerException);
+
+        /// <summary>
+        /// Creates an exception which communicates that an error occured for a specific input value.
+        /// </summary>
+        /// <param name="value">A string representation of the value.</param>
+        /// <param name="customError">A custom explanation of the guard clause failure.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        /// <returns>An exception which communicates the cause of the error.</returns>
+        /// <remarks>
+        /// <para>
+        /// The <paramref name="value" /> is a string representation of the value supplied to the
+        /// <see cref="Execute" /> method. Together with the passed <paramref name="customError"/> and context
+        /// contained within any implementation of <see cref="IGuardClauseCommand" /> this value can be used to
+        /// build an exception message.
+        /// </para>
+        /// </remarks>
+        Exception CreateException(string value, string customError, Exception innerException);
     }
 }

--- a/Src/Idioms/MethodInvokeCommand.cs
+++ b/Src/Idioms/MethodInvokeCommand.cs
@@ -63,7 +63,7 @@ namespace AutoFixture.Idioms
         public string RequestedParameterName => this.ParameterInfo.Name;
 
         /// <summary>
-        /// Invokes the mthod with the specified value.
+        /// Invokes the method with the specified value.
         /// </summary>
         /// <param name="value">The value with wich the method is executed.</param>
         /// <remarks>
@@ -77,47 +77,39 @@ namespace AutoFixture.Idioms
             this.Method.Invoke(this.Expansion.Expand(value));
         }
 
-        /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
-        /// </summary>
-        /// <param name="value">A string representation of the value.</param>
-        /// <returns>
-        /// An exception which communicates the cause of the error.
-        /// </returns>
+        /// <inheritdoc />
         public Exception CreateException(string value)
         {
             return new GuardClauseException(this.CreateExceptionMessage(value));
         }
 
-        /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
-        /// </summary>
-        /// <param name="value">A string representation of the value.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        /// <returns>
-        /// An exception which communicates the cause of the error.
-        /// </returns>
+        /// <inheritdoc />
         public Exception CreateException(string value, Exception innerException)
         {
             return new GuardClauseException(this.CreateExceptionMessage(value), innerException);
         }
 
-        private string CreateExceptionMessage(string value)
+        /// <inheritdoc />
+        public Exception CreateException(string value, string customError, Exception innerException)
+        {
+            return new GuardClauseException(this.CreateExceptionMessage(value, customError), innerException);
+        }
+
+        private string CreateExceptionMessage(string value,
+            string failureReason = "no Guard Clause prevented this. Are you missing a Guard Clause?")
         {
             return string.Format(CultureInfo.CurrentCulture,
-                "An attempt was made to assign the value {0} to the parameter \"{1}\" of the method \"{2}\", " +
-                "and no Guard Clause prevented this. Are you missing a Guard Clause? " +
-                "{7}Method Signature: {3}{7}Parameter Type: {4}{7}Declaring Type: {5}{7}Reflected Type: {6}",
+                "An attempt was made to assign the value {1} to the parameter \"{3}\" of the method \"{4}\", and {2}{0}" +
+                "Method Signature: {5}{0}Parameter Type: {6}{0}Declaring Type: {7}{0}Reflected Type: {8}",
+                Environment.NewLine,
                 value,
+                failureReason,
                 this.ParameterInfo.Name,
                 this.ParameterInfo.Member.Name,
                 this.ParameterInfo.Member,
                 this.ParameterInfo.ParameterType.AssemblyQualifiedName,
                 this.ParameterInfo.Member.DeclaringType.AssemblyQualifiedName,
-                this.ParameterInfo.Member.ReflectedType.AssemblyQualifiedName,
-                Environment.NewLine);
+                this.ParameterInfo.Member.ReflectedType.AssemblyQualifiedName);
         }
     }
 }

--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace AutoFixture.Idioms
 {
@@ -53,7 +54,17 @@ namespace AutoFixture.Idioms
             {
                 if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
                     return;
-                throw command.CreateException("null", e);
+
+                throw command.CreateException(
+                    "<null>",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
+                        "Ensure you pass correct parameter name to the ArgumentNullException constructor.{0}" +
+                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
+                        Environment.NewLine,
+                        command.RequestedParameterName,
+                        e.ParamName),
+                    e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/PropertySetCommand.cs
+++ b/Src/Idioms/PropertySetCommand.cs
@@ -48,7 +48,6 @@ namespace AutoFixture.Idioms
         /// </remarks>
         public Type RequestedType => this.PropertyInfo.PropertyType;
 
-
         /// <summary>
         /// Gets the parameter name of the requested value.
         /// </summary>
@@ -58,13 +57,10 @@ namespace AutoFixture.Idioms
         /// </remarks>
         public string RequestedParameterName => "value";
 
-        /// <summary>
-        /// Executes the action with the specified value.
-        /// </summary>
-        /// <param name="value">The value with wich the action is executed.</param>
+        /// <inheritdoc />
         /// <remarks>
         /// <para>
-        /// Assigns <paramref name="value" /> to the <see cref="PropertyInfo" />.
+        /// Assigns <paramref name="value" /> to the <see cref="AutoFixture.Idioms.PropertySetCommand.PropertyInfo" />.
         /// </para>
         /// </remarks>
         public void Execute(object value)
@@ -72,44 +68,37 @@ namespace AutoFixture.Idioms
             this.PropertyInfo.SetValue(this.Owner, value, null);
         }
 
-        /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
-        /// </summary>
-        /// <param name="value">A string representation of the value.</param>
-        /// <returns>
-        /// An exception which communicates the cause of the error.
-        /// </returns>
+        /// <inheritdoc />
         public Exception CreateException(string value)
         {
             return new GuardClauseException(this.CreateExceptionMessage(value));
         }
 
-        /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
-        /// </summary>
-        /// <param name="value">A string representation of the value.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        /// <returns>
-        /// An exception which communicates the cause of the error.
-        /// </returns>
+        /// <inheritdoc />
         public Exception CreateException(string value, Exception innerException)
         {
             return new GuardClauseException(this.CreateExceptionMessage(value), innerException);
         }
 
-        private string CreateExceptionMessage(string value)
+        /// <inheritdoc />
+        public Exception CreateException(string value, string customError, Exception innerException)
+        {
+            return new GuardClauseException(this.CreateExceptionMessage(value, customError), innerException);
+        }
+
+        private string CreateExceptionMessage(string value,
+            string failureReason = "no Guard Clause prevented this. Are you missing a Guard Clause?")
         {
             return string.Format(CultureInfo.CurrentCulture,
-                "An attempt was made to assign the value {0} to the property {1}, and no Guard Clause prevented this. " +
-                "Are you missing a Guard Clause?{5}Property Type: {2}{5}Declaring Type: {3}{5}Reflected Type: {4}",
+                "An attempt was made to assign the value {1} to the property {3}, and {2}{0}" +
+                "Property Type: {4}{0}Declaring Type: {5}{0}Reflected Type: {6}",
+                Environment.NewLine,
                 value,
+                failureReason,
                 this.PropertyInfo.Name,
                 this.PropertyInfo.PropertyType.AssemblyQualifiedName,
                 this.PropertyInfo.DeclaringType.AssemblyQualifiedName,
-                this.PropertyInfo.ReflectedType.AssemblyQualifiedName,
-                Environment.NewLine);
+                this.PropertyInfo.ReflectedType.AssemblyQualifiedName);
         }
     }
 }

--- a/Src/Idioms/ReflectionExceptionUnwrappingCommand.cs
+++ b/Src/Idioms/ReflectionExceptionUnwrappingCommand.cs
@@ -24,26 +24,10 @@ namespace AutoFixture.Idioms
         /// </summary>
         public IGuardClauseCommand Command { get; }
 
-        /// <summary>
-        /// Gets the type of the requested value.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The return value is the return value of the decorated <see cref="Command" /> instance's
-        /// <see cref="IGuardClauseCommand.RequestedType" /> property.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public Type RequestedType => this.Command.RequestedType;
 
-        /// <summary>
-        /// Gets the parameter name of the requested value.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The return value is the return value of the decorated <see cref="Command" /> instance's
-        /// <see cref="IGuardClauseCommand.RequestedParameterName" /> property.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public string RequestedParameterName => this.Command.RequestedParameterName;
 
         /// <summary>
@@ -64,31 +48,22 @@ namespace AutoFixture.Idioms
             }
         }
 
-        /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
-        /// </summary>
-        /// <param name="value">A string representation of the value.</param>
-        /// <returns>
-        /// The exception created by the decorated <see cref="Command" />.
-        /// </returns>
+        /// <inheritdoc />
         public Exception CreateException(string value)
         {
             return this.Command.CreateException(value);
         }
 
-        /// <summary>
-        /// Creates an exception which communicates that an error occured for a specific input
-        /// value.
-        /// </summary>
-        /// <param name="value">A string representation of the value.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        /// <returns>
-        /// The exception created by the decorated <see cref="Command" />.
-        /// </returns>
+        /// <inheritdoc />
         public Exception CreateException(string value, Exception innerException)
         {
             return this.Command.CreateException(value, innerException);
+        }
+
+        /// <inheritdoc />
+        public Exception CreateException(string value, string customError, Exception innerException)
+        {
+            return this.Command.CreateException(value, customError, innerException);
         }
     }
 }

--- a/Src/IdiomsUnitTest/DelegatingGuardClauseCommand.cs
+++ b/Src/IdiomsUnitTest/DelegatingGuardClauseCommand.cs
@@ -11,6 +11,7 @@ namespace AutoFixture.IdiomsUnitTest
             this.OnExecute = v => { };
             this.OnCreateException = v => new Exception();
             this.OnCreateExceptionWithInner = (v, e) => new Exception();
+            this.OnCreateExceptionWithFailureReason = (v, r, e) => new Exception();
         }
 
         public Action<object> OnExecute { get; set; }
@@ -18,6 +19,8 @@ namespace AutoFixture.IdiomsUnitTest
         public Func<string, Exception> OnCreateException { get; set; }
 
         public Func<string, Exception, Exception> OnCreateExceptionWithInner { get; set; }
+
+        public Func<string, string, Exception, Exception> OnCreateExceptionWithFailureReason { get; set; }
 
         public Type RequestedType { get; set; }
 
@@ -36,6 +39,11 @@ namespace AutoFixture.IdiomsUnitTest
         public Exception CreateException(string value, Exception innerException)
         {
             return this.OnCreateExceptionWithInner(value, innerException);
+        }
+
+        public Exception CreateException(string value, string customError, Exception innerException)
+        {
+            return this.OnCreateExceptionWithFailureReason(value, customError, innerException);
         }
     }
 }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -1112,23 +1112,23 @@ namespace AutoFixture.IdiomsUnitTest
             var constructorInfo = typeof (NonProperlyGuardedClass).GetConstructors().Single();
 
             var exception = Assert.Throws<GuardClauseException>(() => sut.Verify(constructorInfo));
-            Assert.Contains("Are you missing a Guard Clause?", exception.Message);
+            Assert.Contains("Guard Clause prevented it, however", exception.Message);
         }
 
         [Fact]
         public void VerifyNonProperlyGuardedPropertyThrowsException()
         {
             var sut = new GuardClauseAssertion(new Fixture());
-            var propertyInfo = typeof(NonProperlyGuardedClass).GetProperty("Property");
+            var propertyInfo = typeof(NonProperlyGuardedClass).GetProperty(nameof(NonProperlyGuardedClass.Property));
 
             var exception = Assert.Throws<GuardClauseException>(() => sut.Verify(propertyInfo));
-            Assert.Contains("Are you missing a Guard Clause?", exception.Message);
+            Assert.Contains("Guard Clause prevented it, however", exception.Message);
         }
 
         [Theory]
-        [InlineData("Method", "Are you missing a Guard Clause?")]
-        [InlineData("DeferredMethod", "deferred")]
-        [InlineData("AnotherDeferredMethod", "deferred")]
+        [InlineData(nameof(NonProperlyGuardedClass.Method), "Guard Clause prevented it, however")]
+        [InlineData(nameof(NonProperlyGuardedClass.DeferredMethod), "deferred")]
+        [InlineData(nameof(NonProperlyGuardedClass.AnotherDeferredMethod), "deferred")]
         public void VerifyNonProperlyGuardedMethodThrowsException(string methodName, string expectedMessage)
         {
             var sut = new GuardClauseAssertion(new Fixture());

--- a/Src/IdiomsUnitTest/MethodInvokeCommandTest.cs
+++ b/Src/IdiomsUnitTest/MethodInvokeCommandTest.cs
@@ -160,6 +160,25 @@ namespace AutoFixture.IdiomsUnitTest
             Assert.Equal(inner, e.InnerException);
         }
 
+        [Fact]
+        public void CreateExceptionWithCustomFailureReasonReturnsExceptionWithCorrectMessageAndInner()
+        {
+            // Arrange
+            var dummyMethod = new DelegatingMethod();
+            var dummyExpansion = new DelegatingExpansion<object>();
+            var parameter = MethodInvokeCommandTest.CreateAnonymousParameterInfo();
+            var sut = new MethodInvokeCommand(dummyMethod, dummyExpansion, parameter);
+            var inner = new Exception();
+            // Act
+            var dummyValue = "dummy value";
+            var failureReason = "MY_CUSTOM_MESSAGE";
+            var result = sut.CreateException(dummyValue, failureReason, inner);
+            // Assert
+            var ex = Assert.IsAssignableFrom<GuardClauseException>(result);
+            Assert.Contains(", and MY_CUSTOM_MESSAGE", ex.Message);
+            Assert.Equal(inner, ex.InnerException);
+        }
+
         private static ParameterInfo CreateAnonymousParameterInfo()
         {
             var parameter = (from m in typeof(object).GetMethods()

--- a/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
@@ -90,11 +90,29 @@ namespace AutoFixture.IdiomsUnitTest
         {
             var cmd = new DelegatingGuardClauseCommand
             {
-                OnExecute = v => { throw new ArgumentNullException(invalidParamName); }
+                OnExecute = v => throw new ArgumentNullException(invalidParamName)
             };
             var sut = new NullReferenceBehaviorExpectation();
             Assert.Throws<Exception>(() => 
                 sut.Verify(cmd));
+        }
+
+        [Fact]
+        public void VerifyThrowsWithCorrectMessageWhenCommandThrowsArgumentNullExceptionWithInvalidParamName()
+        {
+            // Arrange
+            var invalidParamName = "invalidParameterName";
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => throw new ArgumentNullException(invalidParamName),
+                OnCreateExceptionWithFailureReason = (v, r, ie) => new Exception(r, ie)
+            };
+            var sut = new NullReferenceBehaviorExpectation();
+            // Act & Assert
+            var ex = Assert.Throws<Exception>(() =>
+                sut.Verify(cmd));
+            Assert.Contains(invalidParamName, ex.Message);
+            Assert.Contains("Guard Clause", ex.Message);
         }
 
         [Fact]
@@ -105,7 +123,7 @@ namespace AutoFixture.IdiomsUnitTest
             var expected = new Exception();
             var cmd = new DelegatingGuardClauseCommand
             {
-                OnExecute = v => { throw expectedInner; },
+                OnExecute = v => throw expectedInner,
                 OnCreateExceptionWithInner = (v, e) => v == "null" && expectedInner.Equals(e) ? expected : new Exception()
             };
             var sut = new NullReferenceBehaviorExpectation();

--- a/Src/IdiomsUnitTest/PropertySetCommandTest.cs
+++ b/Src/IdiomsUnitTest/PropertySetCommandTest.cs
@@ -130,5 +130,23 @@ namespace AutoFixture.IdiomsUnitTest
             var e = Assert.IsAssignableFrom<GuardClauseException>(result);
             Assert.Equal(inner, e.InnerException);
         }
+
+        [Fact]
+        public void CreateExceptionWithCustomFailureReasonReturnsExceptionWithCorrectMessageAndInner()
+        {
+            // Arrange
+            var dummyOwner = new PropertyHolder<string>();
+            var dummyProperty = dummyOwner.GetType().GetProperty("Property");
+            var inner = new Exception();
+            var sut = new PropertySetCommand(dummyProperty, dummyOwner);
+            // Act
+            var dummyValue = "dummy value";
+            var failureReason = "MY_CUSTOM_MESSAGE";
+            var result = sut.CreateException(dummyValue, failureReason, inner);
+            // Assert
+            var ex = Assert.IsAssignableFrom<GuardClauseException>(result);
+            Assert.Contains("to the property Property, and MY_CUSTOM_MESSAGE", ex.Message);
+            Assert.Equal(inner, ex.InnerException);
+        }
     }
 }

--- a/Src/IdiomsUnitTest/ReflectionExceptionUnwrappingCommandTest.cs
+++ b/Src/IdiomsUnitTest/ReflectionExceptionUnwrappingCommandTest.cs
@@ -126,5 +126,24 @@ namespace AutoFixture.IdiomsUnitTest
             // Assert
             Assert.Equal(expected, result);
         }
+
+        [Fact]
+        public void CreateExceptionWithFailureReasonReturnsCorrectResult()
+        {
+            // Arrange
+            var value = Guid.NewGuid().ToString();
+            var failureReason = Guid.NewGuid().ToString();
+            var inner = new Exception();
+            var expected = new Exception();
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnCreateExceptionWithFailureReason = (v, r, e) => v == value && r == failureReason && e == inner ? expected : new Exception()
+            };
+            var sut = new ReflectionExceptionUnwrappingCommand(cmd);
+            // Act
+            var result = sut.CreateException(value, failureReason, inner);
+            // Assert
+            Assert.Equal(expected, result);
+        }
     }
 }


### PR DESCRIPTION
Closes #1010 

Improved the failure message in case Guard Clause is present, but is invalid (e.g. wrong parameter name is passed to `ArgumentNullException` constructor). New exception message:

```
AutoFixture.Idioms.GuardClauseException: An attempt was made to assign the value <null> to the property Property, and Guard Clause prevented it, however the thrown exception contains invalid parameter name. Ensure you pass correct parameter name to the ArgumentNullException constructor.
Expected parameter name: value
Actual parameter name: invalidParamName
Property Type: System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
Declaring Type: AutoFixture.IdiomsUnitTest.GuardClauseAssertionTest+NonProperlyGuardedClass, AutoFixture.IdiomsUnitTest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
Reflected Type: AutoFixture.IdiomsUnitTest.GuardClauseAssertionTest+NonProperlyGuardedClass, AutoFixture.IdiomsUnitTest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
```

@moodmosaic Please take a look 😉 