### PR TITLE
Add compatibility with NSubstitute v4

### DIFF
--- a/Src/All.sln
+++ b/Src/All.sln
@@ -87,6 +87,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.SeedExtensions.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy5UnitTest", "AutoFakeItEasy.FakeItEasy5UnitTest\AutoFakeItEasy.FakeItEasy5UnitTest.csproj", "{FA9FA942-3E9F-49B5-A622-396DB0FC791F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoNSubstitute.NSubstitute4UnitTest", "AutoNSubstitute.NSubstitute4UnitTest\AutoNSubstitute.NSubstitute4UnitTest.csproj", "{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -310,6 +312,12 @@ Global
 		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoNSubstitute.NSubstitute4UnitTest/AutoNSubstitute.NSubstitute4UnitTest.csproj
+++ b/Src/AutoNSubstitute.NSubstitute4UnitTest/AutoNSubstitute.NSubstitute4UnitTest.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\Common.props" />
+  <Import Project="..\Common.Test.props" />
+  <Import Project="..\Common.Test.xUnit.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp1.1</TargetFrameworks>
+    <AssemblyTitle>AutoNSubstitute.NSubstitute4.UnitTest</AssemblyTitle>
+    <AssemblyName>AutoFixture.AutoNSubstitute.NSubstitute4UnitTest</AssemblyName>
+    <RootNamespace>AutoFixture.AutoNSubstitute.UnitTest</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="[4.0.0]" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AutoNSubstituteUnitTest\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Remove="..\AutoNSubstituteUnitTest\obj\**" />
+    <Compile Remove="..\AutoNSubstituteUnitTest\*.Compat.PriorV4*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoNSubstitute\AutoNSubstitute.csproj" />
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+    <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/Src/AutoNSubstitute.NSubstitute4UnitTest/NSubstituteRegisterCallHandlerCommandTest.Compat.SinceV4.cs
+++ b/Src/AutoNSubstitute.NSubstitute4UnitTest/NSubstituteRegisterCallHandlerCommandTest.Compat.SinceV4.cs
@@ -1,0 +1,37 @@
+using AutoFixture.AutoNSubstitute.CustomCallHandler;
+using AutoFixture.Kernel;
+using NSubstitute;
+using NSubstitute.Core;
+using Xunit;
+
+namespace AutoFixture.AutoNSubstitute.UnitTest
+{
+    public partial class NSubstituteRegisterCallHandlerCommandTest
+    {
+        [Fact]
+        public void ValidCallSpecificationFactoryIsPassedToHandler()
+        {
+            // Arrange
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
+
+            var specimen = new object();
+            var context = Substitute.For<ISpecimenContext>();
+            var substituteState = Substitute.For<ISubstituteState>();
+
+            var callRouter = new CallRouterStub();
+            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
+
+            var callSpecFactory = Substitute.For<ICallSpecificationFactory>();
+            substitutionContext.CallSpecificationFactory.Returns(callSpecFactory);
+
+            sut.Execute(specimen, context);
+
+            // Act
+            var handler = (AutoFixtureValuesHandler)callRouter.RegisteredFactory.Invoke(substituteState);
+
+            // Assert
+            Assert.Equal(callSpecFactory, handler.CallSpecificationFactory);
+        }
+    }
+}

--- a/Src/AutoNSubstitute.sln
+++ b/Src/AutoNSubstitute.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoNSubstitute", "AutoNSub
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoNSubstitute.NSubstitute3UnitTest", "AutoNSubstitute.NSubstitute3UnitTest\AutoNSubstitute.NSubstitute3UnitTest.csproj", "{7F1F4B6D-0BE8-4F2D-AD11-9DFB44DB2A89}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoNSubstitute.NSubstitute4UnitTest", "AutoNSubstitute.NSubstitute4UnitTest\AutoNSubstitute.NSubstitute4UnitTest.csproj", "{DFE0E90F-F387-440B-BC4F-41F0A06F67C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,6 +60,12 @@ Global
 		{7F1F4B6D-0BE8-4F2D-AD11-9DFB44DB2A89}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7F1F4B6D-0BE8-4F2D-AD11-9DFB44DB2A89}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{7F1F4B6D-0BE8-4F2D-AD11-9DFB44DB2A89}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{DFE0E90F-F387-440B-BC4F-41F0A06F67C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFE0E90F-F387-440B-BC4F-41F0A06F67C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFE0E90F-F387-440B-BC4F-41F0A06F67C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFE0E90F-F387-440B-BC4F-41F0A06F67C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFE0E90F-F387-440B-BC4F-41F0A06F67C9}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{DFE0E90F-F387-440B-BC4F-41F0A06F67C9}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="[2.0.3,4.0.0)" />
+    <PackageReference Include="NSubstitute" Version="[2.0.3,5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoNSubstitute/CompatShim.cs
+++ b/Src/AutoNSubstitute/CompatShim.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NSubstitute.Core;
+using NSubstitute.Routing;
+
+// ReSharper disable InconsistentNaming - it improves readability of the code.
+namespace AutoFixture.AutoNSubstitute
+{
+    /// <summary>
+    ///     Helper to provide binary compatibility with different NSubstitute versions at run-time.
+    /// </summary>
+    internal static class CompatShim
+    {
+        private static readonly Func<ISubstituteState, ISubstitutionContext, ICallSpecificationFactory> CallSpecificationFactoryResolver = GetCallSpecificationFactoryResolver();
+
+        private static readonly Func<ICallResults, ICall, bool> HasCallResultForResolver = GetHasCallResultForResolver();
+
+        private static readonly Func<ICallHandler[], Route> RouteFactory = GetRouteFactory();
+
+        public static ICallSpecificationFactory GetCallSpecificationFactory(ISubstituteState substituteState, ISubstitutionContext substitutionContext) =>
+            CallSpecificationFactoryResolver.Invoke(substituteState, substitutionContext);
+
+        public static bool CallResults_HasCallResultFor(ICallResults callResults, ICall call) =>
+            HasCallResultForResolver.Invoke(callResults, call);
+
+        public static Route Route_CreateNew(ICallHandler[] handlers) =>
+            RouteFactory.Invoke(handlers);
+
+        private static Func<ISubstituteState, ISubstitutionContext, ICallSpecificationFactory> GetCallSpecificationFactoryResolver()
+        {
+            /* Is optimized, as is invoked from the working code. */
+
+            // Prior to v4
+            var substituteState_CallSpecificationFactoryProp =
+                typeof(ISubstituteState).GetTypeInfo().GetProperty("CallSpecificationFactory");
+            if (substituteState_CallSpecificationFactoryProp != null)
+            {
+                var unboundDelegate =
+                    MakeUnboundDelegate<ISubstituteState, ICallSpecificationFactory>(
+                        substituteState_CallSpecificationFactoryProp.GetMethod);
+                return (state, context) => unboundDelegate(state);
+            }
+
+            // Since v4
+            var substitutionContext_CallSpecificationFactoryProp =
+                typeof(ISubstitutionContext).GetTypeInfo().GetProperty("CallSpecificationFactory");
+            if (substitutionContext_CallSpecificationFactoryProp != null)
+            {
+                var unboundDelegate =
+                    MakeUnboundDelegate<ISubstitutionContext, ICallSpecificationFactory>(
+                        substitutionContext_CallSpecificationFactoryProp.GetMethod);
+                return (state, context) => unboundDelegate(context);
+            }
+
+            throw new InvalidOperationException("Cannot bind method.");
+        }
+
+        private static Func<ICallResults, ICall, bool> GetHasCallResultForResolver()
+        {
+            /* Do not optimize, as it's invoked from the obsolete API only. */
+
+            // Prior to v4
+            var hasResultForMethod = typeof(ICallResults).GetTypeInfo().GetMethod("HasResultFor");
+            if (hasResultForMethod != null)
+                return (callResults, call) => (bool)hasResultForMethod.Invoke(callResults, new object[] { call });
+
+            // Since v4
+            var tryGetResultMethod = typeof(ICallResults).GetTypeInfo().GetMethod("TryGetResult");
+            if (tryGetResultMethod != null)
+                return (callResults, call) => (bool)tryGetResultMethod.Invoke(callResults, new object[] { call, null });
+
+            throw new InvalidOperationException("Cannot bind method.");
+        }
+
+        private static Func<ICallHandler[], Route> GetRouteFactory()
+        {
+            /* Do not optimize, as it's invoked from the obsolete API only. */
+
+            var route = typeof(Route);
+
+            // Since v4
+            var constructor = route.GetTypeInfo().GetConstructor(new[] { typeof(ICallHandler[]) });
+            if (constructor == null)
+            {
+                // Prior to v4
+                constructor = route.GetTypeInfo().GetConstructor(new[] { typeof(IEnumerable<ICallHandler>) });
+            }
+
+            if (constructor == null)
+                throw new InvalidOperationException("Unable to resolve Route constructor taking enumerable or array.");
+
+            return callHandlers =>
+                (Route)constructor.Invoke(new object[] { callHandlers });
+        }
+
+        private static Func<TThis, TResult> MakeUnboundDelegate<TThis, TResult>(MethodInfo mi) =>
+            (Func<TThis, TResult>)mi.CreateDelegate(typeof(Func<TThis, TResult>));
+    }
+}

--- a/Src/AutoNSubstitute/NSubstituteRegisterCallHandlerCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteRegisterCallHandlerCommand.cs
@@ -83,18 +83,18 @@ namespace AutoFixture.AutoNSubstitute
                 return;
             }
 
-            // Add extensibility point for users to allow to use differnt cache implementation.
+            // Add extensibility point for users to allow to use different cache implementation.
             // For instance users might want to disable results caching, as was proposed here:
             // https://github.com/AutoFixture/AutoFixture/issues/625
             var resultsCacheForSubstitution = this.CallResultCacheFactory.CreateCache();
-            var callResultsResover = this.CallResultResolverFactory.Create(context);
+            var callResultsResolver = this.CallResultResolverFactory.Create(context);
 
             router.RegisterCustomCallHandlerFactory(
                 substituteState =>
                     new AutoFixtureValuesHandler(
-                        callResultsResover,
+                        callResultsResolver,
                         resultsCacheForSubstitution,
-                        substituteState.CallSpecificationFactory));
+                        CompatShim.GetCallSpecificationFactory(substituteState, this.SubstitutionContext)));
         }
     }
 }

--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -199,7 +199,7 @@ namespace AutoFixture.AutoNSubstitute
                         var callRouter =
                             SubstitutionContext.Current.GetCallRouterFor(this.Substitute);
 
-                        callRouter.SetRoute(state => new Route(
+                        callRouter.SetRoute(state => CompatShim.Route_CreateNew(
                             new ICallHandler[]
                             {
                                 new NoSetupCallbackHandler(state, () =>

--- a/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
+++ b/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
@@ -18,7 +18,7 @@ namespace AutoFixture.AutoNSubstitute
 
         public bool HasResultFor(ICall call)
         {
-            return this.state.CallResults.HasResultFor(call);
+            return CompatShim.CallResults_HasCallResultFor(this.state.CallResults, call);
         }
 
         RouteAction ICallHandler.Handle(ICall call)

--- a/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.Compat.PriorV4.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.Compat.PriorV4.cs
@@ -1,0 +1,37 @@
+using AutoFixture.AutoNSubstitute.CustomCallHandler;
+using AutoFixture.Kernel;
+using NSubstitute;
+using NSubstitute.Core;
+using Xunit;
+
+namespace AutoFixture.AutoNSubstitute.UnitTest
+{
+    public partial class NSubstituteRegisterCallHandlerCommandTest
+    {
+        [Fact]
+        public void ValidCallSpecificationFactoryIsPassedToHandler()
+        {
+            // Arrange
+            var substitutionContext = Substitute.For<ISubstitutionContext>();
+            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
+
+            var specimen = new object();
+            var context = Substitute.For<ISpecimenContext>();
+            var substituteState = Substitute.For<ISubstituteState>();
+
+            var callRouter = new CallRouterStub();
+            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
+
+            var callSpecFactory = Substitute.For<ICallSpecificationFactory>();
+            substituteState.CallSpecificationFactory.Returns(callSpecFactory);
+
+            sut.Execute(specimen, context);
+
+            // Act
+            var handler = (AutoFixtureValuesHandler)callRouter.RegisteredFactory.Invoke(substituteState);
+
+            // Assert
+            Assert.Equal(callSpecFactory, handler.CallSpecificationFactory);
+        }
+    }
+}

--- a/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace AutoFixture.AutoNSubstitute.UnitTest
 {
-    public class NSubstituteRegisterCallHandlerCommandTest
+    public partial class NSubstituteRegisterCallHandlerCommandTest
     {
         [Fact]
         public void ShouldReturnValuesFromConstructor()
@@ -168,32 +168,6 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             Assert.Equal(context, ((CallResultResolver)handler.ResultResolver).SpecimenContext);
         }
 
-        [Fact]
-        public void ValidCallSpecificationFactoryIsPassedToHandler()
-        {
-            // Arrange
-            var substitutionContext = Substitute.For<ISubstitutionContext>();
-            var sut = new NSubstituteRegisterCallHandlerCommand(substitutionContext);
-
-            var specimen = new object();
-            var context = Substitute.For<ISpecimenContext>();
-            var substituteState = Substitute.For<ISubstituteState>();
-
-            var callRouter = new CallRouterStub();
-            substitutionContext.GetCallRouterFor(specimen).Returns(callRouter);
-
-            var callSpecFactory = Substitute.For<ICallSpecificationFactory>();
-            substituteState.CallSpecificationFactory.Returns(callSpecFactory);
-
-            sut.Execute(specimen, context);
-
-            // Act
-            var handler = (AutoFixtureValuesHandler)callRouter.RegisteredFactory.Invoke(substituteState);
-
-            // Assert
-            Assert.Equal(callSpecFactory, handler.CallSpecificationFactory);
-        }
-
         /// <summary>
         /// It's required to create custom mock, because NSubstitute cannot create fully functional
         /// mock for the ICallRouter interface - it plays a special role inside NSubstitute.
@@ -202,9 +176,18 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
         {
             public CallHandlerFactory RegisteredFactory { get; private set; }
 
+            public bool CallBaseByDefault
+            {
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
+            }
+
             public bool IsLastCallInfoPresent() => throw new NotImplementedException();
 
             public ConfiguredCall LastCallShouldReturn(IReturn returnValue, MatchArgs matchArgs) =>
+                throw new NotImplementedException();
+
+            public ConfiguredCall LastCallShouldReturn(IReturn returnValue, MatchArgs matchArgs, PendingSpecificationInfo pendingSpecInfo) =>
                 throw new NotImplementedException();
 
             public object Route(ICall call) => throw new NotImplementedException();


### PR DESCRIPTION
NSubstitute v4 contains huge amount of binary breaking changes. Luckily, we don't use their API very intensively, so faced a couple of them only. Added binary compatibility shim to mitigate that. It's a good sign that in our next major versions it might make sense to consider dropping support of older versions...

While RC is released only, it's very unlikely they NSubstitute team is going to change API shape (I know that as I'm a maintainer of NSubstitute now and in fact all those breaking changes were done by me 😊). So I think it's right time to start working on support.

@moodmosaic Please take a look. 😉 It's my first PR since long pause.