### PR TITLE
To not override ref/out if was modified to same value

### DIFF
--- a/Src/AutoFoq/FoqMethodQuery.fs
+++ b/Src/AutoFoq/FoqMethodQuery.fs
@@ -28,15 +28,15 @@ type FoqMethodQuery(builder : ISpecimenBuilder) =
     /// <summary>
     /// Selects methods for the supplied type.
     /// </summary>
-    /// <param name="type">The type.</param>
+    /// <param name="targetType">The type.</param>
     /// <returns>
-    /// Constructors for <paramref name="type"/>.
+    /// Constructors for <paramref name="targetType"/>.
     /// </returns>
     /// <remarks>
     /// <para>
     /// This method returns a sequence of <see cref="IMethod"/> according to
     /// the public and protected constructors available on 
-    /// <paramref name="type"/>.
+    /// <paramref name="targetType"/>.
     /// </para>
     /// </remarks>
     member this.SelectMethods targetType = 

--- a/Src/AutoNSubstitute/CustomCallHandler/AutoFixtureValuesHandler.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/AutoFixtureValuesHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using NSubstitute.Core;
 
 namespace AutoFixture.AutoNSubstitute.CustomCallHandler
@@ -77,7 +76,7 @@ namespace AutoFixture.AutoNSubstitute.CustomCallHandler
 
         private static bool ArgValueWasModified(object current, object original)
         {
-            return !EqualityComparer<object>.Default.Equals(current, original);
+            return !ReferenceEquals(current, original);
         }
     }
 }

--- a/Src/AutoNSubstituteUnitTest/CustomCallHandler/AutoFixtureValuesHandlerTest.cs
+++ b/Src/AutoNSubstituteUnitTest/CustomCallHandler/AutoFixtureValuesHandlerTest.cs
@@ -205,6 +205,34 @@ namespace AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
         }
 
         [Fact]
+        public void ShouldNotUpdateModifiedRefArgumentIfUpdatedToSame()
+        {
+            // Arrange
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithRefVoidMethod>();
+
+            int origValue = 10;
+            var call = CallHelper.CreateCallMock(() => target.Method(ref origValue));
+            call.GetArguments()[0] = 10;
+
+            var callArgs = call.GetArguments();
+
+            sut.ResultResolver
+                .ResolveResult(call)
+                .Returns(
+                    new CallResultData(
+                        Maybe.Nothing<object>(),
+                        new[] { new CallResultData.ArgumentValue(0, 84) }));
+
+            // Act
+            sut.Handle(call);
+
+            // Assert
+            Assert.Equal(10, callArgs[0]);
+        }
+
+        [Fact]
         public void ShouldNotUpdateModifiedOutArgument()
         {
             // Arrange
@@ -228,6 +256,32 @@ namespace AutoFixture.AutoNSubstitute.UnitTest.CustomCallHandler
 
             // Assert
             Assert.Equal(42, call.GetArguments()[0]);
+        }
+
+        [Fact]
+        public void ShouldNotUpdateModifiedOutArgumentIfUpdatedToDefault()
+        {
+            // Arrange
+            AutoFixtureValuesHandler sut = CreateSutWithMockedDependencies();
+
+            var target = Substitute.For<IInterfaceWithOutVoidMethod>();
+
+            int origValue;
+            var call = CallHelper.CreateCallMock(() => target.Method(out origValue));
+            call.GetArguments()[0] = 0;
+
+            sut.ResultResolver
+                .ResolveResult(call)
+                .Returns(
+                    new CallResultData(
+                        Maybe.Nothing<object>(),
+                        new[] { new CallResultData.ArgumentValue(0, 84) }));
+
+            // Act
+            sut.Handle(call);
+
+            // Assert
+            Assert.Equal(0, call.GetArguments()[0]);
         }
 
         [Fact]

--- a/Src/Idioms.FsCheck/ReturnValueMustNotBeNullAssertion.fs
+++ b/Src/Idioms.FsCheck/ReturnValueMustNotBeNullAssertion.fs
@@ -35,7 +35,6 @@ type ReturnValueMustNotBeNullAssertion (builder) =
     /// <summary>
     /// Verifies that the return value for a method is not null.
     /// </summary>
-    /// <remarks>
     /// <param name="methodInfo">The method to verify.</param>
     override this.Verify (methodInfo : MethodInfo) =
         if methodInfo = null then 


### PR DESCRIPTION
Be more strict on detecting whether the boxed struct value was modified. If we find that user rewrote the value to self (or e.g. re-assigned complex struct which has shallow equality), we should not override the value with auto-generated.

Found this issue when was writing tests with intense usage of `ref/out`.

@aivascu Thank you for the review. It's a small and almost trivial fix, so I don't expect it to break things.