### PR TITLE
Support FakeItEasy 5.0.0+

### DIFF
--- a/Src/All.sln
+++ b/Src/All.sln
@@ -85,6 +85,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.SeedExtensions"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.SeedExtensions.UnitTest", "AutoFixture.SeedExtensions.UnitTest\AutoFixture.SeedExtensions.UnitTest.csproj", "{0F3C467A-ED89-4348-9210-FC2D358E20C5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy5UnitTest", "AutoFakeItEasy.FakeItEasy5UnitTest\AutoFakeItEasy.FakeItEasy5UnitTest.csproj", "{FA9FA942-3E9F-49B5-A622-396DB0FC791F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -302,6 +304,12 @@ Global
 		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{0F3C467A-ED89-4348-9210-FC2D358E20C5}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{FA9FA942-3E9F-49B5-A622-396DB0FC791F}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy.FakeItEasy5UnitTest/AutoFakeItEasy.FakeItEasy5UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy5UnitTest/AutoFakeItEasy.FakeItEasy5UnitTest.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\Common.props" />
+  <Import Project="..\Common.Test.props" />
+  <Import Project="..\Common.Test.xUnit.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <AssemblyTitle>AutoFakeItEasy.FakeItEasy5.UnitTest</AssemblyTitle>
+    <AssemblyName>AutoFixture.AutoFakeItEasy.FakeItEasy5UnitTest</AssemblyName>
+    <RootNamespace>AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
+
+    <DefineConstants>$(DefineConstants);CAN_FAKE_DELEGATES;HAS_A_CALL_TO_SET_SPECIFIER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="[5.0.0]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AutoFakeItEasyUnitTest\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Remove="..\AutoFakeItEasyUnitTest\obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoFakeItEasy\AutoFakeItEasy.csproj" />
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+    <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/Src/AutoFakeItEasy.FakeItEasy5UnitTest/AutoFakeItEasy.FakeItEasy5UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy5UnitTest/AutoFakeItEasy.FakeItEasy5UnitTest.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\Common.Test.xUnit.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <AssemblyTitle>AutoFakeItEasy.FakeItEasy5.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFakeItEasy.FakeItEasy5UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>

--- a/Src/AutoFakeItEasy.sln
+++ b/Src/AutoFakeItEasy.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy3U
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy4UnitTest", "AutoFakeItEasy.FakeItEasy4UnitTest\AutoFakeItEasy.FakeItEasy4UnitTest.csproj", "{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy5UnitTest", "AutoFakeItEasy.FakeItEasy5UnitTest\AutoFakeItEasy.FakeItEasy5UnitTest.csproj", "{FCE84752-3B08-49FB-A432-AE36D27C4D91}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +76,12 @@ Global
 		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{5283E529-A1D8-4E5E-9717-A5F5D3A28A3B}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{FCE84752-3B08-49FB-A432-AE36D27C4D91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCE84752-3B08-49FB-A432-AE36D27C4D91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCE84752-3B08-49FB-A432-AE36D27C4D91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCE84752-3B08-49FB-A432-AE36D27C4D91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCE84752-3B08-49FB-A432-AE36D27C4D91}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{FCE84752-3B08-49FB-A432-AE36D27C4D91}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -20,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="[1.7.4109.1,5.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
-    <PackageReference Include="FakeItEasy" Version="[3.0.0,5.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.6' " />
-    <PackageReference Include="FakeItEasy" Version="[4.9.0,5.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="FakeItEasy" Version="[1.7.4109.1,6.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="FakeItEasy" Version="[3.0.0,6.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.6' " />
+    <PackageReference Include="FakeItEasy" Version="[4.9.0,6.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Moves FakeItEasy version restrictions up to `, 6.0.0)` and adds AutoFakeItEasy.FakeItEasy5UnitTest to ensure the integration works.