### PR TITLE
Update AutoMoq.csproj

### DIFF
--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="[4.1.1308.2120,5.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
-    <PackageReference Include="Moq" Version="[4.7.0,4.11.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
-    <PackageReference Include="Moq" Version="[4.7.0,5.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="Moq" Version="[4.7.49,4.11.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
+    <PackageReference Include="Moq" Version="[4.7.49,5.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Moq reference version 4.7.0 contains a reference to Castle.Core which again contains a reference to System.ComponentModel.TypeConverter 4.0.1
This version (System.ComponentModel.TypeConverter 4.0.1) is not available on NuGet.org and Visual Studio emits a warning.
"Castle.Core 4.0.0 depends on System.ComponentModel.TypeConverter (>= 4.0.1) but System.ComponentModel.TypeConverter 4.0.1 was not found. An approximate best match of System.ComponentModel.TypeConverter 4.1.0 was resolved."

The first version of Moq that references a newer version of Castle.Core with this issue fixed is 4.7.49