### PR TITLE
Add Injected attribute

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/InjectedAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InjectedAttributeTest.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace AutoFixture.NUnit3.UnitTest
+{
+    [TestFixture]
+    public class InjectedAttributeTest
+    {
+        [Test, AutoData]
+        public void SutIsAttribute(int value)
+        {
+            // Arrange
+            // Act
+            var sut = new InjectedAttribute(value);
+            // Assert
+            Assert.That(sut, Is.InstanceOf<CustomizeAttribute>());
+        }
+
+        [Test, AutoData]
+        public void GetCustomizationFromNullParameterThrows(int value)
+        {
+            // Arrange
+            var sut = new InjectedAttribute(value);
+            // Act & Assert
+            Assert.That(() => sut.GetCustomization(null), Throws.ArgumentNullException);
+        }
+
+        [Test, AutoData]
+        public void ValueToInjectReturnsConstructorParameter(int value)
+        {
+            // Arrange
+            var sut = new InjectedAttribute(value);
+            // Act & Assert
+            Assert.That(sut.ValueToInject, Is.EqualTo(value));
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
@@ -331,6 +331,29 @@ namespace AutoFixture.NUnit3.UnitTest
             Assert.AreNotEqual(p1, p2.Field);
         }
 
+        [Test, AutoData]
+        public void InjectFirstParameterShouldReturnAssignedValue(
+            [Injected("Hello World")] string p1)
+        {
+            Assert.AreEqual(p1, "Hello World");
+        }
+
+        [Test, AutoData]
+        public void InjectFirstParameterShouldAssignSameInstanceToSecondParameter(
+            [Injected("Hello World")] string p1,
+            string p2)
+        {
+            Assert.AreEqual(p1, p2);
+        }
+
+        [Test, AutoData]
+        public void InjectParameterShouldAssignSameInstanceToPropertyHolder(
+            [Injected(42)] int value, 
+            PropertyHolder<int> holder)
+        {
+            Assert.AreEqual(value, holder.Property);
+        }
+
         [Test]
         [InlineAutoData(1, 2, 3)]
         public void InlineAutoDataTakesParameterValues(int p1, int p2, int p3)

--- a/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/Scenario.cs
@@ -333,22 +333,22 @@ namespace AutoFixture.NUnit3.UnitTest
 
         [Test, AutoData]
         public void InjectFirstParameterShouldReturnAssignedValue(
-            [Injected("Hello World")] string p1)
+            [Injected(42)] int p1)
         {
-            Assert.AreEqual(p1, "Hello World");
+            Assert.AreEqual(p1, 42);
         }
 
         [Test, AutoData]
         public void InjectFirstParameterShouldAssignSameInstanceToSecondParameter(
-            [Injected("Hello World")] string p1,
-            string p2)
+            [Injected(42)] int p1,
+            int p2)
         {
             Assert.AreEqual(p1, p2);
         }
 
         [Test, AutoData]
         public void InjectParameterShouldAssignSameInstanceToPropertyHolder(
-            [Injected(42)] int value, 
+            [Injected(42)] int value,
             PropertyHolder<int> holder)
         {
             Assert.AreEqual(value, holder.Property);

--- a/Src/AutoFixture.NUnit3/InjectedAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InjectedAttribute.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.NUnit3
+{
+    /// <summary>
+    /// An attribute that can be applied to parameters in an <see cref="AutoDataAttribute"/>-driven
+    /// TestCase to indicate that the parameter value should be injected so that the same instance is
+    /// returned every time the <see cref="IFixture"/> creates an instance of that type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class InjectedAttribute : CustomizeAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InjectedAttribute"/> class.
+        /// </summary>
+        /// <remarks>
+        /// <param name="valueToInject">The value to inject.</param>
+        /// The <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the injected parameter value
+        /// is <see cref="Matching.ExactType"/>.
+        /// </remarks>
+        public InjectedAttribute(object valueToInject)
+            : this(valueToInject, Matching.ExactType)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InjectedAttribute"/> class.
+        /// </summary>
+        /// <param name="valueToInject">The value to inject.</param>
+        /// <param name="by">
+        /// The <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the injected parameter value.
+        /// </param>
+        public InjectedAttribute(object valueToInject, Matching by)
+        {
+            this.ValueToInject = valueToInject;
+            this.By = by;
+        }
+
+        /// <summary>
+        /// The value to inject.
+        /// </summary>
+        public object ValueToInject { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Matching"/> criteria used to determine
+        /// which requests will be satisfied by the frozen parameter value.
+        /// </summary>
+        public Matching By { get; }
+
+        /// <summary>
+        /// Gets a <see cref="InjectOnMatchCustomization"/> configured
+        /// to match requests based on the <see cref="Type"/> and optionally
+        /// the name of the parameter.
+        /// </summary>
+        /// <param name="parameter">
+        /// The parameter for which the customization is requested.
+        /// </param>
+        /// <returns>
+        /// A <see cref="InjectOnMatchCustomization"/> configured
+        /// to match requests based on the <see cref="Type"/> and optionally
+        /// the name of the parameter.
+        /// </returns>
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+
+            return this.InjectByCriteria(parameter);
+        }
+
+        private ICustomization InjectByCriteria(ParameterInfo parameter)
+        {
+            var type = parameter.ParameterType;
+            var name = parameter.Name;
+
+            var filter = new Filter(ByEqual(parameter))
+                         .Or(this.ByExactType(type))
+                         .Or(this.ByBaseType(type))
+                         .Or(this.ByImplementedInterfaces(type))
+                         .Or(this.ByPropertyName(type, name))
+                         .Or(this.ByParameterName(type, name))
+                         .Or(this.ByFieldName(type, name));
+
+            return new InjectOnMatchCustomization(this.ValueToInject, parameter, filter);
+        }
+
+        private static IRequestSpecification ByEqual(object target)
+        {
+            return new EqualRequestSpecification(target);
+        }
+
+        private IRequestSpecification ByExactType(Type type)
+        {
+            return this.ShouldMatchBy(Matching.ExactType)
+                ? new OrRequestSpecification(
+                    new ExactTypeSpecification(type),
+                    new SeedRequestSpecification(type))
+                : NoMatch();
+        }
+
+        private IRequestSpecification ByBaseType(Type type)
+        {
+            return this.ShouldMatchBy(Matching.DirectBaseType)
+                ? new AndRequestSpecification(
+                    new InverseRequestSpecification(
+                        new ExactTypeSpecification(type)),
+                    new DirectBaseTypeSpecification(type))
+                : NoMatch();
+        }
+
+        private IRequestSpecification ByImplementedInterfaces(Type type)
+        {
+            return this.ShouldMatchBy(Matching.ImplementedInterfaces)
+                ? new AndRequestSpecification(
+                    new InverseRequestSpecification(
+                        new ExactTypeSpecification(type)),
+                    new ImplementedInterfaceSpecification(type))
+                : NoMatch();
+        }
+
+        private IRequestSpecification ByParameterName(Type type, string name)
+        {
+            return this.ShouldMatchBy(Matching.ParameterName)
+                ? new ParameterSpecification(
+                    new ParameterTypeAndNameCriterion(
+                        DerivesFrom(type),
+                        IsNamed(name)))
+                : NoMatch();
+        }
+
+        private IRequestSpecification ByPropertyName(Type type, string name)
+        {
+            return this.ShouldMatchBy(Matching.PropertyName)
+                ? new PropertySpecification(
+                    new PropertyTypeAndNameCriterion(
+                        DerivesFrom(type),
+                        IsNamed(name)))
+                : NoMatch();
+        }
+
+        private IRequestSpecification ByFieldName(Type type, string name)
+        {
+            return this.ShouldMatchBy(Matching.FieldName)
+                ? new FieldSpecification(
+                    new FieldTypeAndNameCriterion(
+                        DerivesFrom(type),
+                        IsNamed(name)))
+                : NoMatch();
+        }
+
+        private bool ShouldMatchBy(Matching criteria)
+        {
+            return this.By.HasFlag(criteria);
+        }
+
+        private static IRequestSpecification NoMatch()
+        {
+            return new FalseRequestSpecification();
+        }
+
+        private static Criterion<Type> DerivesFrom(Type type)
+        {
+            return new Criterion<Type>(
+                type,
+                new DerivesFromTypeComparer());
+        }
+
+        private static Criterion<string> IsNamed(string name)
+        {
+            return new Criterion<string>(
+                name,
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        private class Filter : IRequestSpecification
+        {
+            private readonly IRequestSpecification criteria;
+
+            public Filter(IRequestSpecification criteria)
+            {
+                this.criteria = criteria;
+            }
+
+            public Filter Or(IRequestSpecification condition)
+            {
+                return new Filter(
+                    new OrRequestSpecification(
+                        this.criteria,
+                        condition));
+            }
+
+            public bool IsSatisfiedBy(object request)
+            {
+                return this.criteria.IsSatisfiedBy(request);
+            }
+        }
+
+        private class DerivesFromTypeComparer : IEqualityComparer<Type>
+        {
+            public bool Equals(Type x, Type y)
+            {
+                if (y == null && x == null)
+                    return true;
+                if (y == null)
+                    return false;
+                return y.GetTypeInfo().IsAssignableFrom(x);
+            }
+
+            public int GetHashCode(Type obj)
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/Src/AutoFixture/InjectOnMatchCustomization.cs
+++ b/Src/AutoFixture/InjectOnMatchCustomization.cs
@@ -1,0 +1,93 @@
+using System;
+using AutoFixture.Kernel;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// A customization that injects a specific value of a specific <see cref="Type"/>
+    /// and uses them to satisfy requests that match a set of criteria.
+    /// </summary>
+    /// <remarks>
+    /// The criteria that determine whether the frozen specimen will be used
+    /// to satisfy a given request are specified at construction time
+    /// as a <see cref="IRequestSpecification"/> object.
+    /// Multiple criteria can be combined together as a boolean expression
+    /// by composing them into a <see cref="AndRequestSpecification"/>
+    /// or <see cref="OrRequestSpecification"/> object.
+    /// </remarks>
+    public class InjectOnMatchCustomization : ICustomization
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InjectOnMatchCustomization"/> class.
+        /// </summary>
+        /// <param name="valueToInject">The value to inject.</param>
+        /// <param name="request">The request used to create a specimen to freeze.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="valueToInject"/> or <paramref name="request"/> is <see langword="null"/>.
+        /// </exception>
+        public InjectOnMatchCustomization(object valueToInject, object request)
+            : this(valueToInject, request, new EqualRequestSpecification(request))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InjectOnMatchCustomization"/> class.
+        /// </summary>
+        /// <param name="valueToInject">The value to inject.</param>
+        /// <param name="request">The request used to create a specimen to freeze.</param>
+        /// <param name="matcher">
+        /// The <see cref="IRequestSpecification"/> used to match the requests
+        /// that will be satisfied by the frozen specimen.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="valueToInject"/>, <paramref name="request"/> or <paramref name="matcher"/> is <see langword="null"/>.
+        /// </exception>
+        public InjectOnMatchCustomization(object valueToInject, object request, IRequestSpecification matcher)
+        {
+            this.ValueToInject = valueToInject ?? throw new ArgumentNullException(nameof(valueToInject));
+            this.Request = request ?? throw new ArgumentNullException(nameof(request));
+            this.Matcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
+        }
+
+        /// <summary>
+        /// The value to inject.
+        /// </summary>
+        public object ValueToInject { get; }
+
+        /// <summary>
+        /// The request used to resolve specimens. By default that is TargetType.
+        /// </summary>
+        public object Request { get; }
+
+        /// <summary>
+        /// The <see cref="IRequestSpecification"/> used to match the requests
+        /// that will be satisfied by the frozen specimen.
+        /// </summary>
+        public IRequestSpecification Matcher { get; }
+
+        /// <summary>
+        /// Customizes the specified fixture.
+        /// </summary>
+        /// <param name="fixture">The fixture to customize.</param>
+        public void Customize(IFixture fixture)
+        {
+            if (fixture == null) throw new ArgumentNullException(nameof(fixture));
+
+            this.InjectSpecimenForMatchingRequests(fixture);
+        }
+
+        private void InjectSpecimenForMatchingRequests(IFixture fixture)
+        {
+            fixture.Customizations.Insert(
+                0,
+                new FilteringSpecimenBuilder(
+                    this.InjectSpecimen(),
+                    this.Matcher));
+        }
+
+        private ISpecimenBuilder InjectSpecimen()
+        {
+            return new FixedBuilder(this.ValueToInject);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new attribute to be used when working with AutoData-based unit tests.

The `Injected` attribute lets the developer specify a value to be injected in the pipeline to be used whenever the same type is requested. Like for `Frozen`, developers can specify matching rules to restrict when the specified value should be used.

This is a simple use case of the new attribute

```csharp
[Test, AutoData]
public void InjectFirstParameterShouldReturnAssignedValue(
    [Injected(42)] int p1)
{
    Assert.AreEqual(p1, 42);
}

[Test, AutoData]
public void InjectFirstParameterShouldAssignSameInstanceToSecondParameter(
    [Injected(42)] int p1,
    int p2)
{
    Assert.AreEqual(p1, p2);
}

[Test, AutoData]
public void InjectParameterShouldAssignSameInstanceToPropertyHolder(
    [Injected(42)] int value, 
    PropertyHolder<int> holder)
{
    Assert.AreEqual(value, holder.Property);
}
```

The PR is not finished
- [x] Add InjectOnMatchCustomization
- [ ] Add tests for InjectOnMatchCustomization
- [x] Add InjectedAttribute for NUnit 3
- [x] Add tests for InjectedAttribute for NUnit 3
- [x] Add scenario tests for InjectedAttribute for NUnit 3
- [ ] Add InjectedAttribute for Xunit
- [ ] Add tests for InjectedAttribute for Xunit
- [ ] Add scenario tests for InjectedAttribute for Xunit