### PR TITLE
Fix false positive in deferred method detection

### DIFF
--- a/Src/Idioms/MethodInfoExtensions.cs
+++ b/Src/Idioms/MethodInfoExtensions.cs
@@ -7,28 +7,28 @@ namespace AutoFixture.Idioms
     {
         internal static bool IsEqualsMethod(this MethodInfo method)
         {
-            return string.Equals(method.Name, "Equals", StringComparison.Ordinal)
+            return string.Equals(method.Name, nameof(Equals), StringComparison.Ordinal)
                    && method.GetParameters().Length == 1
                    && method.ReturnType == typeof(bool);
         }
 
         internal static bool IsGetHashCodeMethod(this MethodInfo method)
         {
-            return string.Equals(method.Name, "GetHashCode", StringComparison.Ordinal)
+            return string.Equals(method.Name, nameof(GetHashCode), StringComparison.Ordinal)
                    && method.GetParameters().Length == 0
                    && method.ReturnType == typeof(int);
         }
 
         internal static bool IsToString(this MethodInfo method)
         {
-            return string.Equals(method.Name, "ToString", StringComparison.Ordinal)
+            return string.Equals(method.Name, nameof(ToString), StringComparison.Ordinal)
                    && method.GetParameters().Length == 0
                    && method.ReturnType == typeof(string);
         }
 
         internal static bool IsGetType(this MethodInfo method)
         {
-            return string.Equals(method.Name, "GetType", StringComparison.Ordinal)
+            return string.Equals(method.Name, nameof(GetType), StringComparison.Ordinal)
                    && method.GetParameters().Length == 0
                    && method.ReturnType == typeof(Type);
         }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -487,6 +487,7 @@ namespace AutoFixture.IdiomsUnitTest
         [InlineData(typeof(ClassWithEnumerableNonDeferredArrayListMissingGuard))]
         [InlineData(typeof(ClassWithEnumerableNonDeferredStackMissingGuard))]
         [InlineData(typeof(ClassWithEnumerableNonDeferredReadOnlyCollectionBaseMissingGuard))]
+        [InlineData(typeof(ClassWithEnumerableNonDeferredStringMissingGuard))]
         public void VerifyMethodWithNonDeferredMissingGuardThrowsExceptionWithoutDeferredMessage(
             Type type)
         {
@@ -629,6 +630,14 @@ namespace AutoFixture.IdiomsUnitTest
                     { "uniqueKey1", someString },
                     { "uniqueKey2", someString }
                 };
+            }
+        }
+
+        private class ClassWithEnumerableNonDeferredStringMissingGuard
+        {
+            public string GetValues(string someString)
+            {
+                return someString;
             }
         }
 
@@ -1104,8 +1113,10 @@ namespace AutoFixture.IdiomsUnitTest
 
         [Theory]
         [InlineData(nameof(NonProperlyGuardedClass.Method), "Guard Clause prevented it, however")]
-        [InlineData(nameof(NonProperlyGuardedClass.DeferredMethod), "deferred")]
-        [InlineData(nameof(NonProperlyGuardedClass.AnotherDeferredMethod), "deferred")]
+        [InlineData(nameof(NonProperlyGuardedClass.DeferredMethodReturningGenericEnumerable), "deferred")]
+        [InlineData(nameof(NonProperlyGuardedClass.DeferredMethodReturningGenericEnumerator), "deferred")]
+        [InlineData(nameof(NonProperlyGuardedClass.DeferredMethodReturningNonGenericEnumerable), "deferred")]
+        [InlineData(nameof(NonProperlyGuardedClass.DeferredMethodReturningNonGenericEnumerator), "deferred")]
         public void VerifyNonProperlyGuardedMethodThrowsException(string methodName, string expectedMessage)
         {
             var sut = new GuardClauseAssertion(new Fixture());
@@ -1626,11 +1637,9 @@ namespace AutoFixture.IdiomsUnitTest
 
         private class NonProperlyGuardedClass
         {
-            private const string InvalidParamName = "invalidParamName";
-
             public NonProperlyGuardedClass(object argument)
             {
-                if (argument == null) throw new ArgumentNullException(InvalidParamName);
+                if (argument == null) throw new ArgumentNullException("invalid parameter name");
             }
 
             public object Property
@@ -1638,25 +1647,39 @@ namespace AutoFixture.IdiomsUnitTest
                 get => null;
                 set
                 {
-                    if (value == null) throw new ArgumentNullException(InvalidParamName);
+                    if (value == null) throw new ArgumentNullException("invalid parameter name");
                 }
             }
 
             public void Method(object argument)
             {
-                if (argument == null) throw new ArgumentNullException(InvalidParamName);
+                if (argument == null) throw new ArgumentNullException("invalid parameter name");
             }
 
-            public IEnumerable<object> DeferredMethod(object argument)
+            public IEnumerable<object> DeferredMethodReturningGenericEnumerable(object argument)
             {
-                if (argument == null) throw new ArgumentNullException(InvalidParamName);
+                if (argument == null) throw new ArgumentNullException(nameof(argument));
 
                 yield return argument;
             }
 
-            public IEnumerator<object> AnotherDeferredMethod(object argument)
+            public IEnumerator<object> DeferredMethodReturningGenericEnumerator(object argument)
             {
-                if (argument == null) throw new ArgumentNullException(InvalidParamName);
+                if (argument == null) throw new ArgumentNullException(nameof(argument));
+
+                yield return argument;
+            }
+
+            public IEnumerable DeferredMethodReturningNonGenericEnumerable(object argument)
+            {
+                if (argument == null) throw new ArgumentNullException(nameof(argument));
+
+                yield return argument;
+            }
+
+            public IEnumerator DeferredMethodReturningNonGenericEnumerator(object argument)
+            {
+                if (argument == null) throw new ArgumentNullException(nameof(argument));
 
                 yield return argument;
             }


### PR DESCRIPTION
Fixes #1042.

I've found a way to make the deferred method detection even more robust. According to [MSDN](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/yield), return type for the methods with `yield` statement can only have 4 possible values. Therefore, testing for the precisely that types, rather than for any assignable one.

@moodmosaic Please take a look.
@adamchester Might be interesting to you, as you already tried to fix this issue in #278.