### PR TITLE
Updated copyright and author details

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Mark Seemann
+Copyright (c) AutoFixture
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -6,13 +6,11 @@
     <AssemblyTitle>AutoFakeItEasy</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFakeItEasy</AssemblyName>
     <RootNamespace>AutoFixture.AutoFakeItEasy</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.AutoFakeItEasy</PackageId>
     <Title>AutoFixture with Auto Mocking using FakeItEasy</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by FakeItEasy. To use it, add the AutoFakeItEasyCustomization to your Fixture instance.</Description>
-    <Authors>Nikos Baxevanis,AutoFixture</Authors>
 
     <!--  Suppress warning about invalid dependency version in Castle.Core.
           That is FakeItEasy dependency and we cannot fix that somehow. -->

--- a/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
+++ b/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
@@ -6,13 +6,11 @@
     <AssemblyTitle>AutoFixture.NUnit2</AssemblyTitle>
     <AssemblyName>AutoFixture.NUnit2</AssemblyName>
     <RootNamespace>AutoFixture.NUnit2</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.NUnit2</PackageId>
     <Title>AutoFixture with NUnit2</Title>
     <Description>By leveraging the some features of NUnit, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
-    <Authors>Gert Jansen van Rensburg,AutoFixture</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -6,17 +6,15 @@
     <AssemblyTitle>AutoFixture.NUnit3</AssemblyTitle>
     <AssemblyName>AutoFixture.NUnit3</AssemblyName>
     <RootNamespace>AutoFixture.NUnit3</RootNamespace>
-    <Copyright>Copyright © Ploeh 2016</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.NUnit3</PackageId>
     <Title>AutoFixture with NUnit3</Title>
     <Description>By leveraging some features of NUnit3, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
-    <Authors>Hackle Wayne,AutoFixture</Authors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="[3.7.0,4.0.0)" />
+    <PackageReference Include="NUnit" Version="[3.7.0,4.0.0)" />
   </ItemGroup>
 
   <!-- Dependencies added due to transitive vulnerabilities in NUnit -->

--- a/Src/AutoFixture.NUnit4/AutoFixture.NUnit4.csproj
+++ b/Src/AutoFixture.NUnit4/AutoFixture.NUnit4.csproj
@@ -6,13 +6,11 @@
     <AssemblyTitle>AutoFixture.NUnit4</AssemblyTitle>
     <AssemblyName>AutoFixture.NUnit4</AssemblyName>
     <RootNamespace>AutoFixture.NUnit4</RootNamespace>
-    <Copyright>Copyright © AutoFixture Contributors</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.NUnit4</PackageId>
     <Title>AutoFixture with NUnit4</Title>
     <Description>By leveraging some features of NUnit4, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
-    <Authors>AutoFixture Contributors</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.SeedExtensions/AutoFixture.SeedExtensions.csproj
+++ b/Src/AutoFixture.SeedExtensions/AutoFixture.SeedExtensions.csproj
@@ -11,7 +11,6 @@
     <PackageId>AutoFixture.SeedExtensions</PackageId>
     <Title>AutoFixture.SeedExtensions</Title>
     <Description>Extensions for the most common AutoFixture operations to provide overloads with a seed.</Description>
-    <Authors>AutoFixture</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.xUnit/AutoFixture.xUnit.csproj
+++ b/Src/AutoFixture.xUnit/AutoFixture.xUnit.csproj
@@ -6,7 +6,6 @@
     <AssemblyTitle>AutoFixture.xUnit.net</AssemblyTitle>
     <AssemblyName>AutoFixture.Xunit</AssemblyName>
     <RootNamespace>AutoFixture.Xunit</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.Xunit</PackageId>

--- a/Src/AutoFixture.xUnit2/AutoFixture.xUnit2.csproj
+++ b/Src/AutoFixture.xUnit2/AutoFixture.xUnit2.csproj
@@ -6,7 +6,6 @@
     <AssemblyTitle>AutoFixture.xUnit.net2</AssemblyTitle>
     <AssemblyName>AutoFixture.Xunit2</AssemblyName>
     <RootNamespace>AutoFixture.Xunit2</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.Xunit2</PackageId>

--- a/Src/AutoFixture.xUnit3/AutoFixture.xUnit3.csproj
+++ b/Src/AutoFixture.xUnit3/AutoFixture.xUnit3.csproj
@@ -6,7 +6,6 @@
     <AssemblyTitle>AutoFixture.xUnit.net3</AssemblyTitle>
     <AssemblyName>AutoFixture.Xunit3</AssemblyName>
     <RootNamespace>AutoFixture.Xunit3</RootNamespace>
-    <Copyright>Copyright © AutoFixture 2025</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.Xunit3</PackageId>

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -6,8 +6,7 @@
     <AssemblyTitle>AutoFixture</AssemblyTitle>
     <AssemblyName>AutoFixture</AssemblyName>
     <RootNamespace>AutoFixture</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
-    
+
     <!-- NuGet options -->
     <PackageId>AutoFixture</PackageId>
     <Title>AutoFixture</Title>

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -7,10 +7,11 @@
     <AssemblyTitle>AutoFixture.AutoFoq</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFoq</AssemblyName>
     <RootNamespace>AutoFixture.AutoFoq</RootNamespace>
-    <Copyright>Copyright © Ploeh 2013</Copyright>
     <SignAssembly>False</SignAssembly>
+
     <!-- Disable source link support for F# projects as they don't support this feature. -->
     <SourceLinkCreate>false</SourceLinkCreate>
+
     <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects. And about wrong FSharp version during restore. -->
     <NoWarn>$(NoWarn);FS2003;NU1601</NoWarn>
     <Deterministic>false</Deterministic>
@@ -19,7 +20,6 @@
     <PackageId>AutoFixture.AutoFoq</PackageId>
     <Title>AutoFixture with Auto Mocking using Foq</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by Foq. To use it, add the AutoFoqCustomization to your Fixture instance.</Description>
-    <Authors>Nikos Baxevanis,AutoFixture</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -6,7 +6,6 @@
     <AssemblyTitle>AutoMoq</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoMoq</AssemblyName>
     <RootNamespace>AutoFixture.AutoMoq</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.AutoMoq</PackageId>

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -6,13 +6,11 @@
     <AssemblyTitle>AutoNSubstitute</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoNSubstitute</AssemblyName>
     <RootNamespace>AutoFixture.AutoNSubstitute</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.AutoNSubstitute</PackageId>
     <Title>AutoFixture with Auto Mocking using NSubstitute</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by NSubstitute. To use it, add the AutoNSubstituteCustomization to your Fixture instance.</Description>
-    <Authors>Daniel Hilgarth,Alex Povar,AutoFixture</Authors>
 
     <!--  Suppress warning about invalid dependency version in Castle.Core.
           That is NSubstitute dependency and we cannot fix that somehow. -->

--- a/Src/AutoRhinoMock/AutoRhinoMock.csproj
+++ b/Src/AutoRhinoMock/AutoRhinoMock.csproj
@@ -6,8 +6,7 @@
     <AssemblyTitle>AutoFixture.AutoRhinoMock</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoRhinoMock</AssemblyName>
     <RootNamespace>AutoFixture.AutoRhinoMock</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
-    
+
     <!-- NuGet options -->
     <PackageId>AutoFixture.AutoRhinoMocks</PackageId>
     <Title>AutoFixture with Auto Mocking using Rhino Mocks</Title>

--- a/Src/Common.props
+++ b/Src/Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Product>AutoFixture</Product>
     <Company>AutoFixture</Company>
-    <Copyright>Copyright © AutoFixture 2011</Copyright>
+    <Copyright>Copyright © AutoFixture</Copyright>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -25,7 +25,7 @@
     <AnalysisLevel>latest-Recommended</AnalysisLevel>
 
     <!-- NuGet options -->
-    <Authors>Mark Seemann,AutoFixture</Authors>
+    <Authors>AutoFixture Contributors</Authors>
     <PackageProjectUrl>https://github.com/AutoFixture/AutoFixture</PackageProjectUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -7,10 +7,11 @@
     <AssemblyTitle>AutoFixture.Idioms.FsCheck</AssemblyTitle>
     <AssemblyName>AutoFixture.Idioms.FsCheck</AssemblyName>
     <RootNamespace>AutoFixture.Idioms.FsCheck</RootNamespace>
-    <Copyright>Copyright © Ploeh 2014</Copyright>
     <SignAssembly>False</SignAssembly>
+
     <!-- Disable source link support for F# projects as they don't support this feature. -->
     <SourceLinkCreate>false</SourceLinkCreate>
+
     <!-- Skip warning about invalid AssemblyInformationalVersion attribute in F# projects. And about wrong FSharp version during restore. -->
     <NoWarn>$(NoWarn);FS2003;NU1601</NoWarn>
     <Deterministic>false</Deterministic>
@@ -19,7 +20,6 @@
     <PackageId>AutoFixture.Idioms.FsCheck</PackageId>
     <Title>AutoFixture Idioms.FsCheck</Title>
     <Description>Ubiquitous use of AutoFixture for unit testing has given rise to a number of idiomatic unit tests - unit tests that tend to follow common templates. The AutoFixture Idioms.FsCheck library encapsulates these idioms into reusable classes and methods.</Description>
-    <Authors>Nikos Baxevanis,AutoFixture</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -6,7 +6,6 @@
     <AssemblyTitle>AutoFixture.Idioms</AssemblyTitle>
     <AssemblyName>AutoFixture.Idioms</AssemblyName>
     <RootNamespace>AutoFixture.Idioms</RootNamespace>
-    <Copyright>Copyright © Ploeh 2011</Copyright>
 
     <!-- NuGet options -->
     <PackageId>AutoFixture.Idioms</PackageId>


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
This PR changes the copyright and author information in the packages metadata and license the agreements to reference explicitly the AutoFixture project and its contributors (as a collective).
This should remove any legal ambiguity of copyright ownership, in respect to the .NET Foundation CLA agreement.

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
N/A

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
