### PR TITLE
Disable publish of Rhino Mocks, xUnit 1, and NUnit 2 integrations

### DIFF
--- a/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
+++ b/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.NUnit2</PackageId>
     <Title>AutoFixture with NUnit2</Title>
     <Description>By leveraging the some features of NUnit, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.xUnit/AutoFixture.xUnit.csproj
+++ b/Src/AutoFixture.xUnit/AutoFixture.xUnit.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.Xunit</PackageId>
     <Title>AutoFixture with xUnit.net data theories</Title>
     <Description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language). For xUnit.net 2, please use the AutoFixture.Xunit2 NuGet Package.</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoRhinoMock/AutoRhinoMock.csproj
+++ b/Src/AutoRhinoMock/AutoRhinoMock.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.AutoRhinoMocks</PackageId>
     <Title>AutoFixture with Auto Mocking using Rhino Mocks</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by Rhino Mocks. To use it, add the AutoRhinoMockCustomization to your Fixture instance. Read more at http://blog.ploeh.dk/2010/11/13/RhinoMocksbasedAutomockingWithAutoFixture.aspx</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
- Disabled publish of AutoFixture.AutoRhinoMocks
- Disabled publish of AutoFixture.Xunit
- Disabled publish of AutoFixture.NUnit2

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
N/A

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
