### PR TITLE
Deprecate the MapCreateManyToEnumerable customization

### DIFF
--- a/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
@@ -9,6 +9,9 @@ namespace AutoFixture.Kernel
     /// </summary>
     /// <seealso cref="MultipleToEnumerableRelay.Create(object, ISpecimenContext)" />
     /// <seealso cref="MapCreateManyToEnumerable" />
+    [Obsolete("This relay is obsolete and will be removed in future versions. " +
+              "The reason is that it causes recursion overflow for many requests " +
+              "if you forget to add IEnumerable<T> customization.")]
     public class MultipleToEnumerableRelay : ISpecimenBuilder
     {
         /// <summary>

--- a/Src/AutoFixture/MapCreateManyToEnumerable.cs
+++ b/Src/AutoFixture/MapCreateManyToEnumerable.cs
@@ -25,6 +25,20 @@ namespace AutoFixture
     /// </para>
     /// </remarks>
     /// <seealso cref="MultipleToEnumerableRelay" />
+    [Obsolete("This relay is obsolete and will be removed in future versions. " +
+              "The reason is that it causes recursion overflow for \"many\" requests " +
+              "if you forget to add IEnumerable<T> customization.\n" +
+              "Please use the following code snippet instead:\n" +
+              "fixture.Customizations.Add(" +
+              "  new FilteringSpecimenBuilder(" +
+              "    new FixedBuilder(" +
+              "      SEQUENCE_TO_RETURN)," +
+              "    new EqualRequestSpecification(" +
+              "      new MultipleRequest(" +
+              "        new SeededRequest(" +
+              "          typeof(T)," +
+              "          default(T))))));\n\n" +
+              "If you need that often, please create an extension method inside your project.")]
     public class MapCreateManyToEnumerable : ICustomization
     {
         /// <summary>

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4890,7 +4890,7 @@ namespace AutoFixtureUnitTest
             Assert.NotNull(result.Property2);
         }
 
-        [Fact]
+        [Fact, Obsolete]
         public void CustomizingEnumerableCustomizedCreateManyWhenCreateManyIsMappedToEnumerable()
         {
             // Arrange
@@ -4902,6 +4902,29 @@ namespace AutoFixtureUnitTest
             var actual = fixture.CreateMany<string>();
             // Assert
             Assert.Equal(expected, actual.ToArray());
+        }
+
+        [Fact]
+        public void ItIsPossibleToMapManyRequestToCustomEnumerableInstance()
+        {
+            // Arrange
+            var sut = new Fixture();
+            var expected = new[] { "a", "b", "c", "d" };
+            sut.Customizations.Add(
+                new FilteringSpecimenBuilder(
+                    new FixedBuilder(
+                        expected),
+                    new EqualRequestSpecification(
+                        new MultipleRequest(
+                            new SeededRequest(
+                                typeof(string),
+                                default(string))))));
+
+            // Act
+            var actual = sut.CreateMany<string>();
+
+            // Assert
+            Assert.Equal(expected, actual);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest.Kernel
 {
+    [Obsolete]
     public class MultipleToEnumerableRelayTests
     {
         [Fact]

--- a/Src/AutoFixtureUnitTest/MapCreateManyToEnumerableTests.cs
+++ b/Src/AutoFixtureUnitTest/MapCreateManyToEnumerableTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace AutoFixtureUnitTest
 {
+    [Obsolete]
     public class MapCreateManyToEnumerableTests
     {
         [Fact]


### PR DESCRIPTION
Customization was added back in #128.

This customization leads to the recursion if client forgets to add a customization for the particular `IEnumerable<T>`. The reason is that the requests chain for the `IEnumerable<T>` request is following:
```
IEnumerable<T>
    MuiltipleRequest    
```

If customization is added, it leads to the cyclic requests.

This kind of behavior is really confusing to bundle it with the library. Instead, clients are advised to use the code snippet to customize the `MultipleRequest` requests for the desired sequence types only. This way we don't affect `IEnumerable` requests for other types.

Clients are also free to create the own extension methods inside their solutions, so the fact that the suggested chain is quite long shouldn't be a problem.

@moodmosaic Please take a look. The main motivation is to keep our library simple and handle only common scenarios. The scenario mentioned in #128 looks quite ad-hoc to keep the confusing customization for it.