### PR TITLE
Better support for mocking delegates

### DIFF
--- a/Src/AutoMoq/Extensions/TypeExtensions.cs
+++ b/Src/AutoMoq/Extensions/TypeExtensions.cs
@@ -34,5 +34,13 @@ namespace AutoFixture.AutoMoq.Extensions
 
             return result;
         }
+
+        /// <summary>
+        /// Returns whether or not a type represents a delegate.
+        /// </summary>
+        internal static bool IsDelegate(this Type type)
+        {
+            return typeof(MulticastDelegate).IsAssignableFrom(type.GetTypeInfo().BaseType);
+        }
     }
 }

--- a/Src/AutoMoq/MockPostprocessor.cs
+++ b/Src/AutoMoq/MockPostprocessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using AutoFixture.AutoMoq.Extensions;
 using AutoFixture.Kernel;
 using Moq;
 
@@ -79,8 +80,13 @@ namespace AutoFixture.AutoMoq
 
             private static void Configure(Mock<T> mock)
             {
-                mock.CallBase = true;
+                mock.CallBase = ShouldUseCallBase(typeof(T));
                 mock.DefaultValue = DefaultValue.Mock;
+            }
+
+            private static bool ShouldUseCallBase(Type type)
+            {
+                return !type.IsDelegate();
             }
         }
 


### PR DESCRIPTION
- Mock.CallBase is set to true only when the mocked type isn't a delegate

Fixes #1094