### PR TITLE
Fixed SelectMethods when exists more than one method with the same name

### DIFF
--- a/Src/AutoFixture/Kernel/InstanceMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/InstanceMethodQuery.cs
@@ -39,7 +39,8 @@ namespace AutoFixture.Kernel
         /// returns an enumerable containing a single <see cref="InstanceMethod"/> otherwise.</returns>
         public IEnumerable<IMethod> SelectMethods(Type type = default)
         {
-            var method = this.Owner.GetType().GetTypeInfo().GetMethod(this.MethodName);
+            var arguments = this.Owner.GetType().GenericTypeArguments;
+            var method = this.Owner.GetType().GetTypeInfo().GetMethod(this.MethodName, arguments);
 
             return method == null
                 ? new IMethod[0]

--- a/Src/AutoFixtureUnitTest/Kernel/InstanceMethodQueryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/InstanceMethodQueryTest.cs
@@ -81,5 +81,20 @@ namespace AutoFixtureUnitTest.Kernel
             // Assert
             Assert.Empty(result);
         }
+
+        [Fact]
+        public void SelectMethodsDoesNotThrowWithDuplicateMethods()
+        {
+            // Arrange
+            var owner = new CollectionHolder<string>(new ExtendedList<string>()).Collection;
+            var methodName = nameof(CollectionHolder<string>.Collection.Add);
+            var sut = new InstanceMethodQuery(owner, methodName);
+
+            // Act
+            var result = Record.Exception(() => sut.SelectMethods());
+
+            // Assert
+            Assert.Null(result);
+        }
     }
 }

--- a/Src/TestTypeFoundation/CollectionHolder.cs
+++ b/Src/TestTypeFoundation/CollectionHolder.cs
@@ -9,6 +9,11 @@ namespace TestTypeFoundation
             this.Collection = new List<T>();
         }
 
+        public CollectionHolder(ICollection<T> collection)
+        {
+            this.Collection = collection;
+        }
+
         public ICollection<T> Collection { get; private set; }
     }
 }

--- a/Src/TestTypeFoundation/ExtendedList.cs
+++ b/Src/TestTypeFoundation/ExtendedList.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace TestTypeFoundation
+{
+    public class ExtendedList<T> : List<T>
+    {
+        public void Add(IEnumerable<T> collection)
+        {
+            this.AddRange(collection);
+        }
+    }
+}


### PR DESCRIPTION
I found an exception when i was trying to add ReadonlyCollectionPropertiesBehavior to fill Protobuf properties. 