### PR TITLE
Fix NuGet downloading script

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 cls
 
-SET BUILD_DIR=%cd%\build
+SET BUILD_DIR=%~dp0\build
 SET TOOLS_DIR=%BUILD_DIR%\tools
 SET NUGET_PATH=%TOOLS_DIR%\nuget.exe
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 cls
 
-SET BUILD_DIR=build
+SET BUILD_DIR=%cd%\build
 SET TOOLS_DIR=%BUILD_DIR%\tools
 SET NUGET_PATH=%TOOLS_DIR%\nuget.exe
 


### PR DESCRIPTION
When I run `.\build.cmd` locally I receive the following error:

```powershell
Downloading NuGet.exe ...
Invoke-WebRequest : Could not find a part of the path 'C:\Users\<user>\Source\build\tools\nuget.exe'.
At line:1 char:1
+ Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v4.3.0/n ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-WebRequest], DirectoryNotFoundException
    + FullyQualifiedErrorId : System.IO.DirectoryNotFoundException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

'build\tools\nuget.exe' is not recognized as an internal or external command,
operable program or batch file.
...
C:\Users\<user>\Source\autofixture [master ≡]>
```

Please note that the script tries to locate `nuget.exe` using path 
`C:\Users\<user>\Source\build\tools\nuget.exe`
... while the valid path is expected to be 
`C:\Users\<user>\Source\autofixture\build\tools\nuget.exe`.