### PR TITLE
Fix tests compatibility with latest .NET Core 2.x

### DIFF
--- a/Src/AutoFixtureUnitTest/Kernel/ParameterSpecificationTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ParameterSpecificationTest.cs
@@ -144,7 +144,7 @@ namespace AutoFixtureUnitTest.Kernel
             bool expected)
         {
             var parameter =
-                typeof(string).GetMethod("Contains").GetParameters().First();
+                typeof(string).GetMethod("Contains", new[] { typeof(string) }).GetParameters().First();
             var target = new DelegatingCriterion<ParameterInfo>
             {
                 OnEquals = f =>

--- a/Src/AutoFixtureUnitTest/Kernel/ParameterTypeAndNameCriterionTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ParameterTypeAndNameCriterionTests.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest.Kernel
             bool expected)
         {
             var parameter =
-                typeof(string).GetMethod("Contains").GetParameters().First();
+                typeof(string).GetMethod("Contains", new[] { typeof(string) }).GetParameters().First();
             var typeCriterion = new DelegatingCriterion<Type>
             {
                 OnEquals = t =>


### PR DESCRIPTION
In .NET Core 2.x another overload appeared, so we need to specify parameters to avoid `AmbiguousMethodException`.