### PR TITLE
Add .net standard support to AutoFoq

### DIFF
--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AssemblyTitle>AutoFixture.AutoFoq</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFoq</AssemblyName>
     <RootNamespace>AutoFixture.AutoFoq</RootNamespace>
@@ -29,8 +29,12 @@
     <Compile Include="AutoFoqCustomization.fs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Foq" Version="[1.5.1,2.0.0)" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+    <PackageReference Include="Foq" Version="[1.8.0,2.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <PackageReference Include="Foq" Version="[1.5.1,2.0.0)"  />
     <PackageReference Include="FSharp.Core" Version="3.0.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -4,7 +4,7 @@
   <Import Project="..\Common.Test.xUnit.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
     <AssemblyTitle>AutoFixture.AutoFoq.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFoq.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoFoq.UnitTest</RootNamespace>

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -4,7 +4,7 @@
   <Import Project="..\Common.Test.xUnit.props" />
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp3.0</TargetFrameworks>
     <AssemblyTitle>AutoFixture.AutoFoq.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFoq.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoFoq.UnitTest</RootNamespace>
@@ -19,12 +19,15 @@
     <Compile Include="FixtureIntegrationTest.fs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Unquote" Version="3.1.0" />
-    <!-- AutoFoq targets FSharp.Core 3.0.2, but we require 3.1.2 as Unquote was compiled against it. -->
+    <!-- AutoFoq targets FSharp.Core 3.0.2, but we require 3.1.2 as Unquote was compiled against it for .Net Framework. -->
     <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+    <PackageReference Include="Unquote" Version="4.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\AutoFoq\AutoFoq.fsproj" />


### PR DESCRIPTION
In reference to #1143, this PR adds .net standard support for `AutoFoq`.