### PR TITLE
Support inherited members in `MemberAutoDataAttribute`

### DIFF
--- a/Src/AutoFixture.xUnit2.UnitTest/MemberAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/MemberAutoDataAttributeTest.cs
@@ -390,5 +390,41 @@ namespace AutoFixture.Xunit2.UnitTest
                     Assert.Equal(testCase[1], testCase[2]);
                 });
         }
+
+        [Fact]
+        public void SupportsInheritedTestDataMembers()
+        {
+            // Arrange
+            const string memberName = nameof(TestTypeWithMethodData.GetMultipleValueTestCases);
+            var sut = new MemberAutoDataAttribute(memberName);
+            var testMethod = ChildTestTypeMethodData.GetMultipleValueTestMethodInfo();
+
+            // Act
+            var testCases = sut.GetData(testMethod).ToArray();
+
+            // Assert
+            Assert.Collection(testCases,
+                testCase =>
+                {
+                    Assert.Equal(3, testCase.Length);
+                    Assert.Equal("value-one", testCase[0]);
+                    Assert.Equal(12, testCase[1]);
+                    Assert.Equal(23.3m, testCase[2]);
+                },
+                testCase =>
+                {
+                    Assert.Equal(3, testCase.Length);
+                    Assert.Equal("value-two", testCase[0]);
+                    Assert.Equal(38, testCase[1]);
+                    Assert.Equal(12.7m, testCase[2]);
+                },
+                testCase =>
+                {
+                    Assert.Equal(3, testCase.Length);
+                    Assert.Equal("value-three", testCase[0]);
+                    Assert.Equal(94, testCase[1]);
+                    Assert.Equal(52.21m, testCase[2]);
+                });
+        }
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ChildTestTypeMethodData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ChildTestTypeMethodData.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using Xunit;
+
+namespace AutoFixture.Xunit2.UnitTest.TestTypes;
+
+/// <summary>
+/// Created to test whether MemberAutoDataAttribute can discover static test data members from parent classes.
+/// </summary>
+public class ChildTestTypeMethodData : TestTypeWithMethodData
+{
+    public new void MultipleValueTest(string a, int b, decimal c)
+    {
+        Assert.NotNull(a);
+        Assert.NotEmpty(a);
+        Assert.False(string.IsNullOrWhiteSpace(a));
+
+        Assert.True(b != default, "Value should not be default");
+        Assert.True(c != default, "Value should not be default");
+    }
+
+    public static new MethodInfo GetMultipleValueTestMethodInfo()
+    {
+        return typeof(ChildTestTypeMethodData)
+            .GetMethod(nameof(MultipleValueTest));
+    }
+}

--- a/Src/AutoFixture.xUnit2/Internal/MemberTestCaseSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/MemberTestCaseSource.cs
@@ -49,7 +49,7 @@ namespace AutoFixture.Xunit2.Internal
         {
             var sourceMember = this.Type.GetMember(this.Name,
                     MemberTypes.Method | MemberTypes.Field | MemberTypes.Property,
-                    BindingFlags.Static | BindingFlags.Public)
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy)
                 .FirstOrDefault();
 
             if (sourceMember is null)


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
Fixed `MemberAutoData` reflection query to include inherited members

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
fixes #1464 

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
