### PR TITLE
Add With() overload taking factory method

### DIFF
--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -23,6 +23,11 @@ namespace AutoFixture.Dsl
         ICustomizationComposer<T>,
         ISpecimenBuilderNode
     {
+        /// <summary>Gets the encapsulated node.</summary>
+        /// <value>The encapsulated node.</value>
+        /// <seealso cref="CompositeNodeComposer{T}(ISpecimenBuilderNode)" />
+        public ISpecimenBuilderNode Node { get; }
+
         /// <summary>
         /// Initializes a new instance of the
         /// <see cref="CompositeNodeComposer{T}" /> class.
@@ -39,17 +44,7 @@ namespace AutoFixture.Dsl
             this.Node = node ?? throw new ArgumentNullException(nameof(node));
         }
 
-        /// <summary>
-        /// Specifies a function that defines how to create a specimen from a
-        /// seed.
-        /// </summary>
-        /// <param name="factory">
-        /// The factory used to create specimens from seeds.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromSeed(Func<T, T> factory)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
@@ -58,18 +53,7 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Specifies an <see cref="ISpecimenBuilder"/> that can create
-        /// specimens of the appropriate type. Mostly for advanced scenarios.
-        /// </summary>
-        /// <param name="factory">
-        /// An <see cref="ISpecimenBuilder"/> that can create specimens of the
-        /// appropriate type.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
@@ -78,18 +62,7 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Specifies that an anonymous object should be created in a
-        /// particular way; often by using a constructor.
-        /// </summary>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often
-        /// be a constructor.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory(Func<T> factory)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
@@ -98,25 +71,8 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way,
-        /// using a single input parameter for the factory.
-        /// </summary>
-        /// <typeparam name="TInput">
-        /// The type of input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often
-        /// be a constructor that takes a single constructor argument of type
-        /// <typeparamref name="TInput"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
-        public IPostprocessComposer<T> FromFactory<TInput>(
-            Func<TInput, T> factory)
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
@@ -124,29 +80,8 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way,
-        /// using two input parameters for the construction.
-        /// </summary>
-        /// <typeparam name="TInput1">
-        /// The type of the first input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput2">
-        /// The type of the second input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often
-        /// be a constructor that takes two constructor arguments of type
-        /// <typeparamref name="TInput1"/> and <typeparamref name="TInput2"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
-        public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(
-            Func<TInput1, TInput2, T> factory)
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
@@ -154,32 +89,7 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way,
-        /// using three input parameters for the construction.
-        /// </summary>
-        /// <typeparam name="TInput1">
-        /// The type of the first input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput2">
-        /// The type of the second input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput3">
-        /// The type of the third input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often
-        /// be a constructor that takes three constructor arguments of type
-        /// <typeparamref name="TInput1"/>, <typeparamref name="TInput2"/> and
-        /// <typeparamref name="TInput3"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(
             Func<TInput1, TInput2, TInput3, T> factory)
         {
@@ -189,36 +99,7 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way,
-        /// using four input parameters for the construction.
-        /// </summary>
-        /// <typeparam name="TInput1">
-        /// The type of the first input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput2">
-        /// The type of the second input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput3">
-        /// The type of the third input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput4">
-        /// The type of the fourth input parameter to use when invoking
-        /// <paramref name="factory"/>.
-        /// </typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often
-        /// be a constructor that takes three constructor arguments of type
-        /// <typeparamref name="TInput1"/>, <typeparamref name="TInput2"/>,
-        /// <typeparamref name="TInput3"/> and <typeparamref name="TInput4"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(
             Func<TInput1, TInput2, TInput3, TInput4, T> factory)
         {
@@ -236,19 +117,9 @@ namespace AutoFixture.Dsl
         /// produce specimens according to the behavior specified by previous
         /// method calls.
         /// </returns>
-        public ISpecimenBuilder Compose()
-        {
-            return this;
-        }
+        public ISpecimenBuilder Compose() => this;
 
-        /// <summary>
-        /// Performs the specified action on a specimen.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> Do(Action<T> action)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
@@ -257,13 +128,7 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Disables auto-properties for a type of specimen.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> OmitAutoProperties()
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
@@ -272,24 +137,8 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Registers that a writable property or field should be assigned an
-        /// anonymous value as part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">
-        /// The type of the property of field.
-        /// </typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will
-        /// should have a value
-        /// assigned.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
-        public IPostprocessComposer<T> With<TProperty>(
-            Expression<Func<T, TProperty>> propertyPicker)
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
@@ -297,27 +146,8 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Registers that a writable property or field should be assigned a
-        /// specific value as part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">
-        /// The type of the property of field.
-        /// </typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will have
-        /// <paramref name="value"/> assigned.
-        /// </param>
-        /// <param name="value">
-        /// The value to assign to the property or field identified by
-        /// <paramref name="propertyPicker"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
-        public IPostprocessComposer<T> With<TProperty>(
-            Expression<Func<T, TProperty>> propertyPicker, TProperty value)
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
@@ -325,34 +155,25 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Enables auto-properties for a type of specimen.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// Although the default behavior of <see cref="Fixture" /> may make
-        /// this method seem redundant, the purpose of this method is to enable
-        /// an explicit opt-in for certain types, in the case where a Fixture
-        /// instance has been configured to <em>not</em> auto-fill properties
-        /// by default (e.g. if <see cref="Fixture.OmitAutoProperties" /> is
-        /// set to <see langword="true" />).
-        /// </para>
-        /// </remarks>
-        /// <example>
-        /// In this example, result.Property will be assigned a value, even
-        /// though this isn't the default behavior of the Fixture instance.
-        /// <code>
-        /// var fixture = new Fixture { OmitAutoProperties = true };
-        /// PropertyHolder&lt;object&gt; result = fixture
-        ///    .Build&lt;PropertyHolder&lt;object&gt;&gt;()
-        ///    .WithAutoProperties()
-        ///    .Create();
-        /// </code>
-        /// </example>
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
+        {
+            return (CompositeNodeComposer<T>)this.ReplaceNodes(
+                with: n =>
+                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueFactory),
+                when: n => n is NodeComposer<T>);
+        }
+
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
+        {
+            return (CompositeNodeComposer<T>)this.ReplaceNodes(
+                with: n =>
+                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueFactory),
+                when: n => n is NodeComposer<T>);
+        }
+
+        /// <inheritdoc />
         public IPostprocessComposer<T> WithAutoProperties()
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
@@ -361,17 +182,8 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>
-        /// Withouts the specified property picker.
-        /// </summary>
-        /// <typeparam name="TProperty">The type of the property.</typeparam>
-        /// <param name="propertyPicker">The property picker.</param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
-        public IPostprocessComposer<T> Without<TProperty>(
-            Expression<Func<T, TProperty>> propertyPicker)
+        /// <inheritdoc />
+        public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
@@ -379,12 +191,7 @@ namespace AutoFixture.Dsl
                 when: n => n is NodeComposer<T>);
         }
 
-        /// <summary>Composes the supplied builders.</summary>
-        /// <param name="builders">The builders to compose.</param>
-        /// <returns>
-        /// A new <see cref="ISpecimenBuilderNode" /> instance containing
-        /// <paramref name="builders" /> as child nodes.
-        /// </returns>
+        /// <inheritdoc />
         public ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
             var isSingle = builders.Take(2).Count() == 1;
@@ -400,56 +207,19 @@ namespace AutoFixture.Dsl
                     builders));
         }
 
-        /// <summary>Creates a new specimen based on a request.</summary>
-        /// <param name="request">
-        /// The request that describes what to create.
-        /// </param>
-        /// <param name="context">
-        /// A context that can be used to create other specimens.
-        /// </param>
-        /// <returns>
-        /// The requested specimen if possible; otherwise a
-        /// <see cref="NoSpecimen" /> instance.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The <paramref name="request" /> can be any object, but will often
-        /// be a <see cref="Type" /> or other
-        /// <see cref="System.Reflection.MemberInfo" /> instances.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public object Create(object request, ISpecimenContext context)
         {
             return this.Node.Create(request, context);
         }
 
-        /// <summary>
-        /// Returns an enumerator that iterates through the collection.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="IEnumerator{ISpecimenBuilder}" /> that can be used to
-        /// iterate through the collection.
-        /// </returns>
+        /// <inheritdoc />
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
             yield return this.Node;
         }
 
-        /// <summary>
-        /// Returns an enumerator that iterates through a collection.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="System.Collections.IEnumerator" /> object that can
-        /// be used to iterate through the collection.
-        /// </returns>
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
-
-        /// <summary>Gets the encapsulated node.</summary>
-        /// <value>The encapsulated node.</value>
-        /// <seealso cref="CompositeNodeComposer{T}(ISpecimenBuilderNode)" />
-        public ISpecimenBuilderNode Node { get; }
+        /// <inheritdoc />
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -10,6 +10,8 @@ namespace AutoFixture.Dsl
     /// Aggregates an arbitrary number of <see cref="IPostprocessComposer{T}"/> instances.
     /// </summary>
     /// <typeparam name="T">The type of specimen to customize.</typeparam>
+    [Obsolete("This class is deprecated and will be removed in future versions of AutoFixture. " +
+              "Please file an issue on GitHub if you need this class in your project.")]
     public class CompositePostprocessComposer<T> : IPostprocessComposer<T>
     {
         /// <summary>
@@ -37,123 +39,63 @@ namespace AutoFixture.Dsl
         /// </summary>
         public IEnumerable<IPostprocessComposer<T>> Composers { get; }
 
-        /// <summary>
-        /// Performs the specified action on a specimen.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> Do(Action<T> action)
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.Do(action));
         }
 
-        /// <summary>
-        /// Disables auto-properties for a type of specimen.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> OmitAutoProperties()
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.OmitAutoProperties());
         }
 
-        /// <summary>
-        /// Registers that a writable property or field should be assigned an anonymous value as
-        /// part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">The type of the property of field.</typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will should have a value
-        /// assigned.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.With(propertyPicker));
         }
 
-        /// <summary>
-        /// Registers that a writable property or field should be assigned a specific value as
-        /// part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">The type of the property of field.</typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will have
-        /// <paramref name="value"/> assigned.
-        /// </param>
-        /// <param name="value">
-        /// The value to assign to the property or field identified by
-        /// <paramref name="propertyPicker"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.With(propertyPicker, value));
         }
 
-        /// <summary>
-        /// Enables auto-properties for a type of specimen.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
+        {
+            return new CompositePostprocessComposer<T>(from c in this.Composers
+                                                       select c.With(propertyPicker, valueFactory));
+        }
+
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
+        {
+            return new CompositePostprocessComposer<T>(from c in this.Composers
+                                                       select c.With(propertyPicker, valueFactory));
+        }
+
+        /// <inheritdoc />
         public IPostprocessComposer<T> WithAutoProperties()
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.WithAutoProperties());
         }
 
-        /// <summary>
-        /// Registers that a writable property should not be assigned any automatic value as
-        /// part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">The type of the property or field to ignore.</typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field to be ignored.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers
                                                        select c.Without(propertyPicker));
         }
 
-        /// <summary>Creates a new specimen based on a request.</summary>
-        /// <param name="request">
-        /// The request that describes what to create.
-        /// </param>
-        /// <param name="context">
-        /// A context that can be used to create other specimens.
-        /// </param>
-        /// <returns>
-        /// The requested specimen if possible; otherwise a
-        /// <see cref="NoSpecimen" /> instance.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The <paramref name="request" /> can be any object, but will often be a
-        /// <see cref="Type" /> or other <see cref="System.Reflection.MemberInfo" /> instances.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public object Create(object request, ISpecimenContext context)
         {
             return new CompositeSpecimenBuilder(this.Composers)

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using AutoFixture.Kernel;
 
@@ -43,7 +44,7 @@ namespace AutoFixture.Dsl
         /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
         /// post-processing of created specimens.
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "Renaming would be a breaking change.")]
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "Renaming would be a breaking change.")]
         IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker);
 
         /// <summary>
@@ -63,8 +64,33 @@ namespace AutoFixture.Dsl
         /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
         /// post-processing of created specimens.
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "Renaming would be a breaking change.")]
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With",
+            Justification = "Renaming would be a breaking change.")]
         IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value);
+
+        /// <summary>
+        /// Registers that a writable property or field should be assigned generated value as a part of specimen post-processing.
+        /// </summary>
+        /// <param name="propertyPicker">
+        /// An expression that identifies the property or field that will have <paramref name="valueFactory"/> result assigned.
+        /// </param>
+        /// <param name="valueFactory">
+        /// The factory of value to assign to the property or field identified by <paramref name="propertyPicker"/>.
+        /// </param>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "It's a part of the public API we currently have.")]
+        IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory);
+
+        /// <summary>
+        /// Registers that a writable property or field should be assigned generated value as a part of specimen post-processing.
+        /// </summary>
+        /// <param name="propertyPicker">
+        /// An expression that identifies the property or field that will have <paramref name="valueFactory"/> result assigned.
+        /// </param>
+        /// <param name="valueFactory">
+        /// The factory of value to assign to the property or field identified by <paramref name="propertyPicker"/>.
+        /// </param>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "It's a part of the public API we currently have.")]
+        IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory);
 
         /// <summary>
         /// Enables auto-properties for a type of specimen.

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -17,6 +17,11 @@ namespace AutoFixture.Dsl
         ICustomizationComposer<T>,
         ISpecimenBuilderNode
     {
+        /// <summary>Gets the encapsulated builder.</summary>
+        /// <value>The encapsulated builder.</value>
+        /// <seealso cref="NodeComposer{T}(ISpecimenBuilder)" />
+        public ISpecimenBuilder Builder { get; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NodeComposer{T}" />
         /// class.
@@ -37,153 +42,43 @@ namespace AutoFixture.Dsl
             this.Builder = builder;
         }
 
-        /// <summary>
-        /// Specifies a function that defines how to create a specimen from a
-        /// seed.
-        /// </summary>
-        /// <param name="factory">
-        /// The factory used to create specimens from seeds.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromSeed(Func<T, T> factory)
         {
             return this.WithFactory(new SeededFactory<T>(factory));
         }
 
-        /// <summary>
-        /// Specifies an <see cref="ISpecimenBuilder"/> that can create
-        /// specimens of the appropriate type. Mostly for advanced scenarios.
-        /// </summary>
-        /// <param name="factory">
-        /// An <see cref="ISpecimenBuilder"/> that can create specimens of the
-        /// appropriate type.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory)
         {
             return this.WithFactory(factory);
         }
 
-        /// <summary>
-        /// Specifies that an anonymous object should be created in a
-        /// particular way; often by using a constructor.
-        /// </summary>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often
-        /// be a constructor.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory(Func<T> factory)
         {
             return this.WithFactory(new SpecimenFactory<T>(factory));
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way, using a single input
-        /// parameter for the factory.
-        /// </summary>
-        /// <typeparam name="TInput">
-        /// The type of input parameter to use when invoking <paramref name="factory"/>
-        /// .</typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often be a constructor
-        /// that takes a single constructor argument of type <typeparamref name="TInput"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory)
         {
             return this.WithFactory(new SpecimenFactory<TInput, T>(factory));
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way, using two input
-        /// parameters for the construction.
-        /// </summary>
-        /// <typeparam name="TInput1">
-        /// The type of the first input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput2">
-        /// The type of the second input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often be a constructor
-        /// that takes two constructor arguments of type <typeparamref name="TInput1"/> and
-        /// <typeparamref name="TInput2"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory)
         {
             return this.WithFactory(new SpecimenFactory<TInput1, TInput2, T>(factory));
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way, using three input
-        /// parameters for the construction.
-        /// </summary>
-        /// <typeparam name="TInput1">
-        /// The type of the first input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput2">
-        /// The type of the second input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput3">
-        /// The type of the third input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often be a constructor
-        /// that takes three constructor arguments of type <typeparamref name="TInput1"/>,
-        /// <typeparamref name="TInput2"/> and <typeparamref name="TInput3"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(Func<TInput1, TInput2, TInput3, T> factory)
         {
             return this.WithFactory(new SpecimenFactory<TInput1, TInput2, TInput3, T>(factory));
         }
 
-        /// <summary>
-        /// Specifies that a specimen should be created in a particular way, using four input
-        /// parameters for the construction.
-        /// </summary>
-        /// <typeparam name="TInput1">
-        /// The type of the first input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput2">
-        /// The type of the second input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput3">
-        /// The type of the third input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <typeparam name="TInput4">
-        /// The type of the fourth input parameter to use when invoking <paramref name="factory"/>.
-        /// </typeparam>
-        /// <param name="factory">
-        /// A function that will be used to create the object. This will often be a constructor
-        /// that takes three constructor arguments of type <typeparamref name="TInput1"/>,
-        /// <typeparamref name="TInput2"/>, <typeparamref name="TInput3"/> and
-        /// <typeparamref name="TInput4"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
-        /// post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(Func<TInput1, TInput2, TInput3, TInput4, T> factory)
         {
             return this.WithFactory(new SpecimenFactory<TInput1, TInput2, TInput3, TInput4, T>(factory));
@@ -202,14 +97,7 @@ namespace AutoFixture.Dsl
             return this;
         }
 
-        /// <summary>
-        /// Performs the specified action on a specimen.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> Do(Action<T> action)
         {
             var graphWithoutSeedIgnoringRelay = WithoutSeedIgnoringRelay(this);
@@ -246,13 +134,7 @@ namespace AutoFixture.Dsl
                 when: container.Equals);
         }
 
-        /// <summary>
-        /// Disables auto-properties for a type of specimen.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> OmitAutoProperties()
         {
             var autoPropertiesNode = FindAutoPropertiesNode(this);
@@ -273,22 +155,7 @@ namespace AutoFixture.Dsl
                 when: autoPropertiesNode.Equals);
         }
 
-        /// <summary>
-        /// Registers that a writable property or field should be assigned an
-        /// anonymous value as part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">
-        /// The type of the property of field.
-        /// </typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will
-        /// should have a value
-        /// assigned.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker)
         {
@@ -304,27 +171,36 @@ namespace AutoFixture.Dsl
                 when: targetToDecorate.Equals);
         }
 
-        /// <summary>
-        /// Registers that a writable property or field should be assigned a
-        /// specific value as part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">
-        /// The type of the property of field.
-        /// </typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field that will have
-        /// <paramref name="value"/> assigned.
-        /// </param>
-        /// <param name="value">
-        /// The value to assign to the property or field identified by
-        /// <paramref name="propertyPicker"/>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker, TProperty value)
+        {
+            return this.WithCommand(
+                propertyPicker,
+                new BindingCommand<T, TProperty>(propertyPicker, value));
+        }
+
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
+        {
+            return this.WithCommand(
+                propertyPicker,
+                new BindingCommand<T, TProperty>(propertyPicker, _ => valueFactory.Invoke()));
+        }
+
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
+        {
+            return this.WithCommand(
+                propertyPicker,
+                new BindingCommand<T, TProperty>(propertyPicker, context =>
+                {
+                    var arg = (TInput)context.Resolve(typeof(TInput));
+                    return valueFactory.Invoke(arg);
+                }));
+        }
+
+        private IPostprocessComposer<T> WithCommand<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenCommand command)
         {
             ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);
 
@@ -339,7 +215,7 @@ namespace AutoFixture.Dsl
                     {
                         new Postprocessor(
                             CompositeSpecimenBuilder.ComposeIfMultiple(n),
-                            new BindingCommand<T, TProperty>(propertyPicker, value),
+                            command,
                             CreateSpecification()),
                         new SeedIgnoringRelay()
                     }),
@@ -349,13 +225,7 @@ namespace AutoFixture.Dsl
             return (NodeComposer<T>)ExcludeMemberFromAutoProperties(member, graphWithProperty);
         }
 
-        /// <summary>
-        /// Enables auto-properties for a type of specimen.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> WithAutoProperties()
         {
             var g = this.GetGraphWithAutoPropertiesNode();
@@ -369,20 +239,7 @@ namespace AutoFixture.Dsl
                 when: autoProperties.Equals);
         }
 
-        /// <summary>
-        /// Registers that a writable property should not be assigned an
-        /// automatic value as part of specimen post-processing.
-        /// </summary>
-        /// <typeparam name="TProperty">
-        /// The type of the property or field to ignore.
-        /// </typeparam>
-        /// <param name="propertyPicker">
-        /// An expression that identifies the property or field to be ignored.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IPostprocessComposer{T}"/> which can be used to
-        /// further customize the post-processing of created specimens.
-        /// </returns>
+        /// <inheritdoc />
         public IPostprocessComposer<T> Without<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker)
         {
@@ -427,12 +284,7 @@ namespace AutoFixture.Dsl
                 new ExactTypeSpecification(typeof(T)));
         }
 
-        /// <summary>Composes the supplied builders.</summary>
-        /// <param name="builders">The builders to compose.</param>
-        /// <returns>
-        /// A new <see cref="ISpecimenBuilderNode" /> instance containing
-        /// <paramref name="builders" /> as child nodes.
-        /// </returns>
+        /// <inheritdoc />
         public ISpecimenBuilderNode Compose(
             IEnumerable<ISpecimenBuilder> builders)
         {
@@ -441,57 +293,20 @@ namespace AutoFixture.Dsl
             return new NodeComposer<T>(composedBuilder);
         }
 
-        /// <summary>Creates a new specimen based on a request.</summary>
-        /// <param name="request">
-        /// The request that describes what to create.
-        /// </param>
-        /// <param name="context">
-        /// A context that can be used to create other specimens.
-        /// </param>
-        /// <returns>
-        /// The requested specimen if possible; otherwise a
-        /// <see cref="NoSpecimen" /> instance.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The <paramref name="request" /> can be any object, but will often
-        /// be a <see cref="Type" /> or other
-        /// <see cref="System.Reflection.MemberInfo" /> instances.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc />
         public object Create(object request, ISpecimenContext context)
         {
             return this.Builder.Create(request, context);
         }
 
-        /// <summary>
-        /// Returns an enumerator that iterates through the collection.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="IEnumerator{ISpecimenBuilder}" /> that can be used to
-        /// iterate through the collection.
-        /// </returns>
+        /// <inheritdoc />
         public IEnumerator<ISpecimenBuilder> GetEnumerator()
         {
             yield return this.Builder;
         }
 
-        /// <summary>
-        /// Returns an enumerator that iterates through a collection.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="System.Collections.IEnumerator" /> object that can
-        /// be used to iterate through the collection.
-        /// </returns>
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
-
-        /// <summary>Gets the encapsulated builder.</summary>
-        /// <value>The encapsulated builder.</value>
-        /// <seealso cref="NodeComposer{T}(ISpecimenBuilder)" />
-        public ISpecimenBuilder Builder { get; }
+        /// <inheritdoc />
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
 
         /// <summary>
         /// Looks for the AutoProperties postprocessor in the current graph.

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -159,16 +159,9 @@ namespace AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty>(
             Expression<Func<T, TProperty>> propertyPicker)
         {
-            ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);
-
-            var targetToDecorate = this.FindFirstNode(n => n is NoSpecimenOutputGuard);
-
-            return (NodeComposer<T>)this.ReplaceNodes(
-                with: n => new Postprocessor(
-                    n,
-                    new BindingCommand<T, TProperty>(propertyPicker),
-                    CreateSpecification()),
-                when: targetToDecorate.Equals);
+            return this.WithCommand(
+                propertyPicker,
+                new BindingCommand<T, TProperty>(propertyPicker));
         }
 
         /// <inheritdoc />

--- a/Src/AutoFixture/Dsl/NullComposer.cs
+++ b/Src/AutoFixture/Dsl/NullComposer.cs
@@ -42,109 +42,50 @@ namespace AutoFixture.Dsl
             this.compose = factory ?? throw new ArgumentNullException(nameof(factory));
         }
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> FromSeed(Func<T, T> factory)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromSeed(Func<T, T> factory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> FromFactory(Func<T> factory)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory(Func<T> factory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(Func<TInput1, TInput2, TInput3, T> factory)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(Func<TInput1, TInput2, TInput3, T> factory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(Func<TInput1, TInput2, TInput3, TInput4, T> factory)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(Func<TInput1, TInput2, TInput3, TInput4, T> factory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> Do(Action<T> action)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> Do(Action<T> action) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> OmitAutoProperties()
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> OmitAutoProperties() => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> WithAutoProperties()
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory) => this;
 
-        /// <summary>
-        /// Does nothing.
-        /// </summary>
-        public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
-        {
-            return this;
-        }
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory) => this;
+
+        /// <inheritdoc />
+        public IPostprocessComposer<T> WithAutoProperties() => this;
+
+        /// <inheritdoc />
+        public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker) => this;
 
         /// <summary>
         /// Composes a new <see cref="ISpecimenBuilder"/> instance.

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -153,16 +153,8 @@ namespace AutoFixture.Kernel
         }
 
         /// <summary>
-        /// Executes the command on the supplied specimen by assigning the
-        /// property of field the correct value.
+        /// Executes the command on the supplied specimen by assigning the property of field the correct value.
         /// </summary>
-        /// <param name="specimen">
-        /// A specimen that should have its property or field assigned.
-        /// </param>
-        /// <param name="context">
-        /// An <see cref="ISpecimenContext"/> which can supply an anonymous
-        /// value for the property or field.
-        /// </param>
         /// <remarks>
         /// <para>
         /// This method assigns a value to the property or field identified by

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -124,7 +124,7 @@ namespace AutoFixture.Kernel
 
             if (!hasItems)
             {
-                // It's very rare case and it does't make sense to optimize it.
+                // It's very rare case and it doesn't make sense to optimize it.
                 return new CompositeSpecimenBuilder();
             }
 

--- a/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
@@ -474,6 +474,64 @@ namespace AutoFixtureUnitTest.Dsl
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public void WithValueFactoryReturnsCorrectResult(string value)
+        {
+            // Arrange
+            var node = new CompositeSpecimenBuilder(
+                new DelegatingSpecimenBuilder(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                new DelegatingSpecimenBuilder());
+            var sut = new CompositeNodeComposer<PropertyHolder<string>>(node);
+            Func<string> valueFactory = () => value;
+            // Act
+            var actual = sut.With(x => x.Property, valueFactory);
+            // Assert
+            var expected = new CompositeNodeComposer<PropertyHolder<string>>(
+                new CompositeSpecimenBuilder(
+                    new DelegatingSpecimenBuilder(),
+                    (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, valueFactory),
+                    SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                    (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, valueFactory),
+                    new DelegatingSpecimenBuilder()));
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public void WithSingleArgValueFactoryReturnsCorrectResult(string value)
+        {
+            // Arrange
+            var node = new CompositeSpecimenBuilder(
+                new DelegatingSpecimenBuilder(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                new DelegatingSpecimenBuilder());
+            var sut = new CompositeNodeComposer<PropertyHolder<string>>(node);
+            Func<string, string> valueFactory = _ => value;
+            // Act
+            var actual = sut.With(x => x.Property, valueFactory);
+            // Assert
+            var expected = new CompositeNodeComposer<PropertyHolder<string>>(
+                new CompositeSpecimenBuilder(
+                    new DelegatingSpecimenBuilder(),
+                    (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, valueFactory),
+                    SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                    (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, valueFactory),
+                    new DelegatingSpecimenBuilder()));
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+        }
+
         [Fact]
         public void WithoutReturnsCorrectResult()
         {

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -20,81 +20,53 @@ namespace AutoFixtureUnitTest.Dsl
             this.OnDo = f => new DelegatingComposer<T>();
             this.OnOmitAutoProperties = () => new DelegatingComposer<T>();
             this.OnAnonymousWith = f => new DelegatingComposer<T>();
-            this.OnWith = (f, v) => new DelegatingComposer<T>();
+            this.OnWithOverloadValue = (f, v) => new DelegatingComposer<T>();
+            this.OnWithOverloadFactory = (f, vf) => new DelegatingComposer<T>();
             this.OnWithAutoProperties = () => new DelegatingComposer<T>();
             this.OnWithout = f => new DelegatingComposer<T>();
             this.OnCreate = (r, c) => new object();
         }
 
-        public IPostprocessComposer<T> FromSeed(Func<T, T> factory)
-        {
-            return this.OnFromSeed(factory);
-        }
+        public IPostprocessComposer<T> FromSeed(Func<T, T> factory) => this.OnFromSeed(factory);
 
-        public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory)
-        {
-            return this.OnFromBuilder(factory);
-        }
+        public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory) => this.OnFromBuilder(factory);
 
-        public IPostprocessComposer<T> FromFactory(Func<T> factory)
-        {
-            return this.OnFromFactory(factory);
-        }
+        public IPostprocessComposer<T> FromFactory(Func<T> factory) => this.OnFromFactory(factory);
 
-        public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory)
-        {
-            return this.OnFromOverloadFactory(factory);
-        }
+        public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory) =>
+            this.OnFromOverloadFactory(factory);
 
-        public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory)
-        {
-            return this.OnFromOverloadFactory(factory);
-        }
+        public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory) =>
+            this.OnFromOverloadFactory(factory);
 
-        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(Func<TInput1, TInput2, TInput3, T> factory)
-        {
-            return this.OnFromOverloadFactory(factory);
-        }
+        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(Func<TInput1, TInput2, TInput3, T> factory) =>
+            this.OnFromOverloadFactory(factory);
 
-        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(Func<TInput1, TInput2, TInput3, TInput4, T> factory)
-        {
-            return this.OnFromOverloadFactory(factory);
-        }
+        public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(Func<TInput1, TInput2, TInput3, TInput4, T> factory) =>
+            this.OnFromOverloadFactory(factory);
 
-        public IPostprocessComposer<T> Do(Action<T> action)
-        {
-            return this.OnDo(action);
-        }
+        public IPostprocessComposer<T> Do(Action<T> action) => this.OnDo(action);
 
-        public IPostprocessComposer<T> OmitAutoProperties()
-        {
-            return this.OnOmitAutoProperties();
-        }
+        public IPostprocessComposer<T> OmitAutoProperties() => this.OnOmitAutoProperties();
 
-        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
-        {
-            return this.OnAnonymousWith(propertyPicker);
-        }
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker) =>
+            this.OnAnonymousWith(propertyPicker);
 
-        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
-        {
-            return this.OnWith(propertyPicker, value);
-        }
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value) =>
+            this.OnWithOverloadValue(propertyPicker, value);
 
-        public IPostprocessComposer<T> WithAutoProperties()
-        {
-            return this.OnWithAutoProperties();
-        }
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory) =>
+            this.OnWithOverloadFactory(propertyPicker, valueFactory);
 
-        public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
-        {
-            return this.OnWithout(propertyPicker);
-        }
+        public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory) =>
+            this.OnWithOverloadFactory(propertyPicker, valueFactory);
 
-        public object Create(object request, ISpecimenContext context)
-        {
-            return this.OnCreate(request, context);
-        }
+        public IPostprocessComposer<T> WithAutoProperties() => this.OnWithAutoProperties();
+
+        public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker) =>
+            this.OnWithout(propertyPicker);
+
+        public object Create(object request, ISpecimenContext context) => this.OnCreate(request, context);
 
         internal Func<Func<T, T>, IPostprocessComposer<T>> OnFromSeed { get; set; }
         internal Func<ISpecimenBuilder, IPostprocessComposer<T>> OnFromBuilder { get; set; }
@@ -103,7 +75,8 @@ namespace AutoFixtureUnitTest.Dsl
         internal Func<Action<T>, IPostprocessComposer<T>> OnDo { get; set; }
         internal Func<IPostprocessComposer<T>> OnOmitAutoProperties { get; set; }
         internal Func<object, IPostprocessComposer<T>> OnAnonymousWith { get; set; }
-        internal Func<object, object, IPostprocessComposer<T>> OnWith { get; set; }
+        internal Func<object, object, IPostprocessComposer<T>> OnWithOverloadValue { get; set; }
+        internal Func<object, object, IPostprocessComposer<T>> OnWithOverloadFactory { get; set; }
         internal Func<IPostprocessComposer<T>> OnWithAutoProperties { get; set; }
         internal Func<object, IPostprocessComposer<T>> OnWithout { get; set; }
         internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -518,6 +518,91 @@ namespace AutoFixtureUnitTest.Dsl
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public void WithExplicitValueFactoryReturnsCorrectResult(string value)
+        {
+            // Arrange
+            var sut = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>();
+            var pi = typeof(PropertyHolder<string>).GetProperty("Property");
+            Func<string> valueFactory = () => value;
+            // Act
+            var actual = sut.With(x => x.Property, valueFactory);
+            // Assert
+            var expected = new NodeComposer<PropertyHolder<string>>(
+                new FilteringSpecimenBuilder(
+                    new CompositeSpecimenBuilder(
+                        new Postprocessor(
+                            new Postprocessor(
+                                new NoSpecimenOutputGuard(
+                                    new MethodInvoker(
+                                        new ModestConstructorQuery()),
+                                    new InverseRequestSpecification(
+                                        new SeedRequestSpecification(
+                                            typeof(PropertyHolder<string>)))),
+                                new AutoPropertiesCommand(
+                                    typeof(PropertyHolder<string>),
+                                    new InverseRequestSpecification(
+                                        new EqualRequestSpecification(
+                                            pi,
+                                            new MemberInfoEqualityComparer()))),
+                                new FalseRequestSpecification()),
+                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, _ => valueFactory()),
+                            new OrRequestSpecification(
+                                new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                                new ExactTypeSpecification(typeof(PropertyHolder<string>)))),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                        new ExactTypeSpecification(typeof(PropertyHolder<string>)))));
+
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+        }
+
+        [Fact]
+        public void WithExplicitSingleArgValueFactoryReturnsCorrectResult()
+        {
+            // Arrange
+            var sut = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>();
+            var pi = typeof(PropertyHolder<string>).GetProperty("Property");
+            Func<string, string> valueFactory = v => v;
+            // Act
+            var actual = sut.With(x => x.Property, valueFactory);
+            // Assert
+            var expected = new NodeComposer<PropertyHolder<string>>(
+                new FilteringSpecimenBuilder(
+                    new CompositeSpecimenBuilder(
+                        new Postprocessor(
+                            new Postprocessor(
+                                new NoSpecimenOutputGuard(
+                                    new MethodInvoker(
+                                        new ModestConstructorQuery()),
+                                    new InverseRequestSpecification(
+                                        new SeedRequestSpecification(
+                                            typeof(PropertyHolder<string>)))),
+                                new AutoPropertiesCommand(
+                                    typeof(PropertyHolder<string>),
+                                    new InverseRequestSpecification(
+                                        new EqualRequestSpecification(
+                                            pi,
+                                            new MemberInfoEqualityComparer()))),
+                                new FalseRequestSpecification()),
+                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, ctx => valueFactory((string)ctx.Resolve(typeof(string)))),
+                            new OrRequestSpecification(
+                                new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                                new ExactTypeSpecification(typeof(PropertyHolder<string>)))),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                        new ExactTypeSpecification(typeof(PropertyHolder<string>)))));
+
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+        }
+
         [Fact]
         public void WithoutReturnsCorrectResult()
         {

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -389,6 +389,7 @@ namespace AutoFixtureUnitTest.Dsl
         {
             // Arrange
             var sut = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<int>>();
+            var pi = typeof(PropertyHolder<int>).GetProperty("Property");
             // Act
             var actual = sut.With(x => x.Property);
             // Assert
@@ -396,12 +397,20 @@ namespace AutoFixtureUnitTest.Dsl
                 new FilteringSpecimenBuilder(
                     new CompositeSpecimenBuilder(
                         new Postprocessor(
-                            new NoSpecimenOutputGuard(
-                                new MethodInvoker(
-                                    new ModestConstructorQuery()),
-                                new InverseRequestSpecification(
-                                    new SeedRequestSpecification(
-                                        typeof(PropertyHolder<int>)))),
+                            new Postprocessor(
+                                new NoSpecimenOutputGuard(
+                                    new MethodInvoker(
+                                        new ModestConstructorQuery()),
+                                    new InverseRequestSpecification(
+                                        new SeedRequestSpecification(
+                                            typeof(PropertyHolder<int>)))),
+                                new AutoPropertiesCommand(
+                                    typeof(PropertyHolder<int>),
+                                    new InverseRequestSpecification(
+                                        new EqualRequestSpecification(
+                                            pi,
+                                            new MemberInfoEqualityComparer()))),
+                                new FalseRequestSpecification()),
                             new BindingCommand<PropertyHolder<int>, int>(x => x.Property),
                             new OrRequestSpecification(
                                 new SeedRequestSpecification(typeof(PropertyHolder<int>)),

--- a/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
@@ -185,12 +185,34 @@ namespace AutoFixtureUnitTest.Dsl
         }
 
         [Fact]
-        public void WithReturnsCorrectResult()
+        public void WithValueReturnsCorrectResult()
         {
             // Arrange
             var sut = new NullComposer<PropertyHolder<object>>();
             // Act
             var result = sut.With(x => x.Property, new object());
+            // Assert
+            Assert.Same(sut, result);
+        }
+
+        [Fact]
+        public void WithValueFactoryReturnsCorrectResult()
+        {
+            // Arrange
+            var sut = new NullComposer<PropertyHolder<object>>();
+            // Act
+            var result = sut.With(x => x.Property, () => new object());
+            // Assert
+            Assert.Same(sut, result);
+        }
+
+        [Fact]
+        public void WithSingleArgValueFactoryReturnsCorrectResult()
+        {
+            // Arrange
+            var sut = new NullComposer<PropertyHolder<object>>();
+            // Act
+            var result = sut.With(x => x.Property, (object obj) => obj);
             // Assert
             Assert.Same(sut, result);
         }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -3367,7 +3367,9 @@ namespace AutoFixtureUnitTest
             string expectedText = "Anonymous text";
             var sut = new Fixture();
             // Act
-            PropertyHolder<string> result = sut.Build<PropertyHolder<string>>().With(ph => ph.Property, expectedText).CreateAnonymous();
+            PropertyHolder<string> result = sut.Build<PropertyHolder<string>>()
+                .With(ph => ph.Property, expectedText)
+                .CreateAnonymous();
             // Assert
             Assert.Equal(expectedText, result.Property);
         }
@@ -3379,7 +3381,9 @@ namespace AutoFixtureUnitTest
             string expectedText = "Anonymous text";
             var sut = new Fixture();
             // Act
-            PropertyHolder<string> result = sut.Build<PropertyHolder<string>>().With(ph => ph.Property, expectedText).Create();
+            PropertyHolder<string> result = sut.Build<PropertyHolder<string>>()
+                .With(ph => ph.Property, expectedText)
+                .Create();
             // Assert
             Assert.Equal(expectedText, result.Property);
         }
@@ -3392,7 +3396,9 @@ namespace AutoFixtureUnitTest
             string expectedText = "Anonymous text";
             var fixture = new Fixture();
             // Act
-            FieldHolder<string> result = fixture.Build<FieldHolder<string>>().With(fh => fh.Field, expectedText).CreateAnonymous();
+            FieldHolder<string> result = fixture.Build<FieldHolder<string>>()
+                .With(fh => fh.Field, expectedText)
+                .CreateAnonymous();
             // Assert
             Assert.Equal(expectedText, result.Field);
         }
@@ -3404,9 +3410,80 @@ namespace AutoFixtureUnitTest
             string expectedText = "Anonymous text";
             var fixture = new Fixture();
             // Act
-            FieldHolder<string> result = fixture.Build<FieldHolder<string>>().With(fh => fh.Field, expectedText).Create();
+            FieldHolder<string> result = fixture
+                .Build<FieldHolder<string>>()
+                .With(fh => fh.Field, expectedText)
+                .Create();
             // Assert
             Assert.Equal(expectedText, result.Field);
+        }
+
+        [Fact]
+        public void BuildWithFactoryWillSetPropertyOnCreatedObject()
+        {
+            // Arrange
+            var values = new Queue<string>(new[] { "value1", "value2" });
+            var fixture = new Fixture();
+            // Act
+            var builder = fixture
+                .Build<PropertyHolder<string>>()
+                .With(ph => ph.Property, () => values.Dequeue());
+            var result1 = builder.Create();
+            var result2 = builder.Create();
+            // Assert
+            Assert.Equal("value1", result1.Property);
+            Assert.Equal("value2", result2.Property);
+        }
+
+        [Fact]
+        public void BuildWithFactoryWillSetFieldOnCreatedObject()
+        {
+            // Arrange
+            var values = new Queue<string>(new[] { "value1", "value2" });
+            var fixture = new Fixture();
+            // Act
+            var builder = fixture
+                .Build<FieldHolder<string>>()
+                .With(ph => ph.Field, () => values.Dequeue());
+            var result1 = builder.Create();
+            var result2 = builder.Create();
+            // Assert
+            Assert.Equal("value1", result1.Field);
+            Assert.Equal("value2", result2.Field);
+        }
+
+        [Fact]
+        public void BuildWithSingleArgFactoryWillSetPropertyOnCreatedObject()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            fixture.Inject<Queue<string>>(new Queue<string>(new[] { "value1", "value2" }));
+            // Act
+            var builder = fixture
+                .Build<PropertyHolder<string>>()
+                .With(ph => ph.Property, (Queue<string> values) => values.Dequeue());
+            var result1 = builder.Create();
+            var result2 = builder.Create();
+            // Assert
+            Assert.Equal("value1", result1.Property);
+            Assert.Equal("value2", result2.Property);
+        }
+
+        [Fact]
+        public void BuildWithSingleArgFactoryWillSetFieldOnCreatedObject()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            fixture.Inject<Queue<string>>(new Queue<string>(new[] { "value1", "value2" }));
+            // Act
+            var builder = fixture
+                .Build<FieldHolder<string>>()
+                .With(ph => ph.Field, (Queue<string> values) => values.Dequeue());
+            var result1 = builder.Create();
+            var result2 = builder.Create();
+            // Assert
+            Assert.Equal("value1", result1.Field);
+            Assert.Equal("value2", result2.Field);
         }
 
         [Fact]
@@ -3417,7 +3494,11 @@ namespace AutoFixtureUnitTest
             long unexpectedNumber = default(long);
             var sut = new Fixture();
             // Act
-            var result = sut.Build<DoublePropertyHolder<long, long>>().With(ph => ph.Property1).OmitAutoProperties().CreateAnonymous();
+            var result = sut
+                .Build<DoublePropertyHolder<long, long>>()
+                .With(ph => ph.Property1)
+                .OmitAutoProperties()
+                .CreateAnonymous();
             // Assert
             Assert.NotEqual<long>(unexpectedNumber, result.Property1);
         }
@@ -3429,7 +3510,11 @@ namespace AutoFixtureUnitTest
             long unexpectedNumber = default(long);
             var sut = new Fixture();
             // Act
-            var result = sut.Build<DoublePropertyHolder<long, long>>().With(ph => ph.Property1).OmitAutoProperties().Create();
+            var result = sut
+                .Build<DoublePropertyHolder<long, long>>()
+                .With(ph => ph.Property1)
+                .OmitAutoProperties()
+                .Create();
             // Assert
             Assert.NotEqual<long>(unexpectedNumber, result.Property1);
         }
@@ -3442,7 +3527,11 @@ namespace AutoFixtureUnitTest
             int unexpectedNumber = default(int);
             var sut = new Fixture();
             // Act
-            var result = sut.Build<DoubleFieldHolder<int, decimal>>().With(fh => fh.Field1).OmitAutoProperties().CreateAnonymous();
+            var result = sut
+                .Build<DoubleFieldHolder<int, decimal>>()
+                .With(fh => fh.Field1)
+                .OmitAutoProperties()
+                .CreateAnonymous();
             // Assert
             Assert.NotEqual<int>(unexpectedNumber, result.Field1);
         }
@@ -3454,7 +3543,11 @@ namespace AutoFixtureUnitTest
             int unexpectedNumber = default(int);
             var sut = new Fixture();
             // Act
-            var result = sut.Build<DoubleFieldHolder<int, decimal>>().With(fh => fh.Field1).OmitAutoProperties().Create();
+            var result = sut
+                .Build<DoubleFieldHolder<int, decimal>>()
+                .With(fh => fh.Field1)
+                .OmitAutoProperties()
+                .Create();
             // Assert
             Assert.NotEqual<int>(unexpectedNumber, result.Field1);
         }
@@ -4452,7 +4545,9 @@ namespace AutoFixtureUnitTest
             var sut = new Fixture();
             var expected = Guid.NewGuid();
             // Act
-            var result = sut.Build<ConcreteType>().With(x => x.Property4, expected).CreateAnonymous();
+            var result = sut.Build<ConcreteType>()
+                .With(x => x.Property4, expected)
+                .CreateAnonymous();
             // Assert
             Assert.Equal(expected, result.Property4);
         }
@@ -4464,7 +4559,9 @@ namespace AutoFixtureUnitTest
             var sut = new Fixture();
             var expected = Guid.NewGuid();
             // Act
-            var result = sut.Build<ConcreteType>().With(x => x.Property4, expected).Create();
+            var result = sut.Build<ConcreteType>()
+                .With(x => x.Property4, expected)
+                .Create();
             // Assert
             Assert.Equal(expected, result.Property4);
         }

--- a/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
@@ -204,7 +204,8 @@ namespace AutoFixtureUnitTest.Kernel
                     { typeof(SpecimenFactory<,,,>), typeof(SpecimenFactoryEquatable<,,,>) },
                     { typeof(SpecimenFactory<,,,,>), typeof(SpecimenFactoryEquatable<,,,,>) },
                     { typeof(NodeComposer<>), typeof(NodeComposerEquatable<>) },
-                    { typeof(CompositeNodeComposer<>), typeof(CompositeNodeComposerEquatable<>) }
+                    { typeof(CompositeNodeComposer<>), typeof(CompositeNodeComposerEquatable<>) },
+                    { typeof(BindingCommand<,>), typeof(BindingCommandEquatable<,>) }
                 };
 
             public static object CreateFromTemplate(object obj)
@@ -326,6 +327,19 @@ namespace AutoFixtureUnitTest.Kernel
             protected override bool EqualsInstance(CompositeNodeComposer<T> other)
             {
                 return true;
+            }
+        }
+
+        private class BindingCommandEquatable<T, TProperty> : GenericEquatable<BindingCommand<T, TProperty>>
+        {
+            public BindingCommandEquatable(BindingCommand<T, TProperty> item)
+                : base(item)
+            {
+            }
+
+            protected override bool EqualsInstance(BindingCommand<T, TProperty> other)
+            {
+                return this.Item.Member == other.Member;
             }
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/Scenario.cs
@@ -326,6 +326,45 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
+        public void ComposeWithValueFactoryReturnsCorrectResult()
+        {
+            // Arrange
+            var values = new Queue<string>(new[] { "value1", "value2" });
+            var customBuilder = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>()
+                .With(x => x.Property, () => values.Dequeue());
+            var builder = new CompositeSpecimenBuilder(
+                customBuilder,
+                Scenario.CreateCoreBuilder());
+            // Act
+            var result1 = new SpecimenContext(builder).Create<PropertyHolder<string>>();
+            var result2 = new SpecimenContext(builder).Create<PropertyHolder<string>>();
+            // Assert
+            Assert.Equal("value1", result1.Property);
+            Assert.Equal("value2", result2.Property);
+        }
+
+        [Fact]
+        public void ComposeWithSingleArgumentValueFactoryReturnsCorrectResult()
+        {
+            // Arrange
+            var values = new Queue<string>(new[] { "value1", "value2" });
+            var customBuilder = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>()
+                .With(x => x.Property, (Queue<string> v) => v.Dequeue());
+            var builder = new CompositeSpecimenBuilder(
+                customBuilder,
+                new FilteringSpecimenBuilder(
+                    new FixedBuilder(values),
+                    new ExactTypeSpecification(typeof(Queue<string>))),
+                Scenario.CreateCoreBuilder());
+            // Act
+            var result1 = new SpecimenContext(builder).Create<PropertyHolder<string>>();
+            var result2 = new SpecimenContext(builder).Create<PropertyHolder<string>>();
+            // Assert
+            Assert.Equal("value1", result1.Property);
+            Assert.Equal("value2", result2.Property);
+        }
+
+        [Fact]
         [Obsolete]
         public void ComposeWithAutoPropertiesAndExplicitPropertyObsolete()
         {


### PR DESCRIPTION
Closes #708

Added overloads for the `With()` method taking action as a parameter. The following overloads were added:
```c#
With(x => x.Property, () => MakeValue());
With(x => x.Property, (object someInput) => MakeDesiredValueUsingInput(someInput))
```

Usually we have overloads [taking up to 4 input values](https://github.com/AutoFixture/AutoFixture/blob/c969f47c05e12abaadac44b8e9a6221abaa8eee5/Src/AutoFixture/Dsl/IFactoryComposer.cs#L152). Decided to not add those for now, as it's unclear whether they will be demanded in future.

Additionally, added a few more changes:
- deprecated the `CompositePostprocessComposer` as it's not used in our code
- used `interitdoc` whenever possible to not duplicate the parent documentation
- Reworked `With()` overload without parameters to unify graph when we perform `With()` change. The observable behavior hasn't changed and no tests failed, so I presume change might be considered as safe.

@moodmosaic Happy review!
CC @Kralizek