### PR TITLE
[WIP] Add a factory method overload to the .With(...) customization method

### DIFF
--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -325,6 +325,19 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
+        {
+            var value = valueFactory();
+
+            return this.With(propertyPicker, value);
+        }
+
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
+        {
+
+        }
+
+
         /// <summary>
         /// Enables auto-properties for a type of specimen.
         /// </summary>

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -66,7 +66,11 @@ namespace AutoFixture.Dsl
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "Renaming would be a breaking change.")]
         IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value);
 
-        /// <summary>
+        IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory);
+
+        IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory);
+
+            /// <summary>
         /// Enables auto-properties for a type of specimen.
         /// </summary>
         /// <returns>

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -349,6 +349,19 @@ namespace AutoFixture.Dsl
             return (NodeComposer<T>)ExcludeMemberFromAutoProperties(member, graphWithProperty);
         }
 
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
+        {
+            var value = valueFactory();
+
+            return this.With(propertyPicker, value);
+        }
+
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
+        {
+
+        }
+
+
         /// <summary>
         /// Enables auto-properties for a type of specimen.
         /// </summary>

--- a/Src/AutoFixture/Dsl/NullComposer.cs
+++ b/Src/AutoFixture/Dsl/NullComposer.cs
@@ -130,6 +130,17 @@ namespace AutoFixture.Dsl
             return this;
         }
 
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
+        {
+            return this;
+        }
+
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
+        {
+            return this;
+        }
+
+
         /// <summary>
         /// Does nothing.
         /// </summary>

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -81,6 +81,17 @@ namespace AutoFixtureUnitTest.Dsl
             return this.OnWith(propertyPicker, value);
         }
 
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
+        {
+            return this.OnValueFactoryWith(propertyPicker, () => valueFactory());
+        }
+
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
+        {
+            return this.OnInputValueFactoryWith(propertyPicker, o => valueFactory((TInput)o));
+        }
+
+
         public IPostprocessComposer<T> WithAutoProperties()
         {
             return this.OnWithAutoProperties();
@@ -104,6 +115,8 @@ namespace AutoFixtureUnitTest.Dsl
         internal Func<IPostprocessComposer<T>> OnOmitAutoProperties { get; set; }
         internal Func<object, IPostprocessComposer<T>> OnAnonymousWith { get; set; }
         internal Func<object, object, IPostprocessComposer<T>> OnWith { get; set; }
+        internal Func<object, Func<object>, IPostprocessComposer<T>> OnValueFactoryWith { get; set; }
+        internal Func<object, Func<object, object>, IPostprocessComposer<T>> OnInputValueFactoryWith { get; set; }
         internal Func<IPostprocessComposer<T>> OnWithAutoProperties { get; set; }
         internal Func<object, IPostprocessComposer<T>> OnWithout { get; set; }
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }


### PR DESCRIPTION
A work-in-progress PR to solve #708 and cases like #990

Ideally the new overload could be used like the following snippet.
```csharp
fixture.Customize<MyClass>(c =>
    c.With(x => x.Values, f => f.CreateMany<int>(25).ToList())
);
```

The PR is far from done, I'm just trying to wrap my head around what needs to go where.

I added a `PostprocessComposerExtensions` class in the `AutoFixture` namespace instead of `AutoFixture.Dsl` to facilitate the discovery of the extension methods.
Alternatively the file could be placed in the Dsl folder with the namespace not matching the folder. I guess it really is up to the maintainer!

The extension methods allow the user of the library to skip using the fixture to generate values.

```csharp
b.With(p => p.Property, () => DoSomething());

b.With<MyClass, MyPropertyType, string>(p => p.Property, (string a) => DoSomething(a));

b.With<MyClass, MyPropertyType, string, int>(p => p.Property, (string a, int b) => DoSomething(a, b));

b.With<MyClass, MyPropertyType, string, int, DateTime>(p => p.Property, (string a, int b, DateTime c) => DoSomething(a, b, c));

b.With<MyClass, MyPropertyType, string, int, DateTime, long>(p => p.Property, (string a, int b, DateTime c, long d) => DoSomething(a, b, c, d));
```

Note that type inference should kick in and allow the user to remove/skip the types from the method invocation. Something like

```csharp
b.With(p => p.Property, () => DoSomething());

b.With(p => p.Property, (string a) => DoSomething(a));

b.With(p => p.Property, (string a, int b) => DoSomething(a, b));

b.With(p => p.Property, (string a, int b, DateTime c) => DoSomething(a, b, c));

b.With(p => p.Property, (string a, int b, DateTime c, long d) => DoSomething(a, b, c, d));
```