### PR TITLE
Fixes exception when StringLength decorates non-string member

### DIFF
--- a/Src/AutoFixture/DataAnnotations/NumericRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/NumericRangedRequestRelay.cs
@@ -12,10 +12,9 @@ namespace AutoFixture.DataAnnotations
         /// <inheritdoc />
         public object Create(object request, ISpecimenContext context)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
-            var rangedRequest = request as RangedRequest;
-            if (rangedRequest == null)
+            if (request is not RangedRequest rangedRequest)
                 return new NoSpecimen();
 
             if (!rangedRequest.MemberType.IsNumberType())

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.Reflection;
 using AutoFixture.Kernel;
 
 namespace AutoFixture.DataAnnotations
@@ -33,21 +32,20 @@ namespace AutoFixture.DataAnnotations
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             var rangeAttribute = TypeEnvy.GetAttribute<RangeAttribute>(request);
-            if (rangeAttribute == null)
+            if (rangeAttribute is null)
             {
                 return new NoSpecimen();
             }
 
             var memberType = this.GetMemberType(rangeAttribute, request);
-            var rangedRequest =
-                new RangedRequest(
-                    memberType,
-                    rangeAttribute.OperandType,
-                    rangeAttribute.Minimum,
-                    rangeAttribute.Maximum);
+            var rangedRequest = new RangedRequest(
+                memberType,
+                rangeAttribute.OperandType,
+                rangeAttribute.Minimum,
+                rangeAttribute.Maximum);
 
             return context.Resolve(rangedRequest);
         }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthArgumentSupportTests.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthArgumentSupportTests.cs
@@ -11,11 +11,14 @@ namespace AutoFixtureUnitTest.DataAnnotations
         {
             // Arrange
             var fixture = new Fixture();
+
             // Act
             var actual = fixture.Create<ClassWithShortStringLengthConstrainedConstructorArgument>();
+
             // Assert
             Assert.True(
-                actual.ShortText.Length <= ClassWithShortStringLengthConstrainedConstructorArgument.ShortTextMaximumLength,
+                actual.ShortText.Length <=
+                ClassWithShortStringLengthConstrainedConstructorArgument.ShortTextMaximumLength,
                 "AutoFixture should respect [StringLength] attribute on constructor arguments.");
         }
 
@@ -24,8 +27,10 @@ namespace AutoFixtureUnitTest.DataAnnotations
         {
             // Arrange
             var fixture = new Fixture();
+
             // Act
             var actual = fixture.Create<ClassWithLongStringLengthConstrainedConstructorArgument>();
+
             // Assert
             Assert.Equal(
                 ClassWithLongStringLengthConstrainedConstructorArgument.LongTextLength,
@@ -38,7 +43,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             public readonly string ShortText;
 
             public ClassWithShortStringLengthConstrainedConstructorArgument(
-                [StringLength(ShortTextMaximumLength)]string shortText)
+                [StringLength(ShortTextMaximumLength)] string shortText)
             {
                 this.ShortText = shortText;
             }
@@ -50,7 +55,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             public readonly string LongText;
 
             public ClassWithLongStringLengthConstrainedConstructorArgument(
-                [StringLength(LongTextLength, MinimumLength = LongTextLength)]string longText)
+                [StringLength(LongTextLength, MinimumLength = LongTextLength)] string longText)
             {
                 this.LongText = longText;
             }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using AutoFixture;
 using AutoFixture.DataAnnotations;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
+using TestTypeFoundation;
 using Xunit;
 
 namespace AutoFixtureUnitTest.DataAnnotations
@@ -12,23 +16,25 @@ namespace AutoFixtureUnitTest.DataAnnotations
         [Fact]
         public void SutIsSpecimenBuilder()
         {
-            // Arrange
-            // Act
+            // Arrange & Act
             var sut = new StringLengthAttributeRelay();
+
             // Assert
             Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
         }
 
         [Fact]
-        public void CreateWithNullRequestReturnsCorrectResult()
+        public void CreateWithNullRequestReturnsNoSpecimen()
         {
             // Arrange
             var sut = new StringLengthAttributeRelay();
+            var context = new DelegatingSpecimenContext();
+
             // Act
-            var dummyContext = new DelegatingSpecimenContext();
-            var result = sut.Create(null, dummyContext);
+            var result = sut.Create(null, context);
+
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.IsType<NoSpecimen>(result);
         }
 
         [Fact]
@@ -36,24 +42,26 @@ namespace AutoFixtureUnitTest.DataAnnotations
         {
             // Arrange
             var sut = new StringLengthAttributeRelay();
-            var dummyRequest = new object();
+            var request = new object();
+
             // Act & assert
             Assert.Throws<ArgumentNullException>(() =>
-                sut.Create(dummyRequest, null));
+                sut.Create(request, null));
         }
 
         [Fact]
-        public void CreateWithAnonymousRequestReturnsCorrectResult()
+        public void CreateWithAnonymousRequestReturnsNoSpecimen()
         {
             // Arrange
             var sut = new StringLengthAttributeRelay();
-            var dummyRequest = new object();
+            var request = new object();
+            var context = new DelegatingSpecimenContext();
+
             // Act
-            var dummyContainer = new DelegatingSpecimenContext();
-            var result = sut.Create(dummyRequest, dummyContainer);
+            var result = sut.Create(request, context);
+
             // Assert
-            var expectedResult = new NoSpecimen();
-            Assert.Equal(expectedResult, result);
+            Assert.IsType<NoSpecimen>(result);
         }
 
         [Theory]
@@ -64,62 +72,199 @@ namespace AutoFixtureUnitTest.DataAnnotations
         [InlineData(typeof(string))]
         [InlineData(typeof(int))]
         [InlineData(typeof(Version))]
-        public void CreateWithNonConstrainedStringRequestReturnsCorrectResult(object request)
+        public void CreateForUnsupportedRequestReturnsNoSpecimen(object request)
         {
             // Arrange
             var sut = new StringLengthAttributeRelay();
+            var context = new DelegatingSpecimenContext();
+
             // Act
-            var dummyContext = new DelegatingSpecimenContext();
-            var result = sut.Create(request, dummyContext);
+            var result = sut.Create(request, context);
+
             // Assert
-            var expectedResult = new NoSpecimen();
-            Assert.Equal(expectedResult, result);
+            Assert.IsType<NoSpecimen>(result);
         }
 
         [Theory]
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
-        public void CreateWithConstrainedStringRequestReturnsCorrectResult(int maximum)
+        public void CreateWithConstrainedStringRequestReturnsExpectedResult(int maximum)
         {
             // Arrange
             var stringLengthAttribute = new StringLengthAttribute(maximum);
             var providedAttribute = new ProvidedAttribute(stringLengthAttribute, true);
             var request = new FakeMemberInfo(providedAttribute);
             var expectedRequest = new ConstrainedStringRequest(stringLengthAttribute.MaximumLength);
-            var expectedResult = new object();
+            var expected = new object();
+            var typeResolver = new DelegatingRequestMemberTypeResolver
+            {
+                OnTryGetMemberType = _ => typeof(string)
+            };
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expected : new NoSpecimen()
             };
-            var sut = new StringLengthAttributeRelay();
+            var sut = new StringLengthAttributeRelay
+            {
+                RequestMemberTypeResolver = typeResolver
+            };
+
             // Act
             var result = sut.Create(request, context);
+
             // Assert
-            Assert.Equal(expectedResult, result);
+            Assert.Same(expected, result);
         }
 
         [Theory]
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
-        public void CreateWithStringRequestConstrainedbyMinimunLengthReturnsCorrectResult(int maximum)
+        public void CreateWithStringRequestConstrainedByMinimumLengthReturnsCorrectResult(int maximum)
         {
             // Arrange
             var stringLengthAttribute = new StringLengthAttribute(maximum) { MinimumLength = 1 };
             var providedAttribute = new ProvidedAttribute(stringLengthAttribute, true);
             var request = new FakeMemberInfo(providedAttribute);
-            var expectedRequest = new ConstrainedStringRequest(stringLengthAttribute.MinimumLength, stringLengthAttribute.MaximumLength);
+            var expectedRequest = new ConstrainedStringRequest(stringLengthAttribute.MinimumLength,
+                stringLengthAttribute.MaximumLength);
             var expectedResult = new object();
+            var typeResolver = new DelegatingRequestMemberTypeResolver
+            {
+                OnTryGetMemberType = _ => typeof(string)
+            };
             var context = new DelegatingSpecimenContext
             {
                 OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
             };
-            var sut = new StringLengthAttributeRelay();
+            var sut = new StringLengthAttributeRelay
+            {
+                RequestMemberTypeResolver = typeResolver
+            };
+
             // Act
             var result = sut.Create(request, context);
+
             // Assert
             Assert.Equal(expectedResult, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUnsupportedValidatedMembers))]
+        public void CreateForUnsupportedValidatedMembersReturnNoSpecimen(object request)
+        {
+            // Arrange
+            var sut = new StringLengthAttributeRelay();
+            var context = new DelegatingSpecimenContext();
+
+            // Act
+            var actual = sut.Create(request, context);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNonValidatedMembers))]
+        public void CreateForNonValidatedMembersReturnNoSpecimen(object request)
+        {
+            // Arrange
+            var sut = new StringLengthAttributeRelay();
+            var context = new DelegatingSpecimenContext();
+
+            // Act
+            var actual = sut.Create(request, context);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetValidatedMembers))]
+        public void CreateForValidatedMembersReturnsSpecimen(object request)
+        {
+            // Arrange
+            var sut = new StringLengthAttributeRelay();
+            var expectedRequest = new ConstrainedStringRequest(5);
+            var expected = new object();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r => expectedRequest.Equals(r) ? expected : new NoSpecimen()
+            };
+
+            // Act
+            var actual = sut.Create(request, context);
+
+            // Assert
+            Assert.Same(expected, actual);
+        }
+
+        [Fact]
+        public void ShouldConstraintStringMembersDecoratedWithStringLengthAttribute()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            // Act
+            var propertyHolder = fixture.Create<StringLengthValidatedPropertyHolder<string>>();
+            var fieldHolder = fixture.Create<StringLengthValidatedFieldHolder<string>>();
+            var constructorHost = fixture.Create<StringLengthValidatedConstructorHost<string>>();
+            var actual = new[] { propertyHolder.Property, fieldHolder.Field, constructorHost.Value };
+
+            // Assert
+            Assert.All(actual, s => Assert.Equal(5, s.Length));
+        }
+
+        [Fact]
+        public void ShouldNotThrowWhenResolvingDecoratedMembersOfUnsupportedTypes()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            // Act
+            var results = new Action[]
+            {
+                () => _ = fixture.Create<StringLengthValidatedPropertyHolder<int>>(),
+                () => _ = fixture.Create<StringLengthValidatedPropertyHolder<List<string>>>(),
+                () => _ = fixture.Create<StringLengthValidatedPropertyHolder<string[]>>(),
+                () => _ = fixture.Create<StringLengthValidatedFieldHolder<int>>(),
+                () => _ = fixture.Create<StringLengthValidatedFieldHolder<List<string>>>(),
+                () => _ = fixture.Create<StringLengthValidatedFieldHolder<string[]>>(),
+                () => _ = fixture.Create<StringLengthValidatedConstructorHost<int>>(),
+                () => _ = fixture.Create<StringLengthValidatedConstructorHost<List<string>>>(),
+                () => _ = fixture.Create<StringLengthValidatedConstructorHost<string[]>>(),
+            }.Select(Record.Exception);
+
+            // Assert
+            Assert.All(results, Assert.Null);
+        }
+
+        public static IEnumerable<object[]> GetValidatedMembers()
+        {
+            yield return new object[] { StringLengthValidatedPropertyHolder<string>.GetProperty() };
+            yield return new object[] { StringLengthValidatedFieldHolder<string>.GetField() };
+            yield return new object[] { StringLengthValidatedConstructorHost<string>.GetParameter() };
+        }
+
+        public static IEnumerable<object[]> GetUnsupportedValidatedMembers()
+        {
+            yield return new object[] { StringLengthValidatedPropertyHolder<int>.GetProperty() };
+            yield return new object[] { StringLengthValidatedFieldHolder<int>.GetField() };
+            yield return new object[] { StringLengthValidatedConstructorHost<int>.GetParameter() };
+            yield return new object[] { StringLengthValidatedPropertyHolder<List<string>>.GetProperty() };
+            yield return new object[] { StringLengthValidatedFieldHolder<List<string>>.GetField() };
+            yield return new object[] { StringLengthValidatedConstructorHost<List<string>>.GetParameter() };
+            yield return new object[] { StringLengthValidatedPropertyHolder<EnumType>.GetProperty() };
+            yield return new object[] { StringLengthValidatedFieldHolder<EnumType>.GetField() };
+            yield return new object[] { StringLengthValidatedConstructorHost<EnumType>.GetParameter() };
+        }
+
+        public static IEnumerable<object[]> GetNonValidatedMembers()
+        {
+            yield return new object[] { PropertyHolder<string>.GetProperty() };
+            yield return new object[] { FieldHolder<string>.GetField() };
+            yield return new object[] { UnguardedConstructorHost<string>.GetParameter() };
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedConstructorHost.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedConstructorHost.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+
+namespace AutoFixtureUnitTest.DataAnnotations
+{
+    public class StringLengthValidatedConstructorHost<T>
+    {
+        public StringLengthValidatedConstructorHost([StringLength(5)] T value)
+        {
+            this.Value = value;
+        }
+
+        public T Value { get; private set; }
+
+        public static ParameterInfo GetParameter()
+        {
+            return typeof(StringLengthValidatedConstructorHost<T>)
+                .GetConstructor(new Type[] { typeof(T) })
+                ?.GetParameters().Single();
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedFieldHolder.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedFieldHolder.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace AutoFixtureUnitTest.DataAnnotations
+{
+    public class StringLengthValidatedFieldHolder<T>
+    {
+        [StringLength(5)]
+        public T Field;
+
+        public static FieldInfo GetField()
+        {
+            return typeof(StringLengthValidatedFieldHolder<T>)
+                .GetField(nameof(Field));
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedPropertyHolder.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedPropertyHolder.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace AutoFixtureUnitTest.DataAnnotations
+{
+    public class StringLengthValidatedPropertyHolder<T>
+    {
+        [StringLength(5)]
+        public T Property { get; set; }
+
+        public static PropertyInfo GetProperty()
+        {
+            return typeof(StringLengthValidatedPropertyHolder<T>)
+                .GetProperty(nameof(Property));
+        }
+    }
+}

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\Common.props" />
+  <Import Project="..\Common.props"/>
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
@@ -15,12 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Albedo" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Albedo" Version="[2.0.0,3.0.0)"/>
 
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard2.0' "/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj"/>
   </ItemGroup>
 </Project>

--- a/Src/TestTypeFoundation/FieldHolder.cs
+++ b/Src/TestTypeFoundation/FieldHolder.cs
@@ -1,7 +1,15 @@
-﻿namespace TestTypeFoundation
+﻿using System.Reflection;
+
+namespace TestTypeFoundation
 {
     public class FieldHolder<T>
     {
         public T Field;
+
+        public static FieldInfo GetField()
+        {
+            return typeof(FieldHolder<T>)
+                .GetRuntimeField(nameof(Field));
+        }
     }
 }

--- a/Src/TestTypeFoundation/PropertyHolder.cs
+++ b/Src/TestTypeFoundation/PropertyHolder.cs
@@ -1,4 +1,6 @@
-﻿namespace TestTypeFoundation
+﻿using System.Reflection;
+
+namespace TestTypeFoundation
 {
     public class PropertyHolder<T>
     {
@@ -7,6 +9,12 @@
         public void SetProperty(T value)
         {
             this.Property = value;
+        }
+
+        public static PropertyInfo GetProperty()
+        {
+            return typeof(PropertyHolder<T>)
+                .GetRuntimeProperty(nameof(Property));
         }
     }
 }

--- a/Src/TestTypeFoundation/UnguardedConstructorHost.cs
+++ b/Src/TestTypeFoundation/UnguardedConstructorHost.cs
@@ -1,4 +1,7 @@
-﻿namespace TestTypeFoundation
+﻿using System.Linq;
+using System.Reflection;
+
+namespace TestTypeFoundation
 {
     public class UnguardedConstructorHost<T>
     {
@@ -8,5 +11,18 @@
         }
 
         public T Item { get; }
+
+        private static ConstructorInfo GetConstructor()
+        {
+            var typeInfo = typeof(UnguardedConstructorHost<T>)
+                .GetTypeInfo();
+
+            return typeInfo.DeclaredConstructors.Single();
+        }
+
+        public static ParameterInfo GetParameter()
+        {
+            return GetConstructor().GetParameters().Single();
+        }
     }
 }


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
- Added type validation for members decorated with `[StringLength]` attribute

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
fixes #1365 

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
