### PR TITLE
Idiomatic assertions for `IEqualityComparer<T>`

### DIFF
--- a/Src/Idioms/EqualityComparerAssertion.cs
+++ b/Src/Idioms/EqualityComparerAssertion.cs
@@ -29,13 +29,9 @@ namespace AutoFixture.Idioms
         private static IEnumerable<IIdiomaticAssertion> CreateChildAssertions(ISpecimenBuilder builder)
         {
             yield return new EqualityComparerEqualsSelfAssertion(builder);
-
             yield return new EqualityComparerEqualsSymmetricAssertion(builder);
-
             yield return new EqualityComparerEqualsTransitiveAssertion(builder);
-
             yield return new EqualityComparerGetHashCodeAssertion(builder);
-
             yield return new EqualityComparerEqualsNullAssertion(builder);
         }
     }

--- a/Src/Idioms/EqualityComparerAssertion.cs
+++ b/Src/Idioms/EqualityComparerAssertion.cs
@@ -1,16 +1,30 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Reflection;
+﻿using System.Collections.Generic;
 using AutoFixture.Kernel;
 
 namespace AutoFixture.Idioms
 {
+    /// <summary>
+    /// Encapsulates a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly.
+    /// </summary>
     public class EqualityComparerAssertion : CompositeIdiomaticAssertion
     {
-        public EqualityComparerAssertion(ISpecimenBuilder builder) : base(CreateChildAssertions(builder)) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        public EqualityComparerAssertion(ISpecimenBuilder builder)
+            : base(CreateChildAssertions(builder))
+        {
+        }
 
         private static IEnumerable<IIdiomaticAssertion> CreateChildAssertions(ISpecimenBuilder builder)
         {
@@ -24,213 +38,5 @@ namespace AutoFixture.Idioms
 
             yield return new EqualityComparerEqualsNullAssertion(builder);
         }
-    }
-
-    public class EqualityComparerGetHashCodeAssertion : IdiomaticAssertion
-    {
-        public ISpecimenBuilder Builder { get; }
-
-        public EqualityComparerGetHashCodeAssertion(ISpecimenBuilder builder)
-        {
-            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        }
-
-        public override void Verify(MethodInfo methodInfo)
-        {
-            if (methodInfo is { Name: nameof(IEqualityComparer.GetHashCode), ReflectedType: { } type } && methodInfo.GetParameters().Length == 1 && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>)))
-            {
-                var argumentType = methodInfo.GetParameters()[0].ParameterType;
-
-                if (!methodInfo.ReflectedType.ImplementsGenericInterface(typeof(IEqualityComparer<>), argumentType))
-                {
-                    return;
-                }
-
-                var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
-                var testSubject = this.Builder.CreateAnonymous(argumentType);
-
-                var firstHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });
-
-                var secondHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });
-
-                if (firstHashCode != secondHashCode)
-                {
-                    throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
-                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
-                        "calling GetHashCode(x) should always return same value.",
-                        type.FullName));
-                }
-            }
-        }
-    }
-
-    public abstract class EqualityComparerEqualsAssertion : IdiomaticAssertion
-    {
-        public ISpecimenBuilder Builder { get; }
-
-        protected EqualityComparerEqualsAssertion(ISpecimenBuilder builder)
-        {
-            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        }
-
-        public override void Verify(MethodInfo methodInfo)
-        {
-            if (methodInfo is { Name: nameof(IEqualityComparer.Equals), ReflectedType: { } type } && methodInfo.GetParameters().Length == 2 && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>)))
-            {
-                var argumentType = methodInfo.GetParameters()[0].ParameterType;
-
-                if (!methodInfo.ReflectedType.ImplementsGenericInterface(typeof(IEqualityComparer<>), argumentType))
-                {
-                    return;
-                }
-
-                this.VerifyEquals(methodInfo, argumentType);
-            }
-        }
-
-        protected abstract void VerifyEquals(MethodInfo methodInfo, Type argumentType);
-    }
-
-    public class EqualityComparerEqualsSelfAssertion : EqualityComparerEqualsAssertion
-    {
-        public EqualityComparerEqualsSelfAssertion(ISpecimenBuilder builder) : base(builder) { }
-
-        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
-        {
-            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
-            var testSubject = this.Builder.CreateAnonymous(argumentType);
-
-            var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, testSubject });
-
-            if (!result)
-            {
-                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
-                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
-                        "calling Equals(x, x) should return true.",
-                        methodInfo.ReflectedType!.FullName));
-            }
-        }
-    }
-
-    public class EqualityComparerEqualsSymmetricAssertion : EqualityComparerEqualsAssertion
-    {
-        public EqualityComparerEqualsSymmetricAssertion(ISpecimenBuilder builder) : base(builder) { }
-
-        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
-        {
-            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
-            var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
-
-            var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
-
-            var directResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
-
-            var invertedResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, firstTestSubject });
-
-            if (directResult != invertedResult)
-            {
-                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
-                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
-                        "calling Equals(x, y) should return same as Equals(y, x).",
-                        methodInfo.ReflectedType!.FullName));
-            }
-        }
-    }
-
-    public class EqualityComparerEqualsTransitiveAssertion : EqualityComparerEqualsAssertion
-    {
-        public EqualityComparerEqualsTransitiveAssertion(ISpecimenBuilder builder) : base(builder) { }
-
-        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
-        {
-            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
-            var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
-
-            var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
-
-            var thirdTestSubject = this.Builder.CreateAnonymous(argumentType);
-
-            var firstResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
-
-            var secondResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, thirdTestSubject });
-
-            var thirdResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, thirdTestSubject });
-
-            if (firstResult != secondResult || firstResult != thirdResult)
-            {
-                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
-                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
-                        "calling Equals(x, z) should return same as Equals(x, y) and Equals(y, z).",
-                        methodInfo.ReflectedType!.FullName));
-            }
-        }
-    }
-
-    public class EqualityComparerEqualsNullAssertion : EqualityComparerEqualsAssertion
-    {
-        public EqualityComparerEqualsNullAssertion(ISpecimenBuilder builder) : base(builder) { }
-
-        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
-        {
-            if (methodInfo.ReflectedType!.IsValueType)
-            {
-                return;
-            }
-
-            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
-            var testSubject = this.Builder.CreateAnonymous(argumentType);
-
-            var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, null });
-
-            if (result)
-            {
-                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
-                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
-                    "calling Equals(x, null) should return false.",
-                    methodInfo.ReflectedType!.FullName));
-            }
-        }
-    }
-
-    public class EqualityComparerEqualsNullNullAssertion : EqualityComparerEqualsAssertion
-    {
-        public EqualityComparerEqualsNullNullAssertion(ISpecimenBuilder builder) : base(builder) { }
-
-        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
-        {
-            if (methodInfo.ReflectedType!.IsValueType)
-            {
-                return;
-            }
-
-            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
-            var result = (bool)methodInfo.Invoke(comparer, new object[] { null, null });
-
-            if (!result)
-            {
-                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
-                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
-                    "calling Equals(null, null) should return true.",
-                    methodInfo.ReflectedType!.FullName));
-            }
-        }
-    }
-
-    public class EqualityComparerImplementationException : Exception
-    {
-        public EqualityComparerImplementationException(string message) : base(message) { }
-    }
-
-    internal static class TypeExtensions
-    {
-        public static bool ImplementsGenericInterfaceDefinition(this Type type, Type interfaceType) => type.GetInterfaces().Any(i => i.GetGenericTypeDefinition().IsAssignableFrom(interfaceType));
-
-        public static bool ImplementsGenericInterface(this Type type, Type interfaceType, params Type[] argumentTypes) => type.GetInterfaces().Any(i => i.IsAssignableFrom(interfaceType.MakeGenericType(argumentTypes)));
     }
 }

--- a/Src/Idioms/EqualityComparerAssertion.cs
+++ b/Src/Idioms/EqualityComparerAssertion.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    public class EqualityComparerAssertion : CompositeIdiomaticAssertion
+    {
+        public EqualityComparerAssertion(ISpecimenBuilder builder) : base(CreateChildAssertions(builder)) { }
+
+        private static IEnumerable<IIdiomaticAssertion> CreateChildAssertions(ISpecimenBuilder builder)
+        {
+            yield return new EqualityComparerEqualsSelfAssertion(builder);
+
+            yield return new EqualityComparerEqualsSymmetricAssertion(builder);
+
+            yield return new EqualityComparerEqualsTransitiveAssertion(builder);
+
+            yield return new EqualityComparerGetHashCodeAssertion(builder);
+
+            yield return new EqualityComparerEqualsNullAssertion(builder);
+        }
+    }
+
+    public class EqualityComparerGetHashCodeAssertion : IdiomaticAssertion
+    {
+        public ISpecimenBuilder Builder { get; }
+
+        public EqualityComparerGetHashCodeAssertion(ISpecimenBuilder builder)
+        {
+            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        }
+
+        public override void Verify(MethodInfo methodInfo)
+        {
+            if (methodInfo is { Name: nameof(IEqualityComparer.GetHashCode), ReflectedType: { } type } && methodInfo.GetParameters().Length == 1 && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>)))
+            {
+                var argumentType = methodInfo.GetParameters()[0].ParameterType;
+
+                if (!methodInfo.ReflectedType.ImplementsGenericInterface(typeof(IEqualityComparer<>), argumentType))
+                {
+                    return;
+                }
+
+                var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+                var testSubject = this.Builder.CreateAnonymous(argumentType);
+
+                var firstHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });
+
+                var secondHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });
+
+                if (firstHashCode != secondHashCode)
+                {
+                    throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                        "calling GetHashCode(x) should always return same value.",
+                        type.FullName));
+                }
+            }
+        }
+    }
+
+    public abstract class EqualityComparerEqualsAssertion : IdiomaticAssertion
+    {
+        public ISpecimenBuilder Builder { get; }
+
+        protected EqualityComparerEqualsAssertion(ISpecimenBuilder builder)
+        {
+            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        }
+
+        public override void Verify(MethodInfo methodInfo)
+        {
+            if (methodInfo is { Name: nameof(IEqualityComparer.Equals), ReflectedType: { } type } && methodInfo.GetParameters().Length == 2 && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>)))
+            {
+                var argumentType = methodInfo.GetParameters()[0].ParameterType;
+
+                if (!methodInfo.ReflectedType.ImplementsGenericInterface(typeof(IEqualityComparer<>), argumentType))
+                {
+                    return;
+                }
+
+                this.VerifyEquals(methodInfo, argumentType);
+            }
+        }
+
+        protected abstract void VerifyEquals(MethodInfo methodInfo, Type argumentType);
+    }
+
+    public class EqualityComparerEqualsSelfAssertion : EqualityComparerEqualsAssertion
+    {
+        public EqualityComparerEqualsSelfAssertion(ISpecimenBuilder builder) : base(builder) { }
+
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var testSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, testSubject });
+
+            if (!result)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                        "calling Equals(x, x) should return true.",
+                        methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+
+    public class EqualityComparerEqualsSymmetricAssertion : EqualityComparerEqualsAssertion
+    {
+        public EqualityComparerEqualsSymmetricAssertion(ISpecimenBuilder builder) : base(builder) { }
+
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var directResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
+
+            var invertedResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, firstTestSubject });
+
+            if (directResult != invertedResult)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                        "calling Equals(x, y) should return same as Equals(y, x).",
+                        methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+
+    public class EqualityComparerEqualsTransitiveAssertion : EqualityComparerEqualsAssertion
+    {
+        public EqualityComparerEqualsTransitiveAssertion(ISpecimenBuilder builder) : base(builder) { }
+
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var thirdTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var firstResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
+
+            var secondResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, thirdTestSubject });
+
+            var thirdResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, thirdTestSubject });
+
+            if (firstResult != secondResult || firstResult != thirdResult)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                        "calling Equals(x, z) should return same as Equals(x, y) and Equals(y, z).",
+                        methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+
+    public class EqualityComparerEqualsNullAssertion : EqualityComparerEqualsAssertion
+    {
+        public EqualityComparerEqualsNullAssertion(ISpecimenBuilder builder) : base(builder) { }
+
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            if (methodInfo.ReflectedType!.IsValueType)
+            {
+                return;
+            }
+
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var testSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, null });
+
+            if (result)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                    "calling Equals(x, null) should return false.",
+                    methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+
+    public class EqualityComparerEqualsNullNullAssertion : EqualityComparerEqualsAssertion
+    {
+        public EqualityComparerEqualsNullNullAssertion(ISpecimenBuilder builder) : base(builder) { }
+
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            if (methodInfo.ReflectedType!.IsValueType)
+            {
+                return;
+            }
+
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var result = (bool)methodInfo.Invoke(comparer, new object[] { null, null });
+
+            if (!result)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                    "calling Equals(null, null) should return true.",
+                    methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+
+    public class EqualityComparerImplementationException : Exception
+    {
+        public EqualityComparerImplementationException(string message) : base(message) { }
+    }
+
+    internal static class TypeExtensions
+    {
+        public static bool ImplementsGenericInterfaceDefinition(this Type type, Type interfaceType) => type.GetInterfaces().Any(i => i.GetGenericTypeDefinition().IsAssignableFrom(interfaceType));
+
+        public static bool ImplementsGenericInterface(this Type type, Type interfaceType, params Type[] argumentTypes) => type.GetInterfaces().Any(i => i.IsAssignableFrom(interfaceType.MakeGenericType(argumentTypes)));
+    }
+}

--- a/Src/Idioms/EqualityComparerEqualsAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsAssertion.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// A base class for building classes that encapsulate a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly.
+    /// </summary>
+    public abstract class EqualityComparerEqualsAssertion : IdiomaticAssertion
+    {
+        /// <summary>
+        /// Gets the builder supplied by the constructor.
+        /// </summary>
+        public ISpecimenBuilder Builder { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerEqualsAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        protected EqualityComparerEqualsAssertion(ISpecimenBuilder builder)
+        {
+            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        }
+
+        /// <summary>
+        /// Forwards the call to <see cref="VerifyEquals"/> if the supplied method is an implementation of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        public override void Verify(MethodInfo methodInfo)
+        {
+            if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+
+            if (methodInfo is { Name: nameof(IEqualityComparer.Equals), ReflectedType: { } type } && methodInfo.GetParameters().Length == 2 && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>)))
+            {
+                var argumentType = methodInfo.GetParameters()[0].ParameterType;
+
+                if (!methodInfo.ReflectedType.ImplementsGenericInterface(typeof(IEqualityComparer<>), argumentType))
+                {
+                    return;
+                }
+
+                this.VerifyEquals(methodInfo, argumentType);
+            }
+        }
+
+        /// <summary>
+        /// Abstract method used to verify if the method implements correctly <see cref="IEqualityComparer{T}.Equals(T,T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        /// <param name="argumentType">The argument type of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.</param>
+        protected abstract void VerifyEquals(MethodInfo methodInfo, Type argumentType);
+    }
+}

--- a/Src/Idioms/EqualityComparerEqualsAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsAssertion.cs
@@ -41,18 +41,9 @@ namespace AutoFixture.Idioms
         public override void Verify(MethodInfo methodInfo)
         {
             if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+            if (!IsEqualityComparerEqualsMethod(methodInfo)) return;
 
-            if (methodInfo is { Name: nameof(IEqualityComparer.Equals), ReflectedType: { } type } && methodInfo.GetParameters().Length == 2 && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>)))
-            {
-                var argumentType = methodInfo.GetParameters()[0].ParameterType;
-
-                if (!methodInfo.ReflectedType.ImplementsGenericInterface(typeof(IEqualityComparer<>), argumentType))
-                {
-                    return;
-                }
-
-                this.VerifyEquals(methodInfo, argumentType);
-            }
+            this.VerifyEquals(methodInfo, methodInfo.GetParameters()[0].ParameterType);
         }
 
         /// <summary>
@@ -61,5 +52,15 @@ namespace AutoFixture.Idioms
         /// <param name="methodInfo">The method to verify.</param>
         /// <param name="argumentType">The argument type of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.</param>
         protected abstract void VerifyEquals(MethodInfo methodInfo, Type argumentType);
+
+        private static bool IsEqualityComparerEqualsMethod(MethodInfo methodInfo)
+        {
+            return methodInfo is { Name: nameof(IEqualityComparer.Equals), ReflectedType: { } type }
+                   && methodInfo.GetParameters().Length == 2
+                   && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>))
+                   && type.ImplementsGenericInterface(
+                       typeof(IEqualityComparer<>),
+                       methodInfo.GetParameters()[0].ParameterType);
+        }
     }
 }

--- a/Src/Idioms/EqualityComparerEqualsNullAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsNullAssertion.cs
@@ -39,16 +39,10 @@ namespace AutoFixture.Idioms
         protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
         {
             if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
-
             if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
-
-            if (methodInfo.ReflectedType!.IsValueType)
-            {
-                return;
-            }
+            if (methodInfo.ReflectedType!.IsValueType) return;
 
             var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
             var testSubject = this.Builder.CreateAnonymous(argumentType);
 
             var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, null });

--- a/Src/Idioms/EqualityComparerEqualsNullAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsNullAssertion.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Encapsulates a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly
+    /// with respect of the rule: calling Equals(x, null) should return false.
+    /// </summary>
+    public class EqualityComparerEqualsNullAssertion : EqualityComparerEqualsAssertion
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerEqualsNullAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        public EqualityComparerEqualsNullAssertion(ISpecimenBuilder builder)
+            : base(builder)
+        {
+        }
+
+        /// <summary>
+        /// Verifies that `calling Equals(x, null) should return false`
+        /// if the supplied method is an implementation of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        /// <param name="argumentType">The argument type of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.</param>
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+
+            if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
+
+            if (methodInfo.ReflectedType!.IsValueType)
+            {
+                return;
+            }
+
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var testSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, null });
+
+            if (result)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                    "calling Equals(x, null) should return false.",
+                    methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+}

--- a/Src/Idioms/EqualityComparerEqualsNullNullAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsNullNullAssertion.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Encapsulates a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly
+    /// with respect of the rule: calling Equals(null, null) should return true.
+    /// </summary>
+    public class EqualityComparerEqualsNullNullAssertion : EqualityComparerEqualsAssertion
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerEqualsNullNullAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        public EqualityComparerEqualsNullNullAssertion(ISpecimenBuilder builder)
+            : base(builder)
+        {
+        }
+
+        /// <summary>
+        /// Verifies that `calling Equals(null, null) should return true`
+        /// if the supplied method is an implementation of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        /// <param name="argumentType">The argument type of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.</param>
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+
+            if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
+
+            if (methodInfo.ReflectedType!.IsValueType)
+            {
+                return;
+            }
+
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var result = (bool)methodInfo.Invoke(comparer, new object[] { null, null });
+
+            if (!result)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                    "calling Equals(null, null) should return true.",
+                    methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+}

--- a/Src/Idioms/EqualityComparerEqualsNullNullAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsNullNullAssertion.cs
@@ -39,13 +39,8 @@ namespace AutoFixture.Idioms
         protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
         {
             if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
-
             if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
-
-            if (methodInfo.ReflectedType!.IsValueType)
-            {
-                return;
-            }
+            if (methodInfo.ReflectedType!.IsValueType) return;
 
             var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
 

--- a/Src/Idioms/EqualityComparerEqualsSelfAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsSelfAssertion.cs
@@ -39,11 +39,9 @@ namespace AutoFixture.Idioms
         protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
         {
             if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
-
             if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
 
             var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
             var testSubject = this.Builder.CreateAnonymous(argumentType);
 
             var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, testSubject });

--- a/Src/Idioms/EqualityComparerEqualsSelfAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsSelfAssertion.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Encapsulates a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly
+    /// with respect of the rule: calling Equals(x, x) should return true.
+    /// </summary>
+    public class EqualityComparerEqualsSelfAssertion : EqualityComparerEqualsAssertion
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerEqualsSelfAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        public EqualityComparerEqualsSelfAssertion(ISpecimenBuilder builder)
+            : base(builder)
+        {
+        }
+
+        /// <summary>
+        /// Verifies that `calling Equals(x, x) should return true`
+        /// if the supplied method is an implementation of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        /// <param name="argumentType">The argument type of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.</param>
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+
+            if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
+
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var testSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, testSubject });
+
+            if (!result)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                    "calling Equals(x, x) should return true.",
+                    methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+}

--- a/Src/Idioms/EqualityComparerEqualsSymmetricAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsSymmetricAssertion.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Encapsulates a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly
+    /// with respect of the rule: calling Equals(x, y) should return same as Equals(y, x).
+    /// </summary>
+    public class EqualityComparerEqualsSymmetricAssertion : EqualityComparerEqualsAssertion
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerEqualsSymmetricAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        public EqualityComparerEqualsSymmetricAssertion(ISpecimenBuilder builder)
+            : base(builder)
+        {
+        }
+
+        /// <summary>
+        /// Verifies that `calling Equals(x, y) should return same as Equals(y, x)`
+        /// if the supplied method is an implementation of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        /// <param name="argumentType">The argument type of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.</param>
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+
+            if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
+
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var directResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
+
+            var invertedResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, firstTestSubject });
+
+            if (directResult != invertedResult)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                    "calling Equals(x, y) should return same as Equals(y, x).",
+                    methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+}

--- a/Src/Idioms/EqualityComparerEqualsSymmetricAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsSymmetricAssertion.cs
@@ -39,17 +39,13 @@ namespace AutoFixture.Idioms
         protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
         {
             if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
-
             if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
 
             var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
             var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
-
             var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
 
             var directResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
-
             var invertedResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, firstTestSubject });
 
             if (directResult != invertedResult)

--- a/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Encapsulates a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly
+    /// with respect of the rule: calling Equals(x, z) should return same as Equals(x, y) and Equals(y, z).
+    /// </summary>
+    public class EqualityComparerEqualsTransitiveAssertion : EqualityComparerEqualsAssertion
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerEqualsTransitiveAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        public EqualityComparerEqualsTransitiveAssertion(ISpecimenBuilder builder)
+            : base(builder)
+        {
+        }
+
+        /// <summary>
+        /// Verifies that `calling Equals(x, z) should return same as Equals(x, y) and Equals(y, z)`
+        /// if the supplied method is an implementation of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        /// <param name="argumentType">The argument type of <see cref="IEqualityComparer{T}.Equals(T,T)"/>.</param>
+        protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
+        {
+            if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+
+            if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
+
+            var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+            var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var thirdTestSubject = this.Builder.CreateAnonymous(argumentType);
+
+            var firstResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
+
+            var secondResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, thirdTestSubject });
+
+            var thirdResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, thirdTestSubject });
+
+            if (firstResult != secondResult || firstResult != thirdResult)
+            {
+                throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                    "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                    "calling Equals(x, z) should return same as Equals(x, y) and Equals(y, z).",
+                    methodInfo.ReflectedType!.FullName));
+            }
+        }
+    }
+}

--- a/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
@@ -50,13 +50,13 @@ namespace AutoFixture.Idioms
 
             var thirdTestSubject = this.Builder.CreateAnonymous(argumentType);
 
-            var firstResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
+            var firstToSecond = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
 
-            var secondResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, thirdTestSubject });
+            var secondToThird = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, thirdTestSubject });
 
-            var thirdResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, thirdTestSubject });
+            var firstToThird = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, thirdTestSubject });
 
-            if (firstResult != secondResult || firstResult != thirdResult)
+            if ((firstToSecond && secondToThird) != firstToThird)
             {
                 throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
                     "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +

--- a/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
@@ -39,21 +39,15 @@ namespace AutoFixture.Idioms
         protected override void VerifyEquals(MethodInfo methodInfo, Type argumentType)
         {
             if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
-
             if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
 
             var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-
             var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
-
             var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
-
             var thirdTestSubject = this.Builder.CreateAnonymous(argumentType);
 
             var firstToSecond = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
-
             var secondToThird = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, thirdTestSubject });
-
             var firstToThird = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, thirdTestSubject });
 
             if ((firstToSecond && secondToThird) != firstToThird)

--- a/Src/Idioms/EqualityComparerGetHashCodeAssertion.cs
+++ b/Src/Idioms/EqualityComparerGetHashCodeAssertion.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Encapsulates a unit test that verifies that a type implementing <see cref="IEqualityComparer{T}"/> implements it correctly
+    /// with respect of the rule: calling GetHashCode(x) should always return same value.
+    /// </summary>
+    public class EqualityComparerGetHashCodeAssertion : IdiomaticAssertion
+    {
+        /// <summary>
+        /// Gets the builder supplied by the constructor.
+        /// </summary>
+        public ISpecimenBuilder Builder { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualityComparerGetHashCodeAssertion"/> class.
+        /// </summary>
+        /// <param name="builder">
+        /// A composer which can create instances required to implement the idiomatic unit test,
+        /// such as the owner of the property, as well as the value to be assigned and read from
+        /// the member.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="builder" /> will typically be a <see cref="Fixture" /> instance.
+        /// </para>
+        /// </remarks>
+        public EqualityComparerGetHashCodeAssertion(ISpecimenBuilder builder)
+        {
+            this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        }
+
+        /// <summary>
+        /// Verifies that `calling GetHashCode(x) should always return same value`
+        /// if the supplied method is an implementation of <see cref="IEqualityComparer{T}.GetHashCode(T)"/>.
+        /// </summary>
+        /// <param name="methodInfo">The method to verify.</param>
+        public override void Verify(MethodInfo methodInfo)
+        {
+            if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+
+            if (methodInfo is { Name: nameof(IEqualityComparer.GetHashCode), ReflectedType: { } type } && methodInfo.GetParameters().Length == 1 && type.ImplementsGenericInterfaceDefinition(typeof(IEqualityComparer<>)))
+            {
+                var argumentType = methodInfo.GetParameters()[0].ParameterType;
+
+                if (!methodInfo.ReflectedType.ImplementsGenericInterface(typeof(IEqualityComparer<>), argumentType))
+                {
+                    return;
+                }
+
+                var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+
+                var testSubject = this.Builder.CreateAnonymous(argumentType);
+
+                var firstHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });
+
+                var secondHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });
+
+                if (firstHashCode != secondHashCode)
+                {
+                    throw new EqualityComparerImplementationException(string.Format(CultureInfo.CurrentCulture,
+                        "The type '{0}' implements the `IEqualityComparer<T>` interface incorrectly: " +
+                        "calling GetHashCode(x) should always return same value.",
+                        type.FullName));
+                }
+            }
+        }
+    }
+}

--- a/Src/Idioms/EqualityComparerImplementationException.cs
+++ b/Src/Idioms/EqualityComparerImplementationException.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace AutoFixture.Idioms
+{
+    /// <summary>
+    /// Represents an error about an ill-behaved implementation of the <see cref="IEqualityComparer{T}" /> interface.
+    /// </summary>
+    [Serializable]
+    public class EqualityComparerImplementationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of teh <see cref="EqualityComparerImplementationException"/> class.
+        /// </summary>
+        public EqualityComparerImplementationException()
+            : base("The implementation of IEqualityComparer<T> is ill-behaved.")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of teh <see cref="EqualityComparerImplementationException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public EqualityComparerImplementationException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of teh <see cref="EqualityComparerImplementationException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public EqualityComparerImplementationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of teh <see cref="EqualityComparerImplementationException"/> class.
+        /// </summary>
+        /// <param name="info">
+        /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the
+        /// serialized object data about the exception being thrown.
+        /// </param>
+        /// <param name="context">
+        /// The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains
+        /// contextual information about the source or destination.
+        /// </param>
+        protected EqualityComparerImplementationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Src/Idioms/TypeExtensions.cs
+++ b/Src/Idioms/TypeExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq;
+
+namespace AutoFixture.Idioms
+{
+    internal static class TypeExtensions
+    {
+        public static bool ImplementsGenericInterfaceDefinition(this Type type, Type interfaceType) => type.GetInterfaces().Any(i => i.GetGenericTypeDefinition().IsAssignableFrom(interfaceType));
+
+        public static bool ImplementsGenericInterface(this Type type, Type interfaceType, params Type[] argumentTypes) => type.GetInterfaces().Any(i => i.IsAssignableFrom(interfaceType.MakeGenericType(argumentTypes)));
+    }
+}

--- a/Src/IdiomsUnitTest/EqualityComparerAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerAssertionTest.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Idioms;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EqualityComparerAssertionTest
+    {
+        [Fact]
+        public void SutIsIdiomaticAssertion()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            // Act
+            var sut = new EqualityComparerAssertion(dummyComposer);
+            // Assert
+            Assert.IsAssignableFrom<IIdiomaticAssertion>(sut);
+        }
+
+        [Fact]
+        public void ConstructWithNullComposerThrows()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new EqualityComparerAssertion(null));
+        }
+
+        [Fact]
+        public void VerifyNullMethodThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify((MethodInfo)null));
+        }
+
+        [Fact]
+        public void VerifyNonEqualityComparerDoesNothing()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(NonEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyWellBehavedEqualityComparerDoesNotThrow()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedNullEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedNullEqualityComparer)));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedSelfEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedSelfEqualityComparer)));
+        }
+#pragma warning disable 659
+        private class WellBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return x.Property == y.Property;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return obj.Property;
+            }
+        }
+
+        private class IllBehavedNullEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (x == null && y == null)
+                    return false;
+
+                if (x == null ^ y == null)
+                    return true;
+
+                return false;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                throw new Exception();
+            }
+        }
+
+        private class IllBehavedSelfEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return false;
+
+                return true;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                throw new Exception();
+            }
+        }
+
+#pragma warning restore 659
+
+        private class NonEqualityComparer
+        {
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EqualityComparerEqualsNullAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerEqualsNullAssertionTest.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Idioms;
+using AutoFixture.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EqualityComparerEqualsNullAssertionTest
+    {
+        [Fact]
+        public void SutIsIdiomaticAssertion()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            // Act
+            var sut = new EqualityComparerEqualsNullAssertion(dummyComposer);
+            // Assert
+            Assert.IsAssignableFrom<IdiomaticAssertion>(sut);
+        }
+
+        [Fact]
+        public void ComposerIsCorrect()
+        {
+            // Arrange
+            var expectedComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullAssertion(expectedComposer);
+            // Act
+            ISpecimenBuilder result = sut.Builder;
+            // Assert
+            Assert.Equal(expectedComposer, result);
+        }
+
+        [Fact]
+        public void ConstructWithNullComposerThrows()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new EqualityComparerEqualsNullAssertion(null));
+        }
+
+        [Fact]
+        public void VerifyNullMethodThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify((MethodInfo)null));
+        }
+
+        [Fact]
+        public void VerifyNonEqualityComparerDoesNothing()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(NonEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyWellBehavedEqualityComparerDoesNotThrow()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedEqualityComparer)));
+        }
+
+#pragma warning disable 659
+        private class WellBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return x.Property == y.Property;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return obj.Property;
+            }
+        }
+
+        private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (x == null ^ y == null)
+                    return true;
+
+                return false;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                throw new Exception();
+            }
+        }
+#pragma warning restore 659
+
+        private class NonEqualityComparer
+        {
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EqualityComparerEqualsNullNullAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerEqualsNullNullAssertionTest.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Idioms;
+using AutoFixture.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EqualityComparerEqualsNullNullAssertionTest
+    {
+        [Fact]
+        public void SutIsIdiomaticAssertion()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            // Act
+            var sut = new EqualityComparerEqualsNullNullAssertion(dummyComposer);
+            // Assert
+            Assert.IsAssignableFrom<IdiomaticAssertion>(sut);
+        }
+
+        [Fact]
+        public void ComposerIsCorrect()
+        {
+            // Arrange
+            var expectedComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullNullAssertion(expectedComposer);
+            // Act
+            ISpecimenBuilder result = sut.Builder;
+            // Assert
+            Assert.Equal(expectedComposer, result);
+        }
+
+        [Fact]
+        public void ConstructWithNullComposerThrows()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new EqualityComparerEqualsNullNullAssertion(null));
+        }
+
+        [Fact]
+        public void VerifyNullMethodThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify((MethodInfo)null));
+        }
+
+        [Fact]
+        public void VerifyNonEqualityComparerDoesNothing()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(NonEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyWellBehavedEqualityComparerDoesNotThrow()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsNullNullAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedEqualityComparer)));
+        }
+
+#pragma warning disable 659
+        private class WellBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return x.Property == y.Property;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return obj.Property;
+            }
+        }
+
+        private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (x == null && y == null)
+                    return false;
+
+                return true;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                throw new Exception();
+            }
+        }
+#pragma warning restore 659
+
+        private class NonEqualityComparer
+        {
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EqualityComparerEqualsSelfAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerEqualsSelfAssertionTest.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Idioms;
+using AutoFixture.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EqualityComparerEqualsSelfAssertionTest
+    {
+        [Fact]
+        public void SutIsIdiomaticAssertion()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            // Act
+            var sut = new EqualityComparerEqualsSelfAssertion(dummyComposer);
+            // Assert
+            Assert.IsAssignableFrom<IdiomaticAssertion>(sut);
+        }
+
+        [Fact]
+        public void ComposerIsCorrect()
+        {
+            // Arrange
+            var expectedComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSelfAssertion(expectedComposer);
+            // Act
+            ISpecimenBuilder result = sut.Builder;
+            // Assert
+            Assert.Equal(expectedComposer, result);
+        }
+
+        [Fact]
+        public void ConstructWithNullComposerThrows()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new EqualityComparerEqualsSelfAssertion(null));
+        }
+
+        [Fact]
+        public void VerifyNullMethodThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSelfAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify((MethodInfo)null));
+        }
+
+        [Fact]
+        public void VerifyNonEqualityComparerDoesNothing()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSelfAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(NonEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyWellBehavedEqualityComparerDoesNotThrow()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSelfAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSelfAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedEqualityComparer)));
+        }
+
+#pragma warning disable 659
+        private class WellBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return x.Property == y.Property;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return obj.Property;
+            }
+        }
+
+        private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return false;
+
+                return true;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                throw new Exception();
+            }
+        }
+#pragma warning restore 659
+
+        private class NonEqualityComparer
+        {
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EqualityComparerEqualsSymmetricAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerEqualsSymmetricAssertionTest.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Idioms;
+using AutoFixture.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EqualityComparerEqualsSymmetricAssertionTest
+    {
+        [Fact]
+        public void SutIsIdiomaticAssertion()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            // Act
+            var sut = new EqualityComparerEqualsSymmetricAssertion(dummyComposer);
+            // Assert
+            Assert.IsAssignableFrom<IdiomaticAssertion>(sut);
+        }
+
+        [Fact]
+        public void ComposerIsCorrect()
+        {
+            // Arrange
+            var expectedComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSymmetricAssertion(expectedComposer);
+            // Act
+            ISpecimenBuilder result = sut.Builder;
+            // Assert
+            Assert.Equal(expectedComposer, result);
+        }
+
+        [Fact]
+        public void ConstructWithNullComposerThrows()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new EqualityComparerEqualsSymmetricAssertion(null));
+        }
+
+        [Fact]
+        public void VerifyNullMethodThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSymmetricAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify((MethodInfo)null));
+        }
+
+        [Fact]
+        public void VerifyNonEqualityComparerDoesNothing()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSymmetricAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(NonEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyWellBehavedEqualityComparerDoesNotThrow()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSymmetricAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsSymmetricAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedEqualityComparer)));
+        }
+
+#pragma warning disable 659
+        private class WellBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return x.Property == y.Property;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return obj.Property;
+            }
+        }
+
+        private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            private static bool flag = false;
+
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                flag = !flag;
+
+                return flag;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                throw new Exception();
+            }
+        }
+#pragma warning restore 659
+
+        private class NonEqualityComparer
+        {
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EqualityComparerEqualsTransitiveAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerEqualsTransitiveAssertionTest.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Idioms;
+using AutoFixture.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EqualityComparerEqualsTransitiveAssertionTest
+    {
+        [Fact]
+        public void SutIsIdiomaticAssertion()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            // Act
+            var sut = new EqualityComparerEqualsTransitiveAssertion(dummyComposer);
+            // Assert
+            Assert.IsAssignableFrom<IdiomaticAssertion>(sut);
+        }
+
+        [Fact]
+        public void ComposerIsCorrect()
+        {
+            // Arrange
+            var expectedComposer = new Fixture();
+            var sut = new EqualityComparerEqualsTransitiveAssertion(expectedComposer);
+            // Act
+            ISpecimenBuilder result = sut.Builder;
+            // Assert
+            Assert.Equal(expectedComposer, result);
+        }
+
+        [Fact]
+        public void ConstructWithNullComposerThrows()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new EqualityComparerEqualsTransitiveAssertion(null));
+        }
+
+        [Fact]
+        public void VerifyNullMethodThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsTransitiveAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify((MethodInfo)null));
+        }
+
+        [Fact]
+        public void VerifyNonEqualityComparerDoesNothing()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsTransitiveAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(NonEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyWellBehavedEqualityComparerDoesNotThrow()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsTransitiveAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerEqualsTransitiveAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedEqualityComparer)));
+        }
+
+#pragma warning disable 659
+        private class WellBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+
+                if (ReferenceEquals(x, null))
+                    return false;
+
+                if (ReferenceEquals(y, null))
+                    return false;
+
+                if (x.GetType() != y.GetType())
+                    return false;
+
+                return x.Property == y.Property;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return obj.Property;
+            }
+        }
+
+        private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            private static bool flag = false;
+
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                flag = !flag;
+
+                return flag;
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                throw new Exception();
+            }
+        }
+#pragma warning restore 659
+
+        private class NonEqualityComparer
+        {
+        }
+    }
+}

--- a/Src/IdiomsUnitTest/EqualityComparerGetHashCodeAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerGetHashCodeAssertionTest.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Idioms;
+using AutoFixture.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixture.IdiomsUnitTest
+{
+    public class EqualityComparerGetHashCodeAssertionTest
+    {
+        [Fact]
+        public void SutIsIdiomaticAssertion()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            // Act
+            var sut = new EqualityComparerGetHashCodeAssertion(dummyComposer);
+            // Assert
+            Assert.IsAssignableFrom<IdiomaticAssertion>(sut);
+        }
+
+        [Fact]
+        public void ComposerIsCorrect()
+        {
+            // Arrange
+            var expectedComposer = new Fixture();
+            var sut = new EqualityComparerGetHashCodeAssertion(expectedComposer);
+            // Act
+            ISpecimenBuilder result = sut.Builder;
+            // Assert
+            Assert.Equal(expectedComposer, result);
+        }
+
+        [Fact]
+        public void ConstructWithNullComposerThrows()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new EqualityComparerGetHashCodeAssertion(null));
+        }
+
+        [Fact]
+        public void VerifyNullMethodThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerGetHashCodeAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Verify((MethodInfo)null));
+        }
+
+        [Fact]
+        public void VerifyNonEqualityComparerDoesNothing()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerGetHashCodeAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(NonEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyWellBehavedEqualityComparerDoesNotThrow()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerGetHashCodeAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Null(Record.Exception(() =>
+                sut.Verify(typeof(WellBehavedEqualityComparer))));
+        }
+
+        [Fact]
+        public void VerifyIllBehavedEqualityComparerThrows()
+        {
+            // Arrange
+            var dummyComposer = new Fixture();
+            var sut = new EqualityComparerGetHashCodeAssertion(dummyComposer);
+            // Act & Assert
+            Assert.Throws<EqualityComparerImplementationException>(() =>
+                sut.Verify(typeof(IllBehavedEqualityComparer)));
+        }
+
+#pragma warning disable 659
+        private class WellBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                throw new Exception();
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return obj.Property;
+            }
+        }
+
+        private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
+        {
+            private static readonly Random HashCodeGenerator = new Random();
+
+            public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
+            {
+                throw new Exception();
+            }
+
+            public int GetHashCode(PropertyHolder<int> obj)
+            {
+                return HashCodeGenerator.Next();
+            }
+        }
+#pragma warning restore 659
+
+        private class NonEqualityComparer
+        {
+        }
+    }
+}


### PR DESCRIPTION
At my company we have ended up creating some implementations of `IEqualityComparer<T>` so I've worked on an idiomatic assertion to quickly check that they respect some basic requirements:
- `Equals(a, a) == true` (reflexive property)
- `Equals(a, b) == Equals(b, a)` (symmetric property)
- `Equals(a, b) == Equals(b, c) == Equals(a, c)` (transitive property)
- `Equals(a, null) == false`
- `Equals(null, null) == true`
- `GetHashCode(a) == GetHashCode(a)`

I added to this PR all the code produced right now. If there is an interest, I can continue working on this PR.

Here is a sample on how to use it:

Given the following class implementing `IEqualityComparer<string>`
```csharp
public class TestEqualityComparer : IEqualityComparer<string>
{
	public bool Equals(string x, string y)
	{
		if (x is null ^ y is null) return false;
		
		return string.Equals(x, y);
	}

	public int GetHashCode(string obj)
	{
		return obj.GetHashCode();
	}
}
```

Developers can use this assertion as simply as
```csharp
[Test]
public void IEqualityComparer_interface_is_implemented_correctly()
{
	var fixture = new Fixture();
	
	var assertion = fixture.Create<EqualityComparerAssertion>();
	
	assertion.Verify(typeof(TestEqualityComparer));
}
```

I haven't gone added the unit tests I have in my own solution and decorated methods and property with documentation comments. Also, I have used few features from C# 8 but I'm not sure if the current build setup supports them.