### PR TITLE
Enabled portable PDBs for all target frameworks

### DIFF
--- a/Src/Common.props
+++ b/Src/Common.props
@@ -62,9 +62,7 @@
     <When Condition=" '$(Configuration)'=='Release' ">
       <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <!-- Ensure that we create Windows PDB for Full framework and Portable PDB for NET Core -->
-        <DebugType Condition=" '$(_IsFullFramework)'=='true' ">full</DebugType>
-        <DebugType Condition=" '$(_IsFullFramework)'!='true' ">portable</DebugType>
+        <DebugType>portable</DebugType>
       </PropertyGroup>
     </When>
     <When Condition=" '$(Configuration)'=='Verify' ">

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -121,7 +121,6 @@ partial class Build : NukeBuild
                 .SetConfiguration(Configuration)
                 .SetDeterministic(IsContinuousIntegration)
                 .SetContinuousIntegrationBuild(IsContinuousIntegration)
-                .SetSymbolPackageFormat(DotNetSymbolPackageFormat.snupkg)
                 .SetVersion(GitVersion.NuGetVersionV2)
                 .SetAssemblyVersion(GitVersion.AssemblySemVer)
                 .SetFileVersion(GitVersion.AssemblySemFileVer)


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
Fixes nuget.org error when uploading full debug symbols for .NET Framework assemblies.
"The uploaded symbols package contains one or more pdbs that are not portable. "

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
N/A

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
