### PR TITLE
Fixes ConstructorInitializedMemberAssertion false positive for bool arguments

### DIFF
--- a/Src/Idioms/ConstructorInitializedMemberAssertion.cs
+++ b/Src/Idioms/ConstructorInitializedMemberAssertion.cs
@@ -11,7 +11,7 @@ using AutoFixture.Kernel;
 namespace AutoFixture.Idioms
 {
     /// <summary>
-    /// Encapsulates a unit test that verifies that a member (property or field) is correctly intialized
+    /// Encapsulates a unit test that verifies that a member (property or field) is correctly initialized
     /// by the constructor.
     /// </summary>
     public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
@@ -79,7 +79,7 @@ namespace AutoFixture.Idioms
         /// Gets the comparer supplied to the constructor.
         /// </summary>
         /// <remarks>
-        /// This comparer instance is used to determine if all of the value retreived from
+        /// This comparer instance is used to determine if all of the value retrieved from
         /// the members are equal to their corresponding 'matched' constructor parameter.
         /// </remarks>
         public IEqualityComparer Comparer { get; }
@@ -136,7 +136,7 @@ namespace AutoFixture.Idioms
         /// <remarks>
         /// <para>
         /// This method verifies that the <paramref name="propertyInfo" /> is correctly initialized with
-        /// the value given to the same-named constructor paramter. It uses the <see cref="Builder" /> to
+        /// the value given to the same-named constructor parameter. It uses the <see cref="Builder" /> to
         /// supply values to the constructor(s) of the Type on which the field is implemented, and then
         /// reads from the field. The assertion passes if the value read from the property is the same as
         /// the value passed to the constructor. If more than one constructor has an argument with the
@@ -172,11 +172,11 @@ namespace AutoFixture.Idioms
                 throw BuildExceptionDueToPotentialFalsePositive(propertyInfo);
             }
 
-            var expectedAndActuals = matchingConstructors
+            var expectedAndActual = matchingConstructors
                 .Select(ctor => this.BuildSpecimenFromConstructor(ctor, propertyInfo));
 
             // Compare the value passed into the constructor with the value returned from the property
-            if (expectedAndActuals.Any(s => !this.Comparer.Equals(s.Expected, s.Actual)))
+            if (expectedAndActual.Any(s => !this.Comparer.Equals(s.Expected, s.Actual)))
             {
                 throw new ConstructorInitializedMemberException(propertyInfo);
             }
@@ -189,7 +189,7 @@ namespace AutoFixture.Idioms
         /// <remarks>
         /// <para>
         /// This method verifies that <paramref name="fieldInfo" /> is correctly initialized with the
-        /// value given to the same-named constructor paramter. It uses the <see cref="Builder" /> to
+        /// value given to the same-named constructor parameter. It uses the <see cref="Builder" /> to
         /// supply values to the constructor(s) of the Type on which the field is implemented, and then
         /// reads from the field. The assertion passes if the value read from the field is the same as
         /// the value passed to the constructor. If more than one constructor has an argument with the
@@ -223,11 +223,11 @@ namespace AutoFixture.Idioms
                 throw BuildExceptionDueToPotentialFalsePositive(fieldInfo);
             }
 
-            var expectedAndActuals = matchingConstructors
+            var expectedAndActual = matchingConstructors
                 .Select(ctor => this.BuildSpecimenFromConstructor(ctor, fieldInfo));
 
             // Compare the value passed into the constructor with the value returned from the property
-            if (expectedAndActuals.Any(s => !this.Comparer.Equals(s.Expected, s.Actual)))
+            if (expectedAndActual.Any(s => !this.Comparer.Equals(s.Expected, s.Actual)))
             {
                 throw new ConstructorInitializedMemberException(fieldInfo);
             }
@@ -404,7 +404,7 @@ namespace AutoFixture.Idioms
                 public int GetHashCode(NameAndType obj)
                 {
                     // Forces methods like Distinct() to use the Equals method, because
-                    // the hashcodes will all be equal.
+                    // the hash codes will all be equal.
                     return 0;
                 }
             }

--- a/Src/Idioms/TypeExtensions.cs
+++ b/Src/Idioms/TypeExtensions.cs
@@ -5,8 +5,22 @@ namespace AutoFixture.Idioms
 {
     internal static class TypeExtensions
     {
-        public static bool ImplementsGenericInterfaceDefinition(this Type type, Type interfaceType) => type.GetInterfaces().Any(i => i.GetGenericTypeDefinition().IsAssignableFrom(interfaceType));
+        public static bool ImplementsGenericInterfaceDefinition(this Type type, Type interfaceType)
+            => type
+                .GetInterfaces()
+                .Any(i => i
+                    .GetGenericTypeDefinition()
+                    .IsAssignableFrom(interfaceType));
 
-        public static bool ImplementsGenericInterface(this Type type, Type interfaceType, params Type[] argumentTypes) => type.GetInterfaces().Any(i => i.IsAssignableFrom(interfaceType.MakeGenericType(argumentTypes)));
+        public static bool ImplementsGenericInterface(this Type type, Type interfaceType, params Type[] argumentTypes)
+            => type
+                .GetInterfaces()
+                .Any(i => i
+                    .IsAssignableFrom(interfaceType.MakeGenericType(argumentTypes)));
+
+        public static object GetDefaultValue(this Type type)
+            => type.IsValueType
+                ? Activator.CreateInstance(type)
+                : null;
     }
 }

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -556,7 +556,21 @@ namespace AutoFixture.IdiomsUnitTest
             Assert.Throws<ConstructorInitializedMemberException>(() => sut.Verify(type));
         }
 
-        private static void AssertExceptionPropertiesEqual(ConstructorInitializedMemberException ex, ConstructorInfo ctor, ParameterInfo param)
+        [Theory]
+        [InlineData(typeof(IllBehavedFieldMatchedByEvenPositionConstructorParameter<TestIntEnum, bool>))]
+        [InlineData(typeof(IllBehavedPropertyMatchedByEvenPositionConstructorParameter<TestIntEnum, bool>))]
+        public void FailForUninitializedBooleanMember(Type type)
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var sut = new ConstructorInitializedMemberAssertion(fixture);
+
+            // Act & Assert
+            Assert.Throws<ConstructorInitializedMemberException>(() => sut.Verify(type));
+        }
+
+        private static void AssertExceptionPropertiesEqual(
+            ConstructorInitializedMemberException ex, ConstructorInfo ctor, ParameterInfo param)
         {
             Assert.Equal(param, ex.MissingParameter);
             Assert.Equal(ctor, ex.MemberInfo);
@@ -581,6 +595,30 @@ namespace AutoFixture.IdiomsUnitTest
             Assert.Equal(fi, ex.MemberInfo);
             Assert.Equal(fi, ex.FieldInfo);
             Assert.Null(ex.PropertyInfo);
+        }
+
+        private class IllBehavedPropertyMatchedByEvenPositionConstructorParameter<T1, T2>
+        {
+            public IllBehavedPropertyMatchedByEvenPositionConstructorParameter(T1 member1, T2 member2)
+            {
+                this.Member1 = member1;
+            }
+
+            public T1 Member1 { get; }
+
+            public T2 Member2 { get; }
+        }
+
+        private class IllBehavedFieldMatchedByEvenPositionConstructorParameter<T1, T2>
+        {
+            public IllBehavedFieldMatchedByEvenPositionConstructorParameter(T1 member1, T2 member2)
+            {
+                this.Member1 = member1;
+            }
+
+            public readonly T1 Member1;
+
+            public readonly T2 Member2 = default(T2);
         }
 
         private class PublicReadOnlyFieldNotInitializedByConstructor


### PR DESCRIPTION
### Changes
- Fixes `ConstructorInitializedMemberAssertion` false positive results for `bool` constructor parameters occurring at even positions

fixes #1235