### PR TITLE
Enabled XML documentation generation for all build configurations

### DIFF
--- a/Src/Common.props
+++ b/Src/Common.props
@@ -5,6 +5,7 @@
     <Copyright>Copyright © AutoFixture 2011</Copyright>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <CodeAnalysisCulture>en-US</CodeAnalysisCulture>
 
@@ -69,14 +70,12 @@
   <Choose>
     <When Condition=" '$(Configuration)'=='Release' ">
       <PropertyGroup>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <DebugType>portable</DebugType>
       </PropertyGroup>
     </When>
     <When Condition=" '$(Configuration)'=='Verify' ">
       <PropertyGroup>
         <DefineConstants>$(DefineConstants);CODE_ANALYSIS</DefineConstants>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
       </PropertyGroup>


### PR DESCRIPTION
This PR enables XML documentation generation for all build configurations in order to get consistent XML comment analysis.

### Description
<!-- Summarize your changes -->
- Moved property `GenerateDocumentationFile` to the top level property group

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
N/A

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
