### PR TITLE
Proposed fix for #1183 - multiple regex within short time might give identical strings

### DIFF
--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using System.Threading;
 using AutoFixture.Kernel;
 using Fare;
 
@@ -8,9 +9,12 @@ namespace AutoFixture
     /// <summary>
     /// Creates a string that is guaranteed to match a RegularExpressionRequest.
     /// </summary>
-    public class RegularExpressionGenerator : ISpecimenBuilder
+    public class RegularExpressionGenerator : ISpecimenBuilder, IDisposable
     {
         private readonly Random random;
+        private readonly object syncRoot;
+        private readonly ThreadLocal<Random> threadLocalRandom;
+        private bool disposedValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegularExpressionGenerator"/> class.
@@ -18,6 +22,8 @@ namespace AutoFixture
         public RegularExpressionGenerator()
         {
             this.random = new Random();
+            this.syncRoot = new object();
+            this.threadLocalRandom = new ThreadLocal<Random>(() => new Random(this.GenerateSeed()));
         }
 
         /// <summary>
@@ -49,7 +55,8 @@ namespace AutoFixture
             {
                 // Use the Xeger constructor overload that that takes an instance of Random.
                 // Otherwise identically strings can be generated, if regex are generated within short time.
-                string regex = new Xeger(pattern, this.random).Generate();
+                // Use shared random - but one for each thread to avoid threadsafety issues with Random.
+                string regex = new Xeger(pattern, this.threadLocalRandom.Value).Generate();
                 if (Regex.IsMatch(regex, pattern))
                 {
                     return regex;
@@ -65,6 +72,44 @@ namespace AutoFixture
             }
 
             return new NoSpecimen();
+        }
+
+        private int GenerateSeed()
+        {
+            lock (this.syncRoot)
+            {
+                return this.random.Next();
+            }
+        }
+
+        /// <summary>
+        /// Disposes  <see cref="ThreadLocal&lt;Random&gt;"/>.
+        /// </summary>
+        /// <param name="disposing">
+        /// <see langword="true"/> to release both managed and unmanaged resources;
+        /// <see langword="false"/> to release only unmanaged resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposedValue)
+            {
+                if (disposing)
+                {
+                    this.threadLocalRandom?.Dispose();
+                }
+
+                this.disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Disposes  <see cref="ThreadLocal&lt;Random&gt;"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            this.Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -10,6 +10,16 @@ namespace AutoFixture
     /// </summary>
     public class RegularExpressionGenerator : ISpecimenBuilder
     {
+        private readonly Random random;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegularExpressionGenerator"/> class.
+        /// </summary>
+        public RegularExpressionGenerator()
+        {
+            this.random = new Random();
+        }
+
         /// <summary>
         /// Creates a string that is guaranteed to match a RegularExpressionRequest.
         /// </summary>
@@ -28,16 +38,18 @@ namespace AutoFixture
                 return new NoSpecimen();
             }
 
-            return GenerateRegularExpression(regularExpressionRequest);
+            return this.GenerateRegularExpression(regularExpressionRequest);
         }
 
-        private static object GenerateRegularExpression(RegularExpressionRequest request)
+        private object GenerateRegularExpression(RegularExpressionRequest request)
         {
             string pattern = request.Pattern;
 
             try
             {
-                string regex = new Xeger(pattern).Generate();
+                // Use the Xeger constructor overload that that takes an instance of Random.
+                // Otherwise identically strings can be generated, if regex are generated within short time.
+                string regex = new Xeger(pattern, this.random).Generate();
                 if (Regex.IsMatch(regex, pattern))
                 {
                     return regex;

--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using System.Threading;
 using AutoFixture.Kernel;
 using Fare;
 
@@ -9,12 +8,10 @@ namespace AutoFixture
     /// <summary>
     /// Creates a string that is guaranteed to match a RegularExpressionRequest.
     /// </summary>
-    public class RegularExpressionGenerator : ISpecimenBuilder, IDisposable
+    public class RegularExpressionGenerator : ISpecimenBuilder
     {
         private readonly Random random;
         private readonly object syncRoot;
-        private readonly ThreadLocal<Random> threadLocalRandom;
-        private bool disposedValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegularExpressionGenerator"/> class.
@@ -23,7 +20,6 @@ namespace AutoFixture
         {
             this.random = new Random();
             this.syncRoot = new object();
-            this.threadLocalRandom = new ThreadLocal<Random>(() => new Random(this.GenerateSeed()));
         }
 
         /// <summary>
@@ -55,8 +51,7 @@ namespace AutoFixture
             {
                 // Use the Xeger constructor overload that that takes an instance of Random.
                 // Otherwise identically strings can be generated, if regex are generated within short time.
-                // Use shared random - but one for each thread to avoid threadsafety issues with Random.
-                string regex = new Xeger(pattern, this.threadLocalRandom.Value).Generate();
+                string regex = new Xeger(pattern, new Random(this.GenerateSeed())).Generate();
                 if (Regex.IsMatch(regex, pattern))
                 {
                     return regex;
@@ -80,36 +75,6 @@ namespace AutoFixture
             {
                 return this.random.Next();
             }
-        }
-
-        /// <summary>
-        /// Disposes  <see cref="ThreadLocal&lt;Random&gt;"/>.
-        /// </summary>
-        /// <param name="disposing">
-        /// <see langword="true"/> to release both managed and unmanaged resources;
-        /// <see langword="false"/> to release only unmanaged resources.
-        /// </param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!this.disposedValue)
-            {
-                if (disposing)
-                {
-                    this.threadLocalRandom?.Dispose();
-                }
-
-                this.disposedValue = true;
-            }
-        }
-
-        /// <summary>
-        /// Disposes  <see cref="ThreadLocal&lt;Random&gt;"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            this.Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionValidatedType.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionValidatedType.cs
@@ -4,7 +4,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
 {
     public class RegularExpressionValidatedType
     {
-        public const string Pattern = @"^[a-zA-Z''-'\s]{1,40}$";
+        public const string Pattern = @"^[a-zA-Z''-'\s]{20,40}$";
 
         [RegularExpression(Pattern)]
         public string Property { get; set; }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -1637,6 +1637,21 @@ namespace AutoFixtureUnitTest
         }
 
         [Fact]
+        public void CreateManyAnonymousWithRegularExpressionValidatedTypeReturnsDifferentResults()
+        {
+            // This test exposes an issue with Xeger/Random.
+            // Xeger(pattern) internally creates an instance of Random with the default seed.
+            // This means that the RegularExpressionGenerator might create identical strings
+            // if called multiple times within a short time.
+
+            // Arrange
+            var fixture = new Fixture();
+            var result = fixture.CreateMany<RegularExpressionValidatedType>(10).Select(x => x.Property).ToArray();
+            // Assert
+            Assert.Equal(result.Distinct(), result);
+        }
+
+        [Fact]
         public void CreateAnonymousWithStringLengthValidatedTypeReturnsCorrectResult()
         {
             // Arrange

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -117,7 +117,7 @@ namespace AutoFixtureUnitTest
             var request = new RegularExpressionRequest(pattern);
             var dummyContext = new DelegatingSpecimenContext();
 
-            // Repeat a few times - because the issue seen comes from Random class using tickcount as seed.
+            // Repeat a few times to make the test more robust.
             for (int i = 0; i < 10; i++)
             {
                 var result1 = sut.Create(request, dummyContext);

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -104,6 +104,31 @@ namespace AutoFixtureUnitTest
         }
 
         [Theory]
+        [InlineData(@"^[A-Z]{27}$")]
+        public void CreateMultipleWithRegularExpressionRequestReturnsDifferentResults(string pattern)
+        {
+            // This test exposes an issue with Xeger/Random.
+            // Xeger(pattern) internally creates an instance of Random with the default seed.
+            // This means that the RegularExpressionGenerator might create identical strings
+            // if called multiple times within a short time.
+
+            // Arrange
+            var sut = new RegularExpressionGenerator();
+            var request = new RegularExpressionRequest(pattern);
+            var dummyContext = new DelegatingSpecimenContext();
+
+            // Repeat a few times - because the issue seen comes from Random class using tickcount as seed.
+            for (int i = 0; i < 10; i++)
+            {
+                var result1 = sut.Create(request, dummyContext);
+                var result2 = sut.Create(request, dummyContext);
+
+                // Assert
+                Assert.NotEqual(result1, result2);
+            }
+        }
+
+        [Theory]
         [InlineData("[")]
         [InlineData(@"(?\[Test\]|\[Foo\]|\[Bar\])?(?:-)?(?\[[()a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?(?:-)?(?\[[a-zA-Z0-9_\s]+\])?")]
         public void CreateWithNotSupportedRegularExpressionRequestReturnsCorrectResult(string pattern)

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
 using AutoFixture;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
@@ -118,14 +119,10 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
 
             // Repeat a few times to make the test more robust.
-            for (int i = 0; i < 10; i++)
-            {
-                var result1 = sut.Create(request, dummyContext);
-                var result2 = sut.Create(request, dummyContext);
+            // Use ToArray to iterate the IEnumerable at this point.
+            var result = Enumerable.Range(0, 10).Select(_ => sut.Create(request, dummyContext)).ToArray();
 
-                // Assert
-                Assert.NotEqual(result1, result2);
-            }
+            Assert.Equal(result.Distinct(), result);
         }
 
         [Theory]


### PR DESCRIPTION
Included:
- Test that exposes the issue
- Proposed fix:
    - Use `Xeger(pattern, random)` constructor overload
    - Use the same instance of `Random` each time. I figured it should be enough to avoid the issue with identical seeds.

Fix #1183 