### PR TITLE
If MaxLengthAttribute is not present, make it MinLengthAttribute + 10…

### DIFF
--- a/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
@@ -156,7 +156,7 @@ namespace AutoFixture.DataAnnotations
             private static Range GetRange(MinLengthAttribute minLengthAttribute, MaxLengthAttribute maxLengthAttribute)
             {
                 var min = minLengthAttribute?.Length ?? 0;
-                var max = maxLengthAttribute?.Length ?? int.MaxValue;
+                var max = maxLengthAttribute?.Length ?? min + 100;
 
                 // To avoid creation of empty strings/arrays.
                 if (max > 0 && min == 0)

--- a/Src/AutoFixtureUnitTest/DataAnnotations/MinAndMaxLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/MinAndMaxLengthAttributeRelayTest.cs
@@ -98,7 +98,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var request = new FakeMemberInfo(
                 new ProvidedAttribute(minLengthAttribute, true));
 
-            var expectedRequest = new ConstrainedStringRequest(min, int.MaxValue);
+            var expectedRequest = new ConstrainedStringRequest(min, min + 100);
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6190,5 +6190,43 @@ namespace AutoFixtureUnitTest
             // Assert
             Validator.ValidateObject(item, new ValidationContext(item), true);
         }
+
+        private class TypeWithArrayPropertyWithMinLength
+        {
+            [MinLength(5)]
+            public string[] PropertyWithMinLength { get; set; }
+        }
+
+        [Fact]
+        public void ArrayDecoratedWithMinLengthAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithArrayPropertyWithMinLength>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        private class TypeWithArrayPropertyWithMaxLength
+        {
+            [MaxLength(5)]
+            public string[] PropertyWithMaxLength { get; set; }
+        }
+
+        [Fact]
+        public void ArrayDecoratedWithMaxLengthAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithArrayPropertyWithMaxLength>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
     }
 }


### PR DESCRIPTION
…0 instead of int.MaxValue to avoid to avoid creation of too many objects

Addressing #1050 

100 is completely arbitrary, could be a property on the Relay or in its ctor, but this basically adresses the issue.