### PR TITLE
Added .NET 6 time structs

### DIFF
--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -31,6 +31,9 @@ namespace AutoFixture
             yield return new RandomRangedNumberGenerator();
             yield return new RegularExpressionGenerator();
             yield return new RandomDateTimeSequenceGenerator();
+#if NET6_0_OR_GREATER
+            yield return new RandomDateOnlySequenceGenerator();
+#endif
             yield return new BooleanSwitch();
             yield return new GuidGenerator();
             yield return new TypeGenerator();

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -33,6 +33,7 @@ namespace AutoFixture
             yield return new RandomDateTimeSequenceGenerator();
 #if NET6_0_OR_GREATER
             yield return new RandomDateOnlySequenceGenerator();
+            yield return new RandomTimeOnlySequenceGenerator();
 #endif
             yield return new BooleanSwitch();
             yield return new GuidGenerator();

--- a/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
@@ -1,0 +1,82 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture;
+
+/// <summary>
+/// Creates random <see cref="DateOnly"/> specimens.
+/// </summary>
+/// <remarks>
+/// The generated <see cref="DateOnly"/> values will be within
+/// a range of ± two years from today's date,
+/// unless a different range has been specified in the constructor.
+/// </remarks>
+public class RandomDateOnlySequenceGenerator : ISpecimenBuilder
+{
+    private readonly RandomNumericSequenceGenerator randomizer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RandomDateOnlySequenceGenerator"/> class.
+    /// </summary>
+    public RandomDateOnlySequenceGenerator()
+        : this(DateOnly.FromDateTime(DateTime.Today).AddYears(-2),
+               DateOnly.FromDateTime(DateTime.Today).AddYears(2))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RandomDateOnlySequenceGenerator"/> class
+    /// for a specific range of dates.
+    /// </summary>
+    /// <param name="minDate">The lower bound of the date range.</param>
+    /// <param name="maxDate">The upper bound of the date range.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="minDate"/> is greater than <paramref name="maxDate"/>.
+    /// </exception>
+    public RandomDateOnlySequenceGenerator(DateOnly minDate, DateOnly maxDate)
+    {
+        if (minDate >= maxDate)
+        {
+            throw new ArgumentException("The 'minDate' argument must be less than the 'maxDate'.");
+        }
+
+        this.randomizer = new RandomNumericSequenceGenerator(minDate.DayNumber, maxDate.DayNumber);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="DateOnly"/> specimen based on a request.
+    /// </summary>
+    /// <param name="request">The request that describes what to create.</param>
+    /// <param name="context">Not used.</param>
+    /// <returns>
+    /// A new <see cref="DateOnly"/> specimen, if <paramref name="request"/> is a request for a
+    /// <see cref="DateOnly"/> value; otherwise, a <see cref="NoSpecimen"/> instance.
+    /// </returns>
+    public object Create(object request, ISpecimenContext context)
+    {
+        if (context is null) throw new ArgumentNullException(nameof(context));
+
+        return IsNotDateOnlyRequest(request)
+            ? new NoSpecimen()
+            : this.CreateRandomDate(context);
+    }
+
+    private static bool IsNotDateOnlyRequest(object request)
+    {
+        return !typeof(DateOnly).GetTypeInfo().IsAssignableFrom(request as Type);
+    }
+
+    private object CreateRandomDate(ISpecimenContext context)
+    {
+        return DateOnly.FromDayNumber(this.GetRandomNumberOfDays(context));
+    }
+
+    private int GetRandomNumberOfDays(ISpecimenContext context)
+    {
+        return (int)this.randomizer.Create(typeof(int), context);
+    }
+}
+#endif

--- a/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
@@ -59,24 +59,13 @@ public class RandomDateOnlySequenceGenerator : ISpecimenBuilder
     {
         if (context is null) throw new ArgumentNullException(nameof(context));
 
-        return IsNotDateOnlyRequest(request)
-            ? new NoSpecimen()
-            : this.CreateRandomDate(context);
-    }
+        if (!typeof(DateOnly).GetTypeInfo().IsAssignableFrom(request as Type))
+        {
+            return new NoSpecimen();
+        }
 
-    private static bool IsNotDateOnlyRequest(object request)
-    {
-        return !typeof(DateOnly).GetTypeInfo().IsAssignableFrom(request as Type);
-    }
-
-    private object CreateRandomDate(ISpecimenContext context)
-    {
-        return DateOnly.FromDayNumber(this.GetRandomNumberOfDays(context));
-    }
-
-    private int GetRandomNumberOfDays(ISpecimenContext context)
-    {
-        return (int)this.randomizer.Create(typeof(int), context);
+        var dayNumber = (int)this.randomizer.Create(typeof(int), context);
+        return DateOnly.FromDayNumber(dayNumber);
     }
 }
 #endif

--- a/Src/AutoFixture/RandomTimeOnlySequenceGenerator.cs
+++ b/Src/AutoFixture/RandomTimeOnlySequenceGenerator.cs
@@ -1,0 +1,71 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Reflection;
+using AutoFixture.Kernel;
+
+namespace AutoFixture;
+
+/// <summary>
+/// Creates random <see cref="TimeOnly"/> specimens.
+/// </summary>
+/// <remarks>
+/// The generated <see cref="TimeOnly"/> values will be within
+/// a range of ± six hours from noon,
+/// unless a different range has been specified in the constructor.
+/// </remarks>
+public class RandomTimeOnlySequenceGenerator : ISpecimenBuilder
+{
+    private static readonly TimeOnly Default = new(12, 0);
+    private readonly RandomNumericSequenceGenerator randomizer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RandomTimeOnlySequenceGenerator"/> class.
+    /// </summary>
+    public RandomTimeOnlySequenceGenerator()
+        : this(Default.AddHours(-6), Default.AddHours(6))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RandomTimeOnlySequenceGenerator"/> class
+    /// for a specific range of time.
+    /// </summary>
+    /// <param name="minTime">The lower bound of the time range.</param>
+    /// <param name="maxTime">The upper bound of the time range.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="minTime"/> is greater than <paramref name="maxTime"/>.
+    /// </exception>
+    public RandomTimeOnlySequenceGenerator(TimeOnly minTime, TimeOnly maxTime)
+    {
+        if (minTime >= maxTime)
+        {
+            throw new ArgumentException("The 'minTime' argument must be less than the 'maxTime'.");
+        }
+
+        this.randomizer = new RandomNumericSequenceGenerator(minTime.Ticks, maxTime.Ticks);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="TimeOnly"/> specimen based on a request.
+    /// </summary>
+    /// <param name="request">The request that describes what to create.</param>
+    /// <param name="context">Not used.</param>
+    /// <returns>
+    /// A new <see cref="TimeOnly"/> specimen, if <paramref name="request"/> is a request for a
+    /// <see cref="TimeOnly"/> value; otherwise, a <see cref="NoSpecimen"/> instance.
+    /// </returns>
+    public object Create(object request, ISpecimenContext context)
+    {
+        if (context is null) throw new ArgumentNullException(nameof(context));
+
+        if (!typeof(TimeOnly).GetTypeInfo().IsAssignableFrom(request as Type))
+        {
+            return new NoSpecimen();
+        }
+
+        var ticks = (long)this.randomizer.Create(typeof(long), context);
+        return new TimeOnly(ticks);
+    }
+}
+#endif

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -36,6 +36,9 @@ namespace AutoFixtureUnitTest
                     typeof(RandomRangedNumberGenerator),
                     typeof(RegularExpressionGenerator),
                     typeof(RandomDateTimeSequenceGenerator),
+#if NET6_0_OR_GREATER
+                    typeof(RandomDateOnlySequenceGenerator),
+#endif
                     typeof(BooleanSwitch),
                     typeof(GuidGenerator),
                     typeof(TypeGenerator),

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -38,6 +38,7 @@ namespace AutoFixtureUnitTest
                     typeof(RandomDateTimeSequenceGenerator),
 #if NET6_0_OR_GREATER
                     typeof(RandomDateOnlySequenceGenerator),
+                    typeof(RandomTimeOnlySequenceGenerator),
 #endif
                     typeof(BooleanSwitch),
                     typeof(GuidGenerator),

--- a/Src/AutoFixtureUnitTest/RandomDateOnlySequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomDateOnlySequenceGeneratorTest.cs
@@ -1,0 +1,157 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Linq;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace AutoFixtureUnitTest;
+
+public class RandomDateOnlySequenceGeneratorTest
+{
+    [Fact]
+    public void SutIsSpecimenBuilder()
+    {
+        // Arrange
+        // Act
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Assert
+        Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+    }
+
+    [Fact]
+    public void InitializeWithInvertedDateRangeThrowsArgumentException()
+    {
+        // Arrange
+        var minDate = DateOnly.FromDateTime(DateTime.Now);
+        var maxDate = minDate.AddDays(3);
+        // Act & assert
+        Assert.Throws<ArgumentException>(
+            () => new RandomDateOnlySequenceGenerator(maxDate, minDate));
+    }
+
+    [Fact]
+    public void InitializeWithEmptyDateRangeThrowsArgumentException()
+    {
+        // Arrange
+        var date = DateOnly.FromDateTime(DateTime.Now);
+        // Act & assert
+        Assert.Throws<ArgumentException>(
+            () => new RandomDateOnlySequenceGenerator(date, date));
+    }
+
+    [Fact]
+    public void CreateWithNullRequestReturnsNoSpecimen()
+    {
+        // Arrange
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = sut.Create(null, dummyContainer);
+        // Assert
+        Assert.Equal(new NoSpecimen(), result);
+    }
+
+    [Fact]
+    public void CreateWithNullContextThrowsArgumentNullException()
+    {
+        // Arrange
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Act & assert
+        Assert.Throws<ArgumentNullException>(
+            () => sut.Create(typeof(DateOnly), null));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(default(int))]
+    [InlineData(default(bool))]
+    public void CreateWithNonTypeRequestReturnsNoSpecimen(object request)
+    {
+        // Arrange
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = sut.Create(request, dummyContainer);
+        // Assert
+        Assert.Equal(new NoSpecimen(), result);
+    }
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(object))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(bool))]
+    public void CreateWithNonDateTimeTypeRequestReturnsNoSpecimen(Type request)
+    {
+        // Arrange
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = sut.Create(request, dummyContainer);
+        // Assert
+        Assert.Equal(new NoSpecimen(), result);
+    }
+
+    [Fact]
+    public void CreateWithDateTimeRequestReturnsDateTimeValue()
+    {
+        // Arrange
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = sut.Create(typeof(DateOnly), dummyContainer);
+        // Assert
+        Assert.IsAssignableFrom<DateOnly>(result);
+    }
+
+    [Fact]
+    public void CreateWithDateTimeRequestReturnsADateWithinARangeOfPlusMinusTwoYearsFromToday()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var twoYearsAgo = today.AddYears(-2);
+        var twoYearsForward = today.AddYears(2);
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = (DateOnly)sut.Create(typeof(DateOnly), dummyContainer);
+        // Assert
+        Assert.InRange(result, twoYearsAgo, twoYearsForward);
+    }
+
+    [Fact]
+    public void CreateWithMultipleDateTimeRequestsReturnsDifferentDates()
+    {
+        // Arrange
+        const int requestCount = 10;
+        var times = Enumerable.Range(1, requestCount);
+        var sut = new RandomDateOnlySequenceGenerator();
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var results = times
+            .Select(t => sut.Create(typeof(DateOnly), dummyContainer))
+            .Cast<DateOnly>();
+        // Assert
+        Assert.Equal(requestCount, results.Distinct().Count());
+    }
+
+    [Fact]
+    public void CreateWithDateTimeRequestAndDateRangeReturnsDateWithinThatRange()
+    {
+        // Arrange
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var minDate = today;
+        var maxDate = minDate.AddDays(3);
+        var sut = new RandomDateOnlySequenceGenerator(minDate, maxDate);
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = (DateOnly)sut.Create(typeof(DateOnly), dummyContainer);
+        // Assert
+        Assert.InRange(result, minDate, maxDate);
+    }
+}
+
+#endif

--- a/Src/AutoFixtureUnitTest/RandomDateOnlySequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomDateOnlySequenceGeneratorTest.cs
@@ -14,9 +14,9 @@ public class RandomDateOnlySequenceGeneratorTest
     [Fact]
     public void SutIsSpecimenBuilder()
     {
-        // Arrange
-        // Act
+        // Arrange & Act
         var sut = new RandomDateOnlySequenceGenerator();
+
         // Assert
         Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
     }
@@ -25,8 +25,9 @@ public class RandomDateOnlySequenceGeneratorTest
     public void InitializeWithInvertedDateRangeThrowsArgumentException()
     {
         // Arrange
-        var minDate = DateOnly.FromDateTime(DateTime.Now);
+        var minDate = new DateOnly(2013, 07, 21);
         var maxDate = minDate.AddDays(3);
+
         // Act & assert
         Assert.Throws<ArgumentException>(
             () => new RandomDateOnlySequenceGenerator(maxDate, minDate));
@@ -36,7 +37,8 @@ public class RandomDateOnlySequenceGeneratorTest
     public void InitializeWithEmptyDateRangeThrowsArgumentException()
     {
         // Arrange
-        var date = DateOnly.FromDateTime(DateTime.Now);
+        var date = new DateOnly(2017, 08, 12);
+
         // Act & assert
         Assert.Throws<ArgumentException>(
             () => new RandomDateOnlySequenceGenerator(date, date));
@@ -47,9 +49,11 @@ public class RandomDateOnlySequenceGeneratorTest
     {
         // Arrange
         var sut = new RandomDateOnlySequenceGenerator();
-        // Act
         var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
         var result = sut.Create(null, dummyContainer);
+
         // Assert
         Assert.Equal(new NoSpecimen(), result);
     }
@@ -59,6 +63,7 @@ public class RandomDateOnlySequenceGeneratorTest
     {
         // Arrange
         var sut = new RandomDateOnlySequenceGenerator();
+
         // Act & assert
         Assert.Throws<ArgumentNullException>(
             () => sut.Create(typeof(DateOnly), null));
@@ -72,9 +77,11 @@ public class RandomDateOnlySequenceGeneratorTest
     {
         // Arrange
         var sut = new RandomDateOnlySequenceGenerator();
-        // Act
         var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
         var result = sut.Create(request, dummyContainer);
+
         // Assert
         Assert.Equal(new NoSpecimen(), result);
     }
@@ -84,71 +91,81 @@ public class RandomDateOnlySequenceGeneratorTest
     [InlineData(typeof(object))]
     [InlineData(typeof(int))]
     [InlineData(typeof(bool))]
-    public void CreateWithNonDateTimeTypeRequestReturnsNoSpecimen(Type request)
+    public void CreateWithNonDateOnlyTypeRequestReturnsNoSpecimen(Type request)
     {
         // Arrange
         var sut = new RandomDateOnlySequenceGenerator();
-        // Act
         var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
         var result = sut.Create(request, dummyContainer);
+
         // Assert
         Assert.Equal(new NoSpecimen(), result);
     }
 
     [Fact]
-    public void CreateWithDateTimeRequestReturnsDateTimeValue()
+    public void CreateRequestReturnsDateTimeValue()
     {
         // Arrange
         var sut = new RandomDateOnlySequenceGenerator();
-        // Act
         var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
         var result = sut.Create(typeof(DateOnly), dummyContainer);
+
         // Assert
         Assert.IsAssignableFrom<DateOnly>(result);
     }
 
     [Fact]
-    public void CreateWithDateTimeRequestReturnsADateWithinARangeOfPlusMinusTwoYearsFromToday()
+    public void CreateReturnsDateWithinARangeOfPlusMinusTwoYearsFromToday()
     {
         // Arrange
         var today = DateOnly.FromDateTime(DateTime.Today);
         var twoYearsAgo = today.AddYears(-2);
         var twoYearsForward = today.AddYears(2);
         var sut = new RandomDateOnlySequenceGenerator();
-        // Act
         var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
         var result = (DateOnly)sut.Create(typeof(DateOnly), dummyContainer);
+
         // Assert
         Assert.InRange(result, twoYearsAgo, twoYearsForward);
     }
 
     [Fact]
-    public void CreateWithMultipleDateTimeRequestsReturnsDifferentDates()
+    public void CreateWithMultipleRequestsReturnsDifferentDates()
     {
         // Arrange
         const int requestCount = 10;
         var times = Enumerable.Range(1, requestCount);
         var sut = new RandomDateOnlySequenceGenerator();
-        // Act
         var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
         var results = times
             .Select(t => sut.Create(typeof(DateOnly), dummyContainer))
             .Cast<DateOnly>();
+
         // Assert
         Assert.Equal(requestCount, results.Distinct().Count());
     }
 
     [Fact]
-    public void CreateWithDateTimeRequestAndDateRangeReturnsDateWithinThatRange()
+    public void CreateRequestAndDateRangeReturnsValueWithinThatRange()
     {
         // Arrange
         var today = DateOnly.FromDateTime(DateTime.Today);
         var minDate = today;
         var maxDate = minDate.AddDays(3);
         var sut = new RandomDateOnlySequenceGenerator(minDate, maxDate);
-        // Act
         var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
         var result = (DateOnly)sut.Create(typeof(DateOnly), dummyContainer);
+
         // Assert
         Assert.InRange(result, minDate, maxDate);
     }

--- a/Src/AutoFixtureUnitTest/RandomTimeOnlySequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomTimeOnlySequenceGeneratorTest.cs
@@ -1,0 +1,168 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Linq;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace AutoFixtureUnitTest;
+
+public class RandomTimeOnlySequenceGeneratorTest
+{
+    [Fact]
+    public void SutIsSpecimenBuilder()
+    {
+        // Arrange & Act
+        var sut = new RandomTimeOnlySequenceGenerator();
+
+        // Assert
+        Assert.IsAssignableFrom<ISpecimenBuilder>(sut);
+    }
+
+    [Fact]
+    public void InitializeWithInvertedRangeThrowsArgumentException()
+    {
+        // Arrange
+        var minimum = new TimeOnly(12, 03, 21);
+        var maximum = minimum.AddHours(3);
+
+        // Act & assert
+        Assert.Throws<ArgumentException>(
+            () => new RandomTimeOnlySequenceGenerator(maximum, minimum));
+    }
+
+    [Fact]
+    public void InitializeWithEmptyRangeThrowsArgumentException()
+    {
+        // Arrange
+        var time = new TimeOnly(14, 13, 09);
+
+        // Act & assert
+        Assert.Throws<ArgumentException>(
+            () => new RandomTimeOnlySequenceGenerator(time, time));
+    }
+
+    [Fact]
+    public void CreateWithNullRequestReturnsNoSpecimen()
+    {
+        // Arrange
+        var sut = new RandomTimeOnlySequenceGenerator();
+        var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
+        var result = sut.Create(null, dummyContainer);
+
+        // Assert
+        Assert.Equal(new NoSpecimen(), result);
+    }
+
+    [Fact]
+    public void CreateWithNullContextThrowsArgumentNullException()
+    {
+        // Arrange
+        var sut = new RandomTimeOnlySequenceGenerator();
+
+        // Act & assert
+        Assert.Throws<ArgumentNullException>(
+            () => sut.Create(typeof(TimeOnly), null));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(default(int))]
+    [InlineData(default(bool))]
+    public void CreateWithNonTypeRequestReturnsNoSpecimen(object request)
+    {
+        // Arrange
+        var sut = new RandomTimeOnlySequenceGenerator();
+        var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
+        var result = sut.Create(request, dummyContainer);
+
+        // Assert
+        Assert.Equal(new NoSpecimen(), result);
+    }
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(object))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(bool))]
+    public void CreateWithNonTimeOnlyTypeRequestReturnsNoSpecimen(Type request)
+    {
+        // Arrange
+        var sut = new RandomTimeOnlySequenceGenerator();
+        var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
+        var result = sut.Create(request, dummyContainer);
+
+        // Assert
+        Assert.Equal(new NoSpecimen(), result);
+    }
+
+    [Fact]
+    public void CreateWithTimeOnlyRequestReturnsTimeOnlyValue()
+    {
+        // Arrange
+        var sut = new RandomTimeOnlySequenceGenerator();
+        var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
+        var result = sut.Create(typeof(TimeOnly), dummyContainer);
+
+        // Assert
+        Assert.IsAssignableFrom<TimeOnly>(result);
+    }
+
+    [Fact]
+    public void CreateWithTimeOnlyRequestReturnsADateWithinARangeOfPlusMinusTwoYearsFromNoon()
+    {
+        // Arrange
+        var current = new TimeOnly(12, 00);
+        var twoHoursAgo = current.AddHours(-6);
+        var twoHoursForward = current.AddHours(6);
+        var sut = new RandomTimeOnlySequenceGenerator();
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = (TimeOnly)sut.Create(typeof(TimeOnly), dummyContainer);
+        // Assert
+        Assert.InRange(result, twoHoursAgo, twoHoursForward);
+    }
+
+    [Fact]
+    public void CreateWithMultipleRequestsReturnsDifferentTimes()
+    {
+        // Arrange
+        const int requestCount = 10;
+        var times = Enumerable.Range(1, requestCount);
+        var sut = new RandomTimeOnlySequenceGenerator();
+        var dummyContainer = new DelegatingSpecimenContext();
+
+        // Act
+        var results = times
+            .Select(t => sut.Create(typeof(TimeOnly), dummyContainer))
+            .Cast<TimeOnly>();
+
+        // Assert
+        Assert.Equal(requestCount, results.Distinct().Count());
+    }
+
+    [Fact]
+    public void CreateWithTimeOnlyRequestAndTimeRangeReturnsValueWithinThatRange()
+    {
+        // Arrange
+        var minimum = new TimeOnly(13, 00);
+        var maximum = minimum.AddHours(3);
+        var sut = new RandomTimeOnlySequenceGenerator(minimum, maximum);
+        // Act
+        var dummyContainer = new DelegatingSpecimenContext();
+        var result = (TimeOnly)sut.Create(typeof(TimeOnly), dummyContainer);
+        // Assert
+        Assert.InRange(result, minimum, maximum);
+    }
+}
+#endif

--- a/Src/AutoFixtureUnitTest/SpecimenWithEverything.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenWithEverything.cs
@@ -66,6 +66,9 @@ namespace AutoFixtureUnitTest
         public bool? NullableBool { get; set; }
         public Guid? NullableGuid { get; set; }
         public DateTime? NullableDateTime { get; set; }
+#if NET6_0_OR_GREATER
+        public DateOnly? NullableDateOnly { get; set; }
+#endif
         public decimal? NullableDecimal { get; set; }
         public double? NullableDouble { get; set; }
         public float? NullableFloat { get; set; }

--- a/Src/AutoFixtureUnitTest/SpecimenWithEverything.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenWithEverything.cs
@@ -68,6 +68,7 @@ namespace AutoFixtureUnitTest
         public DateTime? NullableDateTime { get; set; }
 #if NET6_0_OR_GREATER
         public DateOnly? NullableDateOnly { get; set; }
+        public TimeOnly? NullableTimeOnly { get; set; }
 #endif
         public decimal? NullableDecimal { get; set; }
         public double? NullableDouble { get; set; }


### PR DESCRIPTION
This PR adds the new .NET 6 time structs `DateOnly` and `TimeOnly`

### Description

- Added `DateOnly` generator
- Added `TimeOnly` generator

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
closes #1354

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
