### PR TITLE
Support ArgumentException for guard clause

### DIFF
--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -50,7 +50,7 @@ namespace AutoFixture.Idioms
             {
                 command.Execute(null);
             }
-            catch (ArgumentNullException e)
+            catch (ArgumentException e)
             {
                 if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
                     return;

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -1045,5 +1045,43 @@ namespace AutoFixture.IdiomsUnitTest
         {
             public abstract void Method(object arg);
         }
+
+        public class TypeWithArgumentExceptionForNullGuardChecks
+        {
+            private string property;
+
+            public TypeWithArgumentExceptionForNullGuardChecks(object obj, string str)
+            {
+                if (obj == null) throw new ArgumentException("Value cannot be null", nameof(obj));
+                if (string.IsNullOrEmpty(str)) throw new ArgumentException("Value cannot be null or empty.", nameof(str));
+
+                this.property = str;
+            }
+
+            private string Property
+            {
+                get => this.property;
+                set
+                {
+                    if (string.IsNullOrEmpty(value)) throw new ArgumentException("Value cannot be null or empty.", nameof(value));
+
+                    this.property = value;
+                }
+            }
+
+            public void RegularMethod(object obj, string str)
+            {
+                if (obj == null) throw new ArgumentException("Value cannot be null", nameof(obj));
+                if (string.IsNullOrEmpty(str)) throw new ArgumentException("Value cannot be null or empty.", nameof(str));
+            }
+        }
+
+        [Fact]
+        public void VerifyShouldRespectArgumentExceptionForNullChecksIfArgumentNameIsValid()
+        {
+            var sut = new GuardClauseAssertion(new Fixture());
+
+            sut.Verify(typeof(TypeWithArgumentExceptionForNullGuardChecks));
+        }
     }
 }

--- a/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/NullReferenceBehaviorExpectationTest.cs
@@ -73,10 +73,25 @@ namespace AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
-        public void VerifySucceedsWhenCommandThrowsCorrectException()
+        public void VerifySucceedsWhenCommandThrowsArgumentNullException()
         {
             // Arrange
-            var cmd = new DelegatingGuardClauseCommand { OnExecute = v => { throw new ArgumentNullException(); } };
+            var cmd = new DelegatingGuardClauseCommand { OnExecute = v => throw new ArgumentNullException() };
+            var sut = new NullReferenceBehaviorExpectation();
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(cmd)));
+        }
+
+        [Fact]
+        public void VerifySucceedsWhenCommandThrowsArgumentException()
+        {
+            // Arrange
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => throw new ArgumentException("Should not be null", "paramName"),
+                RequestedParameterName = "paramName"
+            };
             var sut = new NullReferenceBehaviorExpectation();
             // Act & Assert
             Assert.Null(Record.Exception(() =>


### PR DESCRIPTION
Closes #1107

It's fully legitimate when base `ArgumentException` is thrown instead of `ArgumentNullException` if null value is specified. It's very often case in case of `string` type, when you handle null and empty at the same time.

Additionally I've slightly re-organized facade tests for the `GuardClauseAssertion` as file was really huge.

@moodmosaic Please take a look. Change should be OK, but if you have time to give it a brief look - it would be awesome 😉 