### PR TITLE
Changed message of exception to improve readability

### DIFF
--- a/Src/Idioms/EmptyGuidBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyGuidBehaviorExpectation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace AutoFixture.Idioms
 {
@@ -34,16 +35,33 @@ namespace AutoFixture.Idioms
             {
                 command.Execute(Guid.Empty);
             }
-            catch (ArgumentException)
+            catch (ArgumentException e)
             {
-                return;
+                if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                throw command.CreateException(
+                    EmptyGuid,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
+                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
+                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
+                        Environment.NewLine,
+                        command.RequestedParameterName,
+                        e.ParamName),
+                    e);
             }
             catch (Exception e)
             {
-                throw command.CreateException("\"Guid.Empty\"", e);
+                throw command.CreateException(EmptyGuid, e);
             }
 
-            throw command.CreateException("\"Guid.Empty\"");
+            throw command.CreateException(EmptyGuid);
         }
+        
+        
+        private const string EmptyGuid = "\"Guid.Empty\"";
     }
 }

--- a/Src/Idioms/EmptyGuidBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyGuidBehaviorExpectation.cs
@@ -42,16 +42,7 @@ namespace AutoFixture.Idioms
                     return;
                 }
 
-                throw command.CreateException(
-                    EmptyGuid,
-                    string.Format(CultureInfo.InvariantCulture,
-                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
-                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
-                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
-                        Environment.NewLine,
-                        command.RequestedParameterName,
-                        e.ParamName),
-                    e);
+                throw command.CreateInvalidParamNameException(EmptyGuid, e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/EmptyGuidBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyGuidBehaviorExpectation.cs
@@ -51,8 +51,7 @@ namespace AutoFixture.Idioms
 
             throw command.CreateException(EmptyGuid);
         }
-        
-        
+
         private const string EmptyGuid = "\"Guid.Empty\"";
     }
 }

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -47,16 +47,7 @@ namespace AutoFixture.Idioms
                     return;
                 }
 
-                throw command.CreateException(
-                    EmptyString,
-                    string.Format(CultureInfo.InvariantCulture,
-                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
-                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
-                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
-                        Environment.NewLine,
-                        command.RequestedParameterName,
-                        e.ParamName),
-                    e);
+                throw command.CreateInvalidParamNameException(EmptyString, e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -48,7 +48,7 @@ namespace AutoFixture.Idioms
                 }
 
                 throw command.CreateException(
-                    "<empty string>",
+                    EmptyString,
                     string.Format(CultureInfo.InvariantCulture,
                         "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
                         "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
@@ -60,10 +60,12 @@ namespace AutoFixture.Idioms
             }
             catch (Exception e)
             {
-                throw command.CreateException("<empty string>", e);
+                throw command.CreateException(EmptyString, e);
             }
 
-            throw command.CreateException("<empty string>");
+            throw command.CreateException(EmptyString);
         }
+
+        private const string EmptyString = "<empty string>";
     }
 }

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -50,7 +50,7 @@ namespace AutoFixture.Idioms
                 throw command.CreateException(
                     "<empty string>",
                     string.Format(CultureInfo.InvariantCulture,
-                        "Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
+                        "a Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
                         "Ensure you pass correct parameter name to the ArgumentException constructor.{0}" +
                         "Expected parameter name: {1}{0}Actual parameter name: {2}",
                         Environment.NewLine,

--- a/Src/Idioms/EmptyStringBehaviorExpectation.cs
+++ b/Src/Idioms/EmptyStringBehaviorExpectation.cs
@@ -50,8 +50,8 @@ namespace AutoFixture.Idioms
                 throw command.CreateException(
                     "<empty string>",
                     string.Format(CultureInfo.InvariantCulture,
-                        "a Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
-                        "Ensure you pass correct parameter name to the ArgumentException constructor.{0}" +
+                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
+                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
                         "Expected parameter name: {1}{0}Actual parameter name: {2}",
                         Environment.NewLine,
                         command.RequestedParameterName,

--- a/Src/Idioms/GuardClauseCommandExtensions.cs
+++ b/Src/Idioms/GuardClauseCommandExtensions.cs
@@ -3,12 +3,15 @@ using System.Globalization;
 
 namespace AutoFixture.Idioms
 {
-    public static class GuardClauseCommandExtensions
+    internal static class GuardClauseCommandExtensions
     {
-
         public static Exception CreateInvalidParamNameException(this IGuardClauseCommand command, string value,
             ArgumentException innerException)
         {
+                if (command == null) throw new ArgumentNullException(nameof(command));
+                if (value == null) throw new ArgumentNullException(nameof(value));
+                if (innerException == null) throw new ArgumentNullException(nameof(innerException));
+
                 return command.CreateException(
                     value,
                     string.Format(CultureInfo.InvariantCulture,

--- a/Src/Idioms/GuardClauseCommandExtensions.cs
+++ b/Src/Idioms/GuardClauseCommandExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+
+namespace AutoFixture.Idioms
+{
+    public static class GuardClauseCommandExtensions
+    {
+
+        public static Exception CreateInvalidParamNameException(this IGuardClauseCommand command, string value,
+            ArgumentException innerException)
+        {
+                return command.CreateException(
+                    value,
+                    string.Format(CultureInfo.InvariantCulture,
+                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
+                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
+                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
+                        Environment.NewLine,
+                        command.RequestedParameterName,
+                        innerException.ParamName),
+                    innerException);
+        }
+    }
+}

--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -57,16 +57,7 @@ namespace AutoFixture.Idioms
                     return;
                 }
 
-                throw command.CreateException(
-                    Null,
-                    string.Format(CultureInfo.InvariantCulture,
-                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
-                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
-                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
-                        Environment.NewLine,
-                        command.RequestedParameterName,
-                        e.ParamName),
-                    e);
+                throw command.CreateInvalidParamNameException(Null, e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -53,10 +53,12 @@ namespace AutoFixture.Idioms
             catch (ArgumentNullException e)
             {
                 if (string.Equals(e.ParamName, command.RequestedParameterName, StringComparison.Ordinal))
+                {
                     return;
+                }
 
                 throw command.CreateException(
-                    "<null>",
+                    Null,
                     string.Format(CultureInfo.InvariantCulture,
                         "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
                         "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
@@ -68,10 +70,12 @@ namespace AutoFixture.Idioms
             }
             catch (Exception e)
             {
-                throw command.CreateException("null", e);
+                throw command.CreateException(Null, e);
             }
 
-            throw command.CreateException("null");
+            throw command.CreateException(Null);
         }
+
+        private const string Null = "null";
     }
 }

--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -58,8 +58,8 @@ namespace AutoFixture.Idioms
                 throw command.CreateException(
                     "<null>",
                     string.Format(CultureInfo.InvariantCulture,
-                        "a Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
-                        "Ensure you pass correct parameter name to the ArgumentNullException constructor.{0}" +
+                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
+                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
                         "Expected parameter name: {1}{0}Actual parameter name: {2}",
                         Environment.NewLine,
                         command.RequestedParameterName,

--- a/Src/Idioms/NullReferenceBehaviorExpectation.cs
+++ b/Src/Idioms/NullReferenceBehaviorExpectation.cs
@@ -58,7 +58,7 @@ namespace AutoFixture.Idioms
                 throw command.CreateException(
                     "<null>",
                     string.Format(CultureInfo.InvariantCulture,
-                        "Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
+                        "a Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
                         "Ensure you pass correct parameter name to the ArgumentNullException constructor.{0}" +
                         "Expected parameter name: {1}{0}Actual parameter name: {2}",
                         Environment.NewLine,

--- a/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
+++ b/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
@@ -47,16 +47,7 @@ namespace AutoFixture.Idioms
                     return;
                 }
 
-                throw command.CreateException(
-                    WhiteSpace,
-                    string.Format(CultureInfo.InvariantCulture,
-                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
-                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
-                        "Expected parameter name: {1}{0}Actual parameter name: {2}",
-                        Environment.NewLine,
-                        command.RequestedParameterName,
-                        e.ParamName),
-                    e);
+                throw command.CreateInvalidParamNameException(WhiteSpace, e);
             }
             catch (Exception e)
             {

--- a/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
+++ b/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
@@ -50,7 +50,7 @@ namespace AutoFixture.Idioms
                 throw command.CreateException(
                     "<white space>",
                     string.Format(CultureInfo.InvariantCulture,
-                        "Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
+                        "a Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
                         "Ensure you pass correct parameter name to the ArgumentException constructor.{0}" +
                         "Expected parameter name: {1}{0}Actual parameter name: {2}",
                         Environment.NewLine,

--- a/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
+++ b/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
@@ -48,7 +48,7 @@ namespace AutoFixture.Idioms
                 }
 
                 throw command.CreateException(
-                    "<white space>",
+                    WhiteSpace,
                     string.Format(CultureInfo.InvariantCulture,
                         "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
                         "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
@@ -60,10 +60,12 @@ namespace AutoFixture.Idioms
             }
             catch (Exception e)
             {
-                throw command.CreateException("<white space>", e);
+                throw command.CreateException(WhiteSpace, e);
             }
 
-            throw command.CreateException("<white space>");
+            throw command.CreateException(WhiteSpace);
         }
+
+        private const string WhiteSpace = "<white space>";
     }
 }

--- a/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
+++ b/Src/Idioms/WhiteSpaceStringBehaviorExpectation.cs
@@ -50,8 +50,8 @@ namespace AutoFixture.Idioms
                 throw command.CreateException(
                     "<white space>",
                     string.Format(CultureInfo.InvariantCulture,
-                        "a Guard Clause prevented it, however the thrown exception contains invalid parameter name. " +
-                        "Ensure you pass correct parameter name to the ArgumentException constructor.{0}" +
+                        "a Guard Clause prevented it; however, the thrown exception contains an invalid parameter name. " +
+                        "Ensure you pass the correct parameter name to the ArgumentException constructor.{0}" +
                         "Expected parameter name: {1}{0}Actual parameter name: {2}",
                         Environment.NewLine,
                         command.RequestedParameterName,

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -935,7 +935,7 @@ namespace AutoFixture.IdiomsUnitTest
             var constructorInfo = typeof(NonProperlyGuardedClass).GetConstructors().Single();
 
             var exception = Assert.Throws<GuardClauseException>(() => sut.Verify(constructorInfo));
-            Assert.Contains("Guard Clause prevented it, however", exception.Message);
+            Assert.Contains("Guard Clause prevented it; however", exception.Message);
         }
 
         [Fact]
@@ -945,11 +945,11 @@ namespace AutoFixture.IdiomsUnitTest
             var propertyInfo = typeof(NonProperlyGuardedClass).GetProperty(nameof(NonProperlyGuardedClass.Property));
 
             var exception = Assert.Throws<GuardClauseException>(() => sut.Verify(propertyInfo));
-            Assert.Contains("Guard Clause prevented it, however", exception.Message);
+            Assert.Contains("Guard Clause prevented it; however", exception.Message);
         }
 
         [Theory]
-        [InlineData(nameof(NonProperlyGuardedClass.Method), "Guard Clause prevented it, however")]
+        [InlineData(nameof(NonProperlyGuardedClass.Method), "Guard Clause prevented it; however")]
         [InlineData(nameof(NonProperlyGuardedClass.DeferredMethodReturningGenericEnumerable), "deferred")]
         [InlineData(nameof(NonProperlyGuardedClass.DeferredMethodReturningGenericEnumerator), "deferred")]
         [InlineData(nameof(NonProperlyGuardedClass.DeferredMethodReturningNonGenericEnumerable), "deferred")]


### PR DESCRIPTION
Hey - I don't mean to be an annoying "You have a error" because I make those all the time; I simply wanted to help.

I got the following exception from this great framework:

> AutoFixture.Idioms.GuardClauseException : An attempt was made to assign the value <null> to the parameter "redispatchSeries" of the method ".ctor", and Guard Clause prevented it, however the thrown exception contains invalid parameter name. Ensure you pass correct parameter name to the ArgumentNullException constructor.
Expected parameter name: redispatchSeries
Actual parameter name: unitId

And realized it lacked an  "a" between 

> AutoFixture.Idioms.GuardClauseException : [...] method ".ctor", and **>a<** Guard Clause prevented it[...]

So I wanted to fix those.

However, upon creating this pull request, my subscription to [Grammarly ](https://grammarly.com/) proposed a few other changes, which I've added in a separate commit, which contains those changes.

After doing these changes I tried to live by the Boy Scout Rule, and DRY the creation of these exceptions, as well as implement it for EmptyGuid, which I realize didn't check param name.