### PR TITLE
AutoTestCaseSourceAttribute for AutoFixture.NUnit3

### DIFF
--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NUnit" Version="[3.7.0]" Condition=" '$(TargetFramework)'=='netcoreapp1.1' " />
     <PackageReference Include="NUnit" Version="[3.10.1]" Condition=" '$(TargetFramework)'=='netcoreapp2.1' " />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>
 

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoTestCaseSourceAttributeStub.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoTestCaseSourceAttributeStub.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace AutoFixture.NUnit3.UnitTest
+{
+    public class AutoTestCaseSourceAttributeStub : AutoTestCaseSourceAttribute
+    {
+        public AutoTestCaseSourceAttributeStub(string sourceName, params object[] parameters)
+            : base(sourceName, parameters)
+        {
+        }
+
+        public AutoTestCaseSourceAttributeStub(Type sourceType)
+            : base(sourceType)
+        {
+        }
+
+        public AutoTestCaseSourceAttributeStub(Type sourceType, string sourceName, params object[] parameters)
+            : base(sourceType, sourceName, parameters)
+        {
+        }
+
+        public AutoTestCaseSourceAttributeStub(
+            Func<IFixture> fixtureFactory, Type sourceType,
+            string sourceName, params object[] parameters)
+            : base(fixtureFactory, sourceType, sourceName, parameters)
+        {
+        }
+
+        public AutoTestCaseSourceAttributeStub(Func<IFixture> fixtureFactory)
+            : base(fixtureFactory, null, null, null)
+        {
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoTestCaseSourceAttributeTests.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoTestCaseSourceAttributeTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using TestTypeFoundation;
+
+namespace AutoFixture.NUnit3.UnitTest
+{
+    public class AutoTestCaseSourceAttributeTests
+    {
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("    ")]
+        [TestCase("\t\t\t")]
+        [TestCase("\r\n")]
+        [TestCase("\r")]
+        [TestCase("SomeString")]
+        public void CanCreateInstanceWithSourceName(string sourceName)
+        {
+            // Arrange
+            TestDelegate act = () => _ = new AutoTestCaseSourceAttributeStub(sourceName);
+
+            // Act & Assert
+            Assert.DoesNotThrow(act);
+        }
+
+        [Test]
+        [TestCase(typeof(string))]
+        [TestCase(typeof(PropertyHolder<string>))]
+        public void CanCreateInstanceWithSourceType(Type sourceType)
+        {
+            // Arrange
+            TestDelegate act = () => _ = new AutoTestCaseSourceAttributeStub(sourceType);
+
+            // Act & Assert
+            Assert.DoesNotThrow(act);
+        }
+
+        [Test]
+        [TestCase(typeof(string), "")]
+        [TestCase(typeof(PropertyHolder<string>), nameof(PropertyHolder<object>.Property))]
+        public void CanCreateInstanceWithSourceTypeAndSourceName(Type sourceType, string sourceName)
+        {
+            // Arrange
+            TestDelegate act = () => _ = new AutoTestCaseSourceAttributeStub(sourceType, sourceName);
+
+            // Act & Assert
+            Assert.DoesNotThrow(act);
+        }
+
+        [Test]
+        public void ThrowsWhenExtendedWithNullFixture()
+        {
+            // Arrange
+            TestDelegate act = () => _ = new AutoTestCaseSourceAttributeStub(
+                null,
+                typeof(TypeWithCustomizationAttributes),
+                nameof(TypeWithCustomizationAttributes.CreateWithFrozenAndGreedy));
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(act);
+        }
+
+        [Test]
+        public void FixtureFactoryNotInvokedImmediately()
+        {
+            // Arrange
+            var factory = new DelegatingFixtureFactory();
+
+            // Act
+            var sut = new AutoTestCaseSourceAttributeStub(factory);
+
+            // Assert
+            Assert.False(factory.Invoked);
+        }
+
+        [Test]
+        public void SkipsTestsWhenFixtureThrows()
+        {
+            // Arrange
+            // DummyFixture is set up to throw DummyException when invoked by AutoDataAttribute
+            var fixtureType = typeof(TestClassWithEnumerableSources);
+            var testCasesMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestCasesMethod));
+            var testMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestMethod));
+            var methodWrapper = new MethodWrapper(fixtureType, testMethod);
+            var testSuite = new TestSuite(fixtureType);
+            var sut = new AutoTestCaseSourceAttributeStub(
+                () => new ThrowingStubFixture(),
+                fixtureType, testCasesMethod?.Name);
+
+            // Act
+            var actual = sut.BuildFrom(methodWrapper, testSuite).Skip(1).First();
+
+            // Assert
+            Assert.That(actual.RunState == RunState.NotRunnable);
+        }
+
+        [Test]
+        public void DoesNotActivateFixtureFactoryWhenSourceProvidesSufficientArguments()
+        {
+            // Arrange
+            var factory = new DelegatingFixtureFactory();
+            var fixtureType = typeof(TestClassWithEnumerableSources);
+            var testCasesMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestCasesMethod));
+            var testMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestMethod));
+            var methodWrapper = new MethodWrapper(fixtureType, testMethod);
+            var testSuite = new TestSuite(fixtureType);
+            var sut = new AutoTestCaseSourceAttributeStub(factory, fixtureType, testCasesMethod?.Name);
+
+            // Act
+            _ = sut.BuildFrom(methodWrapper, testSuite).First();
+
+            // Assert
+            Assert.False(factory.Invoked);
+        }
+
+        [Test]
+        public void SetsExpectedTestCaseSource()
+        {
+            // Arrange
+            var fixtureType = typeof(TestClassWithEnumerableSources);
+            var testCasesMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestCasesMethod));
+            var testMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestMethod));
+            var methodWrapper = new MethodWrapper(fixtureType, testMethod);
+            var testSuite = new TestSuite(fixtureType);
+            var sut = new AutoTestCaseSourceAttribute(fixtureType, testCasesMethod?.Name);
+
+            // Act
+            var actual = sut.BuildFrom(methodWrapper, testSuite).ToList();
+
+            Assert.True(actual.All(x => x.GetArguments().Length == methodWrapper.GetParameters().Length));
+        }
+
+        [Test]
+        public void SetsExpectedTestCaseSourceForLocalSourceMethod()
+        {
+            // Arrange
+            var fixtureType = typeof(TestClassWithEnumerableSources);
+            var testCasesMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestCasesMethod));
+            var testMethod = fixtureType.GetMethod(nameof(TestClassWithEnumerableSources.TestMethod));
+            var methodWrapper = new MethodWrapper(fixtureType, testMethod);
+            var testSuite = new TestSuite(fixtureType);
+            var sut = new AutoTestCaseSourceAttribute(testCasesMethod?.Name);
+
+            // Act
+            var actual = sut.BuildFrom(methodWrapper, testSuite).ToList();
+
+            Assert.True(actual.All(x => x.GetArguments().Length == methodWrapper.GetParameters().Length));
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/DelegatingFixtureFactory.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/DelegatingFixtureFactory.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace AutoFixture.NUnit3.UnitTest
+{
+    internal class DelegatingFixtureFactory
+    {
+        public DelegatingFixtureFactory()
+        {
+        }
+
+        public DelegatingFixtureFactory(Func<IFixture> factory)
+        {
+            this.OnFixtureCreated = factory;
+        }
+
+        public Func<IFixture> OnFixtureCreated { get; set; }
+
+        public bool Invoked { get; private set; }
+
+        public void Reset()
+        {
+            this.Invoked = false;
+        }
+
+        public IFixture Invoke()
+        {
+            this.Invoked = true;
+            return this.OnFixtureCreated?.Invoke();
+        }
+
+        public static implicit operator Func<IFixture>(DelegatingFixtureFactory factory)
+        {
+            return factory.Invoke;
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/FavorArraysAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/FavorArraysAttributeTest.cs
@@ -35,13 +35,15 @@ namespace AutoFixture.NUnit3.UnitTest
         {
             // Arrange
             var sut = new FavorArraysAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                ?.GetParameters().Single();
             // Act
             var result = sut.GetCustomization(parameter);
             // Assert
             Assert.IsAssignableFrom<ConstructorCustomization>(result);
             var invoker = (ConstructorCustomization)result;
-            Assert.AreEqual(parameter.ParameterType, invoker.TargetType);
+            Assert.AreEqual(parameter?.ParameterType, invoker.TargetType);
             Assert.IsAssignableFrom<ArrayFavoringConstructorQuery>(invoker.Query);
         }
     }

--- a/Src/AutoFixture.NUnit3.UnitTest/FavorEnumerablesAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/FavorEnumerablesAttributeTest.cs
@@ -35,13 +35,15 @@ namespace AutoFixture.NUnit3.UnitTest
         {
             // Arrange
             var sut = new FavorEnumerablesAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                ?.GetParameters().Single();
             // Act
             var result = sut.GetCustomization(parameter);
             // Assert
             Assert.IsAssignableFrom<ConstructorCustomization>(result);
             var invoker = (ConstructorCustomization)result;
-            Assert.AreEqual(parameter.ParameterType, invoker.TargetType);
+            Assert.AreEqual(parameter?.ParameterType, invoker.TargetType);
             Assert.IsAssignableFrom<EnumerableFavoringConstructorQuery>(invoker.Query);
         }
     }

--- a/Src/AutoFixture.NUnit3.UnitTest/FavorListsAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/FavorListsAttributeTest.cs
@@ -35,7 +35,9 @@ namespace AutoFixture.NUnit3.UnitTest
         {
             // Arrange
             var sut = new FavorListsAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                ?.GetParameters().Single();
             // Act
             var result = sut.GetCustomization(parameter);
             // Assert

--- a/Src/AutoFixture.NUnit3.UnitTest/GreedyAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/GreedyAttributeTest.cs
@@ -35,7 +35,9 @@ namespace AutoFixture.NUnit3.UnitTest
         {
             // Arrange
             var sut = new GreedyAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                ?.GetParameters().Single();
             // Act
             var result = sut.GetCustomization(parameter);
             // Assert

--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
@@ -74,7 +74,7 @@ namespace AutoFixture.NUnit3.UnitTest
             // Arrange
             bool wasActivated = false;
 
-            var sut = new AutoDataAttributeStub(() =>
+            var sut = new InlineAutoDataAttributeStub(() =>
             {
                 wasActivated = true;
                 return null;
@@ -140,7 +140,7 @@ namespace AutoFixture.NUnit3.UnitTest
             };
             var sut = new InlineAutoDataAttributeStub(() => fixture);
             // Act
-            sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
+            _ = sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
             // Assert
             Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
             Assert.True(customizationLog[1] is FreezeOnMatchCustomization);

--- a/Src/AutoFixture.NUnit3.UnitTest/ModestAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/ModestAttributeTest.cs
@@ -35,7 +35,9 @@ namespace AutoFixture.NUnit3.UnitTest
         {
             // Arrange
             var sut = new ModestAttribute();
-            var parameter = typeof(TypeWithOverloadedMembers).GetMethod("DoSomething", new[] { typeof(object) }).GetParameters().Single();
+            var parameter = typeof(TypeWithOverloadedMembers)
+                .GetMethod("DoSomething", new[] { typeof(object) })
+                ?.GetParameters().Single();
             // Act
             var result = sut.GetCustomization(parameter);
             // Assert

--- a/Src/AutoFixture.NUnit3.UnitTest/NoAutoPropertiesAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/NoAutoPropertiesAttributeTest.cs
@@ -36,7 +36,7 @@ namespace AutoFixture.NUnit3.UnitTest
             var sut = new NoAutoPropertiesAttribute();
             var parameter = typeof(TypeWithOverloadedMembers)
                 .GetMethod("DoSomething", new[] { typeof(object) })
-                .GetParameters()
+                ?.GetParameters()
                 .Single();
             // Act
             var result = sut.GetCustomization(parameter);

--- a/Src/AutoFixture.NUnit3.UnitTest/TestClassWithEnumerableSources.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TestClassWithEnumerableSources.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+
+namespace AutoFixture.NUnit3.UnitTest
+{
+    internal class TestClassWithEnumerableSources
+    {
+        public void TestMethod(int anyInt, double anyDouble, string anyString)
+        {
+        }
+
+        public static IEnumerable ParameterizedTestCasesMethod(int anyInt, double anyDouble, string anyString)
+        {
+            yield return new object[] { anyInt, anyDouble, anyString };
+            yield return new object[] { anyInt, anyDouble };
+            yield return new object[] { anyInt };
+        }
+
+        public static IEnumerable TestCasesMethod()
+            => ParameterizedTestCasesMethod(4, 3d, "some string");
+
+        public static IEnumerable TestCasesProperty => TestCasesMethod();
+
+        public static IEnumerable TestCasesField = TestCasesMethod();
+    }
+}

--- a/Src/AutoFixture.NUnit3.UnitTest/TestMethodEnvy.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TestMethodEnvy.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using NUnit.Framework.Internal;
+
+namespace AutoFixture.NUnit3.UnitTest
+{
+    internal static class TestMethodEnvy
+    {
+        public static object[] GetArguments(this TestMethod source)
+        {
+            var value = source.GetType().GetProperty("Arguments",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                ?.GetValue(source);
+
+            return value as object[];
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="NUnit" Version="[3.0.1,4.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
     <PackageReference Include="NUnit" Version="[3.7.0,4.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <PackageReference Include="NUnit" Version="[3.7.0,4.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.NUnit3/AutoTestCaseBuilder.cs
+++ b/Src/AutoFixture.NUnit3/AutoTestCaseBuilder.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
@@ -9,29 +6,11 @@ namespace AutoFixture.NUnit3
 {
     internal class AutoTestCaseBuilder
     {
-        private readonly Func<IFixture> fixtureFactory;
         private readonly NUnitTestCaseBuilder builder = new NUnitTestCaseBuilder();
 
-        public AutoTestCaseBuilder(Func<IFixture> fixtureFactory)
+        public TestMethod BuildTestMethod(IMethodInfo method, Test test, AutoTestCaseParameters parameters)
         {
-            this.fixtureFactory = fixtureFactory;
-        }
-
-        public string Category { get; set; }
-
-        public TestMethod BuildTestMethod(IMethodInfo method, Test test, IReadOnlyList<object> arguments)
-        {
-            var parameters = method.GetParameters();
-            TestCaseParameters args = arguments.Count < parameters.Length
-                ? new AutoTestCaseParameters(this.fixtureFactory, parameters, arguments)
-                : new TestCaseParameters(arguments.ToArray());
-
-            if (!string.IsNullOrWhiteSpace(this.Category))
-            {
-                args.Properties.Add("Category", this.Category);
-            }
-
-            return this.builder.BuildTestMethod(method, test, args);
+            return this.builder.BuildTestMethod(method, test, parameters.GetParameters(method));
         }
     }
 }

--- a/Src/AutoFixture.NUnit3/AutoTestCaseBuilder.cs
+++ b/Src/AutoFixture.NUnit3/AutoTestCaseBuilder.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
+
+namespace AutoFixture.NUnit3
+{
+    internal class AutoTestCaseBuilder
+    {
+        private readonly Func<IFixture> fixtureFactory;
+        private readonly NUnitTestCaseBuilder builder = new NUnitTestCaseBuilder();
+
+        public AutoTestCaseBuilder(Func<IFixture> fixtureFactory)
+        {
+            this.fixtureFactory = fixtureFactory;
+        }
+
+        public string Category { get; set; }
+
+        public TestMethod BuildTestMethod(IMethodInfo method, Test test, IReadOnlyList<object> arguments)
+        {
+            var parameters = method.GetParameters();
+            TestCaseParameters args = arguments.Count < parameters.Length
+                ? new AutoTestCaseParameters(this.fixtureFactory, parameters, arguments)
+                : new TestCaseParameters(arguments.ToArray());
+
+            if (!string.IsNullOrWhiteSpace(this.Category))
+            {
+                args.Properties.Add("Category", this.Category);
+            }
+
+            return this.builder.BuildTestMethod(method, test, args);
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/AutoTestCaseParameters.cs
+++ b/Src/AutoFixture.NUnit3/AutoTestCaseParameters.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.NUnit3
     {
         private readonly Func<IFixture> fixtureFactory;
         private readonly IReadOnlyList<object> arguments;
-        private readonly FixedNameArgumentsPatcher argumentsPatcher = new FixedNameArgumentsPatcher();
+        private IPatchParameters patcher = new FixedNameArgumentsPatcher();
 
         public AutoTestCaseParameters(Func<IFixture> fixtureFactory, IReadOnlyList<object> arguments)
         {
@@ -21,9 +21,15 @@ namespace AutoFixture.NUnit3
 
         public string Category { get; set; }
 
+        public IPatchParameters Patcher
+        {
+            get => this.patcher;
+            set => this.patcher = value;
+        }
+
         public TestCaseParameters GetParameters(IMethodInfo method)
         {
-            var parameters = CreateParameters(method);
+            var parameters = this.CreateParameters(method);
 
             if (!string.IsNullOrWhiteSpace(this.Category))
             {
@@ -57,7 +63,7 @@ namespace AutoFixture.NUnit3
                 var arguments = this.arguments.Concat(missingValues).ToArray();
 
                 var parameters = new TestCaseParameters(arguments);
-                this.argumentsPatcher.Patch(parameters, method);
+                this.patcher.Patch(parameters, method);
                 return parameters;
             }
             catch (Exception e)

--- a/Src/AutoFixture.NUnit3/AutoTestCaseParameters.cs
+++ b/Src/AutoFixture.NUnit3/AutoTestCaseParameters.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace AutoFixture.NUnit3
+{
+    internal class AutoTestCaseParameters
+    {
+        private readonly IReadOnlyList<object> arguments;
+        private readonly Func<IFixture> fixtureFactory;
+        private readonly IReadOnlyList<IParameterInfo> methodParameters;
+        private readonly FixedNameArgumentsPatcher argumentsPatcher;
+
+        public AutoTestCaseParameters(
+            Func<IFixture> fixtureFactory,
+            IReadOnlyList<IParameterInfo> methodParameters,
+            IReadOnlyList<object> arguments)
+        {
+            this.fixtureFactory = fixtureFactory;
+            this.arguments = arguments;
+            this.methodParameters = methodParameters;
+
+            var autoDataStartIndex = methodParameters.Count - arguments.Count;
+            this.argumentsPatcher = new FixedNameArgumentsPatcher(methodParameters, autoDataStartIndex);
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+            Justification = "This method is always expected to return an instance of the TestCaseParameters class.")]
+        private TestCaseParameters Convert()
+        {
+            try
+            {
+                var fixture = this.fixtureFactory();
+                var missingParameters = this.methodParameters.Skip(this.arguments.Count).ToList();
+                missingParameters.Customize(fixture);
+                var missingValues = missingParameters.Select(fixture.Resolve);
+                var parameters = new TestCaseParameters(this.arguments.Concat(missingValues).ToArray());
+                this.argumentsPatcher.Patch(parameters);
+                return parameters;
+            }
+            catch (Exception e)
+            {
+                return new TestCaseParameters(e);
+            }
+        }
+
+        public static implicit operator TestCaseParameters(AutoTestCaseParameters parameters)
+        {
+            return parameters.Convert();
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/AutoTestCaseSourceAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoTestCaseSourceAttribute.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace AutoFixture.NUnit3
+{
+    /// <summary>
+    /// This attribute acts as a <see cref="TestCaseSourceAttribute" /> but allow incomplete parameter values,
+    /// which will be provided by AutoFixture.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [CLSCompliant(false)]
+    [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes",
+        Justification = "This attribute is the root of a potential attribute hierarchy.")]
+    public class AutoTestCaseSourceAttribute : Attribute, ITestBuilder, IImplyFixture
+    {
+        /// <summary>
+        /// The Fixture factory.
+        /// </summary>
+        protected Func<IFixture> FixtureFactory { get; set; }
+
+        /// <summary>
+        /// Creates a new attribute instance.
+        /// </summary>
+        /// <param name="sourceName">The name of the source member.</param>
+        /// <param name="parameters">
+        /// The collection of parameters passed to the source member.
+        /// Ignored if the source member is not a method.
+        /// </param>
+        public AutoTestCaseSourceAttribute(string sourceName, params object[] parameters)
+            : this(() => new Fixture(), default, sourceName, parameters)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new attribute instance.
+        /// </summary>
+        /// <param name="sourceType">The test case source type.</param>
+        public AutoTestCaseSourceAttribute(Type sourceType)
+            : this(() => new Fixture(), sourceType, default, default)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new attribute instance.
+        /// </summary>
+        /// <param name="sourceType">The type holding the test case source member.</param>
+        /// <param name="sourceName">The name of the source member.</param>
+        /// <param name="parameters">
+        /// The collection of parameters passed to the source member.
+        /// Ignored if the source member is not a method.
+        /// </param>
+        public AutoTestCaseSourceAttribute(Type sourceType, string sourceName, params object[] parameters)
+            : this(() => new Fixture(), sourceType, sourceName, parameters)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new attribute instance.
+        /// </summary>
+        /// <param name="fixtureFactory">The factory for creating new Fixture instances.</param>
+        /// <param name="sourceType">The type holding the test case source member.</param>
+        /// <param name="sourceName">The name of the source member.</param>
+        /// <param name="parameters">
+        /// The collection of parameters passed to the source member.
+        /// Ignored if the source member is not a method.
+        /// </param>
+        protected AutoTestCaseSourceAttribute(Func<IFixture> fixtureFactory,
+            Type sourceType, string sourceName, IReadOnlyList<object> parameters)
+        {
+            this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+            this.SourceName = sourceName;
+            this.SourceType = sourceType;
+            this.Parameters = parameters;
+        }
+
+        /// <summary>
+        /// The name of a the method, property or fiend to be used as a source.
+        /// </summary>
+        public string SourceName { get; }
+
+        /// <summary>A Type to be used as a source.</summary>
+        public Type SourceType { get; }
+
+        /// <summary>
+        /// Gets the values passed to the source, if the source member is a method.
+        /// </summary>
+        public IReadOnlyList<object> Parameters { get; }
+
+        /// <summary>
+        /// Gets or sets the category associated with every fixture created from
+        /// this attribute. May be a single category or a comma-separated list.
+        /// </summary>
+        public string Category { get; set; }
+
+        /// <summary>
+        /// Construct one or more TestMethods from a given MethodInfo, using available parameter data.
+        /// </summary>
+        /// <param name="method"> The IMethod for which tests are to be constructed.</param>
+        /// <param name="suite">The suite to which the tests will be added.</param>
+        /// <returns>One or more TestMethods.</returns>
+        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
+        {
+            if (method == null)
+                throw new ArgumentNullException(nameof(method));
+
+            var source = new ReflectedSource(
+                this.SourceType ?? method.TypeInfo.Type,
+                this.SourceName,
+                this.Parameters);
+
+            var builder = new AutoTestCaseBuilder(this.FixtureFactory)
+            {
+                Category = this.Category
+            };
+
+            foreach (var values in source.GetTestCases(method))
+            {
+                yield return builder.BuildTestMethod(method, suite, values);
+            }
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/AutoTestCaseSourceAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoTestCaseSourceAttribute.cs
@@ -112,14 +112,16 @@ namespace AutoFixture.NUnit3
                 this.SourceName,
                 this.Parameters);
 
-            var builder = new AutoTestCaseBuilder(this.FixtureFactory)
-            {
-                Category = this.Category
-            };
+            var builder = new AutoTestCaseBuilder();
 
             foreach (var values in source.GetTestCases(method))
             {
-                yield return builder.BuildTestMethod(method, suite, values);
+                var parameters = new AutoTestCaseParameters(this.FixtureFactory, values)
+                {
+                    Category = this.Category
+                };
+
+                yield return builder.BuildTestMethod(method, suite, parameters);
             }
         }
     }

--- a/Src/AutoFixture.NUnit3/ClassTestCaseSource.cs
+++ b/Src/AutoFixture.NUnit3/ClassTestCaseSource.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace AutoFixture.NUnit3
+{
+    internal class ClassTestCaseSource : TestCaseSourceBase
+    {
+        private readonly Lazy<IEnumerable> lazyEnumerable;
+
+        public ClassTestCaseSource(Type type)
+        {
+            this.Type = type ?? throw new ArgumentNullException(nameof(type));
+            this.lazyEnumerable = new Lazy<IEnumerable>(() => GetInstance(type));
+        }
+
+        public Type Type { get; }
+
+        private IEnumerable TestCases => this.lazyEnumerable.Value;
+
+        public override IEnumerator GetEnumerator()
+        {
+            return this.TestCases.GetEnumerator();
+        }
+
+        private static IEnumerable GetInstance(Type type)
+        {
+            var constructor = type.GetTypeInfo().GetConstructor(EmptyArray<Type>.Value);
+            var instance = constructor?.Invoke(new object[0]);
+            return instance is IEnumerable enumerable
+                ? enumerable
+                : Enumerable.Empty<object>();
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/CustomizationExtensions.cs
+++ b/Src/AutoFixture.NUnit3/CustomizationExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture.Kernel;
+using NUnit.Framework.Interfaces;
+
+namespace AutoFixture.NUnit3
+{
+    internal static class CustomizationExtensions
+    {
+        private static ICustomization Aggregate(this IEnumerable<ICustomization> customizations)
+        {
+            return new CompositeCustomization(customizations);
+        }
+
+        public static void Customize(this IEnumerable<IParameterInfo> source, IFixture fixture)
+        {
+            source
+                .Select(
+                    x => x.GetCustomAttributes<Attribute>(false)
+                        .OfType<IParameterCustomizationSource>()
+                        .OrderBy(y => y, new CustomizeAttributeComparer())
+                        .Select(y => y.GetCustomization(x.ParameterInfo))
+                        .Aggregate())
+                .Aggregate()
+                .Customize(fixture);
+        }
+
+        public static object Resolve(this IFixture source, IParameterInfo parameterInfo)
+        {
+            return new SpecimenContext(source).Resolve(parameterInfo.ParameterInfo);
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/CustomizationExtensions.cs
+++ b/Src/AutoFixture.NUnit3/CustomizationExtensions.cs
@@ -8,23 +8,17 @@ namespace AutoFixture.NUnit3
 {
     internal static class CustomizationExtensions
     {
-        private static ICustomization Aggregate(this IEnumerable<ICustomization> customizations)
+        public static ICustomization Aggregate(this IEnumerable<ICustomization> customizations)
         {
             return new CompositeCustomization(customizations);
         }
 
-        public static void Customize(this IEnumerable<IParameterInfo> source, IFixture fixture)
-        {
-            source
-                .Select(
-                    x => x.GetCustomAttributes<Attribute>(false)
-                        .OfType<IParameterCustomizationSource>()
-                        .OrderBy(y => y, new CustomizeAttributeComparer())
-                        .Select(y => y.GetCustomization(x.ParameterInfo))
-                        .Aggregate())
-                .Aggregate()
-                .Customize(fixture);
-        }
+        public static IEnumerable<ICustomization> GetCustomizations(this IParameterInfo source)
+            => source
+                .GetCustomAttributes<Attribute>(false)
+                .OfType<IParameterCustomizationSource>()
+                .OrderBy(x => x, new CustomizeAttributeComparer())
+                .Select(x => x.GetCustomization(source.ParameterInfo));
 
         public static object Resolve(this IFixture source, IParameterInfo parameterInfo)
         {

--- a/Src/AutoFixture.NUnit3/EmptyArray.cs
+++ b/Src/AutoFixture.NUnit3/EmptyArray.cs
@@ -1,0 +1,7 @@
+namespace AutoFixture.NUnit3
+{
+    internal class EmptyArray<T>
+    {
+        public static readonly T[] Value = new T[0];
+    }
+}

--- a/Src/AutoFixture.NUnit3/EnumerableExtensions.cs
+++ b/Src/AutoFixture.NUnit3/EnumerableExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace AutoFixture.NUnit3
+{
+    internal static class EnumerableExtensions
+    {
+        public static IEnumerable<T> Tap<T>(this IEnumerable<T> source, Action<T> action)
+        {
+            foreach (var item in source)
+            {
+                action?.Invoke(item);
+                yield return item;
+            }
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/FixedNameArgumentsPatcher.cs
+++ b/Src/AutoFixture.NUnit3/FixedNameArgumentsPatcher.cs
@@ -5,7 +5,7 @@ using NUnit.Framework.Internal;
 
 namespace AutoFixture.NUnit3
 {
-    internal class FixedNameArgumentsPatcher
+    internal class FixedNameArgumentsPatcher : IPatchParameters
     {
         public void Patch(TestCaseParameters parameters, IMethodInfo method)
         {

--- a/Src/AutoFixture.NUnit3/FixedNameArgumentsPatcher.cs
+++ b/Src/AutoFixture.NUnit3/FixedNameArgumentsPatcher.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace AutoFixture.NUnit3
+{
+    internal class FixedNameArgumentsPatcher
+    {
+        private readonly int autoDataStartIndex;
+        private readonly IReadOnlyList<IParameterInfo> methodParameters;
+
+        public FixedNameArgumentsPatcher(IReadOnlyList<IParameterInfo> methodParameters, int autoDataStartIndex)
+        {
+            this.methodParameters = methodParameters;
+            this.autoDataStartIndex = autoDataStartIndex;
+        }
+
+        public void Patch(TestCaseParameters parameters)
+        {
+            EnsureOriginalArgumentsArrayIsNotShared(parameters);
+
+            for (var i = this.autoDataStartIndex; i < parameters.OriginalArguments.Length; i++)
+                parameters.OriginalArguments[i] = new TypeNameRenderer(this.methodParameters[i].ParameterType);
+        }
+
+        /// <summary>
+        /// Before NUnit 3.5 the Arguments and OriginalArguments properties are referencing the same array, so
+        /// we cannot safely update the OriginalArguments without touching the Arguments value.
+        /// This method fixes that by making the OriginalArguments array a standalone copy.
+        /// <para>
+        /// When running in NUnit3.5 and later the method is supposed to do nothing.
+        /// </para>
+        /// </summary>
+        protected static void EnsureOriginalArgumentsArrayIsNotShared(TestCaseParameters parameters)
+        {
+            if (!ReferenceEquals(parameters.Arguments, parameters.OriginalArguments)) return;
+
+            var clonedArguments = new object[parameters.OriginalArguments.Length];
+            Array.Copy(parameters.OriginalArguments, clonedArguments, parameters.OriginalArguments.Length);
+
+            // Unfortunately the property has a private setter, so can be updated via reflection only.
+            // Should use the type where the property is declared as otherwise the private setter is not available.
+            var property = typeof(TestParameters)
+                .GetTypeInfo()
+                .GetProperty(nameof(TestCaseParameters.OriginalArguments));
+
+            property?.SetValue(parameters, clonedArguments, null);
+        }
+
+        private class TypeNameRenderer
+        {
+            public TypeNameRenderer(Type type)
+            {
+                this.Type = type ?? throw new ArgumentNullException(nameof(type));
+            }
+
+            private Type Type { get; }
+
+            public override string ToString()
+            {
+                return $"auto<{this.Type.Name}>";
+            }
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/FixedNameTestMethodBuilder.cs
+++ b/Src/AutoFixture.NUnit3/FixedNameTestMethodBuilder.cs
@@ -67,16 +67,18 @@ namespace AutoFixture.NUnit3
         /// </summary>
         private static void EnsureOriginalArgumentsArrayIsNotShared(TestCaseParameters parameters)
         {
-            if (ReferenceEquals(parameters.Arguments, parameters.OriginalArguments))
-            {
-                var clonedArguments = new object[parameters.OriginalArguments.Length];
-                Array.Copy(parameters.OriginalArguments, clonedArguments, parameters.OriginalArguments.Length);
+            if (!ReferenceEquals(parameters.Arguments, parameters.OriginalArguments)) return;
 
-                // Unfortunately the property has a private setter, so can be updated via reflection only.
-                // Should use the type where the property is declared as otherwise the private setter is not available.
-                var property = typeof(TestParameters).GetTypeInfo().GetProperty(nameof(TestCaseParameters.OriginalArguments));
-                property.SetValue(parameters, clonedArguments, null);
-            }
+            var clonedArguments = new object[parameters.OriginalArguments.Length];
+            Array.Copy(parameters.OriginalArguments, clonedArguments, parameters.OriginalArguments.Length);
+
+            // Unfortunately the property has a private setter, so can be updated via reflection only.
+            // Should use the type where the property is declared as otherwise the private setter is not available.
+            var property = typeof(TestParameters)
+                .GetTypeInfo()
+                .GetProperty(nameof(TestCaseParameters.OriginalArguments));
+
+            property?.SetValue(parameters, clonedArguments, null);
         }
 
         private class TypeNameRenderer
@@ -90,7 +92,7 @@ namespace AutoFixture.NUnit3
 
             public override string ToString()
             {
-                return "auto<" + this.Type.Name + ">";
+                return $"auto<{this.Type.Name}>";
             }
         }
     }

--- a/Src/AutoFixture.NUnit3/IPatchParameters.cs
+++ b/Src/AutoFixture.NUnit3/IPatchParameters.cs
@@ -1,0 +1,10 @@
+﻿using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace AutoFixture.NUnit3
+{
+    internal interface IPatchParameters
+    {
+        void Patch(TestCaseParameters parameters, IMethodInfo method);
+    }
+}

--- a/Src/AutoFixture.NUnit3/ITestCaseSource.cs
+++ b/Src/AutoFixture.NUnit3/ITestCaseSource.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using NUnit.Framework.Interfaces;
+
+namespace AutoFixture.NUnit3
+{
+    internal interface ITestCaseSource
+    {
+        IEnumerable<IReadOnlyList<object>> GetTestCases(IMethodInfo method);
+    }
+}

--- a/Src/AutoFixture.NUnit3/NullSource.cs
+++ b/Src/AutoFixture.NUnit3/NullSource.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework.Interfaces;
+
+namespace AutoFixture.NUnit3
+{
+    internal class NullSource : ITestCaseSource, IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            return Enumerable.Empty<object>().GetEnumerator();
+        }
+
+        public IEnumerable<IReadOnlyList<object>> GetTestCases(IMethodInfo methodInfo)
+        {
+            return Enumerable.Empty<object[]>();
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/ReflectedSource.cs
+++ b/Src/AutoFixture.NUnit3/ReflectedSource.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework.Interfaces;
+
+namespace AutoFixture.NUnit3
+{
+    internal class ReflectedSource : ITestCaseSource
+    {
+        private readonly Lazy<ITestCaseSource> lazySource;
+
+        public ReflectedSource(Type type, string memberName, IEnumerable<object> parameters)
+        {
+            this.Type = type;
+            this.MemberName = memberName;
+            this.Parameters = parameters;
+            this.lazySource = new Lazy<ITestCaseSource>(() => GetSource(this.Type, this.MemberName, this.Parameters));
+        }
+
+        public Type Type { get; }
+
+        public string MemberName { get; }
+
+        public IEnumerable<object> Parameters { get; }
+
+        public IEnumerable<IReadOnlyList<object>> GetTestCases(IMethodInfo method)
+        {
+            return this.lazySource.Value.GetTestCases(method);
+        }
+
+        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1012:OpeningBracesMustBeSpacedCorrectly",
+            Justification = "This section makes of use of the new pattern matching syntax.")]
+        private static ITestCaseSource GetSource(Type type, string name, IEnumerable<object> parameters)
+        {
+            return (type, name) switch
+            {
+                ({ } t, { } n) => new StaticMemberSource(t, n, parameters),
+                ({ } t, _) => new ClassTestCaseSource(t),
+                (_, _) => new NullSource()
+            };
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/StaticFieldSource.cs
+++ b/Src/AutoFixture.NUnit3/StaticFieldSource.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace AutoFixture.NUnit3
+{
+    internal class StaticFieldSource : TestCaseSourceBase
+    {
+        public StaticFieldSource(FieldInfo field)
+        {
+            this.Field = field ?? throw new ArgumentNullException(nameof(field));
+        }
+
+        public FieldInfo Field { get; }
+
+        public override IEnumerator GetEnumerator()
+        {
+            return GetFieldData(this.Field).GetEnumerator();
+        }
+
+        private static IEnumerable GetFieldData(FieldInfo field)
+        {
+            return field.GetValue(null) is IEnumerable enumerable
+                ? enumerable
+                : Enumerable.Empty<object>();
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/StaticMemberSource.cs
+++ b/Src/AutoFixture.NUnit3/StaticMemberSource.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework.Interfaces;
+
+namespace AutoFixture.NUnit3
+{
+    internal class StaticMemberSource : ITestCaseSource
+    {
+        private readonly Lazy<ITestCaseSource> lazySource;
+        private const BindingFlags Binding = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+        public StaticMemberSource(Type type, string name, IEnumerable<object> parameters)
+        {
+            this.Type = type ?? throw new ArgumentNullException(nameof(type));
+            this.Name = name ?? throw new ArgumentNullException(nameof(name));
+            this.Parameters = parameters;
+            this.lazySource = new Lazy<ITestCaseSource>(() => GetSource(this.Type, this.Name, this.Parameters));
+        }
+
+        public Type Type { get; }
+
+        public string Name { get; }
+
+        public IEnumerable<object> Parameters { get; }
+
+        public IEnumerable<IReadOnlyList<object>> GetTestCases(IMethodInfo method)
+        {
+            return this.lazySource.Value.GetTestCases(method);
+        }
+
+        private static ITestCaseSource GetSource(Type type, string name, IEnumerable<object> parameters)
+        {
+            return type.GetTypeInfo().GetMember(name, Binding).Single() switch
+            {
+                MethodInfo m => new StaticMethodSource(m, parameters),
+                PropertyInfo p => new StaticPropertySource(p),
+                FieldInfo f => new StaticFieldSource(f),
+                _ => new NullSource()
+            };
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/StaticMethodSource.cs
+++ b/Src/AutoFixture.NUnit3/StaticMethodSource.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace AutoFixture.NUnit3
+{
+    internal class StaticMethodSource : TestCaseSourceBase
+    {
+        public StaticMethodSource(MethodInfo method, IEnumerable<object> parameters)
+        {
+            this.Method = method;
+            this.Parameters = parameters;
+        }
+
+        public MethodInfo Method { get; }
+
+        public IEnumerable<object> Parameters { get; }
+
+        public override IEnumerator GetEnumerator()
+        {
+            return GetMethodData(this.Method, this.Parameters).GetEnumerator();
+        }
+
+        private static IEnumerable GetMethodData(MethodInfo method, IEnumerable<object> parameters)
+        {
+            if (method.Invoke(null, parameters.ToArray()) is IEnumerable enumerable)
+            {
+                return enumerable;
+            }
+            else
+            {
+                return Enumerable.Empty<object>();
+            }
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/StaticPropertySource.cs
+++ b/Src/AutoFixture.NUnit3/StaticPropertySource.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace AutoFixture.NUnit3
+{
+    internal class StaticPropertySource : TestCaseSourceBase
+    {
+        public StaticPropertySource(PropertyInfo property)
+        {
+            this.Property = property ?? throw new ArgumentNullException(nameof(property));
+        }
+
+        public PropertyInfo Property { get; }
+
+        public override IEnumerator GetEnumerator()
+        {
+            return GetPropertyData(this.Property).GetEnumerator();
+        }
+
+        private static IEnumerable GetPropertyData(PropertyInfo property)
+        {
+            return property.GetValue(null) is IEnumerable enumerable
+                ? enumerable
+                : Enumerable.Empty<object>();
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/TestCaseSourceBase.cs
+++ b/Src/AutoFixture.NUnit3/TestCaseSourceBase.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework.Interfaces;
+
+namespace AutoFixture.NUnit3
+{
+    internal abstract class TestCaseSourceBase : ITestCaseSource, IEnumerable
+    {
+        public abstract IEnumerator GetEnumerator();
+
+        public IEnumerable<IReadOnlyList<object>> GetTestCases(IMethodInfo methodInfo)
+        {
+            var parameters = methodInfo.GetParameters();
+            if (parameters.Length == 0)
+            {
+                yield break;
+            }
+
+            var enumerator = this.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var value = enumerator.Current;
+
+                if (parameters[0].ParameterType.GetTypeInfo().IsInstanceOfType(value))
+                {
+                    yield return new[] { value };
+                }
+                else if (value is IEnumerable values)
+                {
+                    yield return values.OfType<object>().ToList();
+                }
+            }
+        }
+    }
+}

--- a/Src/AutoFixture.NUnit3/VolatileNameTestMethodBuilder.cs
+++ b/Src/AutoFixture.NUnit3/VolatileNameTestMethodBuilder.cs
@@ -8,11 +8,13 @@ using NUnit.Framework.Internal.Builders;
 
 namespace AutoFixture.NUnit3
 {
+    /// <summary>
     /// Creates <see cref="TestMethod"/> instances with name that includes actual argument values.
     /// <para>
     /// Notice, this strategy might break compatibility with some test runners that rely on stable test names
     /// (e.g. Visual Studio with NUnit3TestAdapter, NCrunch), therefore use this strategy with caution.
     /// </para>
+    /// </summary>
     public class VolatileNameTestMethodBuilder : ITestMethodBuilder
     {
         /// <inheritdoc />


### PR DESCRIPTION
Implements the `AutoTestCaseSourceAttribute` that acts as a `TestCaseSourceAttribute` but allows incomplete parameter values, which will be provided by AutoFixture.

The name of the attribute preserves the naming convention of NUnit 3 for easier discoverability.

Implements infrastructure abstractions that encapsulate different test case sources and would allow for more extensibility and to deprecate `FixedNameMethodBuilder` and `VolatileNameTestMethodBuilder`.