### PR TITLE
Adds support to IReadOnlySet from .NET 5.0

### DIFF
--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -156,6 +156,11 @@ namespace AutoFixture
                                 new TypeRelay(
                                     typeof(IReadOnlyList<>),
                                     typeof(ReadOnlyCollection<>)),
+#if NET5_0_OR_GREATER
+                                new TypeRelay(
+                                    typeof(IReadOnlySet<>),
+                                    typeof(HashSet<>)),
+#endif
                                 new TypeRelay(
                                     typeof(ISet<>),
                                     typeof(HashSet<>)),

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4939,8 +4939,8 @@ namespace AutoFixtureUnitTest
         [InlineData(typeof(IReadOnlyList<object>), typeof(ReadOnlyCollection<object>))]
         [InlineData(typeof(ICollection<object>), typeof(List<object>))]
         [InlineData(typeof(IReadOnlyCollection<object>), typeof(ReadOnlyCollection<object>))]
-        [InlineData(typeof(IDictionary<string,object>), typeof(Dictionary<string,object>))]
-        [InlineData(typeof(IReadOnlyDictionary<string,object>), typeof(ReadOnlyDictionary<string,object>))]
+        [InlineData(typeof(IDictionary<string, object>), typeof(Dictionary<string, object>))]
+        [InlineData(typeof(IReadOnlyDictionary<string, object>), typeof(ReadOnlyDictionary<string, object>))]
 #if NET5_0_OR_GREATER
         [InlineData(typeof(IReadOnlySet<object>), typeof(HashSet<object>))]
 #endif

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4920,6 +4920,9 @@ namespace AutoFixtureUnitTest
         [InlineData(typeof(ICollection<>), typeof(List<>))]
         [InlineData(typeof(IReadOnlyCollection<>), typeof(ReadOnlyCollection<>))]
         [InlineData(typeof(IDictionary<,>), typeof(Dictionary<,>))]
+#if NET5_0_OR_GREATER 
+        [InlineData(typeof(IReadOnlySet<>), typeof(HashSet<>))]
+#endif
         public void ResidueCollectorsContainForwardsByDefault(Type from, Type to)
         {
             // Arrange

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4920,7 +4920,7 @@ namespace AutoFixtureUnitTest
         [InlineData(typeof(ICollection<>), typeof(List<>))]
         [InlineData(typeof(IReadOnlyCollection<>), typeof(ReadOnlyCollection<>))]
         [InlineData(typeof(IDictionary<,>), typeof(Dictionary<,>))]
-#if NET5_0_OR_GREATER 
+#if NET5_0_OR_GREATER
         [InlineData(typeof(IReadOnlySet<>), typeof(HashSet<>))]
 #endif
         public void ResidueCollectorsContainForwardsByDefault(Type from, Type to)

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4934,6 +4934,28 @@ namespace AutoFixtureUnitTest
         }
 
         [Theory]
+        [InlineData(typeof(IList<object>), typeof(List<object>))]
+        [InlineData(typeof(IReadOnlyList<object>), typeof(ReadOnlyCollection<object>))]
+        [InlineData(typeof(ICollection<object>), typeof(List<object>))]
+        [InlineData(typeof(IReadOnlyCollection<object>), typeof(ReadOnlyCollection<object>))]
+        [InlineData(typeof(IDictionary<string,object>), typeof(Dictionary<string,object>))]
+#if NET5_0_OR_GREATER
+        [InlineData(typeof(IReadOnlySet<object>), typeof(HashSet<object>))]
+#endif
+        public void DefaultForwardsAreUsedWhenTypeIsRequested(Type request, Type expected)
+        {
+            // Arrange
+            var sut = new Fixture();
+            var context = new SpecimenContext(sut);
+
+            // Act
+            var actual = context.Resolve(request);
+
+            // Assert
+            Assert.IsType(expected, actual);
+        }
+
+        [Theory]
         [InlineData(typeof(List<>), typeof(EnumerableFavoringConstructorQuery))]
         [InlineData(typeof(HashSet<>), typeof(EnumerableFavoringConstructorQuery))]
         [InlineData(typeof(Collection<>), typeof(ListFavoringConstructorQuery))]

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -4920,6 +4920,7 @@ namespace AutoFixtureUnitTest
         [InlineData(typeof(ICollection<>), typeof(List<>))]
         [InlineData(typeof(IReadOnlyCollection<>), typeof(ReadOnlyCollection<>))]
         [InlineData(typeof(IDictionary<,>), typeof(Dictionary<,>))]
+        [InlineData(typeof(IReadOnlyDictionary<,>), typeof(ReadOnlyDictionary<,>))]
 #if NET5_0_OR_GREATER
         [InlineData(typeof(IReadOnlySet<>), typeof(HashSet<>))]
 #endif
@@ -4939,6 +4940,7 @@ namespace AutoFixtureUnitTest
         [InlineData(typeof(ICollection<object>), typeof(List<object>))]
         [InlineData(typeof(IReadOnlyCollection<object>), typeof(ReadOnlyCollection<object>))]
         [InlineData(typeof(IDictionary<string,object>), typeof(Dictionary<string,object>))]
+        [InlineData(typeof(IReadOnlyDictionary<string,object>), typeof(ReadOnlyDictionary<string,object>))]
 #if NET5_0_OR_GREATER
         [InlineData(typeof(IReadOnlySet<object>), typeof(HashSet<object>))]
 #endif


### PR DESCRIPTION
This PR adds a type relay from IReadOnlySet to HashSet for builds that target .NET 5.0 and above. Fixes #1343