### PR TITLE
Maintain project

### DIFF
--- a/Src/Common.props
+++ b/Src/Common.props
@@ -73,7 +73,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61" PrivateAssets="all" />
   </ItemGroup>
   

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -19,7 +19,7 @@
     <!-- NuGet options -->
     <Authors>Mark Seemann,AutoFixture</Authors>
     <PackageProjectUrl>https://github.com/AutoFixture/AutoFixture</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/AutoFixture/AutoFixture/blob/master/LICENCE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/AutoFixture/AutoFixture/master/AutoFixtureLogo200x200.png</PackageIconUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
Update Roslyn analyzers version and switch to the new NuGet license format.