### PR TITLE
Added EnumDataTypeAttributeRelay.cs and EnumDataTypeAttributeRelayTes…

### DIFF
--- a/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
@@ -9,6 +9,9 @@ using AutoFixture.Kernel;
 
 namespace AutoFixture.DataAnnotations
 {
+    /// <summary>
+    /// Handles a request for a string that matches an Enum data type.
+    /// </summary>
     public class EnumDataTypeAttributeRelay : ISpecimenBuilder
     {
         private readonly object syncLock = new object();
@@ -24,6 +27,14 @@ namespace AutoFixture.DataAnnotations
             set => this.requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <summary>
+        /// Creates a new specimen based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
             if (request == null)
@@ -61,7 +72,6 @@ namespace AutoFixture.DataAnnotations
             return new NoSpecimen();
         }
 
-        #region EnumGenerator
         /// <summary>
         /// The code below was copied from the <see cref="EnumGenerator"/>.
         /// </summary>
@@ -120,6 +130,5 @@ namespace AutoFixture.DataAnnotations
                 }
             }
         }
-        #endregion
     }
 }

--- a/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.DataAnnotations
+{
+    public class EnumDataTypeAttributeRelay : ISpecimenBuilder
+    {
+        private readonly object syncLock = new object();
+        private readonly Dictionary<Type, IEnumerator> enumerators = new Dictionary<Type, IEnumerator>();
+        private IRequestMemberTypeResolver requestMemberTypeResolver = new RequestMemberTypeResolver();
+
+        /// <summary>
+        /// Gets or sets the current IRequestMemberTypeResolver.
+        /// </summary>
+        public IRequestMemberTypeResolver RequestMemberTypeResolver
+        {
+            get => this.requestMemberTypeResolver;
+            set => this.requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request == null)
+            {
+                return new NoSpecimen();
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var enumDataTypeAttribute = TypeEnvy.GetAttribute<EnumDataTypeAttribute>(request);
+            if (enumDataTypeAttribute == null)
+            {
+                return new NoSpecimen();
+            }
+
+            if (!this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
+            {
+                return new NoSpecimen();
+            }
+
+            if (!enumDataTypeAttribute.EnumType.GetTypeInfo().IsEnum)
+                return new NoSpecimen();
+
+            if (memberType == typeof(string))
+            {
+                lock (this.syncLock)
+                {
+                    return this.CreateValue(enumDataTypeAttribute.EnumType).ToString();
+                }
+            }
+
+            return new NoSpecimen();
+        }
+
+        #region EnumGenerator
+        /// <summary>
+        /// The code below was copied from the <see cref="EnumGenerator"/>.
+        /// </summary>
+        private object CreateValue(Type t)
+        {
+            var generator = this.EnsureGenerator(t);
+            generator.MoveNext();
+            return generator.Current;
+        }
+
+        private IEnumerator EnsureGenerator(Type t)
+        {
+            IEnumerator enumerator = null;
+            if (!this.enumerators.TryGetValue(t, out enumerator))
+            {
+                enumerator = new RoundRobinEnumEnumerable(t).GetEnumerator();
+                this.enumerators.Add(t, enumerator);
+            }
+            return enumerator;
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1010:Collections should implement generic interface",
+            Justification = "This is not a usual enumerable and for our purpose generic interface is not required.")]
+        private class RoundRobinEnumEnumerable : IEnumerable
+        {
+            private readonly IEnumerable<object> values;
+
+            internal RoundRobinEnumEnumerable(Type enumType)
+            {
+                if (enumType == null)
+                {
+                    throw new ArgumentNullException(nameof(enumType));
+                }
+
+                this.values = Enum.GetValues(enumType).Cast<object>();
+
+                if (!this.values.Any())
+                {
+                    throw new ObjectCreationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "AutoFixture was unable to create a value for {0} since it is an enum containing no values. " +
+                            "Please add at least one value to the enum.",
+                            enumType.FullName));
+                }
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                while (true)
+                {
+                    foreach (var obj in this.values)
+                    {
+                        yield return obj;
+                    }
+                }
+            }
+        }
+        #endregion
+    }
+}

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -127,7 +127,8 @@ namespace AutoFixture
                                         new TimeSpanRangedRequestRelay(),
                                         new StringLengthAttributeRelay(),
                                         new MinAndMaxLengthAttributeRelay(),
-                                        new RegularExpressionAttributeRelay())))),
+                                        new RegularExpressionAttributeRelay(),
+                                        new EnumDataTypeAttributeRelay())))),
                         new AutoPropertiesTarget(
                             new Postprocessor(
                                 new CompositeSpecimenBuilder(

--- a/Src/AutoFixtureUnitTest/DataAnnotations/EnumDataTypeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/EnumDataTypeAttributeRelayTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using AutoFixture;
@@ -17,31 +17,44 @@ namespace AutoFixtureUnitTest.DataAnnotations
         {
             // Arrange
             var sut = new EnumDataTypeAttributeRelay();
+
             // Act & assert
             Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
         }
 
         [Fact]
-        public void CreateWithNullRequestReturnsCorrectResult()
+        public void ThrowsForNullArguments()
+        {
+            // Act & assert
+            Assert.Throws<ArgumentNullException>(
+                () => new EnumDataTypeAttributeRelay(null));
+        }
+
+        [Fact]
+        public void CreateWithNullRequestReturnsNoSpecimen()
         {
             // Arrange
             var sut = new EnumDataTypeAttributeRelay();
             var dummyContext = new DelegatingSpecimenContext();
+
             // Act
             var result = sut.Create(null, dummyContext);
+
             // Assert
             Assert.IsType<NoSpecimen>(result);
         }
 
         [Fact]
-        public void CreateWithAnonymousRequestReturnsCorrectResult()
+        public void CreateWithAnonymousRequestReturnsNoSpecimen()
         {
             // Arrange
             var sut = new EnumDataTypeAttributeRelay();
             var dummyRequest = new object();
             var dummyContainer = new DelegatingSpecimenContext();
+
             // Act
             var result = sut.Create(dummyRequest, dummyContainer);
+
             // Assert
             Assert.IsType<NoSpecimen>(result);
         }
@@ -54,27 +67,30 @@ namespace AutoFixtureUnitTest.DataAnnotations
         [InlineData(typeof(string))]
         [InlineData(typeof(int))]
         [InlineData(typeof(Version))]
-        public void CreateWithNonEnumDataTypeAttributeRequestReturnsCorrectResult(object request)
+        public void CreateWithUnsupportedRequestReturnsNoSpecimen(object request)
         {
             // Arrange
             var sut = new EnumDataTypeAttributeRelay();
             var dummyContext = new DelegatingSpecimenContext();
+
             // Act
             var result = sut.Create(request, dummyContext);
+
             // Assert
             Assert.IsType<NoSpecimen>(result);
         }
 
         [Theory]
-        [InlineData(typeof(TriState), 1, TriState.First)]
-        [InlineData(typeof(TriState), 2, TriState.Second)]
-        [InlineData(typeof(TriState), 3, TriState.Third)]
-        [InlineData(typeof(TriState), 4, TriState.First)]
-        [InlineData(typeof(TriState), 5, TriState.Second)]
-        [InlineData(typeof(DayOfWeek), 1, DayOfWeek.Sunday)]
-        [InlineData(typeof(DayOfWeek), 2, DayOfWeek.Monday)]
-        [InlineData(typeof(DayOfWeek), 8, DayOfWeek.Sunday)]
-        public void RequestForEnumTypeReturnsCorrectResult(Type enumType, int requestCount, object expectedResult)
+        [InlineData(typeof(TriState), 1, nameof(TriState.First))]
+        [InlineData(typeof(TriState), 2, nameof(TriState.Second))]
+        [InlineData(typeof(TriState), 3, nameof(TriState.Third))]
+        [InlineData(typeof(TriState), 4, nameof(TriState.First))]
+        [InlineData(typeof(TriState), 5, nameof(TriState.Second))]
+        [InlineData(typeof(DayOfWeek), 1, nameof(DayOfWeek.Sunday))]
+        [InlineData(typeof(DayOfWeek), 2, nameof(DayOfWeek.Monday))]
+        [InlineData(typeof(DayOfWeek), 8, nameof(DayOfWeek.Sunday))]
+        public void RequestForEnumTypeReturnsResultAsString(
+            Type enumType, int requestCount, string expectedResult)
         {
             // Arrange
             var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
@@ -86,13 +102,17 @@ namespace AutoFixtureUnitTest.DataAnnotations
             {
                 RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
                 {
-                    OnTryGetMemberType = r => typeof(string)
+                    OnTryGetMemberType = _ => typeof(string)
                 }
             };
+
             // Act
-            var result = Enumerable.Repeat<Func<object>>(() => sut.Create(request, dummyContext), requestCount).Select(f => f()).ToArray().Last();
+            var result = Enumerable
+                .Repeat<Func<object>>(() => sut.Create(request, dummyContext), requestCount)
+                .Select(f => f()).ToArray().Last();
+
             // Assert
-            Assert.Equal(expectedResult.ToString(), result);
+            Assert.Equal(expectedResult, result);
         }
 
         [Fact]
@@ -108,18 +128,19 @@ namespace AutoFixtureUnitTest.DataAnnotations
             {
                 RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
                 {
-                    OnTryGetMemberType = r => typeof(string)
+                    OnTryGetMemberType = _ => typeof(string)
                 }
             };
+
             // Act & assert
             Assert.Throws<ObjectCreationException>(() => sut.Create(request, dummyContext));
         }
 
         [Theory]
-        [InlineData(typeof(TriState), TriState.Third)]
-        [InlineData(typeof(DayOfWeek), DayOfWeek.Monday)]
-        [InlineData(typeof(ConsoleColor), ConsoleColor.Black)]
-        public void SutCanCorrectlyInterleaveDifferentEnumTypes(Type enumType, object expectedResult)
+        [InlineData(typeof(TriState), nameof(TriState.Third))]
+        [InlineData(typeof(DayOfWeek), nameof(DayOfWeek.Monday))]
+        [InlineData(typeof(ConsoleColor), nameof(ConsoleColor.Black))]
+        public void CanCorrectlyInterleaveDifferentEnumTypes(Type enumType, string expectedResult)
         {
             // Arrange
             var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
@@ -131,7 +152,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             {
                 RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
                 {
-                    OnTryGetMemberType = r => typeof(string)
+                    OnTryGetMemberType = _ => typeof(string)
                 }
             };
 
@@ -143,22 +164,25 @@ namespace AutoFixtureUnitTest.DataAnnotations
             sut.Create(new FakeMemberInfo(triStateProvidedAttribute), dummyContext);
             sut.Create(new FakeMemberInfo(triStateProvidedAttribute), dummyContext);
             sut.Create(new FakeMemberInfo(dayOfWeekProvidedAttribute), dummyContext);
+
             // Act
             var result = sut.Create(request, dummyContext);
+
             // Assert
-            Assert.Equal(expectedResult.ToString(), result);
+            Assert.Equal(expectedResult, result);
         }
 
         [Theory]
         [InlineData(typeof(ByteEnumType), typeof(byte))]
-        [InlineData(typeof(SbyteEnumType), typeof(sbyte))]
+        [InlineData(typeof(SByteEnumType), typeof(sbyte))]
         [InlineData(typeof(ShortEnumType), typeof(short))]
-        [InlineData(typeof(UshortEnumType), typeof(ushort))]
-        [InlineData(typeof(IntEnumType), typeof(int))]
-        [InlineData(typeof(UintEnumType), typeof(uint))]
+        [InlineData(typeof(UShortEnumType), typeof(ushort))]
+        [InlineData(typeof(EnumType), typeof(int))]
+        [InlineData(typeof(UIntEnumType), typeof(uint))]
         [InlineData(typeof(LongEnumType), typeof(long))]
-        [InlineData(typeof(UlongEnumType), typeof(ulong))]
-        public void RequestReturnsCorrectTypeForDifferentMemberTypes(Type enumType, Type memberType)
+        [InlineData(typeof(ULongEnumType), typeof(ulong))]
+        public void RequestReturnsCorrectTypeForDifferentMemberTypes(
+            Type enumType, Type memberType)
         {
             // Arrange
             var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
@@ -170,25 +194,28 @@ namespace AutoFixtureUnitTest.DataAnnotations
             {
                 RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
                 {
-                    OnTryGetMemberType = r => memberType
+                    OnTryGetMemberType = _ => memberType
                 }
             };
+
             // Act
             var result = sut.Create(request, dummyContext);
+
             // Assert
             Assert.IsType(memberType, result);
         }
 
         [Theory]
         [InlineData(typeof(ByteEnumType), typeof(byte), 2, (byte)ByteEnumType.Second)]
-        [InlineData(typeof(SbyteEnumType), typeof(sbyte), 1, (sbyte)SbyteEnumType.First)]
+        [InlineData(typeof(SByteEnumType), typeof(sbyte), 1, (sbyte)SByteEnumType.First)]
         [InlineData(typeof(ShortEnumType), typeof(short), 3, (short)ShortEnumType.Third)]
-        [InlineData(typeof(UshortEnumType), typeof(ushort), 4, (ushort)UshortEnumType.First)]
-        [InlineData(typeof(IntEnumType), typeof(int), 5, (int)IntEnumType.Second)]
-        [InlineData(typeof(UintEnumType), typeof(uint), 2, (uint)UintEnumType.Second)]
+        [InlineData(typeof(UShortEnumType), typeof(ushort), 4, (ushort)UShortEnumType.First)]
+        [InlineData(typeof(EnumType), typeof(int), 5, (int)EnumType.Second)]
+        [InlineData(typeof(UIntEnumType), typeof(uint), 2, (uint)UIntEnumType.Second)]
         [InlineData(typeof(LongEnumType), typeof(long), 1, (long)LongEnumType.First)]
-        [InlineData(typeof(UlongEnumType), typeof(ulong), 8, (ulong)UlongEnumType.Second)]
-        public void RequestReturnsCorrectResultForDifferentEnumTypes(Type enumType, Type memberType, int requestCount, object expectedResult)
+        [InlineData(typeof(ULongEnumType), typeof(ulong), 8, (ulong)ULongEnumType.Second)]
+        public void RequestReturnsCorrectResultForDifferentEnumTypes(
+            Type enumType, Type memberType, int requestCount, object expectedResult)
         {
             // Arrange
             var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
@@ -200,69 +227,171 @@ namespace AutoFixtureUnitTest.DataAnnotations
             {
                 RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
                 {
-                    OnTryGetMemberType = r => memberType
+                    OnTryGetMemberType = _ => memberType
                 }
             };
+
             // Act
-            var result = Enumerable.Repeat<Func<object>>(() => sut.Create(request, dummyContext), requestCount).Select(f => f()).ToArray().Last();
+            var result = Enumerable
+                .Repeat<Func<object>>(() => sut.Create(request, dummyContext), requestCount)
+                .Select(f => f()).ToArray().Last();
+
             // Assert
             Assert.Equal(expectedResult, result);
         }
 
-        private enum ByteEnumType : byte
+        [Theory]
+        [InlineData(typeof(ByteEnumType), ByteEnumType.First)]
+        [InlineData(typeof(SByteEnumType), SByteEnumType.First)]
+        [InlineData(typeof(ShortEnumType), ShortEnumType.First)]
+        [InlineData(typeof(UShortEnumType), UShortEnumType.First)]
+        [InlineData(typeof(EnumType), EnumType.First)]
+        [InlineData(typeof(UIntEnumType), UIntEnumType.First)]
+        [InlineData(typeof(LongEnumType), LongEnumType.First)]
+        [InlineData(typeof(ULongEnumType), ULongEnumType.First)]
+        public void RequestReturnsExpectedResultForObjectMemberType(Type enumType, object expectedResult)
         {
-            First = 99,
-            Second,
-            Third
+            // Arrange
+            var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
+            var providedAttribute = new ProvidedAttribute(enumDataTypeAttribute, true);
+            var request = new FakeMemberInfo(providedAttribute);
+            var dummyContext = new DelegatingSpecimenContext();
+
+            var sut = new EnumDataTypeAttributeRelay
+            {
+                RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
+                {
+                    OnTryGetMemberType = _ => typeof(object)
+                }
+            };
+
+            // Act
+            var actual = sut.Create(request, dummyContext);
+
+            // Assert
+            Assert.Equal(expectedResult, actual);
         }
 
-        private enum SbyteEnumType : sbyte
+        [Theory]
+        [InlineData(typeof(ByteEnumType), typeof(ByteEnumType), ByteEnumType.First)]
+        [InlineData(typeof(SByteEnumType), typeof(SByteEnumType), SByteEnumType.First)]
+        [InlineData(typeof(ShortEnumType), typeof(ShortEnumType), ShortEnumType.First)]
+        [InlineData(typeof(UShortEnumType), typeof(UShortEnumType), UShortEnumType.First)]
+        [InlineData(typeof(EnumType), typeof(EnumType), EnumType.First)]
+        [InlineData(typeof(UIntEnumType), typeof(UIntEnumType), UIntEnumType.First)]
+        [InlineData(typeof(LongEnumType), typeof(LongEnumType), LongEnumType.First)]
+        [InlineData(typeof(ULongEnumType), typeof(ULongEnumType), ULongEnumType.First)]
+        public void RequestReturnsExpectedResultForEnumMemberType(Type enumType, Type memberType, object expectedResult)
         {
-            First = -98,
-            Second,
-            Third
+            // Arrange
+            var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
+            var providedAttribute = new ProvidedAttribute(enumDataTypeAttribute, true);
+            var request = new FakeMemberInfo(providedAttribute);
+            var dummyContext = new DelegatingSpecimenContext();
+
+            var sut = new EnumDataTypeAttributeRelay
+            {
+                RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
+                {
+                    OnTryGetMemberType = _ => memberType
+                }
+            };
+
+            // Act
+            var actual = sut.Create(request, dummyContext);
+
+            // Assert
+            Assert.Equal(expectedResult, actual);
         }
 
-        private enum ShortEnumType : short
+        [Theory]
+        [InlineData(typeof(ByteEnumType))]
+        [InlineData(typeof(SByteEnumType))]
+        [InlineData(typeof(ShortEnumType))]
+        [InlineData(typeof(UShortEnumType))]
+        [InlineData(typeof(EnumType))]
+        [InlineData(typeof(UIntEnumType))]
+        [InlineData(typeof(LongEnumType))]
+        [InlineData(typeof(ULongEnumType))]
+        public void ReturnsNoSpecimenWhenEnumGeneratorReturnsNoSpecimen(Type enumType)
         {
-            First = 100,
-            Second,
-            Third
+            // Arrange
+            var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
+            var providedAttribute = new ProvidedAttribute(enumDataTypeAttribute, true);
+            var request = new FakeMemberInfo(providedAttribute);
+            var enumGenerator = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (_, _) => new NoSpecimen()
+            };
+            var sut = new EnumDataTypeAttributeRelay(enumGenerator);
+
+            // Act
+            var actual = sut.Create(request, null);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(actual);
         }
 
-        private enum UshortEnumType : ushort
+        [Theory]
+        [InlineData(typeof(ByteEnumType))]
+        [InlineData(typeof(SByteEnumType))]
+        [InlineData(typeof(ShortEnumType))]
+        [InlineData(typeof(UShortEnumType))]
+        [InlineData(typeof(EnumType))]
+        [InlineData(typeof(UIntEnumType))]
+        [InlineData(typeof(LongEnumType))]
+        [InlineData(typeof(ULongEnumType))]
+        public void ReturnsNoSpecimenWhenResolverReturnsNoSpecimen(Type enumType)
         {
-            First = 1,
-            Second,
-            Third
+            // Arrange
+            var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
+            var providedAttribute = new ProvidedAttribute(enumDataTypeAttribute, true);
+            var request = new FakeMemberInfo(providedAttribute);
+            var sut = new EnumDataTypeAttributeRelay
+            {
+                RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
+                {
+                    OnTryGetMemberType = _ => null
+                }
+            };
+
+            // Act
+            var actual = sut.Create(request, null);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(actual);
         }
 
-        private enum IntEnumType : int
+        [Theory]
+        [InlineData(typeof(ByteEnumType), typeof(PropertyHolder<string>))]
+        [InlineData(typeof(SByteEnumType), typeof(PropertyHolder<int>))]
+        [InlineData(typeof(ShortEnumType), typeof(PropertyHolder<long>))]
+        [InlineData(typeof(UShortEnumType), typeof(PropertyHolder<object>))]
+        [InlineData(typeof(EnumType), typeof(PropertyHolder<float>))]
+        [InlineData(typeof(UIntEnumType), typeof(PropertyHolder<decimal>))]
+        [InlineData(typeof(LongEnumType), typeof(PropertyHolder<double>))]
+        [InlineData(typeof(ULongEnumType), typeof(PropertyHolder<long>))]
+        public void ReturnsNoSpecimenResultForCustomClassMemberType(Type enumType, Type memberType)
         {
-            First = 7,
-            Second,
-            Third
-        }
+            // Arrange
+            var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
+            var providedAttribute = new ProvidedAttribute(enumDataTypeAttribute, true);
+            var request = new FakeMemberInfo(providedAttribute);
+            var dummyContext = new DelegatingSpecimenContext();
 
-        private enum UintEnumType : uint
-        {
-            First,
-            Second,
-            Third
-        }
+            var sut = new EnumDataTypeAttributeRelay
+            {
+                RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
+                {
+                    OnTryGetMemberType = _ => memberType
+                }
+            };
 
-        private enum LongEnumType : long
-        {
-            First = (long)int.MaxValue + 1,
-            Second,
-            Third
-        }
+            // Act
+            var actual = sut.Create(request, dummyContext);
 
-        private enum UlongEnumType : ulong
-        {
-            First = 1,
-            Second,
-            Third
+            // Assert
+            Assert.IsType<NoSpecimen>(actual);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/EnumDataTypeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/EnumDataTypeAttributeRelayTest.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using AutoFixture;
+using AutoFixture.DataAnnotations;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixtureUnitTest.DataAnnotations
+{
+    public class EnumDataTypeAttributeRelayTest
+    {
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            // Arrange
+            var sut = new EnumDataTypeAttributeRelay();
+            // Act & assert
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+
+        [Fact]
+        public void CreateWithNullContextThrows()
+        {
+            // Arrange
+            var sut = new EnumDataTypeAttributeRelay();
+            var dummyRequest = new object();
+            // Act & assert
+            Assert.Throws<ArgumentNullException>(() =>
+                sut.Create(dummyRequest, null));
+        }
+
+        [Fact]
+        public void CreateWithNullRequestReturnsCorrectResult()
+        {
+            // Arrange
+            var sut = new EnumDataTypeAttributeRelay();
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(null, dummyContext);
+            // Assert
+            Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Fact]
+        public void CreateWithAnonymousRequestReturnsCorrectResult()
+        {
+            // Arrange
+            var sut = new EnumDataTypeAttributeRelay();
+            var dummyRequest = new object();
+            // Act
+            var dummyContainer = new DelegatingSpecimenContext();
+            var result = sut.Create(dummyRequest, dummyContainer);
+            // Assert
+            var expectedResult = new NoSpecimen();
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(Version))]
+        public void CreateWithNonEnumDataTypeAttributeRequestReturnsCorrectResult(object request)
+        {
+            // Arrange
+            var sut = new EnumDataTypeAttributeRelay();
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(request, dummyContext);
+            // Assert
+            var expectedResult = new NoSpecimen();
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(typeof(TriState), 1, TriState.First)]
+        [InlineData(typeof(TriState), 2, TriState.Second)]
+        [InlineData(typeof(TriState), 3, TriState.Third)]
+        [InlineData(typeof(TriState), 4, TriState.First)]
+        [InlineData(typeof(TriState), 5, TriState.Second)]
+        [InlineData(typeof(DayOfWeek), 1, DayOfWeek.Sunday)]
+        [InlineData(typeof(DayOfWeek), 2, DayOfWeek.Monday)]
+        [InlineData(typeof(DayOfWeek), 8, DayOfWeek.Sunday)]
+        public void RequestForEnumTypeReturnsCorrectResult(Type enumType, int requestCount, object expectedResult)
+        {
+            // Arrange
+            var enumDataTypeAttribute = new EnumDataTypeAttribute(enumType);
+            var providedAttribute = new ProvidedAttribute(enumDataTypeAttribute, true);
+            var request = new FakeMemberInfo(providedAttribute);
+
+            var sut = new EnumDataTypeAttributeRelay
+            {
+                RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
+                {
+                    OnTryGetMemberType = r => typeof(string)
+                }
+            };
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = Enumerable.Repeat<Func<object>>(() => sut.Create(request, dummyContext), requestCount).Select(f => f()).ToArray().Last();
+            // Assert
+            Assert.Equal(expectedResult.ToString(), result);
+        }
+
+        [Fact]
+        public void RequestForEnumWithNoValuesThrows()
+        {
+            // Arrange
+            var enumDataTypeAttribute = new EnumDataTypeAttribute(typeof(EmptyEnum));
+            var providedAttribute = new ProvidedAttribute(enumDataTypeAttribute, true);
+            var request = new FakeMemberInfo(providedAttribute);
+
+            var sut = new EnumDataTypeAttributeRelay
+            {
+                RequestMemberTypeResolver = new DelegatingRequestMemberTypeResolver
+                {
+                    OnTryGetMemberType = r => typeof(string)
+                }
+            };
+            // Act & assert
+            var dummyContext = new DelegatingSpecimenContext();
+            Assert.Throws<ObjectCreationException>(() => sut.Create(request, dummyContext));
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6425,10 +6425,10 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             var sut = new Fixture();
-            
+
             // Act
             var result = sut.Create<TypeWithEnumDataAnnotation>();
-            
+
             // Assert
             Assert.Equal(EnumType.First.ToString(), result.EnumStringProperty);
         }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6400,5 +6400,37 @@ namespace AutoFixtureUnitTest
             var resultSeq = ((IEnumerable<object>)result).Cast<string>();
             Assert.Equal(expectedLength, resultSeq.Count());
         }
+
+        private class TypeWithEnumDataAnnotation
+        {
+            [EnumDataType(typeof(EnumType))]
+            public string EnumStringProperty { get; set; }
+        }
+
+        [Fact]
+        public void StringDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithEnumDataAnnotation>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveStringPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+            
+            // Act
+            var result = sut.Create<TypeWithEnumDataAnnotation>();
+            
+            // Assert
+            Assert.Equal(EnumType.First.ToString(), result.EnumStringProperty);
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -1700,6 +1700,7 @@ namespace AutoFixtureUnitTest
             // Assert
             Assert.Equal<int>(expectedRepeatCount, result);
         }
+
         [Fact]
         public void RepeatWillPerformActionTheDefaultNumberOfTimes()
         {
@@ -5802,6 +5803,7 @@ namespace AutoFixtureUnitTest
         }
 
 #if SYSTEM_NET_MAIL
+
         [Fact]
         public void CreateAnonymousWithMailAddressReturnsValidResult()
         {
@@ -5812,6 +5814,7 @@ namespace AutoFixtureUnitTest
             // Assert
             Assert.True(mailAddress != null);
         }
+
 #endif
 
         [Fact]
@@ -6182,6 +6185,7 @@ namespace AutoFixtureUnitTest
         }
 
 #if !VALIDATE_VALIDATEOBJECT_IS_FLACKY
+
         [Fact]
         public void TimeSpanDecoratedWithRangeCreatedByFixtureShouldPassValidation()
         {
@@ -6194,6 +6198,7 @@ namespace AutoFixtureUnitTest
             // Assert
             Validator.ValidateObject(timeSpan, new ValidationContext(timeSpan), true);
         }
+
 #endif
 
         private class TypeWithStringPropertyWithMinLength
@@ -6687,6 +6692,70 @@ namespace AutoFixtureUnitTest
 
             // Assert
             Assert.Equal((ulong)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithObjectPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public object PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void ObjectDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithObjectPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveObjectPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithObjectPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal(EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithEnumPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public EnumType PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void EnumDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithEnumPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveEnumPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithEnumPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal(EnumType.First, result.PropertyWithEnumDataType);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6401,10 +6401,10 @@ namespace AutoFixtureUnitTest
             Assert.Equal(expectedLength, resultSeq.Count());
         }
 
-        private class TypeWithEnumDataAnnotation
+        private class TypeWithStringPropertyWithEnumDataType
         {
             [EnumDataType(typeof(EnumType))]
-            public string EnumStringProperty { get; set; }
+            public string PropertyWithEnumDataType { get; set; }
         }
 
         [Fact]
@@ -6414,7 +6414,7 @@ namespace AutoFixtureUnitTest
             var sut = new Fixture();
 
             // Act
-            var item = sut.Create<TypeWithEnumDataAnnotation>();
+            var item = sut.Create<TypeWithStringPropertyWithEnumDataType>();
 
             // Assert
             Validator.ValidateObject(item, new ValidationContext(item), true);
@@ -6427,10 +6427,266 @@ namespace AutoFixtureUnitTest
             var sut = new Fixture();
 
             // Act
-            var result = sut.Create<TypeWithEnumDataAnnotation>();
+            var result = sut.Create<TypeWithStringPropertyWithEnumDataType>();
 
             // Assert
-            Assert.Equal(EnumType.First.ToString(), result.EnumStringProperty);
+            Assert.Equal(EnumType.First.ToString(), result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithBytePropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public byte PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void ByteDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithBytePropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveBytePropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithBytePropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((byte)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithSbytePropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public sbyte PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void SbyteDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithSbytePropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveSbytePropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithSbytePropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((sbyte)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithShortPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public short PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void ShortDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithShortPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveShortPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithShortPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((short)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithUshortPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public ushort PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void UshortDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithUshortPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveUshortPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithUshortPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((ushort)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithIntPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public int PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void IntDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithIntPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveIntPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithIntPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((int)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithUintPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public uint PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void UintDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithUintPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveUintPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithUintPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((uint)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithLongPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public long PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void LongDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithLongPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveLongPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithLongPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((long)EnumType.First, result.PropertyWithEnumDataType);
+        }
+
+        private class TypeWithUlongPropertyWithEnumDataType
+        {
+            [EnumDataType(typeof(EnumType))]
+            public ulong PropertyWithEnumDataType { get; set; }
+        }
+
+        [Fact]
+        public void UlongDecoratedWithEnumDataTypeAttributeShouldPassValidation()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var item = sut.Create<TypeWithUlongPropertyWithEnumDataType>();
+
+            // Assert
+            Validator.ValidateObject(item, new ValidationContext(item), true);
+        }
+
+        [Fact]
+        public void ShouldCorrectlyResolveUlongPropertiesDecoratedWithEnumDataTypeAttribute()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result = sut.Create<TypeWithUlongPropertyWithEnumDataType>();
+
+            // Assert
+            Assert.Equal((ulong)EnumType.First, result.PropertyWithEnumDataType);
         }
     }
 }

--- a/Src/TestTypeFoundation/EnumType.cs
+++ b/Src/TestTypeFoundation/EnumType.cs
@@ -6,4 +6,53 @@
         Second = 2,
         Third = 3
     }
+
+    public enum ByteEnumType : byte
+    {
+        First = 99,
+        Second,
+        Third
+    }
+
+    public enum SByteEnumType : sbyte
+    {
+        First = -98,
+        Second,
+        Third
+    }
+
+    public enum ShortEnumType : short
+    {
+        First = 100,
+        Second,
+        Third
+    }
+
+    public enum UShortEnumType : ushort
+    {
+        First = 1,
+        Second,
+        Third
+    }
+
+    public enum UIntEnumType : uint
+    {
+        First,
+        Second,
+        Third
+    }
+
+    public enum LongEnumType : long
+    {
+        First = (long)int.MaxValue + 1,
+        Second,
+        Third
+    }
+
+    public enum ULongEnumType : ulong
+    {
+        First = 1,
+        Second,
+        Third
+    }
 }


### PR DESCRIPTION
- Added `EnumDataTypeAttributeRelay.cs` for suport [EnumDataTypeAttribute](https://docs.microsoft.com/en-gb/dotnet/api/system.componentmodel.dataannotations.enumdatatypeattribute?view=net-5.0)
- Added unit tests
