### PR TITLE
Use auto-generated attributes for F#

### DIFF
--- a/Build.fsx
+++ b/Build.fsx
@@ -6,7 +6,6 @@ open Fake.AppVeyor
 open Fake.DotNetCli
 open Fake.Testing
 open System
-open System.Diagnostics;
 open System.Text.RegularExpressions
 
 let buildDir = getBuildParamOrDefault "BuildDir" "build"
@@ -18,7 +17,6 @@ let nuGetPackages = !! (nuGetOutputFolder </> "*.nupkg" )
                     -- (nuGetOutputFolder </> "*.symbols.nupkg")
 let solutionToBuild = "Src/All.sln"
 let configuration = getBuildParamOrDefault "BuildConfiguration" "Release"
-let bakFileExt = ".orig"
 let repositoryUrlsOnGitHub = [ "git@github.com:AutoFixture/AutoFixture.git"
                                "https://github.com/AutoFixture/AutoFixture.git" ]
 
@@ -104,47 +102,6 @@ let setVNextBranchVersion vNextVersion =
                           revision = 0
                           preSuffix = "-alpha" }
             |> calculateVersion
-
-let addBakExt path = sprintf "%s%s" path bakFileExt
-
-Target "PatchAssemblyVersions" (fun _ ->
-    printfn 
-        "Patching assembly versions. Assembly version: %s, File version: %s, Informational version: %s" 
-        buildVersion.assemblyVersion
-        buildVersion.fileVersion
-        buildVersion.infoVersion
-
-    // .NET Core SDK creates attributes for C# automatically, therefore only F# files should be updated.
-    // Patching and backup restore should be completely deleted after F# supports auto-generated attributes.
-    let filesToPatch = !! "Src/*/Properties/AssemblyInfo.fs"
-                       -- addBakExt "Src/*/Properties/*"
-    
-    // Backup the original file versions.
-    filesToPatch
-    |> Seq.iter (fun f ->
-        let bakFilePath = addBakExt f
-        CopyFile bakFilePath f
-
-        printfn "Backed up %s to %s" f bakFilePath
-    )
-
-    ReplaceAssemblyInfoVersionsBulk filesToPatch 
-                                    (fun f -> { f with AssemblyVersion              = buildVersion.assemblyVersion
-                                                       AssemblyFileVersion          = buildVersion.fileVersion
-                                                       AssemblyInformationalVersion = buildVersion.infoVersion })
-)
-
-Target "RestorePatchedAssemblyVersionFiles" (fun _ ->
-    !! (addBakExt "Src/*/Properties/AssemblyInfo.fs")
-    |> Seq.iter (fun bakFile ->
-        let originalPath = bakFile.Substring(0, bakFile.Length - bakFileExt.Length)
-
-        DeleteFile originalPath
-        Rename originalPath bakFile
-
-        printfn "Restored %s to %s" bakFile originalPath
-    )
-)
 
 let mutable enableSourceLink = false
 
@@ -347,12 +304,8 @@ Target "PublishNuGetAll" DoNothing
 "EnableSourceLinkGeneration" ?=> "Verify"
 "VerifyOnly"                 ==> "Verify"
 
-"Verify"                             ==> "Build"
-"PatchAssemblyVersions"              ==> "Build"
-"BuildOnly"                          ==> "Build"
-"RestorePatchedAssemblyVersionFiles" ==> "Build"
-
-"BuildOnly" ?=> "RestorePatchedAssemblyVersionFiles"
+"Verify"    ==> "Build"
+"BuildOnly" ==> "Build"
 
 "BuildOnly"              ==> "TestOnly"
 "CleanTestResultsFolder" ==> "TestOnly"

--- a/Build.fsx
+++ b/Build.fsx
@@ -45,7 +45,7 @@ let getVersionSourceFromGit buildNumber =
       buildNumber = buildNumber
     }
 
-type BuildVersionInfo = { assemblyVersion:string; fileVersion:string; infoVersion:string; nugetVersion:string; 
+type BuildVersionInfo = { assemblyVersion:string; fileVersion:string; infoVersion:string; nugetVersion:string; commitHash: string;
                           source: Option<BuildVersionCalculationSource> }
 let calculateVersion source =
     let s = source
@@ -67,7 +67,7 @@ let calculateVersion source =
                       | 0 -> nugetVersion
                       | _ -> sprintf "%s-%s" nugetVersion sha
 
-    { assemblyVersion=assemblyVersion; fileVersion=fileVersion; infoVersion=infoVersion; nugetVersion=nugetVersion; 
+    { assemblyVersion=assemblyVersion; fileVersion=fileVersion; infoVersion=infoVersion; nugetVersion=nugetVersion; commitHash=s.sha;
       source = Some source }
 
 // Calculate version that should be used for the build. Define globally as data might be required by multiple targets.
@@ -83,6 +83,7 @@ let mutable buildVersion = match getBuildParamOrDefault "BuildVersion" "git" wit
                                               fileVersion = getBuildParamOrDefault "BuildFileVersion" assemblyVer
                                               infoVersion = getBuildParamOrDefault "BuildInfoVersion" assemblyVer
                                               nugetVersion = getBuildParamOrDefault "BuildNugetVersion" assemblyVer
+                                              commitHash = getBuildParamOrDefault "BuildComitHash" ""
                                               source = None }
 
 let setVNextBranchVersion vNextVersion =
@@ -127,6 +128,7 @@ let runMsBuild target configuration properties =
                          "FileVersion", buildVersion.fileVersion
                          "InformationalVersion", buildVersion.infoVersion
                          "PackageVersion", buildVersion.nugetVersion
+                         "CommitHash", buildVersion.commitHash
                          "SourceLinkCreateOverride", sourceLinkCreatePropertyValue ]
 
     solutionToBuild

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -10,6 +10,8 @@
     <SignAssembly>False</SignAssembly>
     <!-- Disable source link support for F# projects as they don't support this feature. -->
     <SourceLinkCreate>false</SourceLinkCreate>
+    <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects -->
+    <NoWarn>FS2003</NoWarn>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.AutoFoq</PackageId>

--- a/Src/AutoFoq/Properties/AssemblyInfo.fs
+++ b/Src/AutoFoq/Properties/AssemblyInfo.fs
@@ -8,13 +8,6 @@ open System.Runtime.InteropServices
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[<assembly: AssemblyTitle("AutoFixture.AutoFoq")>]
-[<assembly: AssemblyDescription("")>]
-[<assembly: AssemblyConfiguration("")>]
-[<assembly: AssemblyCompany("AutoFixture")>]
-[<assembly: AssemblyProduct("AutoFixture")>]
-[<assembly: AssemblyCopyright("Copyright © Ploeh 2013")>]
-[<assembly: AssemblyTrademark("")>]
 [<assembly: AssemblyCulture("")>]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -24,20 +17,6 @@ open System.Runtime.InteropServices
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [<assembly: Guid("d6a08d41-97b4-4d8c-b188-b91e91d9b5e8")>]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[<assembly: AssemblyVersion("1.0.0.0")>]
-[<assembly: AssemblyFileVersion("1.0.0.0")>]
-[<assembly: AssemblyInformationalVersion("1.0.0.0")>]
 
 [<assembly: CLSCompliant(true)>]
 [<assembly: NeutralResourcesLanguage("en")>]

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -8,6 +8,8 @@
     <AssemblyTitle>AutoFixture.AutoFoq.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFoq.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoFoq.UnitTest</RootNamespace>
+    <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects -->
+    <NoWarn>FS2003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -23,6 +23,13 @@
     <PackageIconUrl>https://raw.githubusercontent.com/AutoFixture/AutoFixture/master/AutoFixtureLogo200x200.png</PackageIconUrl>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" '$(CommitHash)' != '' ">
+      <_Parameter1>CommitHash</_Parameter1>
+      <_Parameter2>$(CommitHash)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <Choose>
     <When Condition="$(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp'))">
       <PropertyGroup>

--- a/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
@@ -8,6 +8,8 @@
     <AssemblyTitle>Idioms.FsCheck.FsCheck1UnitTest</AssemblyTitle>
     <AssemblyName>Idioms.FsCheck.FsCheck1UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.Idioms.FsCheckUnitTest</RootNamespace>
+    <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects -->
+    <NoWarn>FS2003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
@@ -8,6 +8,8 @@
     <AssemblyTitle>Idioms.FsCheck.FsCheck2UnitTest</AssemblyTitle>
     <AssemblyName>Idioms.FsCheck.FsCheck2UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.Idioms.FsCheckUnitTest</RootNamespace>
+    <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects -->
+    <NoWarn>FS2003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -10,6 +10,8 @@
     <SignAssembly>False</SignAssembly>
     <!-- Disable source link support for F# projects as they don't support this feature. -->
     <SourceLinkCreate>false</SourceLinkCreate>
+    <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects -->
+    <NoWarn>FS2003</NoWarn>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.Idioms.FsCheck</PackageId>

--- a/Src/Idioms.FsCheck/Properties/AssemblyInfo.fs
+++ b/Src/Idioms.FsCheck/Properties/AssemblyInfo.fs
@@ -5,16 +5,6 @@ open System.Reflection
 open System.Resources
 open System.Runtime.InteropServices
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[<assembly: AssemblyTitle("AutoFixture.Idioms.FsCheck")>]
-[<assembly: AssemblyDescription("")>]
-[<assembly: AssemblyConfiguration("")>]
-[<assembly: AssemblyCompany("AutoFixture")>]
-[<assembly: AssemblyProduct("AutoFixture")>]
-[<assembly: AssemblyCopyright("Copyright © Ploeh 2014")>]
-[<assembly: AssemblyTrademark("")>]
 [<assembly: AssemblyCulture("")>]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -24,21 +14,6 @@ open System.Runtime.InteropServices
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [<assembly: Guid("d6a08d41-97b4-4d8c-b188-b91e91d9b5e8")>]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[<assembly: AssemblyVersion("1.0.0.0")>]
-[<assembly: AssemblyFileVersion("1.0.0.0")>]
-[<assembly: AssemblyInformationalVersion("1.0.0.0")>]
-
 
 [<assembly: CLSCompliant(true)>]
 [<assembly: NeutralResourcesLanguage("en")>]

--- a/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
+++ b/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
@@ -8,6 +8,8 @@
     <AssemblyTitle>AutoFixture.Idioms.FsCheckUnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.Idioms.FsCheckUnitTest</AssemblyName>
     <RootNamespace>AutoFixture.Idioms.FsCheckUnitTest</RootNamespace>
+    <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects -->
+    <NoWarn>FS2003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove the old workaround we had for the F# projects and use the native attributes generation feature.
Additionally, embed hash of the current commit as `[assembly: AssemblyMetadata("CommitHash", "hash")]` attribute.