### PR TITLE
Updated readme FAKE build engine URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ AutoFixture follows [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.ht
 
 ## Build
 
-AutoFixture uses [FAKE](http://fsharp.github.io/FAKE/) as a build engine. If you would like to build the AutoFixture locally, run the `build.cmd` file and wait for the result.
+AutoFixture uses [FAKE](https://github.com/fsprojects/FAKE) as a build engine. If you would like to build the AutoFixture locally, run the `build.cmd` file and wait for the result.
 
 The repository state (the last tag name and number of commits since the last tag) is used to determine the build version. If you would like to override the auto-generated AutoFixture version, set the `BUILD_VERSION` environment variable before calling the `build.cmd` file. Example for PowerShell:
 


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
The previous GitHub pages page is no longer running (http://fsharp.github.io/FAKE/). Linked to the GitHub project page instead (https://github.com/fsprojects/FAKE).

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [ ] Linked the issue(s) the PR closes
- [ ] Implemented automated tests and checked coverage
- [ ] Provided inline documentation comments for new public API
- [ ] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
