### PR TITLE
Add flag to support async methods by null guard check

### DIFF
--- a/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -14,6 +14,8 @@
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\Idioms\Idioms.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
+
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #1106 

Added configuration node to support `async` methods, which are popular nowadays.
Made this feature disabled by default to not cause breaking changes. Potentially we could make this behavior default in v5.

@moodmosaic Please take a look 😉 