### PR TITLE
Fix Pluralsight course link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ If you want to add your own testimonial to this list, we (the AutoFixture mainta
 
 ## Additional resources ##
 
-* [Pluralsight course](http://www.shareasale.com/r.cfm?u=1017843&b=611266&m=53701&afftrack=&urllink=www%2Epluralsight%2Ecom%2Fcourses%2Fautofixture%2Ddotnet%2Dunit%2Dtest%2Dget%2Dstarted)
+* [Pluralsight course](https://www.pluralsight.com/courses/autofixture-dotnet-unit-test-get-started)
 * [ploeh blog](http://blog.ploeh.dk/tags/#AutoFixture-ref)
 * [Nikos Baxevanis' blog](http://nikosbaxevanis.com/categories/autofixture)
 * [Enrico Campidoglio's blog](http://megakemp.com/tag/autofixture)


### PR DESCRIPTION
Updated pluralsight link. The Sharesales link was broken, and returned he following message:

    The link is not currently active.

    There are a number of reasons that you may have received this message. The most common is that the merchant who was advertising 
    is temporarily not-actively promoting that program. If, however, you feel you have reached this page in error, please let us know. 
    Shareasale.com does not tolerate or send any SPAM mail to anyone. If you feel you have been targeted by a SPAM message, we would 
    appreciate if you could forward the message to us at abuse at shareasale.com.

    Shareasale.com manages the relationships between advertisers and affiliates, which is why you were directed to our site. Since the link 
    that you clicked is not currently active, you were not redirected to the site. 

    If you are a new affiliate, your links will not be active until Shareasale.com gets a chance to review your account - you will receive an 
    email when your account is approved and links are activated. This process generally takes around 24 business hours.