### PR TITLE
Adds support for FakeItEasy v6

### DIFF
--- a/Src/All.sln
+++ b/Src/All.sln
@@ -88,6 +88,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFakeItEasy.FakeItEasy5U
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoNSubstitute.NSubstitute4UnitTest", "AutoNSubstitute.NSubstitute4UnitTest\AutoNSubstitute.NSubstitute4UnitTest.csproj", "{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFakeItEasy.FakeItEasy6UnitTest", "AutoFakeItEasy.FakeItEasy6UnitTest\AutoFakeItEasy.FakeItEasy6UnitTest.csproj", "{311A3010-B938-4832-9D3A-21A1A56FE5EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -317,6 +319,12 @@ Global
 		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
 		{4BDBE8A1-CF75-4049-9B3D-B194B1F45369}.Verify|Any CPU.Build.0 = Verify|Any CPU
+		{311A3010-B938-4832-9D3A-21A1A56FE5EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{311A3010-B938-4832-9D3A-21A1A56FE5EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{311A3010-B938-4832-9D3A-21A1A56FE5EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{311A3010-B938-4832-9D3A-21A1A56FE5EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{311A3010-B938-4832-9D3A-21A1A56FE5EA}.Verify|Any CPU.ActiveCfg = Verify|Any CPU
+		{311A3010-B938-4832-9D3A-21A1A56FE5EA}.Verify|Any CPU.Build.0 = Verify|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/AutoFakeItEasy.FakeItEasy6UnitTest/AutoFakeItEasy.FakeItEasy6UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy6UnitTest/AutoFakeItEasy.FakeItEasy6UnitTest.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\Common.props" />
+  <Import Project="..\Common.Test.props" />
+  <Import Project="..\Common.Test.xUnit.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <AssemblyTitle>AutoFakeItEasy.FakeItEasy5.UnitTest</AssemblyTitle>
+    <AssemblyName>AutoFixture.AutoFakeItEasy.FakeItEasy5UnitTest</AssemblyName>
+    <RootNamespace>AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>
+
+    <DefineConstants>$(DefineConstants);CAN_FAKE_DELEGATES;HAS_A_CALL_TO_SET_SPECIFIER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="[6.2.1]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\AutoFakeItEasyUnitTest\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Remove="..\AutoFakeItEasyUnitTest\obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AutoFakeItEasy\AutoFakeItEasy.csproj" />
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+    <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -20,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="[1.7.4109.1,6.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
-    <PackageReference Include="FakeItEasy" Version="[3.0.0,6.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.6' " />
-    <PackageReference Include="FakeItEasy" Version="[4.9.0,6.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="FakeItEasy" Version="[1.7.4109.1,7.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
+    <PackageReference Include="FakeItEasy" Version="[3.0.0,7.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.6' " />
+    <PackageReference Include="FakeItEasy" Version="[4.9.0,7.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Adds a copy of the tests project for `FakeItEasy 6`
- Adds a reflection call to the new `ReturnValue` property setter when setting the return value
- Extends the supported version range for `AutoFakeItEasy` to include `v6` of `FakeItEasy`

closes #1208 