### PR TITLE
Add convenience method to add AutoMoq to a fixture

### DIFF
--- a/Src/AutoMoq/FixtureExtensions.cs
+++ b/Src/AutoMoq/FixtureExtensions.cs
@@ -1,0 +1,35 @@
+﻿using AutoFixture.AutoMoq;
+using AutoFixture.Kernel;
+
+// This class is placed in the AutoFixture namespace to improve discoverability.
+namespace AutoFixture
+{
+    public static class FixtureExtensions
+    {
+        /// <summary>
+        /// Applies the AutoMoqCustomization on the <see cref="IFixture"/>.
+        /// </summary>
+        /// <param name="fixture">The fixture upon which to enable auto-mocking.</param>
+        /// <param name="configureMembers">Specifies whether members of a mock will be automatically setup to retrieve the return values from a fixture.</param>
+        /// <param name="generateDelegates">Specifies whether delegate requests are intercepted and handled by Moq.</param>
+        /// <param name="relay">The relay that will be added to <see cref="IFixture.ResidueCollectors"/> when the customization is applied on the <see cref="fixture"/>.</param>
+        /// <returns>The <see cref="fixture"/> with the customization applied.</returns>
+        public static IFixture AddAutoMoq(this IFixture fixture, bool configureMembers = false, bool generateDelegates = false, ISpecimenBuilder relay = null)
+        {
+            var customization = new AutoMoqCustomization
+            {
+                ConfigureMembers = configureMembers,
+                GenerateDelegates = generateDelegates
+            };
+
+            if (relay != null)
+            {
+                customization.Relay = relay;
+            }
+
+            fixture.Customize(customization);
+
+            return fixture;
+        }
+    }
+}

--- a/Src/AutoMoq/FixtureExtensions.cs
+++ b/Src/AutoMoq/FixtureExtensions.cs
@@ -1,9 +1,13 @@
-﻿using AutoFixture.AutoMoq;
+﻿using System;
+using AutoFixture.AutoMoq;
 using AutoFixture.Kernel;
 
 // This class is placed in the AutoFixture namespace to improve discoverability.
 namespace AutoFixture
 {
+    /// <summary>
+    /// A class to collect extension methods of <see cref="IFixture"/>.
+    /// </summary>
     public static class FixtureExtensions
     {
         /// <summary>
@@ -12,10 +16,15 @@ namespace AutoFixture
         /// <param name="fixture">The fixture upon which to enable auto-mocking.</param>
         /// <param name="configureMembers">Specifies whether members of a mock will be automatically setup to retrieve the return values from a fixture.</param>
         /// <param name="generateDelegates">Specifies whether delegate requests are intercepted and handled by Moq.</param>
-        /// <param name="relay">The relay that will be added to <see cref="IFixture.ResidueCollectors"/> when the customization is applied on the <see cref="fixture"/>.</param>
-        /// <returns>The <see cref="fixture"/> with the customization applied.</returns>
+        /// <param name="relay">The relay that will be added to <see cref="IFixture.ResidueCollectors"/> when the customization is applied on the fixture.</param>
+        /// <returns>The fixture with the customization applied.</returns>
         public static IFixture AddAutoMoq(this IFixture fixture, bool configureMembers = false, bool generateDelegates = false, ISpecimenBuilder relay = null)
         {
+            if (fixture == null)
+            {
+                throw new ArgumentNullException(nameof(fixture));
+            }
+
             var customization = new AutoMoqCustomization
             {
                 ConfigureMembers = configureMembers,

--- a/Src/AutoMoqUnitTest/FixtureExtensionsTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureExtensionsTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoFixture.Kernel;
+using Moq;
+using Xunit;
+
+namespace AutoFixture.AutoMoq.UnitTest
+{
+    public class FixtureExtensionsTest
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        public void AddAutoMoqCustomizesFixture(bool configureMembers, bool generateDelegates)
+        {
+            var fixture = Mock.Of<IFixture>();
+
+            fixture.AddAutoMoq(configureMembers: configureMembers, generateDelegates: generateDelegates);
+
+            Mock.Get(fixture).Verify(p => p.Customize(It.Is<AutoMoqCustomization>(c => c.ConfigureMembers == configureMembers && c.GenerateDelegates == generateDelegates)));
+        }
+
+        [Fact]
+        public void AddAutoMoqCustomizesFixtureWithGivenRelay()
+        {
+            var fixture = Mock.Of<IFixture>();
+
+            var relay = Mock.Of<ISpecimenBuilder>();
+
+            fixture.AddAutoMoq(relay: relay);
+
+            Mock.Get(fixture).Verify(p => p.Customize(It.Is<AutoMoqCustomization>(c => ReferenceEquals(relay, c.Relay))));
+        }
+
+        [Fact]
+        public void AddAutoMoqReturnsSameFixture()
+        {
+            var fixture = Mock.Of<IFixture>();
+
+            var result = fixture.AddAutoMoq();
+
+            Assert.Same(fixture, result);
+        }
+    }
+}

--- a/Src/AutoMoqUnitTest/FixtureExtensionsTest.cs
+++ b/Src/AutoMoqUnitTest/FixtureExtensionsTest.cs
@@ -46,5 +46,13 @@ namespace AutoFixture.AutoMoq.UnitTest
 
             Assert.Same(fixture, result);
         }
+
+        [Fact]
+        public void AddAutoMoqThrowsIfFixtureIsNull()
+        {
+            IFixture fixture = null;
+
+            Assert.Throws<ArgumentNullException>(() => fixture.AddAutoMoq());
+        }
     }
 }


### PR DESCRIPTION
This pull request adds a convenient way customize a fixture with AutoMoq.

Here is an example of the intended usage:
```csharp
// default setup
var fixture = new Fixture().AddAutoMoq();

// enable members configuration
var fixture = new Fixture().AddAutoMoq(configureMembers: true);

// enable delagete generation
var fixture = new Fixture().AddAutoMoq(generateDelegates: true);

// enable both
var fixture = new Fixture().AddAutoMoq(configureMembers: true, generateDelegates: true);
```

The AddAutoMoq extension method has been added in the AutoFixture namespace to increase discoverability.