### PR TITLE
ReadonlyCollectionPropertiesBehavior conversion bug fixed

### DIFF
--- a/Src/AutoFixture/Kernel/EnumerableEnvy.cs
+++ b/Src/AutoFixture/Kernel/EnumerableEnvy.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.Kernel
     {
         public static IEnumerable<object> ConvertObjectType(this IEnumerable<object> enumerable, Type type)
         {
-            return enumerable.Select(v => Convert.ChangeType(v, type, CultureInfo.CurrentCulture));
+            return enumerable.Select(v => v == null || type.IsAssignableFrom(v.GetType()) ? v : Convert.ChangeType(v, type, CultureInfo.CurrentCulture));
         }
     }
 }

--- a/Src/AutoFixture/Kernel/EnumerableEnvy.cs
+++ b/Src/AutoFixture/Kernel/EnumerableEnvy.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.Kernel
     {
         public static IEnumerable<object> ConvertObjectType(this IEnumerable<object> enumerable, Type type)
         {
-            return enumerable.Select(v => v == null || type.IsAssignableFrom(v.GetType()) ? v : Convert.ChangeType(v, type, CultureInfo.CurrentCulture));
+            return enumerable.Select(v => v == null || type.GetTypeInfo().IsAssignableFrom(v.GetTypeInfo().GetType()) ? v : Convert.ChangeType(v, type, CultureInfo.CurrentCulture));
         }
     }
 }

--- a/Src/AutoFixture/Kernel/EnumerableEnvy.cs
+++ b/Src/AutoFixture/Kernel/EnumerableEnvy.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.Kernel
     {
         public static IEnumerable<object> ConvertObjectType(this IEnumerable<object> enumerable, Type type)
         {
-            return enumerable.Select(v => v == null || type.GetTypeInfo().IsAssignableFrom(v.GetTypeInfo().GetType()) ? v : Convert.ChangeType(v, type, CultureInfo.CurrentCulture));
+            return enumerable.Select(v => v == null || type.GetTypeInfo().IsAssignableFrom(v.GetType().GetTypeInfo()) ? v : Convert.ChangeType(v, type, CultureInfo.CurrentCulture));
         }
     }
 }

--- a/Src/AutoFixture/Kernel/EnumerableEnvy.cs
+++ b/Src/AutoFixture/Kernel/EnumerableEnvy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 
 namespace AutoFixture.Kernel
 {


### PR DESCRIPTION
Fixed InvalidCastException: Object must implement IConvertible. when using ReadonlyCollectionPropertiesBehavior