### PR TITLE
Make FSharp.Core references explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ nCrunchTemp_*
 
 # Temp build artifacts and tools
 /build/
+.tmp/
 
 # VIM tmp files
 *.swp

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
+  <Import Project="..\Common.FSharp.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -33,12 +33,12 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Foq" Version="[1.8.0,2.0.0)" />
-    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Foq" Version="[1.5.1,2.0.0)" />
-    <PackageReference Include="FSharp.Core" Version="[3.0.2,5.0.0)" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="[3.0.2,5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -30,13 +30,14 @@
     <Compile Include="AutoFoqCustomization.fs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Foq" Version="[1.8.0,2.0.0)" />
+    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="Foq" Version="[1.5.1,2.0.0)"  />
-    <PackageReference Include="FSharp.Core" Version="3.0.2" PrivateAssets="All" />
+    <PackageReference Include="Foq" Version="[1.5.1,2.0.0)" />
+    <PackageReference Include="FSharp.Core" Version="[3.0.2,5.0.0)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -4,7 +4,7 @@
   <Import Project="..\Common.Test.xUnit.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <AssemblyTitle>AutoFixture.AutoFoq.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFoq.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoFoq.UnitTest</RootNamespace>
@@ -23,12 +23,14 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Unquote" Version="3.1.0" />
     <!-- AutoFoq targets FSharp.Core 3.0.2, but we require 3.1.2 as Unquote was compiled against it for .Net Framework. -->
-    <PackageReference Include="FSharp.Core" Version="3.1.2" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="[3.1.2]" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Unquote" Version="4.0.0" />
+    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\AutoFoq\AutoFoq.fsproj" />

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
+  <Import Project="..\Common.FSharp.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
 
@@ -22,13 +23,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="Unquote" Version="3.1.0" />
-    <!-- AutoFoq targets FSharp.Core 3.0.2, but we require 3.1.2 as Unquote was compiled against it for .Net Framework. -->
+    <!-- AutoFoq targets FSharp.Core 3.0.2, but we require 3.1.2 as Unquote was compiled against it for .NET Framework. -->
     <PackageReference Include="FSharp.Core" Version="[3.1.2]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Unquote" Version="4.0.0" />
-    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Common.FSharp.props
+++ b/Src/Common.FSharp.props
@@ -1,0 +1,7 @@
+<Project>
+    <PropertyGroup>
+        <!--Prevents restoring the latest version of FSharp.Core (i.e. FSharp.Core 5.0.0).
+            Should be safe to remove after dropping net4.5 runtime.-->
+        <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    </PropertyGroup>
+</Project>

--- a/Src/Common.Test.props
+++ b/Src/Common.Test.props
@@ -12,5 +12,8 @@
     <IsPackable>false</IsPackable>
     <!-- Disable source link support for test projects as they are not publishable. -->
     <SourceLinkCreate>false</SourceLinkCreate>
+
+    <!--Prevents failing cross target NuGet package restores-->
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
 </Project>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -25,6 +25,10 @@
     <PackageIconUrl>https://raw.githubusercontent.com/AutoFixture/AutoFixture/79c882c3f4af3cf52ad43e5c95851f25d217ac17/AutoFixtureLogo200x200.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
+    <!--Prevents restoring the latest version of FSharp.Core (i.e. FSharp.Core 5.0.0)-->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\AutoFixtureLogo200x200.png" Pack="true" PackagePath="icon.png"/>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -25,10 +25,6 @@
     <PackageIconUrl>https://raw.githubusercontent.com/AutoFixture/AutoFixture/79c882c3f4af3cf52ad43e5c95851f25d217ac17/AutoFixtureLogo200x200.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-
-    <!--Prevents restoring the latest version of FSharp.Core (i.e. FSharp.Core 5.0.0)-->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\AutoFixtureLogo200x200.png" Pack="true" PackagePath="icon.png"/>

--- a/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
+  <Import Project="..\Common.FSharp.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
 

--- a/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck1UnitTest/Idioms.FsCheck.FsCheck1UnitTest.fsproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="[1.0.0]" />
     <PackageReference Include="Unquote" Version="4.0.0" />
+    <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
+  <Import Project="..\Common.FSharp.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
 
@@ -29,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" />
     <PackageReference Include="FsCheck" Version="2.9.0" />
   </ItemGroup>
 

--- a/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
@@ -4,7 +4,7 @@
   <Import Project="..\Common.Test.xUnit.props" />
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <AssemblyTitle>Idioms.FsCheck.FsCheck2UnitTest</AssemblyTitle>
     <AssemblyName>Idioms.FsCheck.FsCheck2UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.Idioms.FsCheckUnitTest</RootNamespace>
@@ -20,8 +20,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsCheck" Version="[2.0.1]" />
     <PackageReference Include="Unquote" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+    <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" />
+    <PackageReference Include="FsCheck" Version="[2.0.1]" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" />
+    <PackageReference Include="FsCheck" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -28,12 +28,14 @@
     <Compile Include="ReturnValueMustNotBeNullAssertion.fs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FsCheck" Version="[0.9.2,3.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
-    <PackageReference Include="FSharp.Core" Version="3.1.2" Condition=" '$(TargetFramework)'=='net452' " PrivateAssets="All" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
+    <PackageReference Include="FsCheck" Version="[0.9.2,3.0.0)" />
+    <PackageReference Include="FSharp.Core" Version="[3.1.2,5.0.0)" PrivateAssets="All" />
+  </ItemGroup>
 
-    <PackageReference Include="FsCheck" Version="[2.9.0,3.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />    
-    <PackageReference Include="FSharp.Core" Version="4.1.17" Condition=" '$(TargetFramework)'=='netstandard2.0' " PrivateAssets="All" />
+  <ItemGroup Condition=" '$(TargetFramework)'=='netstandard2.0' ">
+    <PackageReference Include="FsCheck" Version="[2.9.0,3.0.0)" />
+    <PackageReference Include="FSharp.Core" Version="4.1.17" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -31,12 +31,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
     <PackageReference Include="FsCheck" Version="[0.9.2,3.0.0)" />
-    <PackageReference Include="FSharp.Core" Version="[3.1.2,5.0.0)" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="[3.1.2,5.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)'=='netstandard2.0' ">
     <PackageReference Include="FsCheck" Version="[2.9.0,3.0.0)" />
-    <PackageReference Include="FSharp.Core" Version="4.1.17" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="4.1.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
+  <Import Project="..\Common.FSharp.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>

--- a/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
+++ b/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
@@ -21,6 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Unquote" Version="4.0.0" />
+    <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" Condition="'$(TargetFramework)'=='net452'" />
+    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" Condition="'$(TargetFramework)'=='netcoreapp2.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
+++ b/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Common.props" />
+  <Import Project="..\Common.FSharp.props" />
   <Import Project="..\Common.Test.props" />
   <Import Project="..\Common.Test.xUnit.props" />
 
@@ -21,8 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Unquote" Version="4.0.0" />
-    <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" Condition="'$(TargetFramework)'=='net452'" />
-    <PackageReference Include="FSharp.Core" Version="4.2.3" PrivateAssets="All" Condition="'$(TargetFramework)'=='netcoreapp2.1'" />
+    <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The latest version of `FSharp.Core` - `5.0.0` , has dropped support for `.NET Framework`.
All F# projects that reference the `.NET Framework`, even those that have explicit package references to older versions of `FSharp.Core`, are now broken.

This PR:
- Prevents projects from restoring the implicit `FSharp.Core` package (i.e. `v5.0.0`)
- Adds explicit `FSharp.Core` package references to F# projects
- Downgrades `AutoFoqUnitTests` target framework `netcoreapp2.2` to LTS `netcoreapp2.1`
- Adds target framework `netcoreapp2.1` to `FsCheck2UnitTest` project
