### PR TITLE
Disabled publish of packages that have been moved to other repositories

### DIFF
--- a/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
+++ b/Src/AutoFixture.NUnit2/AutoFixture.NUnit2.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.NUnit2</PackageId>
     <Title>AutoFixture with NUnit2</Title>
     <Description>By leveraging the some features of NUnit, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.NUnit4/AutoFixture.NUnit4.csproj
+++ b/Src/AutoFixture.NUnit4/AutoFixture.NUnit4.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.NUnit4</PackageId>
     <Title>AutoFixture with NUnit4</Title>
     <Description>By leveraging some features of NUnit4, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.xUnit/AutoFixture.xUnit.csproj
+++ b/Src/AutoFixture.xUnit/AutoFixture.xUnit.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.Xunit</PackageId>
     <Title>AutoFixture with xUnit.net data theories</Title>
     <Description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language). For xUnit.net 2, please use the AutoFixture.Xunit2 NuGet Package.</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.xUnit3/AutoFixture.xUnit3.csproj
+++ b/Src/AutoFixture.xUnit3/AutoFixture.xUnit3.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.Xunit3</PackageId>
     <Title>AutoFixture with xUnit.net v3 data theories</Title>
     <Description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/AutoRhinoMock/AutoRhinoMock.csproj
+++ b/Src/AutoRhinoMock/AutoRhinoMock.csproj
@@ -11,6 +11,7 @@
     <PackageId>AutoFixture.AutoRhinoMocks</PackageId>
     <Title>AutoFixture with Auto Mocking using Rhino Mocks</Title>
     <Description>This extension turns AutoFixture into an Auto-Mocking Container. The mock instances are created by Rhino Mocks. To use it, add the AutoRhinoMockCustomization to your Fixture instance. Read more at http://blog.ploeh.dk/2010/11/13/RhinoMocksbasedAutomockingWithAutoFixture.aspx</Description>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Disabled publish of packages that have been moved to other repositories

### Description
<!-- Summarize your changes -->
- Disabled publish of xUnit 1 integration
- Disabled publish of xUnit 3 integration
- Disabled publish of NUnit 2 integration
- Disabled publish of NUnit 4 integration
- Disabled publish of Rhino Mocks integration

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
