### PR TITLE
Introduce ranged sequence request

### DIFF
--- a/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -67,48 +67,13 @@ namespace AutoFixture.DataAnnotations
 
         private static object ResolveArray(ISpecimenContext context, Type arrayType, Range range)
         {
-            if (!TryGetRandomNumberWithinRange(context, range, out int collectionCount))
-            {
-                return new NoSpecimen();
-            }
-
             var elementType = arrayType.GetElementType();
 
-            if (!TryGetRandomCollection(context, elementType, collectionCount, out IEnumerable randomCollection))
-            {
-                return new NoSpecimen();
-            }
+            var result = context.Resolve(new RangedSequenceRequest(elementType, range.Min, range.Max));
+            if (result is IEnumerable seqResult)
+                return ToArray(seqResult, elementType);
 
-            return ToArray(randomCollection, elementType);
-        }
-
-        private static bool TryGetRandomNumberWithinRange(ISpecimenContext context, Range range, out int randomNumber)
-        {
-            var result = context.Resolve(new RangedNumberRequest(typeof(int), range.Min, range.Max));
-
-            if (result is int number)
-            {
-                randomNumber = number;
-                return true;
-            }
-
-            randomNumber = default(int);
-            return false;
-        }
-
-        private static bool TryGetRandomCollection(ISpecimenContext context, Type elementType, int collectionCount,
-            out IEnumerable randomCollection)
-        {
-            var result = context.Resolve(new FiniteSequenceRequest(elementType, collectionCount));
-
-            if (result is IEnumerable collection)
-            {
-                randomCollection = collection;
-                return true;
-            }
-
-            randomCollection = null;
-            return false;
+            return new NoSpecimen();
         }
 
         private static object ToArray(IEnumerable elements, Type elementType)
@@ -156,7 +121,7 @@ namespace AutoFixture.DataAnnotations
             private static Range GetRange(MinLengthAttribute minLengthAttribute, MaxLengthAttribute maxLengthAttribute)
             {
                 var min = minLengthAttribute?.Length ?? 0;
-                var max = maxLengthAttribute?.Length ?? min + 100;
+                var max = maxLengthAttribute?.Length ?? min * 2;
 
                 // To avoid creation of empty strings/arrays.
                 if (max > 0 && min == 0)

--- a/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
@@ -71,24 +71,9 @@ namespace AutoFixture.DataAnnotations
 
             var result = context.Resolve(new RangedSequenceRequest(elementType, range.Min, range.Max));
             if (result is IEnumerable seqResult)
-                return ToArray(seqResult, elementType);
+                return seqResult.ToTypedArray(elementType);
 
             return new NoSpecimen();
-        }
-
-        private static object ToArray(IEnumerable elements, Type elementType)
-        {
-            var count = elements is ICollection collection ? collection.Count : elements.Cast<object>().Count();
-            var array = Array.CreateInstance(elementType, count);
-            var index = 0;
-
-            foreach (var element in elements)
-            {
-                array.SetValue(element, index);
-                index++;
-            }
-
-            return array;
         }
 
         private class Range

--- a/Src/AutoFixture/DefaultRelays.cs
+++ b/Src/AutoFixture/DefaultRelays.cs
@@ -26,6 +26,7 @@ namespace AutoFixture
             yield return new ParameterRequestRelay();
             yield return new PropertyRequestRelay();
             yield return new FieldRequestRelay();
+            yield return new RangedSequenceRelay();
             yield return new FiniteSequenceRelay();
             yield return new SeedIgnoringRelay();
             yield return new MethodInvoker(

--- a/Src/AutoFixture/Kernel/ArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/ArrayRelay.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Linq;
 
 namespace AutoFixture.Kernel
 {
@@ -36,30 +35,20 @@ namespace AutoFixture.Kernel
             var type = request as Type;
             if (type == null)
                 return new NoSpecimen();
+
             if (!type.IsArray)
                 return new NoSpecimen();
+
             var elementType = type.GetElementType();
             var specimen = context.Resolve(new MultipleRequest(elementType));
             if (specimen is OmitSpecimen)
                 return specimen;
+
             var elements = specimen as IEnumerable;
             if (elements == null)
                 return new NoSpecimen();
-            return ToArray(elements, elementType);
-        }
 
-        private static object ToArray(IEnumerable elements, Type elementType)
-        {
-            var collection = elements as ICollection;
-            var count = (collection != null) ? collection.Count : elements.Cast<object>().Count();
-            var array = Array.CreateInstance(elementType, count);
-            int index = 0;
-            foreach (var element in elements)
-            {
-                array.SetValue(element, index);
-                index++;
-            }
-            return array;
+            return elements.ToTypedArray(elementType);
         }
     }
 }

--- a/Src/AutoFixture/Kernel/RangedSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/RangedSequenceRelay.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace AutoFixture.Kernel
+{
+    /// <summary>
+    /// Relay the <see cref="RangedSequenceRelay"/> to the request for the sequence of the fixed length.
+    /// </summary>
+    public class RangedSequenceRelay : ISpecimenBuilder
+    {
+        /// <inheritdoc />
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var rsr = request as RangedSequenceRequest;
+            if (rsr == null)
+                return new NoSpecimen();
+
+            if (!TryGetSequenceLength(rsr, context, out int sequenceLength))
+                return new NoSpecimen();
+
+            return context.Resolve(new FiniteSequenceRequest(rsr.Request, sequenceLength));
+        }
+
+        private static bool TryGetSequenceLength(RangedSequenceRequest rsr, ISpecimenContext ctx, out int length)
+        {
+            var result = ctx.Resolve(new RangedNumberRequest(typeof(int), rsr.MinLength, rsr.MaxLength));
+            if (result is int randNumber)
+            {
+                length = randNumber;
+                return true;
+            }
+
+            length = default;
+            return false;
+        }
+    }
+}

--- a/Src/AutoFixture/Kernel/RangedSequenceRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedSequenceRequest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+
+namespace AutoFixture.Kernel
+{
+    /// <summary>
+    /// Request for the sequence of <see cref="Request"/> values.
+    /// Sequece size is constrained by the <see cref="MinLength"/> and <see cref="MaxLength"/> values.
+    /// </summary>
+    public class RangedSequenceRequest : IEquatable<RangedSequenceRequest>
+    {
+        /// <summary>
+        /// Gets the request the sequence should contain result of.
+        /// </summary>
+        public object Request { get; }
+
+        /// <summary>
+        /// Gets the minimum number of items in the sequence.
+        /// </summary>
+        public int MinLength { get; }
+
+        /// <summary>
+        /// Gets the maximum number of items in the sequence.
+        /// </summary>
+        public int MaxLength { get; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RangedSequenceRequest"/>.
+        /// </summary>
+        public RangedSequenceRequest(object request, int minLength, int maxLength)
+        {
+            if (minLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(minLength), minLength, "Min length cannot be less than zero.");
+            if (maxLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Max length cannot be less than zero.");
+            if (maxLength < minLength)
+                throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Max length cannot be less than min length.");
+
+            this.Request = request ?? throw new ArgumentNullException(nameof(request));
+            this.MinLength = minLength;
+            this.MaxLength = maxLength;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(RangedSequenceRequest other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return this.Request.Equals(other.Request)
+                   && this.MinLength == other.MinLength
+                   && this.MaxLength == other.MaxLength;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return obj is RangedSequenceRequest sequenceRequest && this.Equals(sequenceRequest);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = this.Request.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.MinLength;
+                hashCode = (hashCode * 397) ^ this.MaxLength;
+                return hashCode;
+            }
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/DefaultRelaysTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultRelaysTest.cs
@@ -32,6 +32,7 @@ namespace AutoFixtureUnitTest
                 typeof(ParameterRequestRelay),
                 typeof(PropertyRequestRelay),
                 typeof(FieldRequestRelay),
+                typeof(RangedSequenceRelay),
                 typeof(FiniteSequenceRelay),
                 typeof(SeedIgnoringRelay),
                 typeof(MethodInvoker)

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4488,7 +4488,7 @@ namespace AutoFixtureUnitTest
             Assert.NotEmpty(result);
         }
 
-        [Fact]
+        [Fact, Obsolete]
         public void CreateAnonymousEnumerableWhenEnumerableRelayIsPresentReturnsCorrectResult()
         {
             // Arrange
@@ -6227,6 +6227,41 @@ namespace AutoFixtureUnitTest
 
             // Assert
             Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldResolveRangedSequenceRequest()
+        {
+            // Arrange
+            var sut = new Fixture();
+            var minLength = 5;
+            var maxLength = 10;
+            var rsr = new RangedSequenceRequest(typeof(string), minLength, maxLength);
+
+            // Act
+            var result = sut.Create(rsr, new SpecimenContext(sut));
+
+            // Assert
+            Assert.IsNotType<NoSpecimen>(result);
+            var resultSeq = ((IEnumerable<object>)result).Cast<string>();
+            Assert.InRange(resultSeq.Count(), minLength, maxLength);
+        }
+
+        [Fact]
+        public void ShouldResolveFixedNumberOfItemsForRangedSequenceRequest()
+        {
+            // Arrange
+            var sut = new Fixture();
+            var expectedLength = 5;
+            var request = new RangedSequenceRequest(typeof(string), expectedLength, expectedLength);
+
+            // Act
+            var result = sut.Create(request, new SpecimenContext(sut));
+
+            // Assert
+            Assert.IsNotType<NoSpecimen>(result);
+            var resultSeq = ((IEnumerable<object>)result).Cast<string>();
+            Assert.Equal(expectedLength, resultSeq.Count());
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/RangedSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedSequenceRelayTest.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using AutoFixture.Kernel;
+using Xunit;
+
+namespace AutoFixtureUnitTest.Kernel
+{
+    public class RangedSequenceRelayTest
+    {
+        [Fact]
+        public void ShouldThrowIfContextIsNull()
+        {
+            // Arrange
+            var request = new object();
+            var sut = new RangedSequenceRelay();
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(request, context: null));
+            Assert.Equal("context", ex.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(int))]
+        public void ShouldReturnNoSpecimenForNonSupportedRequests(object request)
+        {
+            // Arrange
+            var context = new DelegatingSpecimenContext();
+            var sut = new RangedSequenceRelay();
+
+            // Act
+            var result = sut.Create(request, context);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void ShouldEmitRandomNumberRequestWithCorrectBoundaries()
+        {
+            // Arrange
+            var min = 10;
+            var max = 20;
+            var rsr = new RangedSequenceRequest(typeof(object), min, max);
+
+            RangedNumberRequest capturedNumberRequest = null;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (r is RangedNumberRequest rnr)
+                        capturedNumberRequest = rnr;
+
+                    return new NoSpecimen();
+                }
+            };
+
+            var sut = new RangedSequenceRelay();
+
+            // Act
+            sut.Create(rsr, context);
+
+            // Assert
+            Assert.NotNull(capturedNumberRequest);
+            Assert.Equal(min, capturedNumberRequest.Minimum);
+            Assert.Equal(max, capturedNumberRequest.Maximum);
+        }
+
+        [Fact]
+        public void ShouldReturnNoSpecimenIfUnableToGetRandomLength()
+        {
+            // Arrange
+            var rsr = new RangedSequenceRequest(typeof(object), minLength: 10, maxLength: 20);
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (r is RangedNumberRequest)
+                        return new NoSpecimen();
+
+                    return 42;
+                }
+            };
+            var sut = new RangedSequenceRelay();
+
+            // Act
+            var result = sut.Create(rsr, context);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void ShouldUseInitialRequestAndReturnedRandomNumberForFiniteSequenceRequest()
+        {
+            // Arrange
+            var request = new object();
+            var rsr = new RangedSequenceRequest(request, minLength: 10, maxLength: 20);
+            var sequenceLength = 42;
+            FiniteSequenceRequest capturedSequenceRequest = null;
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (r is RangedNumberRequest)
+                        return sequenceLength;
+
+                    if (r is FiniteSequenceRequest fsr)
+                        capturedSequenceRequest = fsr;
+
+                    return new NoSpecimen();
+                }
+            };
+
+            var sut = new RangedSequenceRelay();
+
+            // Act
+            sut.Create(rsr, context);
+
+            // Assert
+            var expectedSequenceRequest = new FiniteSequenceRequest(request, sequenceLength);
+            Assert.Equal(expectedSequenceRequest, capturedSequenceRequest);
+        }
+
+        [Fact]
+        public void ShouldUseFiniteSequenceRequestResultForResult()
+        {
+            // Arrange
+            var rsr = new RangedSequenceRequest(typeof(object), minLength: 10, maxLength: 20);
+            var expectedResult = new object();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (r is RangedNumberRequest)
+                        return 42;
+
+                    if (r is FiniteSequenceRequest)
+                        return expectedResult;
+
+                    return new NoSpecimen();
+                }
+            };
+            var sut = new RangedSequenceRelay();
+
+            // Act
+            var actualResult = sut.Create(rsr, context);
+
+            // Assert
+            Assert.Equal(expectedResult, actualResult);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/Kernel/RangedSequenceRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedSequenceRequestTest.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using AutoFixture.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixtureUnitTest.Kernel
+{
+    public class RangedSequenceRequestTest
+    {
+        [Theory]
+        [InlineData(null, 1, 3, "request")]
+        [InlineData(typeof(object), -1, 3, "minLength")]
+        [InlineData(typeof(object), 1, -1, "maxLength")]
+        public void InitializeWithOutOfBoundaryInputThrows(object request, int minLength, int maxLength,
+            string invalidArgName)
+        {
+            // Act & Assert
+            var ex = Assert.ThrowsAny<ArgumentException>(() =>
+                new RangedSequenceRequest(request, minLength, maxLength));
+            Assert.Equal(invalidArgName, ex.ParamName);
+        }
+
+        [Fact]
+        public void InitializeWithMaxLessThanMinThrows()
+        {
+            // Arrange
+            var request = typeof(object);
+            int max = 2;
+            int min = 3;
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new RangedSequenceRequest(request, min, max));
+            Assert.Contains("less than min", ex.Message);
+        }
+
+        [Fact]
+        public void ShouldExposeTheValuesPassedToConstructor()
+        {
+            // Arrange
+            var request = new object();
+            var min = 100;
+            var max = 200;
+
+            // Act
+            var sut = new RangedSequenceRequest(request, min, max);
+
+            // Assert
+            Assert.Equal(request, sut.Request);
+            Assert.Equal(min, sut.MinLength);
+            Assert.Equal(max, sut.MaxLength);
+        }
+
+        [Fact]
+        public void SutIsEquatable()
+        {
+            // Act
+            var sut = new RangedSequenceRequest(new object(), 10, 20);
+
+            // Assert
+            Assert.IsAssignableFrom<IEquatable<RangedSequenceRequest>>(sut);
+        }
+
+        [Fact]
+        public void SutDoesNotEqualNullObject()
+        {
+            // Arrange
+            var sut = new RangedSequenceRequest(new object(), 10, 20);
+            object other = null;
+
+            // Act
+            var result = sut.Equals(other);
+
+            // Assert
+            Assert.False(result, "Equals");
+        }
+
+        [Fact]
+        public void SutDoesNotEqualNullSut()
+        {
+            // Arrange
+            var sut = new RangedSequenceRequest(new object(), 10, 20);
+            RangedSequenceRequest other = null;
+
+            // Act
+            var result = sut.Equals(other);
+
+            // Assert
+            Assert.False(result, "Equals");
+        }
+
+        [Fact]
+        public void SutDoesNotEqualAnonymousObject()
+        {
+            // Arrange
+            var sut = new RangedSequenceRequest(new object(), 10, 20);
+            object anonymousObject = new ConcreteType();
+
+            // Act
+            var result = sut.Equals(anonymousObject);
+
+            // Assert
+            Assert.False(result, "Equals");
+        }
+
+        [Fact]
+        public void SutDoesNotEqualOtherObjectWhenRequestsDifferButRangeMatches()
+        {
+            // Arrange
+            var min = 10;
+            var max = 10;
+            var sut = new RangedSequenceRequest(new object(), min, max);
+            object other = new RangedSequenceRequest(new object(), min, max);
+
+            // Act
+            var result = sut.Equals(other);
+
+            // Assert
+            Assert.False(result, "Equals");
+        }
+
+        [Fact]
+        public void SutDoesNotEqualOtherObjectWhenRangeDifferButRequestMatches()
+        {
+            // Arrange
+            var request = new object();
+            var sut = new RangedSequenceRequest(request, 10, 20);
+            object other = new RangedSequenceRequest(request, 1, 30);
+
+            // Act
+            var result = sut.Equals(other);
+
+            // Assert
+            Assert.False(result, "Equals");
+        }
+
+        [Fact]
+        public void SutEqualsOtherObjectWhenBothRequestsAndRangeMatch()
+        {
+            // Arrange
+            var request = new object();
+            var min = 10;
+            var max = 20;
+            var sut = new RangedSequenceRequest(request, min, max);
+            object other = new RangedSequenceRequest(request, min, max);
+
+            // Act
+            var result = sut.Equals(other);
+
+            // Assert
+            Assert.True(result, "Equals");
+        }
+
+        [Fact]
+        public void SutEqualsOtherSutWhenBothRequestsAndRangeMatch()
+        {
+            // Arrange
+            var request = new object();
+            var min = 10;
+            var max = 20;
+            var sut = new RangedSequenceRequest(request, min, max);
+            var other = new RangedSequenceRequest(request, min, max);
+
+            // Act
+            var result = sut.Equals(other);
+
+            // Assert
+            Assert.True(result, "Equals");
+        }
+
+        [Theory]
+        [InlineData(typeof(string), 10, 20)]
+        [InlineData(typeof(object), 5, 20)]
+        [InlineData(typeof(object), 5, 50)]
+        public void GetHashCodeChangesWhenAnyMemberDiffers(object request, int minLength, int maxLength)
+        {
+            // Arrange
+            var etalonHashCode = new RangedSequenceRequest(typeof(object), 10, 20).GetHashCode();
+            var sut = new RangedSequenceRequest(request, minLength, maxLength);
+
+            // Act
+            var result = sut.GetHashCode();
+
+            // Assert
+            Assert.NotEqual(etalonHashCode, result);
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/Scenario.cs
+++ b/Src/IdiomsUnitTest/Scenario.cs
@@ -324,6 +324,9 @@ namespace AutoFixture.IdiomsUnitTest
                 typeof(FieldTypeAndNameCriterion),
                 typeof(ParameterTypeAndNameCriterion),
                 typeof(PropertyTypeAndNameCriterion),
+
+                // Needs parameters to have the specific properties (max >= min).
+                typeof(RangedSequenceRequest)
             };
 
             var typesToVerify = typeof(IFixture).Assembly


### PR DESCRIPTION
As promised, created a new kind of request - `RangedSequenceRequest`. It's purpose is to activate a sequence withing the specified boundaries.

Currently I'm simply picking a random value withing a range. Later we might change the strategy if really needed.

@moodmosaic Please take a look 😉 