### PR TITLE
Add a specimen builder to generate enum values from a subset

### DIFF
--- a/Src/AutoFixture/EnumValueCollection.cs
+++ b/Src/AutoFixture/EnumValueCollection.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// A collection of enum values.
+    /// </summary>
+    /// <typeparam name="TEnum">The type of enum values.</typeparam>
+    public sealed class EnumValueCollection<TEnum> : IEnumerable<TEnum>
+        where TEnum : struct, Enum
+    {
+        private readonly IEnumerable<TEnum> values;
+
+        internal EnumValueCollection(IEnumerable<TEnum> values)
+        {
+            this.values = values;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection of enum values.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection of enum values.</returns>
+        public IEnumerator<TEnum> GetEnumerator()
+        {
+            return this.values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/Src/AutoFixture/RestrictedEnum.cs
+++ b/Src/AutoFixture/RestrictedEnum.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// Defines methods to create an <see cref="EnumValueCollection{TEnum}"/> that the
+    /// <see cref="RestrictedEnumGenerator{TEnum}"/> will use to generate values.
+    /// </summary>
+    public static class RestrictedEnum
+    {
+        /// <summary>
+        /// Returns a subset of values of <typeparamref name="TEnum"/> that excludes the <paramref name="values"/>
+        /// specified.
+        /// </summary>
+        /// <param name="values">The values of <typeparamref name="TEnum"/> to exclude.</param>
+        /// <returns>a <see cref="EnumValueCollection{TEnum}"/> containing a subset of values of
+        /// <typeparamref name="TEnum"/> that excludes the <paramref name="values"/> specified.</returns>
+        public static EnumValueCollection<TEnum> ExcludeValues<TEnum>(params TEnum[] values)
+            where TEnum : struct, Enum
+        {
+            return ExcludeValues((IEnumerable<TEnum>)values);
+        }
+
+        /// <summary>
+        /// Returns a subset of values of <typeparamref name="TEnum"/> that excludes the <paramref name="values"/>
+        /// specified.
+        /// </summary>
+        /// <param name="values">The values of <typeparamref name="TEnum"/> to exclude.</param>
+        /// <returns>a <see cref="EnumValueCollection{TEnum}"/> containing a subset of values of
+        /// <typeparamref name="TEnum"/> that excludes the <paramref name="values"/> specified.</returns>
+        public static EnumValueCollection<TEnum> ExcludeValues<TEnum>(IEnumerable<TEnum> values)
+            where TEnum : struct, Enum
+        {
+            return Create(Enumerable.Except, values);
+        }
+
+        /// <summary>
+        /// Returns a subset of values of <typeparamref name="TEnum"/> that includes only the
+        /// <paramref name="values"/> specified.
+        /// </summary>
+        /// <param name="values">The values of <typeparamref name="TEnum"/> to include.</param>
+        /// <returns>a <see cref="EnumValueCollection{TEnum}"/> containing a subset of values of
+        /// <typeparamref name="TEnum"/> that includes only the <paramref name="values"/> specified.</returns>
+        public static EnumValueCollection<TEnum> IncludeValues<TEnum>(params TEnum[] values)
+            where TEnum : struct, Enum
+        {
+            return IncludeValues((IEnumerable<TEnum>)values);
+        }
+
+        /// <summary>
+        /// Returns a subset of values of <typeparamref name="TEnum"/> that includes only the
+        /// <paramref name="values"/> specified.
+        /// </summary>
+        /// <param name="values">The values of <typeparamref name="TEnum"/> to include.</param>
+        /// <returns>a <see cref="EnumValueCollection{TEnum}"/> containing a subset of values of
+        /// <typeparamref name="TEnum"/> that includes only the <paramref name="values"/> specified.</returns>
+        public static EnumValueCollection<TEnum> IncludeValues<TEnum>(IEnumerable<TEnum> values)
+            where TEnum : struct, Enum
+        {
+            return Create(Enumerable.Intersect, values);
+        }
+
+        private static EnumValueCollection<TEnum> Create<TEnum>(
+            Func<IEnumerable<TEnum>, IEnumerable<TEnum>, IEnumerable<TEnum>> setOperation,
+            IEnumerable<TEnum> values)
+            where TEnum : struct, Enum
+        {
+            if (values is null)
+                throw new ArgumentNullException(nameof(values));
+
+            var enumType = typeof(TEnum);
+
+            var availableValues = Enum.GetValues(enumType).Cast<TEnum>();
+            if (!availableValues.Any())
+            {
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    "{0} is an enum containing no values. Please add at least one value to the enum.",
+                    enumType.FullName);
+
+                throw new ArgumentException(message, nameof(values));
+            }
+
+            var selectedValues = setOperation(availableValues, values);
+            if (!selectedValues.Any())
+            {
+                const string message = "The values selected results in no available values. " +
+                    "Please make sure that at least one value is available.";
+
+                throw new ArgumentException(message, nameof(values));
+            }
+
+            return new EnumValueCollection<TEnum>(selectedValues);
+        }
+    }
+}

--- a/Src/AutoFixture/RestrictedEnumGenerator.cs
+++ b/Src/AutoFixture/RestrictedEnumGenerator.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using AutoFixture.Kernel;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// Generates enum values in a round-robin fashion from a subset of values.
+    /// </summary>
+    /// <typeparam name="TEnum">The type of enum values to generate.</typeparam>
+    public sealed class RestrictedEnumGenerator<TEnum> : ISpecimenBuilder
+        where TEnum : struct, Enum
+    {
+        private readonly IEnumerator enumerator;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RestrictedEnumGenerator{TEnum}"/> class
+        /// with the value selection options provided.
+        /// </summary>
+        /// <param name="values">The subset of values from which to generate values of
+        /// <typeparamref name="TEnum"/>.</param>
+        public RestrictedEnumGenerator(EnumValueCollection<TEnum> values)
+        {
+            if (values is null)
+                throw new ArgumentNullException(nameof(values));
+
+            this.enumerator = new RoundRobinEnumEnumerable(values).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Creates a new enum value based on a request.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens. Not used.</param>
+        /// <returns>An enum value if appropriate; otherwise a <see cref="NoSpecimen"/> instance.</returns>
+        /// <remarks>
+        /// <para>
+        /// If <paramref name="request"/> is <typeparamref name="TEnum"/>, an instance of that enum is returned.
+        /// Differing values are returned, starting with the first value from the subset of enum values.
+        /// When all values of the subset have been served, the sequence starts over again.
+        /// </para>
+        /// </remarks>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request as Type != typeof(TEnum))
+                return new NoSpecimen();
+
+            this.enumerator.MoveNext();
+
+            return this.enumerator.Current;
+        }
+
+        private class RoundRobinEnumEnumerable : IEnumerable
+        {
+            private readonly IEnumerable<TEnum> values;
+
+            internal RoundRobinEnumEnumerable(IEnumerable<TEnum> values)
+            {
+                this.values = values;
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                while (true)
+                {
+                    foreach (var obj in this.values)
+                    {
+                        yield return obj;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/RestrictedEnumGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RestrictedEnumGeneratorTest.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Linq;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixtureUnitTest
+{
+    public class RestrictedEnumGeneratorTest
+    {
+        [Fact]
+        public void InitializeWithNullRestrictedEnumValueSelectionThrows()
+        {
+            // Arrange
+            // Act & assert
+            Assert.Throws<ArgumentNullException>(() => new RestrictedEnumGenerator<TriState>(null));
+        }
+
+        [Theory]
+        [InlineData(typeof(DayOfWeek))]
+        [InlineData(typeof(EnumType))]
+        public void RequestDifferentTypeOfEnumReturnsCorrectResult(object request)
+        {
+            // Arrange
+            var values = RestrictedEnum.ExcludeValues(TriState.First);
+            var sut = new RestrictedEnumGenerator<TriState>(values);
+
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(request, dummyContext);
+            // Assert
+            var expectedResult = new NoSpecimen();
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(typeof(DayOfWeek), 1, DayOfWeek.Monday)]
+        [InlineData(typeof(DayOfWeek), 2, DayOfWeek.Tuesday)]
+        [InlineData(typeof(DayOfWeek), 3, DayOfWeek.Wednesday)]
+        [InlineData(typeof(DayOfWeek), 4, DayOfWeek.Thursday)]
+        [InlineData(typeof(DayOfWeek), 5, DayOfWeek.Monday)]
+        [InlineData(typeof(DayOfWeek), 6, DayOfWeek.Tuesday)]
+        public void RequestForEnumTypeExcludeValuesReturnsCorrectResult(
+            Type enumType,
+            int requestCount,
+            object expectedResult)
+        {
+            // Arrange
+            var values = RestrictedEnum.ExcludeValues(DayOfWeek.Friday, DayOfWeek.Saturday, DayOfWeek.Sunday);
+            var sut = new RestrictedEnumGenerator<DayOfWeek>(values);
+
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = Enumerable
+                .Repeat<Func<object>>(() => sut.Create(enumType, dummyContext), requestCount)
+                .Select(f => f())
+                .ToArray()
+                .Last();
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(typeof(DayOfWeek), 1, DayOfWeek.Monday)]
+        [InlineData(typeof(DayOfWeek), 2, DayOfWeek.Tuesday)]
+        [InlineData(typeof(DayOfWeek), 3, DayOfWeek.Monday)]
+        [InlineData(typeof(DayOfWeek), 4, DayOfWeek.Tuesday)]
+        [InlineData(typeof(DayOfWeek), 5, DayOfWeek.Monday)]
+        [InlineData(typeof(DayOfWeek), 6, DayOfWeek.Tuesday)]
+        public void RequestForEnumTypeIncludeValuesReturnsCorrectResult(
+            Type enumType,
+            int requestCount,
+            object expectedResult)
+        {
+            // Arrange
+            var values = RestrictedEnum.IncludeValues(DayOfWeek.Monday, DayOfWeek.Tuesday);
+            var sut = new RestrictedEnumGenerator<DayOfWeek>(values);
+
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = Enumerable
+                .Repeat<Func<object>>(() => sut.Create(enumType, dummyContext), requestCount)
+                .Select(f => f())
+                .ToArray()
+                .Last();
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(typeof(ActivityScope), 1, ActivityScope.OnDuty)]
+        [InlineData(typeof(ActivityScope), 2, ActivityScope.OffDuty)]
+        [InlineData(typeof(ActivityScope), 3, ActivityScope.Standalone)]
+        [InlineData(typeof(ActivityScope), 4, ActivityScope.Parent)]
+        [InlineData(typeof(ActivityScope), 5, ActivityScope.AllInitiatingScopes)]
+        [InlineData(typeof(ActivityScope), 6, ActivityScope.Child)]
+        [InlineData(typeof(ActivityScope), 7, ActivityScope.All)]
+        [InlineData(typeof(ActivityScope), 8, ActivityScope.OnDuty)]
+        [InlineData(typeof(ActivityScope), 9, ActivityScope.OffDuty)]
+        [InlineData(typeof(ActivityScope), 10, ActivityScope.Standalone)]
+        [InlineData(typeof(ActivityScope), 11, ActivityScope.Parent)]
+        [InlineData(typeof(ActivityScope), 20, ActivityScope.Child)]
+        [InlineData(typeof(ActivityScope), 21, ActivityScope.All)]
+        [InlineData(typeof(ActivityScope), 100, ActivityScope.OffDuty)]
+        public void RequestForFlagEnumTypeExcludeValuesReturnsCorrectResult(
+            Type enumType,
+            int requestCount,
+            object expectedResult)
+        {
+            // Arrange
+            var values = RestrictedEnum.ExcludeValues(ActivityScope.Undefined);
+            var sut = new RestrictedEnumGenerator<ActivityScope>(values);
+
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = Enumerable
+                .Repeat<Func<object>>(() => sut.Create(enumType, dummyContext), requestCount)
+                .Select(f => f())
+                .ToArray()
+                .Last();
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(typeof(ActivityScope), 1, ActivityScope.Standalone)]
+        [InlineData(typeof(ActivityScope), 2, ActivityScope.Parent)]
+        [InlineData(typeof(ActivityScope), 3, ActivityScope.Child)]
+        [InlineData(typeof(ActivityScope), 4, ActivityScope.Standalone)]
+        [InlineData(typeof(ActivityScope), 5, ActivityScope.Parent)]
+        [InlineData(typeof(ActivityScope), 6, ActivityScope.Child)]
+        [InlineData(typeof(ActivityScope), 7, ActivityScope.Standalone)]
+        [InlineData(typeof(ActivityScope), 8, ActivityScope.Parent)]
+        [InlineData(typeof(ActivityScope), 9, ActivityScope.Child)]
+        [InlineData(typeof(ActivityScope), 10, ActivityScope.Standalone)]
+        [InlineData(typeof(ActivityScope), 11, ActivityScope.Parent)]
+        [InlineData(typeof(ActivityScope), 20, ActivityScope.Parent)]
+        [InlineData(typeof(ActivityScope), 21, ActivityScope.Child)]
+        [InlineData(typeof(ActivityScope), 100, ActivityScope.Standalone)]
+        public void RequestForFlagEnumTypeIncludeValuesReturnsCorrectResult(
+            Type enumType,
+            int requestCount,
+            object expectedResult)
+        {
+            // Arrange
+            var values = RestrictedEnum.IncludeValues(
+                ActivityScope.Standalone,
+                ActivityScope.Parent,
+                ActivityScope.Child);
+
+            var sut = new RestrictedEnumGenerator<ActivityScope>(values);
+
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = Enumerable
+                .Repeat<Func<object>>(() => sut.Create(enumType, dummyContext), requestCount)
+                .Select(f => f())
+                .ToArray()
+                .Last();
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(1)]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        public void RequestNonEnumReturnsCorrectResult(object request)
+        {
+            // Arrange
+            var values = RestrictedEnum.ExcludeValues(TriState.First);
+            var sut = new RestrictedEnumGenerator<TriState>(values);
+
+            // Act
+            var dummyContext = new DelegatingSpecimenContext();
+            var result = sut.Create(request, dummyContext);
+            // Assert
+            var expectedResult = new NoSpecimen();
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void SutIsSpecimenBuilder()
+        {
+            // Arrange
+            // Act
+            var values = RestrictedEnum.ExcludeValues(TriState.First);
+            var sut = new RestrictedEnumGenerator<TriState>(values);
+
+            // Assert
+            Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/RestrictedEnumTest.cs
+++ b/Src/AutoFixtureUnitTest/RestrictedEnumTest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using AutoFixture;
+using TestTypeFoundation;
+using Xunit;
+
+namespace AutoFixtureUnitTest
+{
+    public class RestrictedEnumTest
+    {
+        [Fact]
+        public void InitializeWithEmptyEnumTypeThrows()
+        {
+            // Arrange
+            // Act & assert
+            Assert.Throws<ArgumentException>(() => RestrictedEnum.IncludeValues((EmptyEnum)0));
+        }
+
+        [Fact]
+        public void InitializeWithNoAvailableValuesThrows()
+        {
+            // Arrange
+            // Act & assert
+            Assert.Throws<ArgumentException>(() => RestrictedEnum.IncludeValues<TriState>());
+        }
+
+        [Fact]
+        public void InitializeWithNullValuesThrows()
+        {
+            // Arrange
+            // Act & assert
+            Assert.Throws<ArgumentNullException>(() => RestrictedEnum.IncludeValues<TriState>(null));
+        }
+    }
+}


### PR DESCRIPTION
I'm working on a code base at the moment where it would be useful to be able to restrict the values that are generated for a particular type of `enum` to a subset of the available values. If we use the `TriState` enumeration as an example, I might want to exclude the value `TriState.First`, or alternatively to include only the values `TriState.Second` and `TriState.Third`.

Although it is already possible to create a customization with functionality similar to that implemented here I don't think it is particularly obvious how to do so. This would make it relatively easy to create a customization that restricts enum values to a subset, as follows.

```c#
internal sealed class ExampleEnumCustomization : ICustomization
{
    public void Customize(IFixture fixture)
    {
        fixture.Customize<TriState>(
            _ => new RestrictedEnumGenerator<TriState>(RestrictedEnum.ExcludeValues(TriState.First)));
    }
}
```

Admittedly, having to do this may be indicative of a code smell in certain circumstances but I still think it could be useful – particularly for those of use that have to work on existing/legacy code bases from time to time, where the abuse of enums can be quite common. Perhaps it may also be useful to exclude the zero value from an enum, which is often the equivalent of *None* and may not be expected to occur except in certain conditions.

I'll be using this code, or some variation of it, elsewhere so it won't go to waste if rejected but I thought it might be worth seeing if you think it's worth including in AutoFixture. I didn't think it was worth opening an issue for this so please accept my apologies if I should have done so. I'd be most grateful for your thoughts.