### PR TITLE
Allow factory methods returning interface to be selected

### DIFF
--- a/Src/AutoFixture/Kernel/FactoryMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/FactoryMethodQuery.cs
@@ -38,7 +38,7 @@ namespace AutoFixture.Kernel
             if (type == null) throw new ArgumentNullException(nameof(type));
 
             return from mi in type.GetTypeInfo().GetMethods(BindingFlags.Static | BindingFlags.Public)
-                   where mi.ReturnType == type &&
+                   where mi.ReturnType.GetTypeInfo().IsAssignableFrom(type) &&
                          !string.Equals(mi.Name, "op_Implicit", StringComparison.Ordinal) &&
                          !string.Equals(mi.Name, "op_Explicit", StringComparison.Ordinal)
                    let parameters = mi.GetParameters()

--- a/Src/AutoFixtureUnitTest/Kernel/FactoryMethodQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FactoryMethodQueryTest.cs
@@ -86,5 +86,20 @@ namespace AutoFixtureUnitTest.Kernel
             // Assert
             Assert.Empty(result);
         }
+
+        [Fact]
+        public void
+            SelectMethodsFromTypeWithInterfacePropertyReturnsNonEmptyResult()
+        {
+            // Arrange
+            var type = typeof(TypeWithFactoryMethodReturningInterface);
+            var sut = new FactoryMethodQuery();
+
+            // Act
+            var result = sut.SelectMethods(type);
+
+            // Assert
+            Assert.NotEmpty(result);
+        }
     }
 }

--- a/Src/TestTypeFoundation/TypeWithFactoryMethodReturningInterface.cs
+++ b/Src/TestTypeFoundation/TypeWithFactoryMethodReturningInterface.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace TestTypeFoundation
+{
+    public sealed class TypeWithFactoryMethodReturningInterface
+        : IEquatable<TypeWithFactoryMethodReturningInterface>
+    {
+        private TypeWithFactoryMethodReturningInterface()
+        {
+        }
+        
+        public static IEquatable<TypeWithFactoryMethodReturningInterface> Instance
+        {
+            get;
+        } = new TypeWithFactoryMethodReturningInterface();
+
+        public bool Equals(TypeWithFactoryMethodReturningInterface other) =>
+            true;
+
+        public override bool Equals(object obj) =>
+            obj is TypeWithFactoryMethodReturningInterface other &&
+            Equals(other);
+
+        public override int GetHashCode() => 0;
+    }
+}

--- a/Src/TestTypeFoundation/TypeWithFactoryMethodReturningInterface.cs
+++ b/Src/TestTypeFoundation/TypeWithFactoryMethodReturningInterface.cs
@@ -8,18 +8,19 @@ namespace TestTypeFoundation
         private TypeWithFactoryMethodReturningInterface()
         {
         }
-        
+
         public static IEquatable<TypeWithFactoryMethodReturningInterface> Instance
         {
             get;
-        } = new TypeWithFactoryMethodReturningInterface();
+        }
+        = new TypeWithFactoryMethodReturningInterface();
 
         public bool Equals(TypeWithFactoryMethodReturningInterface other) =>
             true;
 
         public override bool Equals(object obj) =>
             obj is TypeWithFactoryMethodReturningInterface other &&
-            Equals(other);
+            this.Equals(other);
 
         public override int GetHashCode() => 0;
     }


### PR DESCRIPTION
This MR enhances `FactoryMethodQuery` to allow factory methods returning an interface to be selected.