### PR TITLE
Implements parameter name check for empty guid expectation

### DIFF
--- a/Src/Idioms/EmptyGuidBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyGuidBehaviorExpectation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace AutoFixture.Idioms
 {
@@ -25,18 +26,37 @@ namespace AutoFixture.Idioms
         /// </remarks>
         public void Verify(IGuardClauseCommand command)
         {
-            if (command == null) throw new ArgumentNullException(nameof(command));
+            if (command == null)
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
 
             if (command.RequestedType != typeof(Guid))
+            {
                 return;
+            }
 
             try
             {
                 command.Execute(Guid.Empty);
             }
-            catch (ArgumentException)
+            catch (ArgumentException e)
             {
-                return;
+                if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                throw command.CreateException(
+                    "\"Guid.Empty\"",
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
+                        "Ensure you pass correct parameter name to the ArgumentException constructor.{0}" +
+                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
+                        Environment.NewLine,
+                        command.RequestedParameterName,
+                        e.ParamName),
+                    e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/EmptyGuidBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyGuidBehaviorExpectation.cs
@@ -26,15 +26,9 @@ namespace AutoFixture.Idioms
         /// </remarks>
         public void Verify(IGuardClauseCommand command)
         {
-            if (command == null)
-            {
-                throw new ArgumentNullException(nameof(command));
-            }
+            if (command == null) throw new ArgumentNullException(nameof(command));
 
-            if (command.RequestedType != typeof(Guid))
-            {
-                return;
-            }
+            if (command.RequestedType != typeof(Guid)) return;
 
             try
             {
@@ -42,10 +36,7 @@ namespace AutoFixture.Idioms
             }
             catch (ArgumentException e)
             {
-                if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
-                {
-                    return;
-                }
+                if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal)) return;
 
                 throw command.CreateException(
                     "\"Guid.Empty\"",

--- a/Src/IdiomsUnitTest/EmptyGuidBehaviorExpectationTest.cs
+++ b/Src/IdiomsUnitTest/EmptyGuidBehaviorExpectationTest.cs
@@ -118,5 +118,90 @@ namespace AutoFixture.IdiomsUnitTest
                 sut.Verify(cmd));
             Assert.Equal(expected, result);
         }
+
+        [Fact]
+        public void VerifyThrowsExpectedWhenCommandThrowsWithIncorrectParameterName()
+        {
+            // Arrange
+            var expected = new Exception();
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => throw new ArgumentException(string.Empty, "wrongParamName"),
+                OnCreateExceptionWithFailureReason = (v, r, e) => expected,
+                RequestedParameterName = "expectedParamName",
+                RequestedType = typeof(Guid)
+            };
+            var sut = new EmptyGuidBehaviorExpectation();
+
+            // Act
+            var actual = Record.Exception(() => sut.Verify(cmd));
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void VerifyThrowsWithExpectedMessageWhenCommandThrowsWithIncorrectParameterName()
+        {
+            // Arrange
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => throw new ArgumentException(string.Empty, "wrongParamName"),
+                OnCreateExceptionWithFailureReason = (v, r, e) => new Exception(r, e),
+                RequestedParameterName = "expectedParamName",
+                RequestedType = typeof(Guid)
+            };
+            var sut = new EmptyGuidBehaviorExpectation();
+
+            // Act
+            var actual = Record.Exception(() => sut.Verify(cmd));
+
+            // Assert
+            Assert.EndsWith(
+                string.Format("Expected parameter name: expectedParamName{0}Actual parameter name: wrongParamName",
+                              Environment.NewLine),
+                actual.Message);
+        }
+
+        [Fact]
+        public void VerifyThrowsWithExpectedInnerWhenCommandThrowsWithIncorrectParameterName()
+        {
+            // Arrange
+            var expected = new ArgumentException(string.Empty, "wrongParamName");
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => throw expected,
+                OnCreateExceptionWithFailureReason = (v, r, e) => new Exception(r, e),
+                RequestedParameterName = "expectedParamName",
+                RequestedType = typeof(Guid)
+            };
+            var sut = new EmptyGuidBehaviorExpectation();
+
+            // Act
+            var actual = Record.Exception(() => sut.Verify(cmd));
+
+            // Assert
+            Assert.Equal(expected, actual.InnerException);
+        }
+
+        [Fact]
+        public void VerifyDoesNotThrowWhenCommandThrowsWithCorrectParameterName()
+        {
+            // Arrange
+            var cmd = new DelegatingGuardClauseCommand
+            {
+                OnExecute = v => throw new ArgumentException(string.Empty, "paramName"),
+                OnCreateExceptionWithFailureReason = (v, r, e) => new Exception(r, e),
+                RequestedParameterName = "paramName",
+                RequestedType = typeof(Guid)
+            };
+            var sut = new EmptyGuidBehaviorExpectation();
+
+            // Act
+            var actual = Record.Exception(() => sut.Verify(cmd));
+
+            // Assert
+            Assert.Null(actual);
+        }
     }
 }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -1034,6 +1034,91 @@ namespace AutoFixture.IdiomsUnitTest
         }
 
         [Fact]
+        public void VerifyNonProperlyGuidGuardedConstructorThrowsException()
+        {
+            var sut = new GuardClauseAssertion(new Fixture());
+            var constructorInfo = typeof(NonProperlyGuidGuardedClass).GetConstructors().Single();
+
+            var exception = Assert.Throws<GuardClauseException>(() => sut.Verify(constructorInfo));
+            Assert.Contains("Guard Clause prevented it, however", exception.Message);
+        }
+
+        [Fact]
+        public void VerifyNonProperlyGuidGuardedPropertyThrowsException()
+        {
+            var sut = new GuardClauseAssertion(new Fixture());
+            var propertyInfo = typeof(NonProperlyGuidGuardedClass).GetProperty(nameof(NonProperlyGuidGuardedClass.Property));
+
+            var exception = Assert.Throws<GuardClauseException>(() => sut.Verify(propertyInfo));
+            Assert.Contains("Guard Clause prevented it, however", exception.Message);
+        }
+
+        [Theory]
+        [InlineData(nameof(NonProperlyGuidGuardedClass.Method), "Guard Clause prevented it, however")]
+        [InlineData(nameof(NonProperlyGuidGuardedClass.DeferredMethodReturningGenericEnumerable), "deferred")]
+        [InlineData(nameof(NonProperlyGuidGuardedClass.DeferredMethodReturningGenericEnumerator), "deferred")]
+        [InlineData(nameof(NonProperlyGuidGuardedClass.DeferredMethodReturningNonGenericEnumerable), "deferred")]
+        [InlineData(nameof(NonProperlyGuidGuardedClass.DeferredMethodReturningNonGenericEnumerator), "deferred")]
+        public void VerifyNonProperlyGuidGuardedMethodThrowsException(string methodName, string expectedMessage)
+        {
+            var sut = new GuardClauseAssertion(new Fixture());
+            var methodInfo = typeof(NonProperlyGuidGuardedClass).GetMethod(methodName);
+
+            var exception = Assert.Throws<GuardClauseException>(() => sut.Verify(methodInfo));
+            Assert.Contains(expectedMessage, exception.Message);
+        }
+
+        private class NonProperlyGuidGuardedClass
+        {
+            public NonProperlyGuidGuardedClass(Guid argument)
+            {
+                if (argument == Guid.Empty) throw new ArgumentException(string.Empty, "invalid parameter name");
+            }
+
+            public Guid Property
+            {
+                get => Guid.Empty;
+                set
+                {
+                    if (value == Guid.Empty) throw new ArgumentException(string.Empty, "invalid parameter name");
+                }
+            }
+
+            public void Method(Guid argument)
+            {
+                if (argument == Guid.Empty) throw new ArgumentException(string.Empty, "invalid parameter name");
+            }
+
+            public IEnumerable<Guid> DeferredMethodReturningGenericEnumerable(Guid argument)
+            {
+                if (argument == Guid.Empty) throw new ArgumentException(string.Empty, "invalid parameter name");
+
+                yield return argument;
+            }
+
+            public IEnumerator<Guid> DeferredMethodReturningGenericEnumerator(Guid argument)
+            {
+                if (argument == Guid.Empty) throw new ArgumentException(string.Empty, "invalid parameter name");
+
+                yield return argument;
+            }
+
+            public IEnumerable DeferredMethodReturningNonGenericEnumerable(Guid argument)
+            {
+                if (argument == Guid.Empty) throw new ArgumentException(string.Empty, "invalid parameter name");
+
+                yield return argument;
+            }
+
+            public IEnumerator DeferredMethodReturningNonGenericEnumerator(Guid argument)
+            {
+                if (argument == Guid.Empty) throw new ArgumentException(string.Empty, "invalid parameter name");
+
+                yield return argument;
+            }
+        }
+
+        [Fact]
         public void VerifyOnAbstractMethodDoesNotThrow()
         {
             var method = typeof(AbstractTypeWithAbstractMethod)


### PR DESCRIPTION
This pr fixes #1009 

- Implements parameter name check for `EmptyGuidBehaviorExpectation`