### PR TITLE
Adds mention of copy constructors to terminating error

### DIFF
--- a/Src/AutoFixture/Kernel/TerminatingSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingSpecimenBuilder.cs
@@ -30,7 +30,7 @@ namespace AutoFixture.Kernel
             throw new ObjectCreationException(
                 string.Format(
                     CultureInfo.CurrentCulture,
-                    "AutoFixture was unable to create an instance from {0}, most likely because it has no public constructor, is an abstract or non-public type.",
+                    "AutoFixture was unable to create an instance from {0}, most likely because it has no public non-copy constructor, is an abstract or non-public type.",
                     request));
         }
     }


### PR DESCRIPTION
Adds a mention about the copy constructors being ignored by default by AutoFixture.
fixes #1293 