### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If you want to add your own testimonial to this list, we (the AutoFixture mainta
 
 * [Pluralsight course](https://www.pluralsight.com/courses/autofixture-dotnet-unit-test-get-started)
 * [ploeh blog](http://blog.ploeh.dk/tags/#AutoFixture-ref)
-* [Nikos Baxevanis' blog](http://nikosbaxevanis.com/categories/autofixture)
+* [Nikos Baxevanis' blog](http://blog.nikosbaxevanis.com/tags/#autofixture)
 * [Enrico Campidoglio's blog](http://megakemp.com/tag/autofixture)
 * [Gert Jansen van Rensburg's blog](http://gertjvr.wordpress.com/category/autofixture)
 * [Questions on Stack Overflow](http://stackoverflow.com/questions/tagged/autofixture)


### PR DESCRIPTION
Replace old (*very* old, actually) location of @moodmosaic blog with the current one. The reason is, if I add a new AutoFixture post, it will show up in the new location, but won't show up in the old one.

---

(Sure I could add a redirect, but I just consider web to be currently broken anyways, [unless](https://ipfs.io/) ...[etcetera](https://ipfs.io/ipfs/QmNhFJjGcMPqpuYfxL62VVB9528NXqDNMFXiqN5bgFYiZ1/its-time-for-the-permanent-web.html)). :wink: 