### PR TITLE
Adding ISpecimenBuilder as param on With method

### DIFF
--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -174,6 +174,15 @@ namespace AutoFixture.Dsl
         }
 
         /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
+        {
+            return (CompositeNodeComposer<T>)this.ReplaceNodes(
+                with: n =>
+                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, (IFixture f) => f.Build<TProperty>().FromFactory(builder).Create()),
+                when: n => n is NodeComposer<T>);
+        }
+
+        /// <inheritdoc />
         public IPostprocessComposer<T> WithAutoProperties()
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -178,7 +178,7 @@ namespace AutoFixture.Dsl
         {
             return (CompositeNodeComposer<T>)this.ReplaceNodes(
                 with: n =>
-                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, (IFixture f) => f.Build<TProperty>().FromFactory(builder).Create()),
+                    (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, builder),
                 when: n => n is NodeComposer<T>);
         }
 

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -82,6 +82,13 @@ namespace AutoFixture.Dsl
         }
 
         /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
+        {
+            return new CompositePostprocessComposer<T>(from c in this.Composers
+                                                       select c.With(propertyPicker, builder));
+        }
+
+        /// <inheritdoc />
         public IPostprocessComposer<T> WithAutoProperties()
         {
             return new CompositePostprocessComposer<T>(from c in this.Composers

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -93,6 +93,21 @@ namespace AutoFixture.Dsl
         IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory);
 
         /// <summary>
+        /// Registers that a writable property or field should be assigned generated value as a part of specimen post-processing.
+        /// </summary>
+        /// <param name="propertyPicker">
+        /// An expression that identifies the property or field that will have <paramref name="builder"/> result assigned.
+        /// </param>
+        /// <param name="builder">
+        /// The specimen builder to assign to the property or field identified by <paramref name="propertyPicker"/>.
+        /// </param>
+        /// <returns>
+        /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
+        /// post-processing of created specimens.
+        /// </returns>
+        IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder);
+
+        /// <summary>
         /// Enables auto-properties for a type of specimen.
         /// </summary>
         /// <returns>

--- a/Src/AutoFixture/Dsl/IPostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/IPostprocessComposer.cs
@@ -105,6 +105,7 @@ namespace AutoFixture.Dsl
         /// An <see cref="IPostprocessComposer{T}"/> which can be used to further customize the
         /// post-processing of created specimens.
         /// </returns>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "With", Justification = "It's a part of the public API we currently have.")]
         IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder);
 
         /// <summary>

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -193,6 +193,12 @@ namespace AutoFixture.Dsl
                 }));
         }
 
+        /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
+        {
+            return this.With(propertyPicker, (IFixture f) => f.Build<TProperty>().FromFactory(builder).Create());
+        }
+
         private IPostprocessComposer<T> WithCommand<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenCommand command)
         {
             ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -198,7 +198,8 @@ namespace AutoFixture.Dsl
         {
             return this.WithCommand(
                 propertyPicker,
-                new BindingCommand<T, TProperty>(propertyPicker, builder));
+                new BindingCommand<T, TProperty>(propertyPicker,
+                    c => (TProperty)builder.Create(typeof(TProperty), c)));
         }
 
         private IPostprocessComposer<T> WithCommand<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenCommand command)

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -196,7 +196,9 @@ namespace AutoFixture.Dsl
         /// <inheritdoc />
         public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
         {
-            return this.With(propertyPicker, (IFixture f) => f.Build<TProperty>().FromFactory(builder).Create());
+            return this.WithCommand(
+                propertyPicker,
+                new BindingCommand<T, TProperty>(propertyPicker, builder));
         }
 
         private IPostprocessComposer<T> WithCommand<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenCommand command)

--- a/Src/AutoFixture/Dsl/NullComposer.cs
+++ b/Src/AutoFixture/Dsl/NullComposer.cs
@@ -82,6 +82,9 @@ namespace AutoFixture.Dsl
         public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory) => this;
 
         /// <inheritdoc />
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder) => this;
+
+        /// <inheritdoc />
         public IPostprocessComposer<T> WithAutoProperties() => this;
 
         /// <inheritdoc />

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -73,7 +73,6 @@ namespace AutoFixture.Kernel
             this.ValueCreator = valueCreator;
         }
 
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BindingCommand{T, TProperty}"/> class with
         /// the supplied property picker expression and a specimen builder.

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -106,14 +106,12 @@ namespace AutoFixture.Kernel
 
             var bindingValue = this.ValueCreator(context);
 
-            var pi = this.Member as PropertyInfo;
-            if (pi != null)
+            if (this.Member is PropertyInfo pi)
             {
                 pi.SetValue(specimen, bindingValue, null);
             }
 
-            var fi = this.Member as FieldInfo;
-            if (fi != null)
+            if (this.Member is FieldInfo fi)
             {
                 fi.SetValue(specimen, bindingValue);
             }
@@ -140,7 +138,7 @@ namespace AutoFixture.Kernel
         private TProperty CreateAnonymousValue(ISpecimenContext container)
         {
             var bindingValue = container.Resolve(this.Member);
-            if ((bindingValue != null) && !(bindingValue is TProperty))
+            if (bindingValue is not null and not TProperty)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
                     "The specimen created for assignment is not compatible with {0}.", typeof(TProperty)));
@@ -167,8 +165,7 @@ namespace AutoFixture.Kernel
 
             var bindingValue = this.ValueCreator(context);
 
-            var pi = this.Member as PropertyInfo;
-            if (pi != null)
+            if (this.Member is PropertyInfo pi)
             {
                 TrySetValue(
                     specimen,
@@ -177,8 +174,7 @@ namespace AutoFixture.Kernel
                     (s, v) => pi.SetValue(s, v, null));
             }
 
-            var fi = this.Member as FieldInfo;
-            if (fi != null)
+            if (this.Member is FieldInfo fi)
             {
                 TrySetValue(
                     specimen,

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -73,6 +73,25 @@ namespace AutoFixture.Kernel
             this.ValueCreator = valueCreator;
         }
 
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BindingCommand{T, TProperty}"/> class with
+        /// the supplied property picker expression and a specimen builder.
+        /// </summary>
+        /// <param name="propertyPicker">An expression that identifies a property or field.</param>
+        /// <param name="builder">
+        /// A specimen builder that creates a value that will be assigned to the property or field
+        /// identified by <paramref name="propertyPicker"/>.
+        /// </param>
+        public BindingCommand(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
+        {
+            if (propertyPicker is null) throw new ArgumentNullException(nameof(propertyPicker));
+            if (builder is null) throw new ArgumentNullException(nameof(builder));
+
+            this.Member = propertyPicker.GetWritableMember().Member;
+            this.ValueCreator = c => (TProperty)builder.Create(typeof(TProperty), c);
+        }
+
         /// <summary>
         /// Gets the member identified by the expression supplied through the constructor.
         /// </summary>

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -30,7 +30,7 @@ namespace AutoFixture.Kernel
         /// </remarks>
         public BindingCommand(Expression<Func<T, TProperty>> propertyPicker)
         {
-            if (propertyPicker == null) throw new ArgumentNullException(nameof(propertyPicker));
+            if (propertyPicker is null) throw new ArgumentNullException(nameof(propertyPicker));
 
             this.Member = propertyPicker.GetWritableMember().Member;
             this.ValueCreator = this.CreateAnonymousValue;
@@ -43,15 +43,11 @@ namespace AutoFixture.Kernel
         /// </summary>
         /// <param name="propertyPicker">An expression that identifies a property or field.</param>
         /// <param name="propertyValue">
-        /// The value to assign to the property or field identified by
-        /// <paramref name="propertyPicker"/>.
+        /// The value to assign to the property or field identified by <paramref name="propertyPicker"/>.
         /// </param>
         public BindingCommand(Expression<Func<T, TProperty>> propertyPicker, TProperty propertyValue)
+            : this(propertyPicker, _ => propertyValue)
         {
-            if (propertyPicker == null) throw new ArgumentNullException(nameof(propertyPicker));
-
-            this.Member = propertyPicker.GetWritableMember().Member;
-            this.ValueCreator = c => propertyValue;
         }
 
         /// <summary>
@@ -66,29 +62,11 @@ namespace AutoFixture.Kernel
         /// </param>
         public BindingCommand(Expression<Func<T, TProperty>> propertyPicker, Func<ISpecimenContext, TProperty> valueCreator)
         {
-            if (propertyPicker == null) throw new ArgumentNullException(nameof(propertyPicker));
-            if (valueCreator == null) throw new ArgumentNullException(nameof(valueCreator));
+            if (propertyPicker is null) throw new ArgumentNullException(nameof(propertyPicker));
+            if (valueCreator is null) throw new ArgumentNullException(nameof(valueCreator));
 
             this.Member = propertyPicker.GetWritableMember().Member;
             this.ValueCreator = valueCreator;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BindingCommand{T, TProperty}"/> class with
-        /// the supplied property picker expression and a specimen builder.
-        /// </summary>
-        /// <param name="propertyPicker">An expression that identifies a property or field.</param>
-        /// <param name="builder">
-        /// A specimen builder that creates a value that will be assigned to the property or field
-        /// identified by <paramref name="propertyPicker"/>.
-        /// </param>
-        public BindingCommand(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
-        {
-            if (propertyPicker is null) throw new ArgumentNullException(nameof(propertyPicker));
-            if (builder is null) throw new ArgumentNullException(nameof(builder));
-
-            this.Member = propertyPicker.GetWritableMember().Member;
-            this.ValueCreator = c => (TProperty)builder.Create(typeof(TProperty), c);
         }
 
         /// <summary>
@@ -123,8 +101,8 @@ namespace AutoFixture.Kernel
         [Obsolete("This method is no longer used and will be removed in future versions. Please use the Execute(object, ISpecimenContext) overload instead.")]
         public void Execute(T specimen, ISpecimenContext context)
         {
-            if (specimen == null) throw new ArgumentNullException(nameof(specimen));
-            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (specimen is null) throw new ArgumentNullException(nameof(specimen));
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             var bindingValue = this.ValueCreator(context);
 
@@ -153,7 +131,7 @@ namespace AutoFixture.Kernel
         [Obsolete("This method is no longer used and will be removed in future versions. Please use this.Member property for specification instead.")]
         public bool IsSatisfiedBy(object request)
         {
-            if (request == null) throw new ArgumentNullException(nameof(request));
+            if (request is null) throw new ArgumentNullException(nameof(request));
 
             IEqualityComparer comparer = new MemberInfoEqualityComparer();
             return comparer.Equals(this.Member, request);
@@ -167,6 +145,7 @@ namespace AutoFixture.Kernel
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
                     "The specimen created for assignment is not compatible with {0}.", typeof(TProperty)));
             }
+
             return (TProperty)bindingValue;
         }
 
@@ -183,8 +162,8 @@ namespace AutoFixture.Kernel
         /// </remarks>
         public void Execute(object specimen, ISpecimenContext context)
         {
-            if (specimen == null) throw new ArgumentNullException(nameof(specimen));
-            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (specimen is null) throw new ArgumentNullException(nameof(specimen));
+            if (context is null) throw new ArgumentNullException(nameof(context));
 
             var bindingValue = this.ValueCreator(context);
 
@@ -219,11 +198,8 @@ namespace AutoFixture.Kernel
             {
                 setValue(specimen, value);
             }
-            catch (ArgumentException)
+            catch (ArgumentException) when (value is IConvertible)
             {
-                if (!(value is IConvertible))
-                    throw;
-
                 setValue(
                     specimen,
                     Convert.ChangeType(

--- a/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using AutoFixture;
 using AutoFixture.Dsl;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
@@ -527,6 +528,35 @@ namespace AutoFixtureUnitTest.Dsl
                     (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, valueFactory),
                     SpecimenBuilderNodeFactory.CreateComposer<Version>(),
                     (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, valueFactory),
+                    new DelegatingSpecimenBuilder()));
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foo")]
+        [InlineData("bar")]
+        public void WithSpecimenBuilderReturnsCorrectResult(string value)
+        {
+            // Arrange
+            var node = new CompositeSpecimenBuilder(
+                new DelegatingSpecimenBuilder(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>(),
+                new DelegatingSpecimenBuilder());
+            var sut = new CompositeNodeComposer<PropertyHolder<string>>(node);
+            var builder = new ElementsBuilder<string>(value);
+            // Act
+            var actual = sut.With(x => x.Property, builder);
+            // Assert
+            var expected = new CompositeNodeComposer<PropertyHolder<string>>(
+                new CompositeSpecimenBuilder(
+                    new DelegatingSpecimenBuilder(),
+                    (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, builder),
+                    SpecimenBuilderNodeFactory.CreateComposer<Version>(),
+                    (ISpecimenBuilder)SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>().With(x => x.Property, builder),
                     new DelegatingSpecimenBuilder()));
             var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
             Assert.True(expected.GraphEquals(n, new NodeComparer()));

--- a/Src/AutoFixtureUnitTest/Dsl/CompositePostprocessComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositePostprocessComposerTest.cs
@@ -182,6 +182,28 @@ namespace AutoFixtureUnitTest.Dsl
         }
 
         [Fact]
+        public void WithSpecimenBuilderReturnsCorrectResult()
+        {
+            // Arrange
+            Expression<Func<PropertyHolder<object>, object>> expectedExpression = x => x.Property;
+            var builder = new AutoFixture.ElementsBuilder<object>(new object());
+
+            var expectedComposers = Enumerable.Range(1, 3).Select(i => new DelegatingComposer<PropertyHolder<object>>()).ToArray();
+            var initialComposers = (from c in expectedComposers
+                                    select new DelegatingComposer<PropertyHolder<object>>
+                                    {
+                                        OnWithOverloadFactory = (f, vf) =>
+                                            f == expectedExpression && object.Equals(vf, builder) ? c : new DelegatingComposer<PropertyHolder<object>>()
+                                    }).ToArray();
+            var sut = new CompositePostprocessComposer<PropertyHolder<object>>(initialComposers);
+            // Act
+            var result = sut.With(expectedExpression, builder);
+            // Assert
+            var composite = Assert.IsAssignableFrom<CompositePostprocessComposer<PropertyHolder<object>>>(result);
+            Assert.True(expectedComposers.SequenceEqual(composite.Composers));
+        }
+
+        [Fact]
         public void WithAutoPropertiesReturnsCorrectResult()
         {
             // Arrange

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -61,6 +61,9 @@ namespace AutoFixtureUnitTest.Dsl
         public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory) =>
             this.OnWithOverloadFactory(propertyPicker, valueFactory);
 
+        public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder) =>
+            this.OnWithOverloadFactory(propertyPicker, builder);
+
         public IPostprocessComposer<T> WithAutoProperties() => this.OnWithAutoProperties();
 
         public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker) =>

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using AutoFixture;
 using AutoFixture.Dsl;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
@@ -580,6 +581,48 @@ namespace AutoFixtureUnitTest.Dsl
             Func<string, string> valueFactory = v => v;
             // Act
             var actual = sut.With(x => x.Property, valueFactory);
+            // Assert
+            var expected = new NodeComposer<PropertyHolder<string>>(
+                new FilteringSpecimenBuilder(
+                    new CompositeSpecimenBuilder(
+                        new Postprocessor(
+                            new Postprocessor(
+                                new NoSpecimenOutputGuard(
+                                    new MethodInvoker(
+                                        new ModestConstructorQuery()),
+                                    new InverseRequestSpecification(
+                                        new SeedRequestSpecification(
+                                            typeof(PropertyHolder<string>)))),
+                                new AutoPropertiesCommand(
+                                    typeof(PropertyHolder<string>),
+                                    new InverseRequestSpecification(
+                                        new EqualRequestSpecification(
+                                            pi,
+                                            new MemberInfoEqualityComparer()))),
+                                new FalseRequestSpecification()),
+                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, ctx => valueFactory((string)ctx.Resolve(typeof(string)))),
+                            new OrRequestSpecification(
+                                new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                                new ExactTypeSpecification(typeof(PropertyHolder<string>)))),
+                        new SeedIgnoringRelay()),
+                    new OrRequestSpecification(
+                        new SeedRequestSpecification(typeof(PropertyHolder<string>)),
+                        new ExactTypeSpecification(typeof(PropertyHolder<string>)))));
+
+            var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
+            Assert.True(expected.GraphEquals(n, new NodeComparer()));
+        }
+        
+        [Fact]
+        public void WithSpecimenBuilderReturnsCorrectResult()
+        {
+            // Arrange
+            var sut = SpecimenBuilderNodeFactory.CreateComposer<PropertyHolder<string>>();
+            var pi = typeof(PropertyHolder<string>).GetProperty("Property");
+            Func<string, string> valueFactory = v => v;
+            var builder = new ElementsBuilder<string>(Guid.NewGuid().ToString());
+            // Act
+            var actual = sut.With(x => x.Property, builder);
             // Assert
             var expected = new NodeComposer<PropertyHolder<string>>(
                 new FilteringSpecimenBuilder(

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -612,7 +612,7 @@ namespace AutoFixtureUnitTest.Dsl
             var n = Assert.IsAssignableFrom<ISpecimenBuilderNode>(actual);
             Assert.True(expected.GraphEquals(n, new NodeComparer()));
         }
-        
+
         [Fact]
         public void WithSpecimenBuilderReturnsCorrectResult()
         {

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -642,7 +642,7 @@ namespace AutoFixtureUnitTest.Dsl
                                             pi,
                                             new MemberInfoEqualityComparer()))),
                                 new FalseRequestSpecification()),
-                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, ctx => valueFactory((string)ctx.Resolve(typeof(string)))),
+                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, builder),
                             new OrRequestSpecification(
                                 new SeedRequestSpecification(typeof(PropertyHolder<string>)),
                                 new ExactTypeSpecification(typeof(PropertyHolder<string>)))),

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using AutoFixture;
 using AutoFixture.Dsl;

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -642,7 +642,7 @@ namespace AutoFixtureUnitTest.Dsl
                                             pi,
                                             new MemberInfoEqualityComparer()))),
                                 new FalseRequestSpecification()),
-                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, builder),
+                            new BindingCommand<PropertyHolder<string>, string>(x => x.Property, c => (string)builder.Create(typeof(string), c)),
                             new OrRequestSpecification(
                                 new SeedRequestSpecification(typeof(PropertyHolder<string>)),
                                 new ExactTypeSpecification(typeof(PropertyHolder<string>)))),

--- a/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NullComposerTest.cs
@@ -218,6 +218,18 @@ namespace AutoFixtureUnitTest.Dsl
         }
 
         [Fact]
+        public void WithSpecimenBuilderReturnsCorrectResult()
+        {
+            // Arrange
+            var sut = new NullComposer<PropertyHolder<object>>();
+            var dummyFactory = new DelegatingSpecimenBuilder();
+            // Act
+            var result = sut.With(x => x.Property, dummyFactory);
+            // Assert
+            Assert.Same(sut, result);
+        }
+
+        [Fact]
         public void WithAutoPropertiesReturnsCorrectResult()
         {
             // Arrange

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -1947,6 +1947,24 @@ namespace AutoFixtureUnitTest
         }
 
         [Fact]
+        public void RegisterTypeWithBuilderCanResolveValuesFromUnderlyingContext()
+        {
+            // Arrange
+            var builder = new DelegatingSpecimenBuilder
+            {
+                OnCreate = (r, c) => c.Resolve(r)
+            };
+            var sut = new Fixture();
+            var frozenValue = sut.Freeze<string>();
+            // Act
+            sut.Customize<PropertyHolder<string>>(f => f.With(ph => ph.Property, builder));
+            var result = sut.Create<PropertyHolder<string>>();
+
+            // Assert
+            Assert.Equal(frozenValue, result.Property);
+        }
+
+        [Fact]
         public void RegisterTypeWithDefaultPrimitiveBuilderSetsPropertyValueCorrectly()
         {
             // Arrange

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -1915,6 +1915,84 @@ namespace AutoFixtureUnitTest
         }
 
         [Fact]
+        public void RegisterTypeWithElementsBuilderSetsPropertyValueCorrectly()
+        {
+            // Arrange
+            var values = new[] { "one", "two", "three" };
+            var builder = new ElementsBuilder<string>(values);
+            var sut = new Fixture();
+            // Act
+            sut.Customize<PropertyHolder<string>>(f => f.With(ph => ph.Property, builder));
+            var result = sut.CreateMany<PropertyHolder<string>>();
+
+            // Assert
+            Assert.All(result, result =>
+            {
+                Assert.Contains(result.Property, values);
+            });
+        }
+
+        [Fact]
+        public void RegisterTypeWithFixedPropertyBuilderSetsPropertyValueCorrectly()
+        {
+            // Arrange
+            var builder = new FixedBuilder("hello-world");
+            var sut = new Fixture();
+            // Act
+            sut.Customize<PropertyHolder<string>>(f => f.With(ph => ph.Property, builder));
+            var result = sut.Create<PropertyHolder<string>>();
+
+            // Assert
+            Assert.Equal("hello-world", result.Property);
+        }
+
+        [Fact]
+        public void RegisterTypeWithDefaultPrimitiveBuilderSetsPropertyValueCorrectly()
+        {
+            // Arrange
+            var builder = new CompositeSpecimenBuilder(new DefaultPrimitiveBuilders());
+            var sut = new Fixture();
+            // Act
+            sut.Customize<PropertyHolder<string>>(f => f.With(ph => ph.Property, builder));
+            var result = sut.Create<PropertyHolder<string>>();
+
+            // Assert
+            Assert.True(Guid.TryParse(result.Property, out var _));
+        }
+
+        [Fact]
+        public void RegisterTypeWithBuilderReturningIncorrectTypeThrowsCastException()
+        {
+            // Arrange
+            var builder = new FixedBuilder(42);
+            var sut = new Fixture();
+
+            // Act
+            sut.Customize<PropertyHolder<string>>(f => f.With(ph => ph.Property, builder));
+
+            // Assert
+            var exception = Record.Exception(() => sut.Create<PropertyHolder<string>>());
+            Assert.IsAssignableFrom<ObjectCreationException>(exception);
+            Assert.IsType<InvalidCastException>(exception.InnerException);
+        }
+
+        [Fact]
+        public void RegisteringTypeWithPropertyBuilderRespectsOmittingAutoProperties()
+        {
+            // Arrange
+            var builder = new FixedBuilder("some-string");
+            var sut = new Fixture();
+
+            // Act
+            sut.Customize<DoublePropertyHolder<string, string>>(f => f.With(ph => ph.Property1, builder).OmitAutoProperties());
+            var actual = sut.Create<DoublePropertyHolder<string, string>>();
+
+            // Assert
+            Assert.Equal("some-string", actual.Property1);
+            Assert.Null(actual.Property2);
+        }
+
+        [Fact]
         public void CreateNestedTypeWillPopulateNestedProperty()
         {
             // Arrange

--- a/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using AutoFixture;
 using AutoFixture.Kernel;
 using TestTypeFoundation;
 using Xunit;

--- a/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
@@ -55,15 +55,6 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void InitializeSpecimenBuilderConstructorWithNullPropertyPickerWillThrow()
-        {
-            // Arrange
-            var builder = new ElementsBuilder<object>(new object());
-            // Act & assert
-            Assert.Throws<ArgumentNullException>(() => new BindingCommand<PropertyHolder<object>, object>(null, builder));
-        }
-
-        [Fact]
         public void InitializeDelegateValueConstructorWithNonMemberExpressionWillThrow()
         {
             // Arrange
@@ -121,16 +112,6 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void InitializeSpecimenBuilderConstructorWithNonMemberExpressionWillThrow()
-        {
-            // Arrange
-            Expression<Func<object, object>> invalidExpression = obj => obj;
-            var dummyBuilder = new ElementsBuilder<object>(new object());
-            // Act & assert
-            Assert.Throws<ArgumentException>(() => new BindingCommand<object, object>(invalidExpression, dummyBuilder));
-        }
-
-        [Fact]
         public void InitializeInstanceValueConstructorWithMethodExpressionWillThrow()
         {
             // Arrange
@@ -138,18 +119,6 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyValue = "Anonymous value";
             // Act & assert
             Assert.Throws<ArgumentException>(() => new BindingCommand<object, string>(methodExpression, dummyValue));
-        }
-
-        [Fact]
-        public void InitializeSpecimenBuilderConstructorWithMethodExpressionWillThrow()
-        {
-            // Arrange
-            Expression<Func<object, string>> methodExpression = obj => obj.ToString();
-            var dummyValue = "Anonymous value";
-            var builder = new ElementsBuilder<string>(dummyValue);
-
-            // Act & assert
-            Assert.Throws<ArgumentException>(() => new BindingCommand<object, string>(methodExpression, builder));
         }
 
         [Fact]
@@ -163,32 +132,12 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void InitializeSpecimenBuilderConstructorWithReadOnlyPropertyExpressionWillThrow()
-        {
-            // Arrange
-            Expression<Func<SingleParameterType<object>, object>> readOnlyPropertyExpression = sp => sp.Parameter;
-            var dummyValue = new object();
-            var builder = new ElementsBuilder<object>(dummyValue);
-            // Act & assert
-            Assert.Throws<ArgumentException>(() => new BindingCommand<SingleParameterType<object>, object>(readOnlyPropertyExpression, builder));
-        }
-
-        [Fact]
         public void InitializeInstanceValueConstructorWithNullValueDoesNotThrow()
         {
             // Arrange
             // Act & assert
             Assert.Null(Record.Exception(() =>
                 new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, (object)null)));
-        }
-
-        [Fact]
-        public void InitializeSpecimenBuilderConstructorWithNullValueWillThrow()
-        {
-            // Arrange
-            // Act & assert
-            Assert.Throws<ArgumentNullException>(() =>
-                 new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, (ISpecimenBuilder)null));
         }
 
         [Fact]
@@ -498,22 +447,6 @@ namespace AutoFixtureUnitTest.Kernel
             var expectedValue = new object();
 
             var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, expectedValue);
-            var specimen = new PropertyHolder<object>();
-            // Act
-            var dummyContext = new DelegatingSpecimenContext();
-            sut.Execute((object)specimen, dummyContext);
-            // Assert
-            Assert.Equal(expectedValue, specimen.Property);
-        }
-
-        [Fact]
-        public void ExecuteSetsCorrectPropertyWhenUsingSpecimenBuilderWithSuppliedValue()
-        {
-            // Arrange
-            var expectedValue = new object();
-
-            var builder = new ElementsBuilder<object>(expectedValue);
-            var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, builder);
             var specimen = new PropertyHolder<object>();
             // Act
             var dummyContext = new DelegatingSpecimenContext();


### PR DESCRIPTION
### Description
Accepting `ISpecimentBuilder` interface as value generator for `With` method:

``` c#
  ISpecimenBuilder specimenBuilder = new ElementsBuilder<string>("ios", "windows", "linux");

  var foo = _fixture.Build<Data>()
                   .With(d => d.Name, specimenBuilder)
                   .Create();
```

### Closed issues
#1421

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
