### PR TITLE
upgraded to secure version 4.7.0 of System.ComponentModel.Annotations

### DIFF
--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fare" Version="[2.1.1,3.0.0)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <Reference Include="System.ComponentModel.DataAnnotations" Condition=" '$(TargetFramework)'=='net452' " />
   </ItemGroup>

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fare" Version="[2.1.1,3.0.0)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.1" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <Reference Include="System.ComponentModel.DataAnnotations" Condition=" '$(TargetFramework)'=='net452' " />
   </ItemGroup>

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fare" Version="[2.1.1,3.0.0)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.1" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <Reference Include="System.ComponentModel.DataAnnotations" Condition=" '$(TargetFramework)'=='net452' " />
   </ItemGroup>


### PR DESCRIPTION
### Description
Updated to next secured version 4.7.0 as recommended by Microsoft Advisory [here](https://github.com/dotnet/announcements/issues/111)

since System.Text.RegularExpressions 4.3.1 was release 14-05-2019, next secured stable versions for System.ComponentModel.Annotations are:
 - 4.6.0 - released 29-09-2019 
 - 4.7.0 - released 03-12-2019

Went for the last 4.7.0 since it's the last before net5 which is known to have breaking changes on APIs;
therefore limiting the change to addressing the security issue only, without major impact on the rest of the framework.

Snyk does not report the issue mentioned below when referencing System.ComponentModel.Annotations 4.7.0
### Closed issues
fixes #1356