### PR TITLE
Bugfix/1097 fix time zone info randomness

### DIFF
--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -46,6 +46,7 @@ namespace AutoFixture
 #endif
             yield return new EmailAddressLocalPartGenerator();
             yield return new DomainNameGenerator();
+            yield return new ElementsBuilder<TimeZoneInfo>(TimeZoneInfo.GetSystemTimeZones());
         }
 
         /// <summary>

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -46,7 +46,7 @@ namespace AutoFixture
 #endif
             yield return new EmailAddressLocalPartGenerator();
             yield return new DomainNameGenerator();
-            yield return new ElementsBuilder<TimeZoneInfo>(TimeZoneInfo.GetSystemTimeZones());
+            yield return new TimeZoneInfoGenerator();
         }
 
         /// <summary>

--- a/Src/AutoFixture/TimeZoneInfoGenerator.cs
+++ b/Src/AutoFixture/TimeZoneInfoGenerator.cs
@@ -22,9 +22,19 @@ namespace AutoFixture
             if (!typeof(TimeZoneInfo).Equals(request)) return NoSpecimen.Instance;
 
             var timeZoneRangeRequest = new RangedNumberRequest(typeof(int), -12, 14);
-            var offset = (int)context.Resolve(timeZoneRangeRequest);
-            var baseUtcOffset = TimeSpan.FromHours(offset);
+            var offsetResult = context.Resolve(timeZoneRangeRequest);
+            if (offsetResult is NoSpecimen or OmitSpecimen)
+            {
+                return offsetResult;
+            }
 
+            if (offsetResult is not int offset)
+            {
+                throw new InvalidOperationException(
+                    $"The result of ranged number request must be an int, but was {offsetResult?.GetType().FullName ?? "null"}.");
+            }
+
+            var baseUtcOffset = TimeSpan.FromHours(offset);
             var sign = baseUtcOffset < TimeSpan.Zero ? "-" : "+";
             var id = $"UTC{sign}{baseUtcOffset:hh}";
             var displayName = $"(UTC{sign}{baseUtcOffset:hh\\:mm}) Test Time Zone{sign}{baseUtcOffset:hh}";

--- a/Src/AutoFixture/TimeZoneInfoGenerator.cs
+++ b/Src/AutoFixture/TimeZoneInfoGenerator.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using AutoFixture.DataAnnotations;
+using AutoFixture.Kernel;
+
+namespace AutoFixture
+{
+    /// <summary>
+    /// Creates new <see cref="TimeZoneInfoGenerator"/> instances.
+    /// </summary>
+    public class TimeZoneInfoGenerator : ISpecimenBuilder
+    {
+        /// <summary>
+        /// Creates a new TimeZoneInfo.
+        /// </summary>
+        /// <param name="request">The request that describes what to create.</param>
+        /// <param name="context">A context that can be used to create other specimens.</param>
+        /// <returns>
+        /// The requested specimen if possible; otherwise a <see cref="NoSpecimen"/> instance.
+        /// </returns>
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            if (!typeof(TimeZoneInfo).Equals(request))
+            {
+                return new NoSpecimen();
+            }
+
+            var id = (string)context.Resolve(typeof(string));
+            var tmp1 = new RangedNumberRequest(typeof(int), -14, 14);
+            var tmp2 = context.Resolve(tmp1);
+            int offset = (int)tmp2;
+            var baseUtcOffset = TimeSpan.FromHours(offset);
+            var displayName = (string)context.Resolve(typeof(string));
+            var standardDisplayName = (string)context.Resolve(typeof(string));
+
+            return TimeZoneInfo.CreateCustomTimeZone(id, baseUtcOffset, displayName, standardDisplayName);
+        }
+    }
+}

--- a/Src/AutoFixture/TimeZoneInfoGenerator.cs
+++ b/Src/AutoFixture/TimeZoneInfoGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using AutoFixture.DataAnnotations;
 using AutoFixture.Kernel;
 
 namespace AutoFixture
@@ -19,22 +18,22 @@ namespace AutoFixture
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (context is null) throw new ArgumentNullException(nameof(context));
+            if (!typeof(TimeZoneInfo).Equals(request)) return new NoSpecimen();
 
-            if (!typeof(TimeZoneInfo).Equals(request))
-            {
-                return new NoSpecimen();
-            }
-
-            var id = (string)context.Resolve(typeof(string));
-            var tmp1 = new RangedNumberRequest(typeof(int), -14, 14);
-            var tmp2 = context.Resolve(tmp1);
-            int offset = (int)tmp2;
+            var timeZoneRangeRequest = new RangedNumberRequest(typeof(int), -12, 14);
+            var offset = (int)context.Resolve(timeZoneRangeRequest);
             var baseUtcOffset = TimeSpan.FromHours(offset);
-            var displayName = (string)context.Resolve(typeof(string));
-            var standardDisplayName = (string)context.Resolve(typeof(string));
 
-            return TimeZoneInfo.CreateCustomTimeZone(id, baseUtcOffset, displayName, standardDisplayName);
+            var sign = baseUtcOffset < TimeSpan.Zero ? "-" : "+";
+            var id = $"UTC{sign}{baseUtcOffset:hh}";
+            var displayName = $"(UTC{sign}{baseUtcOffset:hh\\:mm}) Test Time Zone{sign}{baseUtcOffset:hh}";
+
+            return TimeZoneInfo.CreateCustomTimeZone(
+                id: id,
+                baseUtcOffset: baseUtcOffset,
+                displayName: displayName,
+                standardDisplayName: id);
         }
     }
 }

--- a/Src/AutoFixture/TimeZoneInfoGenerator.cs
+++ b/Src/AutoFixture/TimeZoneInfoGenerator.cs
@@ -4,7 +4,7 @@ using AutoFixture.Kernel;
 namespace AutoFixture
 {
     /// <summary>
-    /// Creates new <see cref="TimeZoneInfoGenerator"/> instances.
+    /// Creates new <see cref="TimeZoneInfo"/> instances.
     /// </summary>
     public class TimeZoneInfoGenerator : ISpecimenBuilder
     {

--- a/Src/AutoFixture/TimeZoneInfoGenerator.cs
+++ b/Src/AutoFixture/TimeZoneInfoGenerator.cs
@@ -19,7 +19,7 @@ namespace AutoFixture
         public object Create(object request, ISpecimenContext context)
         {
             if (context is null) throw new ArgumentNullException(nameof(context));
-            if (!typeof(TimeZoneInfo).Equals(request)) return new NoSpecimen();
+            if (!typeof(TimeZoneInfo).Equals(request)) return NoSpecimen.Instance;
 
             var timeZoneRangeRequest = new RangedNumberRequest(typeof(int), -12, 14);
             var offset = (int)context.Resolve(timeZoneRangeRequest);

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -50,7 +50,8 @@ namespace AutoFixtureUnitTest
                     typeof(MailAddressGenerator),
 #endif
                     typeof(EmailAddressLocalPartGenerator),
-                    typeof(DomainNameGenerator)
+                    typeof(DomainNameGenerator),
+                    typeof(ElementsBuilder<TimeZoneInfo>)
                 };
             // Act
             var sut = new DefaultPrimitiveBuilders();

--- a/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
+++ b/Src/AutoFixtureUnitTest/DefaultPrimitiveBuildersTest.cs
@@ -51,7 +51,7 @@ namespace AutoFixtureUnitTest
 #endif
                     typeof(EmailAddressLocalPartGenerator),
                     typeof(DomainNameGenerator),
-                    typeof(ElementsBuilder<TimeZoneInfo>)
+                    typeof(TimeZoneInfoGenerator)
                 };
             // Act
             var sut = new DefaultPrimitiveBuilders();

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -6907,5 +6907,21 @@ namespace AutoFixtureUnitTest
             // Assert
             Assert.Equal(EnumType.First, result.PropertyWithEnumDataType);
         }
+
+        [Fact]
+        public void ShouldReturnDifferentTimeZoneInfoEveryTime()
+        {
+            // Arrange
+            var sut = new Fixture();
+
+            // Act
+            var result1 = sut.Create<TimeZoneInfo>();
+            var result2 = sut.Create<TimeZoneInfo>();
+            var result3 = sut.Create<TimeZoneInfo>();
+
+            // Assert
+            Assert.NotEqual(result1, result2);
+            Assert.NotEqual(result1, result3);
+        }
     }
 }

--- a/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace AutoFixtureUnitTest
     public class TimeZoneInfoGeneratorTests
     {
         [Fact]
-        public void Create_WithNullContext_ThrowsArgumentNullException()
+        public void WhenNullContext_ThrowsArgumentNullException()
         {
             var sut = new TimeZoneInfoGenerator();
 
@@ -17,7 +17,7 @@ namespace AutoFixtureUnitTest
         }
 
         [Fact]
-        public void Create_WithNullRequest_ReturnsCorrectResult()
+        public void WhenNullRequest_ReturnsNoSpecimen()
         {
             var sut = new DomainNameGenerator();
             var context = new DelegatingSpecimenContext();
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest
         }
 
         [Fact]
-        public void Create_WithNonTimeZoneInfoRequest_ReturnsNoSpecimen()
+        public void WhenNonTimeZoneInfoRequest_ReturnsNoSpecimen()
         {
             var sut = new TimeZoneInfoGenerator();
             var context = new DelegatingSpecimenContext();
@@ -39,7 +39,7 @@ namespace AutoFixtureUnitTest
         }
 
         [Fact]
-        public void Create_WithTimeZoneInfoRequest_ReturnsCustomTimeZoneInfo()
+        public void WhenTimeZoneInfoRequest_ReturnsCustomTimeZoneInfo()
         {
             var sut = new TimeZoneInfoGenerator();
             var context = new DelegatingSpecimenContext

--- a/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using AutoFixture;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
@@ -13,18 +14,19 @@ namespace AutoFixtureUnitTest
         {
             var sut = new TimeZoneInfoGenerator();
 
-            Assert.Throws<ArgumentNullException>(() => sut.Create(typeof(TimeZoneInfo), null));
+            Assert.Throws<ArgumentNullException>(
+                () => sut.Create(typeof(TimeZoneInfo), null));
         }
 
         [Fact]
         public void WhenNullRequest_ReturnsNoSpecimen()
         {
-            var sut = new DomainNameGenerator();
+            var sut = new TimeZoneInfoGenerator();
             var context = new DelegatingSpecimenContext();
 
             var result = sut.Create(null, context);
 
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.IsType<NoSpecimen>(result);
         }
 
         [Fact]
@@ -44,28 +46,20 @@ namespace AutoFixtureUnitTest
             var sut = new TimeZoneInfoGenerator();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r =>
+                OnResolve = r => r switch
                 {
-                    if (typeof(string).Equals(r))
-                    {
-                        return "testString";
-                    }
-                    else if (r is RangedNumberRequest)
-                    {
-                        return 2;
-                    }
-
-                    return new NoSpecimen();
+                    RangedNumberRequest _ => 2,
+                    _ => new NoSpecimen()
                 }
             };
 
             var result = sut.Create(typeof(TimeZoneInfo), context);
 
             var tz = Assert.IsType<TimeZoneInfo>(result);
-            Assert.Equal("testString", tz.Id);
             Assert.Equal(TimeSpan.FromHours(2), tz.BaseUtcOffset);
-            Assert.Equal("testString", tz.DisplayName);
-            Assert.Equal("testString", tz.StandardName);
+            Assert.Equal("UTC+02", tz.Id);
+            Assert.Equal("UTC+02", tz.StandardName);
+            Assert.Equal("(UTC+02:00) Test Time Zone+02", tz.DisplayName);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+using AutoFixtureUnitTest.Kernel;
+using Xunit;
+
+namespace AutoFixtureUnitTest
+{
+    public class TimeZoneInfoGeneratorTests
+    {
+        [Fact]
+        public void Create_WithNullContext_ThrowsArgumentNullException()
+        {
+            var sut = new TimeZoneInfoGenerator();
+
+            Assert.Throws<ArgumentNullException>(() => sut.Create(typeof(TimeZoneInfo), null));
+        }
+
+        [Fact]
+        public void Create_WithNullRequest_ReturnsCorrectResult()
+        {
+            var sut = new DomainNameGenerator();
+            var context = new DelegatingSpecimenContext();
+
+            var result = sut.Create(null, context);
+
+            Assert.Equal(new NoSpecimen(), result);
+        }
+
+        [Fact]
+        public void Create_WithNonTimeZoneInfoRequest_ReturnsNoSpecimen()
+        {
+            var sut = new TimeZoneInfoGenerator();
+            var context = new DelegatingSpecimenContext();
+
+            var result = sut.Create(typeof(string), context);
+
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void Create_WithTimeZoneInfoRequest_ReturnsCustomTimeZoneInfo()
+        {
+            var sut = new TimeZoneInfoGenerator();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = r =>
+                {
+                    if (typeof(string).Equals(r))
+                    {
+                        return "testString";
+                    }
+                    else if (r is RangedNumberRequest)
+                    {
+                        return 2;
+                    }
+
+                    return new NoSpecimen();
+                }
+            };
+
+            var result = sut.Create(typeof(TimeZoneInfo), context);
+
+            var tz = Assert.IsType<TimeZoneInfo>(result);
+            Assert.Equal("testString", tz.Id);
+            Assert.Equal(TimeSpan.FromHours(2), tz.BaseUtcOffset);
+            Assert.Equal("testString", tz.DisplayName);
+            Assert.Equal("testString", tz.StandardName);
+        }
+    }
+}

--- a/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using AutoFixture;
 using AutoFixture.Kernel;
 using AutoFixtureUnitTest.Kernel;
@@ -12,8 +11,10 @@ namespace AutoFixtureUnitTest
         [Fact]
         public void WhenNullContext_ThrowsArgumentNullException()
         {
+            // Arrange
             var sut = new TimeZoneInfoGenerator();
 
+            // Act & Assert
             Assert.Throws<ArgumentNullException>(
                 () => sut.Create(typeof(TimeZoneInfo), null));
         }
@@ -21,28 +22,84 @@ namespace AutoFixtureUnitTest
         [Fact]
         public void WhenNullRequest_ReturnsNoSpecimen()
         {
+            // Arrange
             var sut = new TimeZoneInfoGenerator();
             var context = new DelegatingSpecimenContext();
 
+            // Act
             var result = sut.Create(null, context);
 
+            // Assert
             Assert.IsType<NoSpecimen>(result);
         }
 
         [Fact]
         public void WhenNonTimeZoneInfoRequest_ReturnsNoSpecimen()
         {
+            // Arrange
             var sut = new TimeZoneInfoGenerator();
             var context = new DelegatingSpecimenContext();
 
+            // Act
             var result = sut.Create(typeof(string), context);
 
+            // Assert
             Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void WhenTimeOffsetIsNoSpecimen_ReturnsNoSpecimen()
+        {
+            // Arrange
+            var sut = new TimeZoneInfoGenerator();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = _ => NoSpecimen.Instance
+            };
+
+            // Act
+            var result = sut.Create(typeof(TimeZoneInfo), context);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(result);
+        }
+
+        [Fact]
+        public void WhenTimeOffsetIsOmitSpecimen_ReturnsOmitSpecimen()
+        {
+            // Arrange
+            var sut = new TimeZoneInfoGenerator();
+            var context = new DelegatingSpecimenContext
+            {
+                OnResolve = _ => new OmitSpecimen()
+            };
+
+            // Act
+            var result = sut.Create(typeof(TimeZoneInfo), context);
+
+            // Assert
+            Assert.IsType<OmitSpecimen>(result);
+        }
+
+        [Fact]
+        public void WhenTimeOffsetIsNotInt_ThrowsArgumentException()
+        {
+            // Arrange
+            var sut = new TimeZoneInfoGenerator();
+            var context = new DelegatingSpecimenContext { OnResolve = _ => "not int" };
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => sut.Create(typeof(TimeZoneInfo), context));
+            Assert.Equal(
+                "The result of ranged number request must be an int, but was System.String.",
+                exception.Message);
         }
 
         [Fact]
         public void WhenTimeZoneInfoRequest_ReturnsCustomTimeZoneInfo()
         {
+            // Arrange
             var sut = new TimeZoneInfoGenerator();
             var context = new DelegatingSpecimenContext
             {
@@ -53,8 +110,10 @@ namespace AutoFixtureUnitTest
                 }
             };
 
+            // Act
             var result = sut.Create(typeof(TimeZoneInfo), context);
 
+            // Assert
             var tz = Assert.IsType<TimeZoneInfo>(result);
             Assert.Equal(TimeSpan.FromHours(2), tz.BaseUtcOffset);
             Assert.Equal("UTC+02", tz.Id);

--- a/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
+++ b/Src/AutoFixtureUnitTest/TimeZoneInfoGeneratorTests.cs
@@ -49,7 +49,7 @@ namespace AutoFixtureUnitTest
                 OnResolve = r => r switch
                 {
                     RangedNumberRequest _ => 2,
-                    _ => new NoSpecimen()
+                    _ => NoSpecimen.Instance
                 }
             };
 


### PR DESCRIPTION
### Description
This PR changes the default behavior to return random time zones instead of always returning the local one.

### Closed issues
#1097

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
