### PR TITLE
Removed obsolete NoSpecimen(object) constructor overload

### DIFF
--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -14,38 +14,12 @@ namespace AutoFixture.Kernel
     /// </remarks>
     public class NoSpecimen : IEquatable<NoSpecimen>
     {
-        private readonly object request;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSpecimen"/> class with a null request.
         /// </summary>
         public NoSpecimen()
         {
         }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NoSpecimen"/> class with the supplied
-        /// request.
-        /// </summary>
-        /// <param name="request">
-        /// The original request that prompts the creation of this instance.
-        /// </param>
-        [Obsolete("Use NoSpecimen() instead of NoSpecimen(object). The Request property, and this constructor that populates it, is being retired in future versions of AutoFixture, as it has turned out that no one uses it. You can still use the parameterless NoSpecimen constructor overload. The NoSpecimen class itself will remain. If you're seeing this warning in AutoFixture 3.x, and, despite expectations, have a real need to use the Request property, please provide feedback on https://github.com/AutoFixture/AutoFixture/issues/475 .", true)]
-        public NoSpecimen(object request)
-        {
-            this.request = request;
-        }
-
-        /// <summary>
-        /// Gets the original request that prompted the creation of the current instance.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This property value may be <see langword="null"/>.
-        /// </para>
-        /// </remarks>
-        [Obsolete("The Request property is being retired in future versions of AutoFixture, as it has turned out that no one uses it. If you're seeing this warning in AutoFixture 3.x, and, despite expectations, have a real need to use the Request property, please provide feedback on https://github.com/AutoFixture/AutoFixture/issues/475.", true)]
-        public object Request => this.request;
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current
@@ -71,9 +45,7 @@ namespace AutoFixture.Kernel
         /// <returns>A hash code for the current <see cref="NoSpecimen"/> instance.</returns>
         public override int GetHashCode()
         {
-#pragma warning disable 618
-            return this.request == null ? 0 : this.request.GetHashCode();
-#pragma warning restore 618
+            return 0;
         }
 
         /// <summary>
@@ -93,10 +65,6 @@ namespace AutoFixture.Kernel
             {
                 return false;
             }
-
-#pragma warning disable 618
-            return object.Equals(this.request, other.request);
-#pragma warning restore 618
         }
     }
 }

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -36,7 +36,7 @@ namespace AutoFixture.Kernel
             {
                 return this.Equals(other);
             }
-            return base.Equals(obj);
+            return false;
         }
 
         /// <summary>
@@ -61,10 +61,7 @@ namespace AutoFixture.Kernel
         /// </returns>
         public bool Equals(NoSpecimen other)
         {
-            if (other == null)
-            {
-                return false;
-            }
+            return other is not null;
         }
     }
 }

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -15,7 +15,7 @@ namespace AutoFixture.Kernel
     public class NoSpecimen : IEquatable<NoSpecimen>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="NoSpecimen"/> class with a null request.
+        /// Initializes a new instance of the <see cref="NoSpecimen"/> class.
         /// </summary>
         public NoSpecimen()
         {

--- a/Src/AutoFixtureUnitTest/Kernel/NoSpecimenTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NoSpecimenTest.cs
@@ -8,48 +8,6 @@ namespace AutoFixtureUnitTest.Kernel
     public class NoSpecimenTest
     {
         [Fact]
-        [Obsolete]
-        public void DefaultConstructorWillSetRequestToNull()
-        {
-            // Arrange
-            var sut = new NoSpecimen();
-            // Act
-#pragma warning disable 618
-            var result = sut.Request;
-#pragma warning restore 618
-            // Assert
-            Assert.Null(result);
-        }
-
-        [Fact]
-        [Obsolete]
-        public void CreateWithNullRequestWillSetCorrectRequest()
-        {
-            // Arrange
-            // Act
-#pragma warning disable 618
-            var sut = new NoSpecimen(null);
-            // Assert
-            Assert.Null(sut.Request);
-#pragma warning restore 618
-        }
-
-        [Fact]
-        [Obsolete]
-        public void RequestWillMatchConstructorArgument()
-        {
-            // Arrange
-            var expectedRequest = new object();
-#pragma warning disable 618
-            var sut = new NoSpecimen(expectedRequest);
-            // Act
-            var result = sut.Request;
-#pragma warning restore 618
-            // Assert
-            Assert.Equal(expectedRequest, result);
-        }
-
-        [Fact]
         public void SutIsEquatable()
         {
             // Arrange
@@ -98,97 +56,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        [Obsolete]
-        public void SutDoesNotEqualOtherObjectWhenSutRequestIsNull()
-        {
-            // Arrange
-            var sut = new NoSpecimen();
-#pragma warning disable 618
-            object other = new NoSpecimen(new object());
-#pragma warning restore 618
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.False(result, "Equals");
-        }
-
-        [Fact]
-        [Obsolete]
-        public void SutDoesNotEqualOtherSutWhenSutRequestIsNull()
-        {
-            // Arrange
-            var sut = new NoSpecimen();
-#pragma warning disable 618
-            var other = new NoSpecimen(new object());
-#pragma warning restore 618
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.False(result, "Equals");
-        }
-
-        [Fact]
-        [Obsolete]
-        public void SutDoesNotEqualOtherObjectWhenOtherRequestIsNull()
-        {
-            // Arrange
-#pragma warning disable 618
-            var sut = new NoSpecimen(new object());
-#pragma warning restore 618
-            object other = new NoSpecimen();
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.False(result, "Equals");
-        }
-
-        [Fact]
-        [Obsolete]
-        public void SutDoesNotEqualOtherSutWhenOtherRequestIsNull()
-        {
-            // Arrange
-#pragma warning disable 618
-            var sut = new NoSpecimen(new object());
-#pragma warning restore 618
-            var other = new NoSpecimen();
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.False(result, "Equals");
-        }
-
-        [Fact]
-        [Obsolete]
-        public void SutDoesNotEqualOtherObjectWhenRequestsDiffer()
-        {
-            // Arrange
-#pragma warning disable 618
-            var sut = new NoSpecimen(new object());
-            object other = new NoSpecimen(new object());
-#pragma warning restore 618
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.False(result, "Equals");
-        }
-
-        [Fact]
-        [Obsolete]
-        public void SutDoesNotEqualOtherSutWhenRequestsDiffer()
-        {
-            // Arrange
-#pragma warning disable 618
-            var sut = new NoSpecimen(new object());
-            var other = new NoSpecimen(new object());
-#pragma warning restore 618
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.False(result, "Equals");
-        }
-
-        [Fact]
-        public void SutEqualsOtherObjectWhenBothRequestsAreNull()
+        public void SutEqualsOtherObject()
         {
             // Arrange
             var sut = new NoSpecimen();
@@ -200,7 +68,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        public void SutEqualsOtherSutWhenBothRequestsAreNull()
+        public void SutEqualsOtherSut()
         {
             // Arrange
             var sut = new NoSpecimen();
@@ -212,39 +80,7 @@ namespace AutoFixtureUnitTest.Kernel
         }
 
         [Fact]
-        [Obsolete]
-        public void SutEqualsOtherObjectWhenRequestsAreEqual()
-        {
-            // Arrange
-            var request = new object();
-#pragma warning disable 618
-            var sut = new NoSpecimen(request);
-            object other = new NoSpecimen(request);
-#pragma warning restore 618
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.True(result, "Equals");
-        }
-
-        [Fact]
-        [Obsolete]
-        public void SutEqualsOtherSutWhenRequestsAreEqual()
-        {
-            // Arrange
-            var request = new object();
-#pragma warning disable 618
-            var sut = new NoSpecimen(request);
-            var other = new NoSpecimen(request);
-#pragma warning restore 618
-            // Act
-            var result = sut.Equals(other);
-            // Assert
-            Assert.True(result, "Equals");
-        }
-
-        [Fact]
-        public void GetHashCodeWhenRequestIsNullWillReturnCorrectResult()
+        public void GetHashCodeWillAlwaysReturnZeroResult()
         {
             // Arrange
             var sut = new NoSpecimen();
@@ -252,22 +88,6 @@ namespace AutoFixtureUnitTest.Kernel
             var result = sut.GetHashCode();
             // Assert
             Assert.Equal(0, result);
-        }
-
-        [Fact]
-        [Obsolete]
-        public void GetHashCodeWhenRequestIsNotNullWillReturnCorrectResult()
-        {
-            // Arrange
-            var request = new object();
-#pragma warning disable 618
-            var sut = new NoSpecimen(request);
-#pragma warning restore 618
-            // Act
-            var result = sut.GetHashCode();
-            // Assert
-            var expectedHashCode = request.GetHashCode();
-            Assert.Equal(expectedHashCode, result);
         }
     }
 }


### PR DESCRIPTION
### Description
NoSpecimen constructor has been marked as obsolete for 10 years.

### Closed issues
#475

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
