### PR TITLE
Fix missing support for generic method implementation in GuardClauseAssertion

### DIFF
--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -821,6 +821,7 @@ See e.g. http://codeblog.jonskeet.uk/2008/03/02/c-4-idea-iterator-blocks-and-par
             private void ImplementMethod()
             {
                 this.DefineMethodBuilder();
+                this.DefineMethodGenericParameters();
                 this.DefineStaticSpecimenBuilderFieldBuilder();
                 this.EmitReturningDefaultValue();
             }
@@ -833,6 +834,26 @@ See e.g. http://codeblog.jonskeet.uk/2008/03/02/c-4-idea-iterator-blocks-and-par
                     CallingConventions.Standard,
                     this.methodInfo.ReturnType,
                     this.methodInfo.GetParameters().Select(p => p.ParameterType).ToArray());
+            }
+
+            private void DefineMethodGenericParameters()
+            {
+                var genericArguments = this.methodInfo.GetGenericArguments();
+                if (genericArguments.Any())
+                {
+                    var typeParameters = this.methodBuilder.DefineGenericParameters(genericArguments.Select(a => a.Name).ToArray());
+                    for (int i = 0; i < genericArguments.Length; i++)
+                    {
+                        DefineMethodGenericConstraints(genericArguments[i], typeParameters[i]);
+                    }
+                }
+            }
+
+            private static void DefineMethodGenericConstraints(Type genericArgument, GenericTypeParameterBuilder typeParameter)
+            {
+                typeParameter.SetGenericParameterAttributes(genericArgument.GenericParameterAttributes);
+                typeParameter.SetBaseTypeConstraint(genericArgument.BaseType);
+                typeParameter.SetInterfaceConstraints(genericArgument.GetInterfaces());
             }
 
             private void EmitReturningDefaultValue()

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -1240,6 +1240,10 @@ namespace AutoFixture.IdiomsUnitTest
             object Property { get; set; }
 
             void Method(object argument);
+
+            TResult GenericMethod<TValue, TResult>(TValue argument)
+                where TValue : ICloneable
+                where TResult : class, ICloneable;
         }
 
         private class ClassContraint<T>


### PR DESCRIPTION
When trying to implement generic methods, GuardClauseAssertion was not adding generic parameters and their contraints.

For example, the following interface:
```
public interface ISomeInterface
{
    ...

    TResult GenericMethod<TValue, TResult>(TValue argument)
        where TValue : ICloneable
        where TResult : class, ICloneable;
}
```

... was throwing the following error: `Method 'GenericMethod' in type 'ValueType5638d03332334b2b9d3caa1b60c1bf67' from assembly 'AutoFixture.DynamicProxyAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.`

The reason was that the emitted method did not have the same signature as the implemented interface.

This pull request intends to emit the same signature.