### PR TITLE
Add AsCustomization extension method

### DIFF
--- a/Src/AutoFixture/CustomizationExtensions.cs
+++ b/Src/AutoFixture/CustomizationExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using AutoFixture.Kernel;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// A set of useful helpers to simplify work with fixture customizations.
+    /// </summary>
+    public static class CustomizationExtensions
+    {
+        /// <summary>
+        /// Create customization that inserts the <paramref name="builder"/> to the beginning of the
+        /// customizations collection.
+        /// </summary>
+        public static ICustomization ToCustomization(this ISpecimenBuilder builder)
+        {
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+            return new InsertCustomization(builder);
+        }
+
+        private class InsertCustomization : ICustomization
+        {
+            private readonly ISpecimenBuilder builder;
+
+            public InsertCustomization(ISpecimenBuilder builder)
+            {
+                this.builder = builder;
+            }
+
+            public void Customize(IFixture fixture)
+            {
+                if (fixture == null) throw new ArgumentNullException(nameof(fixture));
+
+                fixture.Customizations.Insert(0, this.builder);
+            }
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/CustomizationExtensionsTest.cs
+++ b/Src/AutoFixtureUnitTest/CustomizationExtensionsTest.cs
@@ -1,0 +1,48 @@
+using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace AutoFixtureUnitTest
+{
+    public class CustomizationExtensionsTest
+    {
+        [Fact]
+        public void ToCustomization_ShouldThrowIfBuilderIsNull()
+        {
+            // Arrange
+            ISpecimenBuilder nullBuilder = null;
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                nullBuilder.ToCustomization());
+        }
+
+        [Fact]
+        public void ToCustomization_ShouldThrowIfNullFixturePassedToCustomization()
+        {
+            // Arrange
+            var sut = new DelegatingSpecimenBuilder().ToCustomization();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Customize(fixture: null));
+        }
+
+        [Fact]
+        public void ToCustomization_ReturnedCustomizationShouldInsertAtTheBeginning()
+        {
+            // Arrange
+            var builder = new DelegatingSpecimenBuilder();
+            var fixture = new Fixture();
+
+            // Act
+            var sut = builder.ToCustomization();
+            fixture.Customize(sut);
+
+            // Assert
+            Assert.Same(builder, fixture.Customizations[0]);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1056

Add `AsCustomization` extension method which wraps the `builder` to the `ICustomization` which inserts the `builder` to the beginning of the `Customizations` collection.

@moodmosaic Please take a look 😉 