### PR TITLE
Add support for null as argument for the NUnit3 InlineAutoDataAttribute

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
@@ -12,12 +12,6 @@ namespace AutoFixture.NUnit3.UnitTest
     public class InlineAutoDataAttributeTest
     {
         [Test]
-        public void IfArguementsIsNullThenThrows()
-        {
-            Assert.Throws<ArgumentNullException>(() => new InlineAutoDataAttribute(null));
-        }
-
-        [Test]
         public void IfExtendedWithNullFixtureThenThrows()
         {
 #pragma warning disable 612
@@ -107,6 +101,18 @@ namespace AutoFixture.NUnit3.UnitTest
             var result = sut.Arguments;
             // Assert
             Assert.AreSame(expectedArguments, result);
+        }
+
+        [Test]
+        public void ArgumentsIsNullBecomesObjectArrayWithNull()
+        {
+            // Arrange
+            var expectedArguments = new object[] { null };
+            var sut = new InlineAutoDataAttribute(null);
+            // Act
+            var result = sut.Arguments;
+            // Assert
+            Assert.AreEqual(expectedArguments, result);
         }
 
         [TestCase("CreateWithFrozenAndFavorArrays")]

--- a/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
@@ -393,5 +393,29 @@ namespace AutoFixture.NUnit3.UnitTest
         {
             Assert.True(p.Length == 3);
         }
+
+        [Test]
+        [InlineAutoData(null)]
+        public void InlineAutoDataTakesNullAsParameterValue(string p1)
+        {
+            Assert.That(p1, Is.Null);
+        }
+
+        [Test]
+        [InlineAutoData(null)]
+        public void InlineAutoDataWithNullArgumentProvidesParameterValuesWhenMissing(string p1, string p2, string p3)
+        {
+            Assert.That(p1, Is.Null);
+            Assert.That(p2, Is.Not.Null);
+            Assert.That(p3, Is.Not.Null);
+        }
+
+        [Test]
+        [InlineAutoData(null)]
+        public void InlineAutoDataWithNullArgumentCanBeUsedWithFrozen(int? p1, int p2, [Frozen]string p3, string p4)
+        {
+            Assert.That(p1, Is.Null);
+            Assert.That(p3, Is.EqualTo(p4));
+        }
     }
 }

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -53,7 +53,7 @@ namespace AutoFixture.NUnit3
             if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
             this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
-            this.existingParameterValues = arguments ?? throw new ArgumentNullException(nameof(arguments));
+            this.existingParameterValues = arguments ?? new object[] { null };
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace AutoFixture.NUnit3
             if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
 
             this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
-            this.existingParameterValues = arguments ?? throw new ArgumentNullException(nameof(arguments));
+            this.existingParameterValues = arguments ?? new object[] { null };
         }
 
         /// <summary>


### PR DESCRIPTION
This PR closes #1126. Instead of throwing an exception when `null` is supplied as argument for an InlineAutoDataAttribute, the argument gets now replaced with an object array that has exactly one element, which is `null`. 