### PR TITLE
Enumerate builders in CompositeNodeComposer.Compose only once

### DIFF
--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -194,17 +194,17 @@ namespace AutoFixture.Dsl
         /// <inheritdoc />
         public ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
         {
-            var isSingle = builders.Take(2).Count() == 1;
-            if (isSingle)
+            var buildersArray = builders as ISpecimenBuilder[] ?? builders.ToArray();
+
+            if (buildersArray.Length == 1)
             {
-                var single = builders.Single() as ISpecimenBuilderNode;
-                if (single != null)
+                if (buildersArray[0] is ISpecimenBuilderNode single)
                     return new CompositeNodeComposer<T>(single);
             }
 
             return new CompositeNodeComposer<T>(
                 new CompositeSpecimenBuilder(
-                    builders));
+                    buildersArray));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
### Description
Remove multiple enumeration to optimize method a little bit.

I think it is possible to do this because if there is one item in Enumerable you obviosly can convert it to array. 
And if execution go to  else branch in line 205 it is ok to enumerate to array because `CompositeSpecimenBuilder` converts it to array in constructor
```
public CompositeSpecimenBuilder(IEnumerable<ISpecimenBuilder> builders)
    : this(builders.ToArray())
```
