### PR TITLE
Make NoSpecimen singleton

### DIFF
--- a/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
@@ -57,12 +57,12 @@ namespace AutoFixture.AutoFakeItEasy
         {
             if (request is not Type type || !type.IsFake())
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var fake = this.Builder.Create(request, context);
 
-            return type.IsInstanceOfType(fake) ? fake : new NoSpecimen();
+            return type.IsInstanceOfType(fake) ? fake : NoSpecimen.Instance;
         }
     }
 }

--- a/Src/AutoFakeItEasy/FakeItEasyRelay.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyRelay.cs
@@ -62,17 +62,17 @@ namespace AutoFixture.AutoFakeItEasy
             if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (!this.FakeableSpecification.IsSatisfiedBy(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (request is not Type type)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var fakeType = typeof(Fake<>).MakeGenericType(type);
 
             var fake = context.Resolve(fakeType);
             if (!fakeType.IsInstanceOfType(fake))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return fake.GetType().GetProperty("FakedObject").GetValue(fake, null);

--- a/Src/AutoFakeItEasyUnitTest/FakeItEasyBuilderTest.cs
+++ b/Src/AutoFakeItEasyUnitTest/FakeItEasyBuilderTest.cs
@@ -54,7 +54,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             var dummyContext = A.Fake<ISpecimenContext>();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -89,7 +89,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -108,7 +108,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -126,7 +126,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoFakeItEasyUnitTest/FakeItEasyRelayTest.cs
+++ b/Src/AutoFakeItEasyUnitTest/FakeItEasyRelayTest.cs
@@ -76,7 +76,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -114,7 +114,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             // Act
             var result = sut.Create(request, contextStub.FakedObject);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -162,7 +162,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
             var dummyContext = A.Fake<ISpecimenContext>();
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
     }

--- a/Src/AutoFixture.SeedExtensions.UnitTest/CreateSeedExtensionsTest.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/CreateSeedExtensionsTest.cs
@@ -15,7 +15,7 @@ namespace AutoFixture.SeedExtensions.UnitTest
             // Arrange
             var seed = TimeSpan.FromMinutes(8);
             object expectedResult = TimeSpan.FromHours(2);
-            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : NoSpecimen.Instance };
             // Act
             var result = container.CreateAnonymous(seed);
             // Assert
@@ -100,7 +100,7 @@ namespace AutoFixture.SeedExtensions.UnitTest
             {
                 OnResolve = r => r.Equals(new MultipleRequest(new SeededRequest(typeof(Version), seed))) ?
                     (object)expectedResult.Cast<object>() :
-                    new NoSpecimen()
+                    NoSpecimen.Instance
             };
             // Act
             var result = container.CreateMany(seed);
@@ -191,7 +191,7 @@ namespace AutoFixture.SeedExtensions.UnitTest
             {
                 OnResolve = r => r.Equals(new FiniteSequenceRequest(new SeededRequest(typeof(Version), seed), count)) ?
                     (object)expectedResult.Cast<object>() :
-                    new NoSpecimen()
+                    NoSpecimen.Instance
             };
             // Act
             var result = container.CreateMany(seed, count);
@@ -266,7 +266,7 @@ namespace AutoFixture.SeedExtensions.UnitTest
             // Arrange
             var seed = TimeSpan.FromMinutes(8);
             object expectedResult = TimeSpan.FromHours(2);
-            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(TimeSpan), seed)) ? expectedResult : NoSpecimen.Instance };
             // Act
             var result = container.Create(seed);
             // Assert

--- a/Src/AutoFixture/BooleanSwitch.cs
+++ b/Src/AutoFixture/BooleanSwitch.cs
@@ -66,7 +66,7 @@ namespace AutoFixture
         {
             if (!typeof(bool).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/ByteSequenceGenerator.cs
+++ b/Src/AutoFixture/ByteSequenceGenerator.cs
@@ -56,7 +56,7 @@ namespace AutoFixture
         {
             if (!typeof(byte).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/CharSequenceGenerator.cs
+++ b/Src/AutoFixture/CharSequenceGenerator.cs
@@ -30,7 +30,7 @@ namespace AutoFixture
         {
             if (!typeof(char).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.Create();

--- a/Src/AutoFixture/ConstrainedStringGenerator.cs
+++ b/Src/AutoFixture/ConstrainedStringGenerator.cs
@@ -24,7 +24,7 @@ namespace AutoFixture
             var constrain = request as ConstrainedStringRequest;
             if (constrain == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return Create(constrain.MinimumLength, constrain.MaximumLength, context);

--- a/Src/AutoFixture/CurrentDateTimeGenerator.cs
+++ b/Src/AutoFixture/CurrentDateTimeGenerator.cs
@@ -21,7 +21,7 @@ namespace AutoFixture
         {
             if (!typeof(DateTime).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return DateTime.Now;

--- a/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
@@ -52,17 +52,17 @@ namespace AutoFixture.DataAnnotations
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (request == null) return new NoSpecimen();
+            if (request == null) return NoSpecimen.Instance;
 
             var attribute = TypeEnvy.GetAttribute<EnumDataTypeAttribute>(request);
-            if (attribute == null || !attribute.EnumType.GetTypeInfo().IsEnum) return new NoSpecimen();
+            if (attribute == null || !attribute.EnumType.GetTypeInfo().IsEnum) return NoSpecimen.Instance;
 
             var enumValue = this.enumGenerator.Create(attribute.EnumType, context);
             if (enumValue is NoSpecimen) return enumValue;
 
             if (!this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return memberType switch
@@ -71,7 +71,7 @@ namespace AutoFixture.DataAnnotations
                 var t when t == typeof(object) => enumValue,
                 var t when t.IsNumberType() => Convert.ChangeType(enumValue, memberType, CultureInfo.CurrentCulture),
                 var t when t == typeof(string) => enumValue.ToString(),
-                _ => new NoSpecimen()
+                _ => NoSpecimen.Instance
             };
         }
     }

--- a/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumRangedRequestRelay.cs
@@ -18,10 +18,10 @@ namespace AutoFixture.DataAnnotations
 
             var rangedRequest = request as RangedRequest;
             if (rangedRequest == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!rangedRequest.MemberType.GetTypeInfo().IsEnum)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var underlyingNumericType = rangedRequest.MemberType.GetTypeInfo().GetEnumUnderlyingType();
 
@@ -43,7 +43,7 @@ namespace AutoFixture.DataAnnotations
 
             var numericValue = context.Resolve(new RangedNumberRequest(underlyingNumericType, numericMin, numericMax));
             if (numericValue is NoSpecimen)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return Enum.ToObject(rangedRequest.MemberType, numericValue);
         }

--- a/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
@@ -37,13 +37,13 @@ namespace AutoFixture.DataAnnotations
 
             if (!this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var range = Range.From(request);
             if (!range.IsConstrained)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if (memberType == typeof(string))
@@ -53,14 +53,14 @@ namespace AutoFixture.DataAnnotations
 
             if (!memberType.IsArray)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var elementType = memberType.GetElementType();
             var result = context.Resolve(range.ToSequenceRequest(elementType));
             if (result is not IEnumerable seqResult)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return seqResult.ToTypedArray(elementType);

--- a/Src/AutoFixture/DataAnnotations/NumericRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/NumericRangedRequestRelay.cs
@@ -15,10 +15,10 @@ namespace AutoFixture.DataAnnotations
             if (context is null) throw new ArgumentNullException(nameof(context));
 
             if (request is not RangedRequest rangedRequest)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!rangedRequest.MemberType.IsNumberType())
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var convertedMinimum = rangedRequest.GetConvertedMinimum(rangedRequest.MemberType);
             var convertedMaximum = rangedRequest.GetConvertedMaximum(rangedRequest.MemberType);

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -37,7 +37,7 @@ namespace AutoFixture.DataAnnotations
             var rangeAttribute = TypeEnvy.GetAttribute<RangeAttribute>(request);
             if (rangeAttribute is null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var memberType = this.GetMemberType(rangeAttribute, request);

--- a/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RegularExpressionAttributeRelay.cs
@@ -21,7 +21,7 @@ namespace AutoFixture.DataAnnotations
         {
             if (request == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if (context == null)
@@ -32,7 +32,7 @@ namespace AutoFixture.DataAnnotations
             var regularExpressionAttribute = TypeEnvy.GetAttribute<RegularExpressionAttribute>(request);
             if (regularExpressionAttribute == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return context.Resolve(new RegularExpressionRequest(regularExpressionAttribute.Pattern));

--- a/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
@@ -36,23 +36,23 @@ namespace AutoFixture.DataAnnotations
 
             if (request is null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var attribute = TypeEnvy.GetAttribute<StringLengthAttribute>(request);
             if (attribute is null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if (!this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if (memberType != typeof(string))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var stringRequest = new ConstrainedStringRequest(

--- a/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/TimeSpanRangedRequestRelay.cs
@@ -18,10 +18,10 @@ namespace AutoFixture.DataAnnotations
             var rangedRequest = request as RangedRequest;
 
             if (rangedRequest == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (rangedRequest.MemberType != typeof(TimeSpan))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return CreateRangedTimeSpanSpecimen(rangedRequest, context);
         }
@@ -29,7 +29,7 @@ namespace AutoFixture.DataAnnotations
         private static object CreateRangedTimeSpanSpecimen(RangedRequest rangedRequest, ISpecimenContext context)
         {
             if (!(rangedRequest.Minimum is string) || !(rangedRequest.Maximum is string))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var range = ParseTimeSpanRange(rangedRequest);
             return RandomizeTimeSpanInRange(range, context);
@@ -50,7 +50,7 @@ namespace AutoFixture.DataAnnotations
                 new RangedNumberRequest(typeof(double), range.Min.TotalMilliseconds, range.Max.TotalMilliseconds));
 
             if (millisecondsInRange is NoSpecimen)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return TimeSpan.FromMilliseconds((double)millisecondsInRange);
         }

--- a/Src/AutoFixture/DecimalSequenceGenerator.cs
+++ b/Src/AutoFixture/DecimalSequenceGenerator.cs
@@ -45,7 +45,7 @@ namespace AutoFixture
         {
             if (!typeof(decimal).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/DomainNameGenerator.cs
+++ b/Src/AutoFixture/DomainNameGenerator.cs
@@ -19,11 +19,11 @@ namespace AutoFixture
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             if (request == null || !typeof(DomainName).Equals(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var domainName = this.fictitiousDomainBuilder.Create(typeof(string), context) as string;
             if (domainName == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return new DomainName(domainName);
         }

--- a/Src/AutoFixture/DoubleSequenceGenerator.cs
+++ b/Src/AutoFixture/DoubleSequenceGenerator.cs
@@ -45,7 +45,7 @@ namespace AutoFixture
         {
             if (!typeof(double).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/ElementsBuilder.cs
+++ b/Src/AutoFixture/ElementsBuilder.cs
@@ -56,7 +56,7 @@ namespace AutoFixture
         public object Create(object request, ISpecimenContext context)
         {
             if (!typeof(T).Equals(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return this.elements[this.GetNextIndex()];
         }

--- a/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
+++ b/Src/AutoFixture/EmailAddressLocalPartGenerator.cs
@@ -22,14 +22,14 @@ namespace AutoFixture
 
             if (request == null || !typeof(EmailAddressLocalPart).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var localPart = context.Resolve(typeof(string)) as string;
 
             if (string.IsNullOrEmpty(localPart))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return new EmailAddressLocalPart(localPart);

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -47,10 +47,10 @@ namespace AutoFixture
         {
             var type = request as Type;
             if (type == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!type.GetTypeInfo().IsEnum)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             lock (this.syncRoot)
             {

--- a/Src/AutoFixture/GuidGenerator.cs
+++ b/Src/AutoFixture/GuidGenerator.cs
@@ -31,7 +31,7 @@ namespace AutoFixture
         {
             if (!typeof(Guid).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/Int16SequenceGenerator.cs
+++ b/Src/AutoFixture/Int16SequenceGenerator.cs
@@ -56,7 +56,7 @@ namespace AutoFixture
         {
             if (!typeof(short).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/Int32SequenceGenerator.cs
+++ b/Src/AutoFixture/Int32SequenceGenerator.cs
@@ -45,7 +45,7 @@ namespace AutoFixture
         {
             if (!typeof(int).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/Int64SequenceGenerator.cs
+++ b/Src/AutoFixture/Int64SequenceGenerator.cs
@@ -45,7 +45,7 @@ namespace AutoFixture
         {
             if (!typeof(long).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/InvariantCultureGenerator.cs
+++ b/Src/AutoFixture/InvariantCultureGenerator.cs
@@ -28,10 +28,10 @@ namespace AutoFixture
         public object Create(object request, ISpecimenContext context)
         {
             if (request == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!this.cultureTypeSpecification.IsSatisfiedBy(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return CultureInfo.InvariantCulture;
         }

--- a/Src/AutoFixture/Kernel/ArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/ArrayRelay.cs
@@ -34,10 +34,10 @@ namespace AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!type.IsArray)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var elementType = type.GetElementType();
             var specimen = context.Resolve(new MultipleRequest(elementType));
@@ -46,7 +46,7 @@ namespace AutoFixture.Kernel
 
             var elements = specimen as IEnumerable;
             if (elements == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return elements.ToTypedArray(elementType);
         }

--- a/Src/AutoFixture/Kernel/AsyncEnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/AsyncEnumerableRelay.cs
@@ -25,18 +25,18 @@ namespace AutoFixture.Kernel
         public object Create(object request, ISpecimenContext context)
         {
             if (context is null) throw new ArgumentNullException(nameof(context));
-            if (request is not Type type) return new NoSpecimen();
+            if (request is not Type type) return NoSpecimen.Instance;
 
             if (!type.TryGetSingleGenericTypeArgument(typeof(IAsyncEnumerable<>), out Type enumerableType))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var specimen = context.Resolve(new MultipleRequest(enumerableType));
             if (specimen is OmitSpecimen) return specimen;
 
             if (specimen is not IEnumerable<object> enumerable)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var typedAdapterType = typeof(SynchronousAsyncEnumerable<>).MakeGenericType(enumerableType);
             return Activator.CreateInstance(typedAdapterType, enumerable);

--- a/Src/AutoFixture/Kernel/AsyncEnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/AsyncEnumeratorRelay.cs
@@ -38,10 +38,10 @@ namespace AutoFixture.Kernel
         {
             if (context is null) throw new ArgumentNullException(nameof(context));
 
-            if (request is not Type type) return new NoSpecimen();
+            if (request is not Type type) return NoSpecimen.Instance;
 
             if (!type.TryGetSingleGenericTypeArgument(typeof(IAsyncEnumerator<>), out Type enumeratorType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var specimenBuilder = (IAsyncEnumeratorBuilder)Activator.CreateInstance(
                 typeof(GenericAsyncEnumeratorRelay<>).MakeGenericType(enumeratorType));
@@ -65,7 +65,7 @@ namespace AutoFixture.Kernel
                 if (result is IAsyncEnumerable<T> enumerable)
                     return enumerable.GetAsyncEnumerator();
 
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
         }
     }

--- a/Src/AutoFixture/Kernel/CollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/CollectionRelay.cs
@@ -35,11 +35,11 @@ namespace AutoFixture.Kernel
             // This is performance-sensitive code when used repeatedly over many requests.
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
-            if (type == null) return new NoSpecimen();
+            if (type == null) return NoSpecimen.Instance;
             var typeArguments = type.GetTypeInfo().GetGenericArguments();
-            if (typeArguments.Length != 1) return new NoSpecimen();
+            if (typeArguments.Length != 1) return NoSpecimen.Instance;
             var gtd = type.GetGenericTypeDefinition();
-            if (gtd != typeof(ICollection<>)) return new NoSpecimen();
+            if (gtd != typeof(ICollection<>)) return NoSpecimen.Instance;
             return context.Resolve(typeof(List<>).MakeGenericType(typeArguments));
         }
     }

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -53,7 +53,7 @@ namespace AutoFixture.Kernel
                 if (!(result is NoSpecimen)) return result;
             }
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         /// <summary>Composes the supplied builders.</summary>

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -48,10 +48,10 @@ namespace AutoFixture.Kernel
 
             var delegateType = request as Type;
             if (delegateType == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!this.Specification.IsSatisfiedBy(delegateType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var delegateMethod = delegateType.GetTypeInfo().GetMethod("Invoke");
             var methodSpecimenParams = CreateMethodSpecimenParameters(delegateMethod);

--- a/Src/AutoFixture/Kernel/DictionaryRelay.cs
+++ b/Src/AutoFixture/Kernel/DictionaryRelay.cs
@@ -35,11 +35,11 @@ namespace AutoFixture.Kernel
             // This is performance-sensitive code when used repeatedly over many requests.
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
-            if (type == null) return new NoSpecimen();
+            if (type == null) return NoSpecimen.Instance;
             var typeArguments = type.GetTypeInfo().GetGenericArguments();
-            if (typeArguments.Length != 2) return new NoSpecimen();
+            if (typeArguments.Length != 2) return NoSpecimen.Instance;
             var gtd = type.GetGenericTypeDefinition();
-            if (gtd != typeof(IDictionary<,>)) return new NoSpecimen();
+            if (gtd != typeof(IDictionary<,>)) return NoSpecimen.Instance;
             return context.Resolve(typeof(Dictionary<,>).MakeGenericType(typeArguments));
         }
     }

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -36,10 +36,10 @@ namespace AutoFixture.Kernel
             // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
             var type = request as Type;
             if (type == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!type.TryGetSingleGenericTypeArgument(typeof(IEnumerable<>), out Type enumerableType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var specimen = context.Resolve(new MultipleRequest(enumerableType));
             if (specimen is OmitSpecimen)
@@ -47,7 +47,7 @@ namespace AutoFixture.Kernel
 
             var enumerable = specimen as IEnumerable<object>;
             if (enumerable == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var typedAdapterType = typeof(ConvertedEnumerable<>).MakeGenericType(enumerableType);
             return Activator.CreateInstance(typedAdapterType, enumerable);

--- a/Src/AutoFixture/Kernel/EnumeratorRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumeratorRelay.cs
@@ -40,10 +40,10 @@ namespace AutoFixture.Kernel
 
             var type = request as Type;
             if (type == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!type.TryGetSingleGenericTypeArgument(typeof(IEnumerator<>), out Type enumeratorType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var specimenBuilder = (IEnumeratorBuilder)Activator.CreateInstance(
                 typeof(GenericEnumeratorRelay<>).MakeGenericType(enumeratorType));
@@ -65,7 +65,7 @@ namespace AutoFixture.Kernel
                 if (result is IEnumerable<T> enumerable)
                     return enumerable.GetEnumerator();
 
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
         }
     }

--- a/Src/AutoFixture/Kernel/FieldRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/FieldRequestRelay.cs
@@ -26,7 +26,7 @@ namespace AutoFixture.Kernel
             var fieldInfo = request as FieldInfo;
             if (fieldInfo == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return context.Resolve(new SeededRequest(fieldInfo.FieldType, fieldInfo.Name));

--- a/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
@@ -47,7 +47,7 @@ namespace AutoFixture.Kernel
         {
             if (!this.Specification.IsSatisfiedBy(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.Builder.Create(request, context);

--- a/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRelay.cs
@@ -32,7 +32,7 @@ namespace AutoFixture.Kernel
             var manyRequest = request as FiniteSequenceRequest;
             if (manyRequest == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return from req in manyRequest.CreateRequests()

--- a/Src/AutoFixture/Kernel/IntPtrGuard.cs
+++ b/Src/AutoFixture/Kernel/IntPtrGuard.cs
@@ -38,7 +38,7 @@ namespace AutoFixture.Kernel
         {
             if (!typeof(IntPtr).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             throw new IllegalRequestException("A request for an IntPtr was detected. This is an unsafe resource that will crash the process if used, so the request is denied. A common source of IntPtr requests are requests for delegates such as Func<T> or Action<T>. If this is the case, the expected workaround is to Customize (Register or Inject) the offending type by specifying a proper creational strategy.");

--- a/Src/AutoFixture/Kernel/ListRelay.cs
+++ b/Src/AutoFixture/Kernel/ListRelay.cs
@@ -34,12 +34,12 @@ namespace AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var typeArguments = t.GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof(IList<>) != t.GetGenericTypeDefinition())
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return context.Resolve(
                 typeof(List<>).MakeGenericType(typeArguments));

--- a/Src/AutoFixture/Kernel/MethodInvoker.cs
+++ b/Src/AutoFixture/Kernel/MethodInvoker.cs
@@ -59,7 +59,7 @@ namespace AutoFixture.Kernel
                 }
             }
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         private IEnumerable<IMethod> GetConstructors(object request)

--- a/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
+++ b/Src/AutoFixture/Kernel/MultidimensionalArrayRelay.cs
@@ -28,7 +28,7 @@ namespace AutoFixture.Kernel
 
             var arrayType = request as Type;
             if (arrayType == null || !IsMultidimensionalArray(arrayType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return CreateMultidimensionalArray(arrayType, context);
         }

--- a/Src/AutoFixture/Kernel/MultipleRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleRelay.cs
@@ -54,7 +54,7 @@ namespace AutoFixture.Kernel
             var manyRequest = request as MultipleRequest;
             if (manyRequest == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return context.Resolve(new FiniteSequenceRequest(manyRequest.Request, this.Count));

--- a/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleToEnumerableRelay.cs
@@ -50,13 +50,13 @@ namespace AutoFixture.Kernel
 
             var multipleRequest = request as MultipleRequest;
             if (multipleRequest == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var innerRequest = GetInnerRequest(multipleRequest);
 
             var itemType = innerRequest as Type;
             if (itemType == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return context.Resolve(
                 typeof(IEnumerable<>).MakeGenericType(itemType));

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -17,7 +17,9 @@ namespace AutoFixture.Kernel
         /// <summary>
         /// The singleton instance of <see cref="NoSpecimen"/>.
         /// </summary>
+#pragma warning disable 0618
         public static NoSpecimen Instance { get; } = new NoSpecimen();
+#pragma warning restore 0618
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSpecimen"/> class.

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -17,12 +17,13 @@ namespace AutoFixture.Kernel
         /// <summary>
         /// The singleton instance of <see cref="NoSpecimen"/>.
         /// </summary>
-        public static readonly NoSpecimen Instance = new NoSpecimen();
+        public static NoSpecimen Instance { get; } = new NoSpecimen();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSpecimen"/> class.
         /// </summary>
-        private NoSpecimen()
+        [Obsolete(@"Use the NoSpecimen.Instance property instead of calling new NoSpecimen(). This constructor is being deprecated in future versions of AutoFixture, as creating many NoSpecimen instances causes excessive memory usage: https://github.com/AutoFixture/AutoFixture/issues/1489", false)]
+        public NoSpecimen()
         {
         }
 

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -22,10 +22,12 @@ namespace AutoFixture.Kernel
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSpecimen"/> class.
         /// </summary>
+#pragma warning disable 0618
         [Obsolete(@"Use the NoSpecimen.Instance property instead of calling new NoSpecimen(). This constructor is being deprecated in future versions of AutoFixture, as creating many NoSpecimen instances causes excessive memory usage: https://github.com/AutoFixture/AutoFixture/issues/1489", false)]
         public NoSpecimen()
         {
         }
+#pragma warning restore 0618
 
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -12,12 +12,17 @@ namespace AutoFixture.Kernel
     /// <see langword="null"/> can be used as a proper return value.
     /// </para>
     /// </remarks>
-    public class NoSpecimen : IEquatable<NoSpecimen>
+    public sealed class NoSpecimen : IEquatable<NoSpecimen>
     {
+        /// <summary>
+        /// The singleton instance of <see cref="NoSpecimen"/>.
+        /// </summary>
+        public static readonly NoSpecimen Instance = new NoSpecimen();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NoSpecimen"/> class.
         /// </summary>
-        public NoSpecimen()
+        private NoSpecimen()
         {
         }
 

--- a/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitArrayParameterRequestRelay.cs
@@ -55,10 +55,10 @@ namespace AutoFixture.Kernel
 
             var pi = request as ParameterInfo;
             if (pi == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!pi.ParameterType.IsArray)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var returnValue = context.Resolve(
                 new SeededRequest(

--- a/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/OmitEnumerableParameterRequestRelay.cs
@@ -56,10 +56,10 @@ namespace AutoFixture.Kernel
 
             var pi = request as ParameterInfo;
             if (pi == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!pi.ParameterType.TryGetSingleGenericTypeArgument(typeof(IEnumerable<>), out Type enumerableType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var returnValue = context.Resolve(
                 new SeededRequest(

--- a/Src/AutoFixture/Kernel/Omitter.cs
+++ b/Src/AutoFixture/Kernel/Omitter.cs
@@ -57,7 +57,7 @@ namespace AutoFixture.Kernel
             if (this.Specification.IsSatisfiedBy(request))
                 return new OmitSpecimen();
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         /// <summary>

--- a/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/ParameterRequestRelay.cs
@@ -26,7 +26,7 @@ namespace AutoFixture.Kernel
             var paramInfo = request as ParameterInfo;
             if (paramInfo == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return context.Resolve(new SeededRequest(paramInfo.ParameterType, paramInfo.Name));

--- a/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
+++ b/Src/AutoFixture/Kernel/PropertyRequestRelay.cs
@@ -26,7 +26,7 @@ namespace AutoFixture.Kernel
             var propertyInfo = request as PropertyInfo;
             if (propertyInfo == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return context.Resolve(new SeededRequest(propertyInfo.PropertyType, propertyInfo.Name));

--- a/Src/AutoFixture/Kernel/RangedSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/RangedSequenceRelay.cs
@@ -14,10 +14,10 @@ namespace AutoFixture.Kernel
 
             var rsr = request as RangedSequenceRequest;
             if (rsr == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!TryGetSequenceLength(rsr, context, out int sequenceLength))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return context.Resolve(new FiniteSequenceRequest(rsr.Request, sequenceLength));
         }

--- a/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
+++ b/Src/AutoFixture/Kernel/ReadOnlyCollectionRelay.cs
@@ -34,12 +34,12 @@ namespace AutoFixture.Kernel
 
             var t = request as Type;
             if (t == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var typeArguments = t.GetTypeInfo().GetGenericArguments();
             if (typeArguments.Length != 1 ||
                 typeof(IReadOnlyCollection<>) != t.GetGenericTypeDefinition())
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return context.Resolve(
                 typeof(List<>).MakeGenericType(typeArguments));

--- a/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
+++ b/Src/AutoFixture/Kernel/SeedIgnoringRelay.cs
@@ -36,7 +36,7 @@ namespace AutoFixture.Kernel
             var seededRequest = request as SeededRequest;
             if (seededRequest == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return context.Resolve(seededRequest.Request);

--- a/Src/AutoFixture/Kernel/SeededFactory.cs
+++ b/Src/AutoFixture/Kernel/SeededFactory.cs
@@ -42,18 +42,18 @@ namespace AutoFixture.Kernel
             var seededRequest = request as SeededRequest;
             if (seededRequest == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if (!seededRequest.Request.Equals(typeof(T)))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if ((seededRequest.Seed != null)
                 && !(seededRequest.Seed is T))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
             var seed = (T)seededRequest.Seed;
 

--- a/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
+++ b/Src/AutoFixture/Kernel/StableFiniteSequenceRelay.cs
@@ -43,7 +43,7 @@ namespace AutoFixture.Kernel
             var manyRequest = request as FiniteSequenceRequest;
             if (manyRequest == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return (from req in manyRequest.CreateRequests()

--- a/Src/AutoFixture/Kernel/TypeRelay.cs
+++ b/Src/AutoFixture/Kernel/TypeRelay.cs
@@ -94,7 +94,7 @@ namespace AutoFixture.Kernel
             if (request is Type t && this.fromSpecification.IsSatisfiedBy(request))
                 return context.Resolve(this.GetRedirectedTypeRequest(t));
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         private Type GetRedirectedTypeRequest(Type originalRequest)

--- a/Src/AutoFixture/LambdaExpressionGenerator.cs
+++ b/Src/AutoFixture/LambdaExpressionGenerator.cs
@@ -32,10 +32,10 @@ namespace AutoFixture
 
             var requestType = request as Type;
             if (requestType == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!typeof(LambdaExpression).GetTypeInfo().IsAssignableFrom(requestType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var delegateType = requestType == typeof(LambdaExpression)
                                ? typeof(Action)

--- a/Src/AutoFixture/LazyRelay.cs
+++ b/Src/AutoFixture/LazyRelay.cs
@@ -38,10 +38,10 @@ namespace AutoFixture
 
             var type = request as Type;
             if (type == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             if (!type.TryGetSingleGenericTypeArgument(typeof(Lazy<>), out Type lazyType))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var lazyBuilderType = typeof(LazyBuilder<>).MakeGenericType(lazyType);
             var builder = (ILazyBuilder)Activator.CreateInstance(lazyBuilderType);

--- a/Src/AutoFixture/MailAddressGenerator.cs
+++ b/Src/AutoFixture/MailAddressGenerator.cs
@@ -30,7 +30,7 @@ namespace AutoFixture
 
             if (!typeof(MailAddress).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             try
@@ -39,7 +39,7 @@ namespace AutoFixture
             }
             catch (FormatException)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
         }
 
@@ -50,7 +50,7 @@ namespace AutoFixture
 
             if (localPart == null || domainName == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var email = string.Format(CultureInfo.InvariantCulture, "{0} <{0}@{1}>", localPart, domainName);

--- a/Src/AutoFixture/MutableValueTypeGenerator.cs
+++ b/Src/AutoFixture/MutableValueTypeGenerator.cs
@@ -32,7 +32,7 @@ namespace AutoFixture
             Type type = request as Type;
             if (type == null || !this.valueTypeWithoutConstructorsSpecification.IsSatisfiedBy(type))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return Activator.CreateInstance(type);

--- a/Src/AutoFixture/NumericSequenceGenerator.cs
+++ b/Src/AutoFixture/NumericSequenceGenerator.cs
@@ -24,7 +24,7 @@ namespace AutoFixture
         {
             var type = request as Type;
             if (type == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return this.CreateNumericSpecimen(type);
         }
@@ -58,7 +58,7 @@ namespace AutoFixture
                 case TypeCode.UInt64:
                     return (ulong)this.GetNextNumber();
                 default:
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
             }
         }
 

--- a/Src/AutoFixture/RandomBooleanSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomBooleanSequenceGenerator.cs
@@ -32,7 +32,7 @@ namespace AutoFixture
         {
             if (!typeof(bool).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.GenerateBoolean(context);

--- a/Src/AutoFixture/RandomCharSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomCharSequenceGenerator.cs
@@ -34,7 +34,7 @@ namespace AutoFixture
         public object Create(object request, ISpecimenContext context)
         {
             if (!typeof(char).Equals(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return Convert.ToChar(
                 this.randomPrintableCharNumbers.Create(typeof(int), context),

--- a/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
@@ -61,7 +61,7 @@ public class RandomDateOnlySequenceGenerator : ISpecimenBuilder
 
         if (!typeof(DateOnly).GetTypeInfo().IsAssignableFrom(request as Type))
         {
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         var dayNumber = (int)this.randomizer.Create(typeof(int), context);

--- a/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
@@ -57,7 +57,7 @@ namespace AutoFixture
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             return IsNotDateTimeRequest(request)
-                       ? new NoSpecimen()
+                       ? NoSpecimen.Instance
                        : this.CreateRandomDate(context);
         }
 

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -82,7 +82,7 @@ namespace AutoFixture
             var type = request as Type;
             if (type == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.CreateRandom(type);
@@ -135,7 +135,7 @@ namespace AutoFixture
                     return (ulong)this.GetNextRandom();
 
                 default:
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
             }
         }
 

--- a/Src/AutoFixture/RandomRangedNumberGenerator.cs
+++ b/Src/AutoFixture/RandomRangedNumberGenerator.cs
@@ -39,7 +39,7 @@ namespace AutoFixture
 
             var rangedNumberRequest = request as RangedNumberRequest;
             if (rangedNumberRequest == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             try
             {
@@ -47,7 +47,7 @@ namespace AutoFixture
             }
             catch (ArgumentException)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
         }
 
@@ -129,7 +129,7 @@ namespace AutoFixture
             public object Create(object request, ISpecimenContext context)
             {
                 var randomValue = this.generator.Create(typeof(double), context);
-                if (randomValue is NoSpecimen) return new NoSpecimen();
+                if (randomValue is NoSpecimen) return NoSpecimen.Instance;
 
                 // Half offset is needed to avoid overflow - full offset might be larger than double range.
                 double halfOffset = (this.factor / 2) * (double)randomValue;
@@ -163,7 +163,7 @@ namespace AutoFixture
             public object Create(object request, ISpecimenContext context)
             {
                 var randomValue = this.generator.Create(typeof(decimal), context);
-                if (randomValue is NoSpecimen) return new NoSpecimen();
+                if (randomValue is NoSpecimen) return NoSpecimen.Instance;
 
                 // Half offset is needed to avoid overflow - full offset might be larger than decimal range.
                 var halfOffset = (this.factor / 2) * (decimal)randomValue;

--- a/Src/AutoFixture/RandomTimeOnlySequenceGenerator.cs
+++ b/Src/AutoFixture/RandomTimeOnlySequenceGenerator.cs
@@ -61,7 +61,7 @@ public class RandomTimeOnlySequenceGenerator : ISpecimenBuilder
 
         if (!typeof(TimeOnly).GetTypeInfo().IsAssignableFrom(request as Type))
         {
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         var ticks = (long)this.randomizer.Create(typeof(long), context);

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -37,7 +37,7 @@ namespace AutoFixture
             var range = request as RangedNumberRequest;
             if (range == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if (range.Minimum.Equals(range.Maximum))
@@ -48,7 +48,7 @@ namespace AutoFixture
             var value = context.Resolve(range.OperandType) as IComparable;
             if (value == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             try
@@ -57,7 +57,7 @@ namespace AutoFixture
             }
             catch (InvalidOperationException)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.rangedValue;

--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -32,12 +32,12 @@ namespace AutoFixture
         /// </returns>
         public object Create(object request, ISpecimenContext context)
         {
-            if (request == null) return new NoSpecimen();
+            if (request == null) return NoSpecimen.Instance;
 
             var regularExpressionRequest = request as RegularExpressionRequest;
             if (regularExpressionRequest == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.GenerateRegularExpression(regularExpressionRequest);
@@ -59,14 +59,14 @@ namespace AutoFixture
             }
             catch (InvalidOperationException)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
             catch (ArgumentException)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         private int GenerateSeed()

--- a/Src/AutoFixture/SByteSequenceGenerator.cs
+++ b/Src/AutoFixture/SByteSequenceGenerator.cs
@@ -58,7 +58,7 @@ namespace AutoFixture
         {
             if (!typeof(sbyte).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/SingleSequenceGenerator.cs
+++ b/Src/AutoFixture/SingleSequenceGenerator.cs
@@ -56,7 +56,7 @@ namespace AutoFixture
         {
             if (!typeof(float).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
 #pragma warning disable 618

--- a/Src/AutoFixture/StrictlyMonotonicallyIncreasingDateTimeGenerator.cs
+++ b/Src/AutoFixture/StrictlyMonotonicallyIncreasingDateTimeGenerator.cs
@@ -34,7 +34,7 @@ namespace AutoFixture
         {
             if (!typeof(DateTime).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.seed.AddDays(this.GetNextNumberInSequence());

--- a/Src/AutoFixture/StringGenerator.cs
+++ b/Src/AutoFixture/StringGenerator.cs
@@ -41,13 +41,13 @@ namespace AutoFixture
         {
             if (!typeof(string).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var specimen = this.Factory();
             if (specimen == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
             if (specimen is NoSpecimen)
             {

--- a/Src/AutoFixture/StringSeedRelay.cs
+++ b/Src/AutoFixture/StringSeedRelay.cs
@@ -33,13 +33,13 @@ namespace AutoFixture
             if (seededRequest == null ||
                 (!seededRequest.Request.Equals(typeof(string))))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var seed = seededRequest.Seed as string;
             if (seed == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var containerResult = context.Resolve(typeof(string));

--- a/Src/AutoFixture/TaskGenerator.cs
+++ b/Src/AutoFixture/TaskGenerator.cs
@@ -28,7 +28,7 @@ namespace AutoFixture
 
             var type = request as Type;
             if (type == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             // check if type is a constructed generic type whose definition matches Task<>.
             if (type.TryGetSingleGenericTypeArgument(typeof(Task<>), out Type taskResultType))
@@ -38,7 +38,7 @@ namespace AutoFixture
             if (type == typeof(Task))
                 return CreateNonGenericTask();
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
 
         private static object CreateGenericTask(Type resultType, ISpecimenContext context)

--- a/Src/AutoFixture/TypeGenerator.cs
+++ b/Src/AutoFixture/TypeGenerator.cs
@@ -24,7 +24,7 @@ namespace AutoFixture
                 return typeof(object);
             }
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
     }
 }

--- a/Src/AutoFixture/UInt16SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt16SequenceGenerator.cs
@@ -43,7 +43,7 @@ namespace AutoFixture
         {
             if (!typeof(ushort).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             lock (this.syncRoot)

--- a/Src/AutoFixture/UInt32SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt32SequenceGenerator.cs
@@ -43,7 +43,7 @@ namespace AutoFixture
         {
             if (!typeof(uint).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             lock (this.syncRoot)

--- a/Src/AutoFixture/UInt64SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt64SequenceGenerator.cs
@@ -43,7 +43,7 @@ namespace AutoFixture
         {
             if (!typeof(ulong).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             lock (this.syncRoot)

--- a/Src/AutoFixture/UnwrapMemberRequest.cs
+++ b/Src/AutoFixture/UnwrapMemberRequest.cs
@@ -43,7 +43,7 @@ namespace AutoFixture
                 return this.Builder.Create(memberType, context);
             }
 
-            return new NoSpecimen();
+            return NoSpecimen.Instance;
         }
     }
 }

--- a/Src/AutoFixture/UriGenerator.cs
+++ b/Src/AutoFixture/UriGenerator.cs
@@ -22,19 +22,19 @@ namespace AutoFixture
 
             if (!typeof(Uri).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var scheme = context.Resolve(typeof(UriScheme)) as UriScheme;
             if (scheme == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var authority = context.Resolve(typeof(string)) as string;
             if (authority == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return MakeUri(scheme, authority);

--- a/Src/AutoFixture/UriSchemeGenerator.cs
+++ b/Src/AutoFixture/UriSchemeGenerator.cs
@@ -19,7 +19,7 @@ namespace AutoFixture
         {
             if (!typeof(UriScheme).Equals(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return new UriScheme();

--- a/Src/AutoFixture/Utf8EncodingGenerator.cs
+++ b/Src/AutoFixture/Utf8EncodingGenerator.cs
@@ -28,12 +28,12 @@ namespace AutoFixture
         {
             if (request == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             if (!this.encodingTypeSpecification.IsSatisfiedBy(request))
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return Encoding.UTF8;

--- a/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
+++ b/Src/AutoFixtureUnitTest/BooleanSwitchTest.cs
@@ -133,7 +133,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonBooleanRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ByteSequenceGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonByteRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/CharSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/CharSequenceGeneratorTest.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/CompositeSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/CompositeSpecimenBuilderTest.cs
@@ -84,7 +84,7 @@ namespace AutoFixtureUnitTest
             // Arrange
             var builders = new ISpecimenBuilder[]
             {
-                new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() },
+                new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance },
                 new DelegatingSpecimenBuilder { OnCreate = (r, c) => null },
                 new DelegatingSpecimenBuilder { OnCreate = (r, c) => new object() }
             };

--- a/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/ConstrainedStringGeneratorTest.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace AutoFixtureUnitTest
             object contextValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedType.Equals(r) ? contextValue : new NoSpecimen()
+                OnResolve = r => expectedType.Equals(r) ? contextValue : NoSpecimen.Instance
             };
             var sut = new ConstrainedStringGenerator();
             // Act
@@ -80,7 +80,7 @@ namespace AutoFixtureUnitTest
             object expectedValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => typeof(string).Equals(r) ? expectedValue : new NoSpecimen()
+                OnResolve = r => typeof(string).Equals(r) ? expectedValue : NoSpecimen.Instance
             };
             var sut = new ConstrainedStringGenerator();
             // Act & assert
@@ -97,7 +97,7 @@ namespace AutoFixtureUnitTest
             object contextValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => typeof(string).Equals(r) ? contextValue : new NoSpecimen()
+                OnResolve = r => typeof(string).Equals(r) ? contextValue : NoSpecimen.Instance
             };
             var sut = new ConstrainedStringGenerator();
             // Act
@@ -117,7 +117,7 @@ namespace AutoFixtureUnitTest
             object contextValue = Guid.NewGuid().ToString();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => typeof(string).Equals(r) ? contextValue : new NoSpecimen()
+                OnResolve = r => typeof(string).Equals(r) ? contextValue : NoSpecimen.Instance
             };
             var sut = new ConstrainedStringGenerator();
             // Act

--- a/Src/AutoFixtureUnitTest/CurrentDateTimeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/CurrentDateTimeGeneratorTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDateTimeRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/DataAnnotations/DataAnnotationsSupportNodeTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/DataAnnotationsSupportNodeTest.cs
@@ -57,7 +57,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
 
             var builder = new DelegatingSpecimenBuilder
             {
-                OnCreate = (r, ctx) => r == request ? expectedResult : new NoSpecimen()
+                OnCreate = (r, ctx) => r == request ? expectedResult : NoSpecimen.Instance
             };
 
             var sut = new DataAnnotationsSupportNode(builder);

--- a/Src/AutoFixtureUnitTest/DataAnnotations/EnumDataTypeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/EnumDataTypeAttributeRelayTest.cs
@@ -321,7 +321,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var request = new FakeMemberInfo(providedAttribute);
             var enumGenerator = new DelegatingSpecimenBuilder
             {
-                OnCreate = (_, _) => new NoSpecimen()
+                OnCreate = (_, _) => NoSpecimen.Instance
             };
             var sut = new EnumDataTypeAttributeRelay(enumGenerator);
 

--- a/Src/AutoFixtureUnitTest/DataAnnotations/EnumRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/EnumRangedRequestRelayTest.cs
@@ -44,7 +44,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var result = sut.Create(request, context);
 
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -98,14 +98,14 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 new RangedRequest(memberType: typeof(EnumType), operandType: typeof(int), minimum: 1, maximum: 2);
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = _ => new NoSpecimen()
+                OnResolve = _ => NoSpecimen.Instance
             };
 
             // Act
             var result = sut.Create(request, context);
 
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Theory]
@@ -125,7 +125,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve = r =>
                 {
                     capturedNumericRequest = (RangedNumberRequest)r;
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 
@@ -154,7 +154,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve = r =>
                 {
                     capturedNumericRequest = (RangedNumberRequest)r;
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 
@@ -177,7 +177,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var result = (int)EnumType.Second;
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => r is RangedNumberRequest ? (object)result : new NoSpecimen()
+                OnResolve = r => r is RangedNumberRequest ? (object)result : NoSpecimen.Instance
             };
 
             // Act

--- a/Src/AutoFixtureUnitTest/DataAnnotations/MinAndMaxLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/MinAndMaxLengthAttributeRelayTest.cs
@@ -32,7 +32,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var result = sut.Create(null, dummyContext);
 
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var result = sut.Create(dummyRequest, dummyContainer);
 
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -81,7 +81,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var result = sut.Create(request, dummyContext);
 
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -100,7 +100,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
 
             var sut = new MinAndMaxLengthAttributeRelay
@@ -133,7 +133,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
 
             var sut = new MinAndMaxLengthAttributeRelay
@@ -169,7 +169,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
 
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
 
             var sut = new MinAndMaxLengthAttributeRelay
@@ -208,7 +208,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve = r =>
                 {
                     if (expectedRangedSequenceRequest.Equals(r)) return expectedResult;
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 
@@ -248,7 +248,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve = r =>
                 {
                     if (expectedRangedSequenceRequest.Equals(r)) return expectedResult;
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 
@@ -290,7 +290,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve = r =>
                 {
                     if (expectedRangedSequenceRequest.Equals(r)) return expectedResult;
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 
@@ -374,7 +374,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             {
                 OnResolve = r => expectedRangedSequenceRequest.Equals(r)
                     ? expectedResult
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
 
             var sut = new MinAndMaxLengthAttributeRelay

--- a/Src/AutoFixtureUnitTest/DataAnnotations/NumericRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/NumericRangedRequestRelayTest.cs
@@ -113,7 +113,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve =
                     r => r is RangedNumberRequest rr && rr.OperandType == requestType
                         ? expectedResult
-                        : new NoSpecimen()
+                        : NoSpecimen.Instance
             };
 
             // Act
@@ -141,7 +141,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve =
                     r => r.Equals(expectedNestedRequest)
                         ? expectedResult
-                        : new NoSpecimen()
+                        : NoSpecimen.Instance
             };
 
             // Act

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RangeAttributeRelayTest.cs
@@ -30,7 +30,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -74,7 +74,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -99,7 +99,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
             var sut = new RangeAttributeRelay();
             // Act
@@ -122,7 +122,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
             var sut = new RangeAttributeRelay();
             // Act
@@ -146,7 +146,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
             var sut = new RangeAttributeRelay();
             // Act
@@ -170,7 +170,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
             var sut = new RangeAttributeRelay();
             // Act

--- a/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/RegularExpressionAttributeRelayTest.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -72,7 +72,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -90,7 +90,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
             var sut = new RegularExpressionAttributeRelay();
             // Act

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthAttributeRelayTest.cs
@@ -103,7 +103,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             };
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expected : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expected : NoSpecimen.Instance
             };
             var sut = new StringLengthAttributeRelay
             {
@@ -136,7 +136,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             };
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
             var sut = new StringLengthAttributeRelay
             {
@@ -190,7 +190,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var expected = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expected : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expected : NoSpecimen.Instance
             };
 
             // Act

--- a/Src/AutoFixtureUnitTest/DataAnnotations/TimeSpanRangedRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/TimeSpanRangedRequestRelayTest.cs
@@ -43,7 +43,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
             var result = sut.Create(request, context);
 
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -78,14 +78,14 @@ namespace AutoFixtureUnitTest.DataAnnotations
 
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = _ => new NoSpecimen()
+                OnResolve = _ => NoSpecimen.Instance
             };
 
             // Act
             var actualResult = sut.Create(request, context);
 
             // Assert
-            Assert.Equal(new NoSpecimen(), actualResult);
+            Assert.Equal(NoSpecimen.Instance, actualResult);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace AutoFixtureUnitTest.DataAnnotations
                 OnResolve = r =>
                 {
                     capturedNumericRequest = (RangedNumberRequest)r;
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 

--- a/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DecimalSequenceGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDecimalRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
+++ b/Src/AutoFixtureUnitTest/DictionaryFillerTest.cs
@@ -60,7 +60,7 @@ namespace AutoFixtureUnitTest
                 var expectedResult = Enumerable.Range(1, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
                 var context = new DelegatingSpecimenContext
                 {
-                    OnResolve = r => expectedRequest.Equals(r) ? (object)expectedResult : new NoSpecimen()
+                    OnResolve = r => expectedRequest.Equals(r) ? (object)expectedResult : NoSpecimen.Instance
                 };
                 // Act
                 DictionaryFiller.AddMany(dictionary, context);
@@ -120,7 +120,7 @@ namespace AutoFixtureUnitTest
 
             var expectedRequest = new MultipleRequest(typeof(KeyValuePair<int, string>));
             var expectedResult = Enumerable.Range(1, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)expectedResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)expectedResult : NoSpecimen.Instance };
 
             var sut = new DictionaryFiller();
             // Act
@@ -137,7 +137,7 @@ namespace AutoFixtureUnitTest
 
             var request = new MultipleRequest(typeof(KeyValuePair<int, string>));
             var sequence = Enumerable.Repeat(0, 3).Select(i => new KeyValuePair<int, string>(i, i.ToString()));
-            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? (object)sequence : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? (object)sequence : NoSpecimen.Instance };
 
             var sut = new DictionaryFiller();
             // Act & Assert

--- a/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DomainNameGeneratorTest.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(null, context);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(nonDomainNameRequest, context);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/DoubleSequenceGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDoubleRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/CompositeNodeComposerTests.cs
@@ -82,7 +82,7 @@ namespace AutoFixtureUnitTest.Dsl
             {
                 OnCreate = (r, c) => r == request && c == context ?
                     expected :
-                    new NoSpecimen()
+                    NoSpecimen.Instance
             };
             var sut = new CompositeNodeComposer<ushort>(
                 new CompositeSpecimenBuilder(

--- a/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/NodeComposerTest.cs
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest.Dsl
             {
                 OnCreate = (r, c) => r == request && c == context ?
                     expected :
-                    new NoSpecimen()
+                    NoSpecimen.Instance
             };
             var sut = new NodeComposer<object>(builder);
             // Act

--- a/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EmailAddressLocalPartGeneratorTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -71,7 +71,7 @@ namespace AutoFixtureUnitTest
             var sut = new EmailAddressLocalPartGenerator();
             // Act & assert
             var result = sut.Create(request, context);
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -116,7 +116,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(typeof(EmailAddressLocalPart), context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/EnumGeneratorTest.cs
@@ -34,7 +34,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
+++ b/Src/AutoFixtureUnitTest/FreezeOnMatchCustomizationTest.cs
@@ -145,7 +145,7 @@ namespace AutoFixtureUnitTest
                 OnCreate = (request, ctx) =>
                     request.Equals(frozenType)
                         ? new object()
-                        : new NoSpecimen()
+                        : NoSpecimen.Instance
 #pragma warning restore 618
             };
             var sut = new FreezeOnMatchCustomization(
@@ -171,7 +171,7 @@ namespace AutoFixtureUnitTest
                 OnCreate = (req, ctx) =>
                     req.Equals(request)
                         ? new object()
-                        : new NoSpecimen()
+                        : NoSpecimen.Instance
             };
             var sut = new FreezeOnMatchCustomization(
                 request,

--- a/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/GuidGeneratorTest.cs
@@ -75,7 +75,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(nonGuidRequest, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int16SequenceGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt16Request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int32SequenceCreatorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt32Request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Int64SequenceGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonInt64Request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/InvariantCultureGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/InvariantCultureGeneratorTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest
 #pragma warning restore 618
             var actual = sut.Create(null, new DelegatingSpecimenContext());
 
-            Assert.Equal(new NoSpecimen(), actual);
+            Assert.Equal(NoSpecimen.Instance, actual);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace AutoFixtureUnitTest
 #pragma warning restore 618
             var actual = sut.Create(new object(), new DelegatingSpecimenContext());
 
-            Assert.Equal(new NoSpecimen(), actual);
+            Assert.Equal(NoSpecimen.Instance, actual);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace AutoFixtureUnitTest
 #pragma warning restore 618
             var actual = sut.Create(typeof(object), new DelegatingSpecimenContext());
 
-            Assert.Equal(new NoSpecimen(), actual);
+            Assert.Equal(NoSpecimen.Instance, actual);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/Kernel/ArrayRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ArrayRelayTest.cs
@@ -44,7 +44,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -58,7 +58,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedRequest = new MultipleRequest(itemType);
             object expectedResult = Array.CreateInstance(itemType, 0);
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? expectedResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? expectedResult : NoSpecimen.Instance };
 
             var sut = new ArrayRelay();
             // Act
@@ -74,7 +74,7 @@ namespace AutoFixtureUnitTest.Kernel
             var request = typeof(int[]);
             var expectedRequest = new MultipleRequest(typeof(int));
             var enumerable = Enumerable.Range(1, 3);
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : NoSpecimen.Instance };
 
             var sut = new ArrayRelay();
             // Act
@@ -98,7 +98,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/AsyncEnumerableRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/AsyncEnumerableRelayTest.cs
@@ -78,7 +78,7 @@ namespace AutoFixtureUnitTest.Kernel
             {
                 OnResolve = r => expectedRequest.Equals(r)
                     ? contextResult
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
             var sut = new AsyncEnumerableRelay();
 
@@ -100,7 +100,7 @@ namespace AutoFixtureUnitTest.Kernel
             {
                 OnResolve = r => expectedRequest.Equals(r)
                     ? enumerable.Cast<object>()
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
             var sut = new AsyncEnumerableRelay();
 
@@ -147,7 +147,7 @@ namespace AutoFixtureUnitTest.Kernel
             {
                 OnResolve = r => expectedRequest.Equals(r)
                     ? enumerable
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
 
             var sut = new AsyncEnumerableRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/AsyncEnumeratorRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/AsyncEnumeratorRelayTests.cs
@@ -99,7 +99,7 @@ namespace AutoFixtureUnitTest.Kernel
             {
                 OnResolve = r => expectedRequest.Equals(r)
                     ? asyncEnumerable
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
             var sut = new AsyncEnumeratorRelay();
 
@@ -121,7 +121,7 @@ namespace AutoFixtureUnitTest.Kernel
             {
                 OnResolve = r => r.Equals(typeof(IAsyncEnumerable<int>))
                     ? collection.ToAsyncEnumerable()
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
 
             // Act
@@ -139,7 +139,7 @@ namespace AutoFixtureUnitTest.Kernel
             var request = typeof(IAsyncEnumerator<int>);
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = _ => new NoSpecimen()
+                OnResolve = _ => NoSpecimen.Instance
             };
 
             // Act

--- a/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/BindingCommandTest.cs
@@ -191,7 +191,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedValue = new object();
             var expectedRequest = typeof(PropertyHolder<object>).GetProperty("Property");
-            var container = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? expectedValue : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? expectedValue : NoSpecimen.Instance };
 
             var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property);
             var specimen = new PropertyHolder<object>();
@@ -209,7 +209,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedValue = new object();
             var expectedRequest = typeof(FieldHolder<object>).GetField("Field");
-            var container = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? expectedValue : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? expectedValue : NoSpecimen.Instance };
 
             var sut = new BindingCommand<FieldHolder<object>, object>(ph => ph.Field);
             var specimen = new FieldHolder<object>();
@@ -243,7 +243,7 @@ namespace AutoFixtureUnitTest.Kernel
             var expectedValue = new object();
             var expectedContainer = new DelegatingSpecimenContext();
 
-            var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, c => expectedContainer == c ? expectedValue : new NoSpecimen());
+            var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, c => expectedContainer == c ? expectedValue : NoSpecimen.Instance);
             var specimen = new PropertyHolder<object>();
             // Act
 #pragma warning disable 618
@@ -382,7 +382,7 @@ namespace AutoFixtureUnitTest.Kernel
             var expectedRequest = typeof(PropertyHolder<object>).GetProperty("Property");
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedValue : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedValue : NoSpecimen.Instance
             };
 
             var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property);
@@ -401,7 +401,7 @@ namespace AutoFixtureUnitTest.Kernel
             var expectedRequest = typeof(FieldHolder<object>).GetField("Field");
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? expectedValue : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? expectedValue : NoSpecimen.Instance
             };
 
             var sut = new BindingCommand<FieldHolder<object>, object>(ph => ph.Field);
@@ -431,7 +431,7 @@ namespace AutoFixtureUnitTest.Kernel
             var expectedValue = new object();
             var expectedContext = new DelegatingSpecimenContext();
 
-            var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, c => expectedContext == c ? expectedValue : new NoSpecimen());
+            var sut = new BindingCommand<PropertyHolder<object>, object>(ph => ph.Property, c => expectedContext == c ? expectedValue : NoSpecimen.Instance);
             var specimen = new PropertyHolder<object>();
             // Act
             sut.Execute((object)specimen, expectedContext);

--- a/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CollectionRelayTest.cs
@@ -54,7 +54,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedRequest = typeof(List<>).MakeGenericType(itemType);
             object contextResult = typeof(List<>).MakeGenericType(itemType).GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : NoSpecimen.Instance };
 
             var sut = new CollectionRelay();
             // Act

--- a/Src/AutoFixtureUnitTest/Kernel/CompositeSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/CompositeSpecimenBuilderTest.cs
@@ -146,7 +146,7 @@ namespace AutoFixtureUnitTest.Kernel
             var expectedResult = new object();
             var builders = new ISpecimenBuilder[]
             {
-                new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() },
+                new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance },
                 new DelegatingSpecimenBuilder { OnCreate = (r, c) => expectedResult },
                 new DelegatingSpecimenBuilder { OnCreate = (r, c) => new object() }
             };
@@ -165,9 +165,9 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var builders = new ISpecimenBuilder[]
             {
-                new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() },
-                new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() },
-                new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() }
+                new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance },
+                new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance },
+                new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance }
             };
             var sut = new CompositeSpecimenBuilder(builders);
             // Act
@@ -175,7 +175,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(anonymousRequest, dummyContainer);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegateGeneratorTest.cs
@@ -44,7 +44,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonDelegateRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DictionaryRelayTest.cs
@@ -59,7 +59,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -73,7 +73,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedRequest = typeof(Dictionary<,>).MakeGenericType(keyType, itemType);
             object contextResult = typeof(Dictionary<,>).MakeGenericType(keyType, itemType).GetTypeInfo().GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : NoSpecimen.Instance };
 
             var sut = new DictionaryRelay();
             // Act

--- a/Src/AutoFixtureUnitTest/Kernel/DisposableTrackerTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DisposableTrackerTest.cs
@@ -73,7 +73,7 @@ namespace AutoFixtureUnitTest.Kernel
 
             var builder = new DelegatingSpecimenBuilder
             {
-                OnCreate = (r, c) => (r == request) && (c == ctx) ? expectedResult : new NoSpecimen()
+                OnCreate = (r, c) => (r == request) && (c == ctx) ? expectedResult : NoSpecimen.Instance
             };
 
             var sut = new DisposableTracker(builder);

--- a/Src/AutoFixtureUnitTest/Kernel/EnumerableRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumerableRelayTest.cs
@@ -53,7 +53,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext { OnResolve = r => Enumerable.Empty<object>() };
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -67,7 +67,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedRequest = new MultipleRequest(itemType);
             object contextResult = Enumerable.Empty<object>();
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : NoSpecimen.Instance };
 
             var sut = new EnumerableRelay();
             // Act
@@ -83,7 +83,7 @@ namespace AutoFixtureUnitTest.Kernel
             var request = typeof(IEnumerable<int>);
             var expectedRequest = new MultipleRequest(typeof(int));
             var enumerable = Enumerable.Range(1, 3).Cast<object>();
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : NoSpecimen.Instance };
 
             var sut = new EnumerableRelay();
             // Act
@@ -107,7 +107,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -126,7 +126,7 @@ namespace AutoFixtureUnitTest.Kernel
             };
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : new NoSpecimen()
+                OnResolve = r => expectedRequest.Equals(r) ? (object)enumerable : NoSpecimen.Instance
             };
 
             var sut = new EnumerableRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/EnumeratorRelayTest.cs
@@ -40,7 +40,7 @@ namespace AutoFixtureUnitTest.Kernel
 
             var result = sut.Create(request, dummyContext);
 
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -61,7 +61,7 @@ namespace AutoFixtureUnitTest.Kernel
             {
                 OnResolve = r => expectedRequest.Equals(r)
                     ? (object)enumerable
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
             var sut = new EnumeratorRelay();
 
@@ -88,7 +88,7 @@ namespace AutoFixtureUnitTest.Kernel
 
             var result = sut.Create(request, context);
 
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoFixtureUnitTest/Kernel/FieldRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FieldRequestRelayTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonFieldRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -61,12 +61,12 @@ namespace AutoFixtureUnitTest.Kernel
         {
             // Arrange
             var fieldInfo = typeof(FieldHolder<object>).GetField("Field");
-            var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => NoSpecimen.Instance };
             var sut = new FieldRequestRelay();
             // Act
             var result = sut.Create(fieldInfo, container);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/FilteringSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FilteringSpecimenBuilderTest.cs
@@ -75,7 +75,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/FiniteSequenceRelayTest.cs
@@ -39,7 +39,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -55,7 +55,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest.Kernel
             var manyRequest = new FiniteSequenceRequest(request, count);
 
             var expectedResult = new object();
-            var container = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? expectedResult : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? expectedResult : NoSpecimen.Instance };
 
             var sut = new FiniteSequenceRelay();
             // Act
@@ -95,7 +95,7 @@ namespace AutoFixtureUnitTest.Kernel
             var q = new Queue<object>(results);
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => request.Equals(r) ? q.Dequeue() : new NoSpecimen()
+                OnResolve = r => request.Equals(r) ? q.Dequeue() : NoSpecimen.Instance
             };
 
             var sut = new FiniteSequenceRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/IntPtrGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/IntPtrGuardTest.cs
@@ -35,7 +35,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ListRelayTest.cs
@@ -54,7 +54,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedRequest = typeof(List<>).MakeGenericType(itemType);
             object contextResult = typeof(List<>).MakeGenericType(itemType).GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : NoSpecimen.Instance };
 
             var sut = new ListRelay();
             // Act

--- a/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MethodInvokerTest.cs
@@ -50,7 +50,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -75,7 +75,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Act
             var result = sut.Create(nonTypeRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -90,7 +90,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -99,12 +99,12 @@ namespace AutoFixtureUnitTest.Kernel
         {
             // Arrange
             var type = typeof(string);
-            var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => NoSpecimen.Instance };
             var sut = new MethodInvoker(new ModestConstructorQuery());
             // Act
             var result = sut.Create(type, container);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -117,7 +117,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Act
             var result = sut.Create(typeof(AbstractType), container);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -127,7 +127,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var requestedType = typeof(DoubleParameterType<string, int>);
             var parameters = requestedType.GetConstructors().Single().GetParameters();
-            var container = new DelegatingSpecimenContext { OnResolve = r => parameters[0] == r ? new object() : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => parameters[0] == r ? new object() : NoSpecimen.Instance };
             var sut = new MethodInvoker(new ModestConstructorQuery());
             // Act
             var result = sut.Create(requestedType, container);
@@ -228,7 +228,7 @@ namespace AutoFixtureUnitTest.Kernel
                         return expectedNumber;
                     }
                 }
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             };
             // Act
             var result = sut.Create(requestedType, context);

--- a/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultidimensionalArrayRelayTest.cs
@@ -41,7 +41,7 @@ namespace AutoFixtureUnitTest.Kernel
         {
             var sut = new MultidimensionalArrayRelay();
             var dummyContext = new DelegatingSpecimenContext();
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
 
             var actual = sut.Create(invalidRequest, dummyContext);
 

--- a/Src/AutoFixtureUnitTest/Kernel/MultipleRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultipleRelayTest.cs
@@ -73,7 +73,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -89,7 +89,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -101,7 +101,7 @@ namespace AutoFixtureUnitTest.Kernel
             var count = 7;
             var expectedTranslation = new FiniteSequenceRequest(request.Request, 7);
             var expectedResult = new object();
-            var container = new DelegatingSpecimenContext { OnResolve = r => expectedTranslation.Equals(r) ? expectedResult : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => expectedTranslation.Equals(r) ? expectedResult : NoSpecimen.Instance };
 
             var sut = new MultipleRelay { Count = count };
             // Act

--- a/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/MultipleToEnumerableRelayTests.cs
@@ -32,7 +32,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 
@@ -82,7 +82,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 
@@ -136,7 +136,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/NoSpecimenOutputGuardTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NoSpecimenOutputGuardTest.cs
@@ -105,7 +105,7 @@ namespace AutoFixtureUnitTest.Kernel
             var request = new object();
             var context = new DelegatingSpecimenContext();
             var expectedResult = new object();
-            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == request && c == context ? expectedResult : new NoSpecimen() };
+            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == request && c == context ? expectedResult : NoSpecimen.Instance };
 
             var sut = new NoSpecimenOutputGuard(builder);
             // Act
@@ -118,7 +118,7 @@ namespace AutoFixtureUnitTest.Kernel
         public void CreateThrowsWhenDecoratedBuilderReturnsNoSpecimen()
         {
             // Arrange
-            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() };
+            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance };
             var sut = new NoSpecimenOutputGuard(builder);
             // Act & assert
             var dummyRequest = new object();
@@ -133,14 +133,14 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var request = new object();
 
-            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() };
+            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance };
             var spec = new DelegatingRequestSpecification { OnIsSatisfiedBy = r => request == r ? false : true };
             var sut = new NoSpecimenOutputGuard(builder, spec);
             // Act
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/NoSpecimenTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NoSpecimenTest.cs
@@ -12,7 +12,7 @@ namespace AutoFixtureUnitTest.Kernel
         {
             // Arrange
             // Act
-            var sut = new NoSpecimen();
+            var sut = NoSpecimen.Instance;
             // Assert
             Assert.IsAssignableFrom<IEquatable<NoSpecimen>>(sut);
         }
@@ -22,7 +22,7 @@ namespace AutoFixtureUnitTest.Kernel
         public void SutDoesNotEqualNullObject()
         {
             // Arrange
-            var sut = new NoSpecimen();
+            var sut = NoSpecimen.Instance;
             object other = null;
             // Act
             var result = sut.Equals(other);
@@ -35,7 +35,7 @@ namespace AutoFixtureUnitTest.Kernel
         public void SutDoesNotEqualNullSut()
         {
             // Arrange
-            var sut = new NoSpecimen();
+            var sut = NoSpecimen.Instance;
             NoSpecimen other = null;
             // Act
             var result = sut.Equals(other);
@@ -47,7 +47,7 @@ namespace AutoFixtureUnitTest.Kernel
         public void SutDoesNotEqualAnonymousObject()
         {
             // Arrange
-            var sut = new NoSpecimen();
+            var sut = NoSpecimen.Instance;
             var anonymousObject = new object();
             // Act
             var result = sut.Equals(anonymousObject);
@@ -59,8 +59,8 @@ namespace AutoFixtureUnitTest.Kernel
         public void SutEqualsOtherObject()
         {
             // Arrange
-            var sut = new NoSpecimen();
-            object other = new NoSpecimen();
+            var sut = NoSpecimen.Instance;
+            object other = NoSpecimen.Instance;
             // Act
             var result = sut.Equals(other);
             // Assert
@@ -71,8 +71,8 @@ namespace AutoFixtureUnitTest.Kernel
         public void SutEqualsOtherSut()
         {
             // Arrange
-            var sut = new NoSpecimen();
-            var other = new NoSpecimen();
+            var sut = NoSpecimen.Instance;
+            var other = NoSpecimen.Instance;
             // Act
             var result = sut.Equals(other);
             // Assert
@@ -83,7 +83,7 @@ namespace AutoFixtureUnitTest.Kernel
         public void GetHashCodeWillAlwaysReturnZeroResult()
         {
             // Arrange
-            var sut = new NoSpecimen();
+            var sut = NoSpecimen.Instance;
             // Act
             var result = sut.GetHashCode();
             // Assert

--- a/Src/AutoFixtureUnitTest/Kernel/OmitArrayParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitArrayParameterRequestRelayTests.cs
@@ -67,7 +67,7 @@ namespace AutoFixtureUnitTest.Kernel
         {
             var sut = new OmitArrayParameterRequestRelay();
             var actual = sut.Create(request, new DelegatingSpecimenContext());
-            Assert.Equal(new NoSpecimen(), actual);
+            Assert.Equal(NoSpecimen.Instance, actual);
         }
 
         [Theory]
@@ -91,7 +91,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(parameterInfo, dummyContext);
 
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitEnumerableParameterRequestRelayTests.cs
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest.Kernel
         {
             var sut = new OmitEnumerableParameterRequestRelay();
             var actual = sut.Create(request, new DelegatingSpecimenContext());
-            Assert.Equal(new NoSpecimen(), actual);
+            Assert.Equal(NoSpecimen.Instance, actual);
         }
 
         [Theory]
@@ -92,7 +92,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(parameterInfo, dummyContext);
 
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/OmitterTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/OmitterTests.cs
@@ -71,7 +71,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/ParameterRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ParameterRequestRelayTest.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -53,7 +53,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonParameterRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -62,12 +62,12 @@ namespace AutoFixtureUnitTest.Kernel
         {
             // Arrange
             var parameterInfo = typeof(SingleParameterType<string>).GetTypeInfo().GetConstructors().First().GetParameters().First();
-            var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => NoSpecimen.Instance };
             var sut = new ParameterRequestRelay();
             // Act
             var result = sut.Create(parameterInfo, container);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/PostprocessorGenericTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/PostprocessorGenericTest.cs
@@ -255,7 +255,7 @@ namespace AutoFixtureUnitTest.Kernel
         public void CreateReturnsCorrectResultWhenBuilderReturnsNoSpecimen()
         {
             // Arrange
-            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => new NoSpecimen() };
+            var builder = new DelegatingSpecimenBuilder { OnCreate = (r, c) => NoSpecimen.Instance };
 
             var dummyCommand = new DelegatingSpecimenCommand();
             var sut = new Postprocessor<int>(builder, dummyCommand);

--- a/Src/AutoFixtureUnitTest/Kernel/PropertyRequestRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/PropertyRequestRelayTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonParameterRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -61,12 +61,12 @@ namespace AutoFixtureUnitTest.Kernel
         {
             // Arrange
             var propertyInfo = typeof(PropertyHolder<object>).GetProperty("Property");
-            var container = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => NoSpecimen.Instance };
             var sut = new PropertyRequestRelay();
             // Act
             var result = sut.Create(propertyInfo, container);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/RangedSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/RangedSequenceRelayTest.cs
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest.Kernel
                     if (r is RangedNumberRequest rnr)
                         capturedNumberRequest = rnr;
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 
@@ -77,7 +77,7 @@ namespace AutoFixtureUnitTest.Kernel
                 OnResolve = r =>
                 {
                     if (r is RangedNumberRequest)
-                        return new NoSpecimen();
+                        return NoSpecimen.Instance;
 
                     return 42;
                 }
@@ -109,7 +109,7 @@ namespace AutoFixtureUnitTest.Kernel
                     if (r is FiniteSequenceRequest fsr)
                         capturedSequenceRequest = fsr;
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
 
@@ -139,7 +139,7 @@ namespace AutoFixtureUnitTest.Kernel
                     if (r is FiniteSequenceRequest)
                         return expectedResult;
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
             var sut = new RangedSequenceRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/ReadOnlyCollectionRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ReadOnlyCollectionRelayTest.cs
@@ -54,7 +54,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest.Kernel
             // Arrange
             var expectedRequest = typeof(List<>).MakeGenericType(itemType);
             object contextResult = typeof(List<>).MakeGenericType(itemType).GetConstructor(Type.EmptyTypes).Invoke(new object[0]);
-            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => expectedRequest.Equals(r) ? contextResult : NoSpecimen.Instance };
 
             var sut = new ReadOnlyCollectionRelay();
             // Act

--- a/Src/AutoFixtureUnitTest/Kernel/SeedIgnoringRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SeedIgnoringRelayTest.cs
@@ -25,7 +25,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -45,12 +45,12 @@ namespace AutoFixtureUnitTest.Kernel
         {
             // Arrange
             var anonymousSeed = new SeededRequest(typeof(object), new object());
-            var unableContainer = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen() };
+            var unableContainer = new DelegatingSpecimenContext { OnResolve = r => NoSpecimen.Instance };
             var sut = new SeedIgnoringRelay();
             // Act
             var result = sut.Create(anonymousSeed, unableContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/SeededFactoryTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SeededFactoryTest.cs
@@ -47,7 +47,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -63,7 +63,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -82,7 +82,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(seededRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithDoubleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithDoubleParameterFuncTest.cs
@@ -62,9 +62,9 @@ namespace AutoFixtureUnitTest.Kernel
             var container = new DelegatingSpecimenContext();
             container.OnResolve = r => (from x in subRequests
                                         where x.ExpectedRequest.Equals(r)
-                                        select x.Specimen).DefaultIfEmpty(new NoSpecimen()).SingleOrDefault();
+                                        select x.Specimen).DefaultIfEmpty(NoSpecimen.Instance).SingleOrDefault();
 
-            Func<decimal, TimeSpan, object> f = (d, ts) => param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) ? expectedSpecimen : new NoSpecimen();
+            Func<decimal, TimeSpan, object> f = (d, ts) => param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) ? expectedSpecimen : NoSpecimen.Instance;
             var sut = new SpecimenFactory<decimal, TimeSpan, object>(f);
             // Act
             var dummyRequest = new object();

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithQuadrupleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithQuadrupleParameterFuncTest.cs
@@ -66,10 +66,10 @@ namespace AutoFixtureUnitTest.Kernel
             var container = new DelegatingSpecimenContext();
             container.OnResolve = r => (from x in subRequests
                                         where x.ExpectedRequest.Equals(r)
-                                        select x.Specimen).DefaultIfEmpty(new NoSpecimen()).SingleOrDefault();
+                                        select x.Specimen).DefaultIfEmpty(NoSpecimen.Instance).SingleOrDefault();
 
             Func<decimal, TimeSpan, string, int, object> f = (d, ts, s, i) =>
-                param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) && param3.Specimen.Equals(s) && param4.Specimen.Equals(i) ? expectedSpecimen : new NoSpecimen();
+                param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) && param3.Specimen.Equals(s) && param4.Specimen.Equals(i) ? expectedSpecimen : NoSpecimen.Instance;
             var sut = new SpecimenFactory<decimal, TimeSpan, string, int, object>(f);
             // Act
             var dummyRequest = new object();

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithSingleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithSingleParameterFuncTest.cs
@@ -56,9 +56,9 @@ namespace AutoFixtureUnitTest.Kernel
 
             var dtSpecimen = DateTimeOffset.Now;
             var expectedParameterRequest = typeof(DateTimeOffset);
-            var container = new DelegatingSpecimenContext { OnResolve = r => expectedParameterRequest.Equals(r) ? (object)dtSpecimen : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => expectedParameterRequest.Equals(r) ? (object)dtSpecimen : NoSpecimen.Instance };
 
-            Func<DateTimeOffset, object> f = dt => dtSpecimen.Equals(dt) ? expectedSpecimen : new NoSpecimen();
+            Func<DateTimeOffset, object> f = dt => dtSpecimen.Equals(dt) ? expectedSpecimen : NoSpecimen.Instance;
             var sut = new SpecimenFactory<DateTimeOffset, object>(f);
             // Act
             var dummyRequest = new object();

--- a/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithTripleParameterFuncTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/SpecimenFactoryWithTripleParameterFuncTest.cs
@@ -63,10 +63,10 @@ namespace AutoFixtureUnitTest.Kernel
             var container = new DelegatingSpecimenContext();
             container.OnResolve = r => (from x in subRequests
                                         where x.ExpectedRequest.Equals(r)
-                                        select x.Specimen).DefaultIfEmpty(new NoSpecimen()).SingleOrDefault();
+                                        select x.Specimen).DefaultIfEmpty(NoSpecimen.Instance).SingleOrDefault();
 
             Func<decimal, TimeSpan, string, object> f = (d, ts, s) =>
-                param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) && param3.Specimen.Equals(s) ? expectedSpecimen : new NoSpecimen();
+                param1.Specimen.Equals(d) && param2.Specimen.Equals(ts) && param3.Specimen.Equals(s) ? expectedSpecimen : NoSpecimen.Instance;
             var sut = new SpecimenFactory<decimal, TimeSpan, string, object>(f);
             // Act
             var dummyRequest = new object();

--- a/Src/AutoFixtureUnitTest/Kernel/StableFiniteSequenceRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/StableFiniteSequenceRelayTest.cs
@@ -39,7 +39,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -55,7 +55,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest.Kernel
             var manyRequest = new FiniteSequenceRequest(request, count);
 
             var expectedResult = new object();
-            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? expectedResult : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? expectedResult : NoSpecimen.Instance };
 
             var sut = new StableFiniteSequenceRelay();
             // Act
@@ -86,7 +86,7 @@ namespace AutoFixtureUnitTest.Kernel
             var count = 3;
             var manyRequest = new FiniteSequenceRequest(request, count);
 
-            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? new object() : new NoSpecimen() };
+            var context = new DelegatingSpecimenContext { OnResolve = r => request.Equals(r) ? new object() : NoSpecimen.Instance };
 
             var sut = new StableFiniteSequenceRelay();
             // Act
@@ -113,7 +113,7 @@ namespace AutoFixtureUnitTest.Kernel
             var q = new Queue<object>(results);
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => request.Equals(r) ? q.Dequeue() : new NoSpecimen()
+                OnResolve = r => request.Equals(r) ? q.Dequeue() : NoSpecimen.Instance
             };
 
             var sut = new StableFiniteSequenceRelay();

--- a/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TerminatingWithPathSpecimenBuilderTest.cs
@@ -217,7 +217,7 @@ namespace AutoFixtureUnitTest.Kernel
             {
                 OnCreate = (r, c) => requestQueue.Count > 0
                     ? c.Resolve(requestQueue.Dequeue())
-                    : new NoSpecimen()
+                    : NoSpecimen.Instance
             };
             var sut = new TerminatingWithPathSpecimenBuilder(builder);
             // Cause sut to be executed recursively for multiple times.
@@ -237,7 +237,7 @@ namespace AutoFixtureUnitTest.Kernel
             var builder = new DelegatingSpecimenBuilder
             {
                 // Returns NoSpecimen only on the last specimen request
-                OnCreate = (r, c) => r == requests[2] ? new NoSpecimen() : new object()
+                OnCreate = (r, c) => r == requests[2] ? NoSpecimen.Instance : new object()
             };
 
             var sut = new TerminatingWithPathSpecimenBuilder(builder);
@@ -257,7 +257,7 @@ namespace AutoFixtureUnitTest.Kernel
         {
             var builder = new DelegatingSpecimenBuilder
             {
-                OnCreate = (r, c) => new NoSpecimen()
+                OnCreate = (r, c) => NoSpecimen.Instance
             };
             var sut = new TerminatingWithPathSpecimenBuilder(builder);
 

--- a/Src/AutoFixtureUnitTest/Kernel/TracingBuilderTest.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TracingBuilderTest.cs
@@ -87,8 +87,8 @@ namespace AutoFixtureUnitTest.Kernel
             object subRequest = "Some sub request";
 
             var spy = new List<RequestTraceEventArgs>();
-            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == requestedObject ? c.Resolve(subRequest) : new NoSpecimen() };
-            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? new object() : new NoSpecimen() };
+            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == requestedObject ? c.Resolve(subRequest) : NoSpecimen.Instance };
+            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? new object() : NoSpecimen.Instance };
             var compBuilder = new CompositeSpecimenBuilder(builder2, builder3);
 
             var sut = new DelegatingTracingBuilder(compBuilder);
@@ -110,8 +110,8 @@ namespace AutoFixtureUnitTest.Kernel
             object requestedObject = "The request";
             object subRequest = "Some sub request";
             var spy = new List<object>();
-            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == requestedObject ? c.Resolve(subRequest) : new NoSpecimen() };
-            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? new object() : new NoSpecimen() };
+            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == requestedObject ? c.Resolve(subRequest) : NoSpecimen.Instance };
+            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? new object() : NoSpecimen.Instance };
             var compBuilder = new CompositeSpecimenBuilder(builder2, builder3);
 
             var sut = new DelegatingTracingBuilder(compBuilder);
@@ -167,8 +167,8 @@ namespace AutoFixtureUnitTest.Kernel
             var createdSpecimen = new object();
 
             var spy = new List<SpecimenCreatedEventArgs>();
-            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == request ? c.Resolve(subRequest) : new NoSpecimen() };
-            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? createdSpecimen : new NoSpecimen() };
+            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == request ? c.Resolve(subRequest) : NoSpecimen.Instance };
+            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? createdSpecimen : NoSpecimen.Instance };
             var compBuilder = new CompositeSpecimenBuilder(builder2, builder3);
 
             var sut = new DelegatingTracingBuilder(compBuilder);
@@ -193,8 +193,8 @@ namespace AutoFixtureUnitTest.Kernel
             object subRequest = "Some sub request";
             object createdSpecimen = Guid.NewGuid();
             var spy = new List<object>();
-            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == requestedObject ? c.Resolve(subRequest) : new NoSpecimen() };
-            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? createdSpecimen : new NoSpecimen() };
+            var builder2 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == requestedObject ? c.Resolve(subRequest) : NoSpecimen.Instance };
+            var builder3 = new DelegatingSpecimenBuilder { OnCreate = (r, c) => r == subRequest ? createdSpecimen : NoSpecimen.Instance };
             var compBuilder = new CompositeSpecimenBuilder(builder2, builder3);
 
             var sut = new DelegatingTracingBuilder(compBuilder);

--- a/Src/AutoFixtureUnitTest/Kernel/TypeRelayTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/TypeRelayTests.cs
@@ -61,7 +61,7 @@ namespace AutoFixtureUnitTest.Kernel
             var dummyContext = new DelegatingSpecimenContext();
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 
@@ -169,7 +169,7 @@ namespace AutoFixtureUnitTest.Kernel
             var expectedResult = new object();
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => expectedRelay.Equals(r) ? expectedResult : new NoSpecimen()
+                OnResolve = r => expectedRelay.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
 
             // Act

--- a/Src/AutoFixtureUnitTest/LazyRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/LazyRelayTest.cs
@@ -50,7 +50,7 @@ namespace AutoFixtureUnitTest
             // Act
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 
@@ -67,7 +67,7 @@ namespace AutoFixtureUnitTest
             // Act
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 
@@ -84,7 +84,7 @@ namespace AutoFixtureUnitTest
             // Act
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
 

--- a/Src/AutoFixtureUnitTest/MailAddressGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/MailAddressGeneratorTest.cs
@@ -30,7 +30,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -106,7 +106,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -129,7 +129,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -159,7 +159,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoFixtureUnitTest/MutableValueTypeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/MutableValueTypeGeneratorTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonValueTypeRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -66,7 +66,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonValueTypeRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/NumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/NumericSequenceGeneratorTest.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -68,7 +68,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/RandomBooleanSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomBooleanSequenceGeneratorTest.cs
@@ -26,7 +26,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonBooleanRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/RandomCharSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomCharSequenceGeneratorTest.cs
@@ -37,7 +37,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(null, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -63,7 +63,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -83,7 +83,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/RandomDateOnlySequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomDateOnlySequenceGeneratorTest.cs
@@ -55,7 +55,7 @@ public class RandomDateOnlySequenceGeneratorTest
         var result = sut.Create(null, dummyContainer);
 
         // Assert
-        Assert.Equal(new NoSpecimen(), result);
+        Assert.Equal(NoSpecimen.Instance, result);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class RandomDateOnlySequenceGeneratorTest
         var result = sut.Create(request, dummyContainer);
 
         // Assert
-        Assert.Equal(new NoSpecimen(), result);
+        Assert.Equal(NoSpecimen.Instance, result);
     }
 
     [Theory]
@@ -101,7 +101,7 @@ public class RandomDateOnlySequenceGeneratorTest
         var result = sut.Create(request, dummyContainer);
 
         // Assert
-        Assert.Equal(new NoSpecimen(), result);
+        Assert.Equal(NoSpecimen.Instance, result);
     }
 
     [Fact]

--- a/Src/AutoFixtureUnitTest/RandomDateTimeSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomDateTimeSequenceGeneratorTest.cs
@@ -49,7 +49,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Theory]
@@ -90,7 +90,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomNumericSequenceGeneratorTest.cs
@@ -127,7 +127,7 @@ namespace AutoFixtureUnitTest
             // Act
             object result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             var dummyContext = new DelegatingSpecimenContext();
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             var sut = new RandomNumericSequenceGenerator();
             // Act
             object result = sut.Create(request, dummyContext);
@@ -163,7 +163,7 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             var dummyContext = new DelegatingSpecimenContext();
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             var sut = new RandomNumericSequenceGenerator();
             // Act
             object result = sut.Create(request, dummyContext);

--- a/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomRangedNumberGeneratorTest.cs
@@ -30,7 +30,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(dummyRequest, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Theory]
@@ -70,7 +70,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Verify
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]

--- a/Src/AutoFixtureUnitTest/RandomTimeOnlySequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RandomTimeOnlySequenceGeneratorTest.cs
@@ -55,7 +55,7 @@ public class RandomTimeOnlySequenceGeneratorTest
         var result = sut.Create(null, dummyContainer);
 
         // Assert
-        Assert.Equal(new NoSpecimen(), result);
+        Assert.Equal(NoSpecimen.Instance, result);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class RandomTimeOnlySequenceGeneratorTest
         var result = sut.Create(request, dummyContainer);
 
         // Assert
-        Assert.Equal(new NoSpecimen(), result);
+        Assert.Equal(NoSpecimen.Instance, result);
     }
 
     [Theory]
@@ -101,7 +101,7 @@ public class RandomTimeOnlySequenceGeneratorTest
         var result = sut.Create(request, dummyContainer);
 
         // Assert
-        Assert.Equal(new NoSpecimen(), result);
+        Assert.Equal(NoSpecimen.Instance, result);
     }
 
     [Fact]

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -31,7 +31,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(dummyRequest, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Theory]
@@ -203,7 +203,7 @@ namespace AutoFixtureUnitTest
             };
             var loopTest = new LoopTest<RangedNumberGenerator, object>(sut => (object)sut.Create(request, context));
             // Act & assert
-            loopTest.Execute(2, new NoSpecimen());
+            loopTest.Execute(2, NoSpecimen.Instance);
         }
 
         [Theory]
@@ -242,7 +242,7 @@ namespace AutoFixtureUnitTest
                     if (r.Equals(typeof(decimal)))
                         return Convert.ToDecimal(numbers.Next());
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
             var sut = new RangedNumberGenerator();
@@ -366,7 +366,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 20, contextValue: 21, expectedResult: 10);
                 yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 13, contextValue: 4, expectedResult: 10);
                 yield return CreateTestCase(operandType: typeof(int), minimum: 10, maximum: 20, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue: 1, expectedResult: 11U);
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue: 2, expectedResult: 12U);
@@ -377,7 +377,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue: 21, expectedResult: 10U);
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 13, contextValue: 4, expectedResult: 10U);
                 yield return CreateTestCase(operandType: typeof(uint), minimum: 10, maximum: 20, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(double), minimum: -5.0, maximum: -1.0, contextValue: 1.0, expectedResult: -5.0);
                 yield return CreateTestCase(operandType: typeof(double), minimum: -5.0, maximum: -1.0, contextValue: -1.0, expectedResult: -1.0);
@@ -392,7 +392,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 20.0, contextValue: 21.0, expectedResult: 10.0);
                 yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 13.0, contextValue: 4.0, expectedResult: 10.0);
                 yield return CreateTestCase(operandType: typeof(double), minimum: 10.0, maximum: 20.0, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(long), minimum: -50000000000, maximum: -10000000000, contextValue: 10000000000, expectedResult: -50000000000);
                 yield return CreateTestCase(operandType: typeof(long), minimum: -50000000000, maximum: -10000000000, contextValue: -10000000000, expectedResult: -10000000000);
@@ -407,7 +407,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 200000000000, contextValue: 210000000000, expectedResult: 100000000000);
                 yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 130000000000, contextValue: 40000000000, expectedResult: 100000000000);
                 yield return CreateTestCase(operandType: typeof(long), minimum: 100000000000, maximum: 200000000000, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue: 1, expectedResult: 11UL);
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue: 2, expectedResult: 12UL);
@@ -418,7 +418,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue: 21, expectedResult: 10UL);
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 13, contextValue: 4, expectedResult: 10UL);
                 yield return CreateTestCase(operandType: typeof(ulong), minimum: 10, maximum: 20, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: -5.0m, maximum: -1.0m, contextValue: 1.0m, expectedResult: -5.0m);
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: -5.0m, maximum: -1.0m, contextValue: -1.0m, expectedResult: -1.0m);
@@ -433,13 +433,13 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 20.0m, contextValue: 21.0m, expectedResult: 10.0m);
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 13.0m, contextValue: 4.0m, expectedResult: 10.0m);
                 yield return CreateTestCase(operandType: typeof(decimal), minimum: 10.0m, maximum: 20.0m, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(char), minimum: 'a', maximum: 'b', contextValue: 'a', expectedResult: 'a');
                 yield return CreateTestCase(operandType: typeof(char), minimum: 'a', maximum: 'b', contextValue: 'b', expectedResult: 'b');
                 yield return CreateTestCase(operandType: typeof(char), minimum: 'a', maximum: 'b', contextValue: 'c', expectedResult: 'a');
                 yield return CreateTestCase(operandType: typeof(char), minimum: 'b', maximum: 'c', contextValue: 'a',
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue: 1, expectedResult: (byte)11);
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue: 2, expectedResult: (byte)12);
@@ -450,7 +450,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (byte)10);
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 13, contextValue: 4, expectedResult: (byte)10);
                 yield return CreateTestCase(operandType: typeof(byte), minimum: 10, maximum: 20, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: -5, maximum: -1, contextValue: 1, expectedResult: (sbyte)-5);
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: -5, maximum: -1, contextValue: -1, expectedResult: (sbyte)-1);
@@ -465,7 +465,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (sbyte)10);
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 13, contextValue: 4, expectedResult: (sbyte)10);
                 yield return CreateTestCase(operandType: typeof(sbyte), minimum: 10, maximum: 20, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(float), minimum: -5.0f, maximum: -1.0f, contextValue: 1.0f, expectedResult: -5.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: -5.0f, maximum: -1.0f, contextValue: -1.0f, expectedResult: -1.0f);
@@ -480,7 +480,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 20.0f, contextValue: 21.0f, expectedResult: 10.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 13.0f, contextValue: 4.0f, expectedResult: 10.0f);
                 yield return CreateTestCase(operandType: typeof(float), minimum: 10.0f, maximum: 20.0f, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(short), minimum: -5, maximum: -1, contextValue: 1, expectedResult: (short)-5);
                 yield return CreateTestCase(operandType: typeof(short), minimum: -5, maximum: -1, contextValue: -1, expectedResult: (short)-1);
@@ -495,7 +495,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(short), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (short)10);
                 yield return CreateTestCase(operandType: typeof(short), minimum: 10, maximum: 13, contextValue: 4, expectedResult: (short)10);
                 yield return CreateTestCase(operandType: typeof(short), minimum: 10, maximum: 20, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
 
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue: 1, expectedResult: (ushort)11);
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue: 2, expectedResult: (ushort)12);
@@ -506,7 +506,7 @@ namespace AutoFixtureUnitTest
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue: 21, expectedResult: (ushort)10);
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 13, contextValue: 4, expectedResult: (ushort)10);
                 yield return CreateTestCase(operandType: typeof(ushort), minimum: 10, maximum: 20, contextValue: new object(),
-                    expectedResult: new NoSpecimen());
+                    expectedResult: NoSpecimen.Instance);
             }
 
             IEnumerator IEnumerable.GetEnumerator()

--- a/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RegularExpressionGeneratorTest.cs
@@ -28,7 +28,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Theory]
@@ -137,7 +137,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/SByteSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/SByteSequenceGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonSByteRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/SingleSequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/SingleSequenceGeneratorTest.cs
@@ -69,7 +69,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonSingleRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/SpecimenFactoryTest.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenFactoryTest.cs
@@ -43,7 +43,7 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             object expectedResult = 1;
-            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(int), 0)) ? expectedResult : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(int), 0)) ? expectedResult : NoSpecimen.Instance };
             // Act
             var result = container.CreateAnonymous<int>();
             // Assert
@@ -55,7 +55,7 @@ namespace AutoFixtureUnitTest
         {
             // Arrange
             object expectedResult = 1;
-            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(int), 0)) ? expectedResult : new NoSpecimen() };
+            var container = new DelegatingSpecimenContext { OnResolve = r => r.Equals(new SeededRequest(typeof(int), 0)) ? expectedResult : NoSpecimen.Instance };
             // Act
             var result = container.Create<int>();
             // Assert
@@ -171,7 +171,7 @@ namespace AutoFixtureUnitTest
             {
                 OnResolve = r => r.Equals(new MultipleRequest(new SeededRequest(typeof(int), 0))) ?
                     (object)expectedResult.Cast<object>() :
-                    new NoSpecimen()
+                    NoSpecimen.Instance
             };
             // Act
             var result = container.CreateMany<int>();
@@ -253,7 +253,7 @@ namespace AutoFixtureUnitTest
             {
                 OnResolve = r => r.Equals(new FiniteSequenceRequest(new SeededRequest(typeof(DateTime), default(DateTime)), count)) ?
                     (object)expectedResult.Cast<object>() :
-                    new NoSpecimen()
+                    NoSpecimen.Instance
             };
             // Act
             var result = container.CreateMany<DateTime>(count);

--- a/Src/AutoFixtureUnitTest/StrictlyMonotonicallyIncreasingDateTimeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/StrictlyMonotonicallyIncreasingDateTimeGeneratorTest.cs
@@ -31,7 +31,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Theory]
@@ -47,7 +47,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -65,7 +65,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/StringGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/StringGeneratorTest.cs
@@ -50,7 +50,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -75,7 +75,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonStringRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -105,7 +105,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(stringRequest, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -113,7 +113,7 @@ namespace AutoFixtureUnitTest
         public void CreateFromStringRequestWhenFactoryReturnsNoSpecimenWillReturnCorrectResult()
         {
             // Arrange
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             var sut = new StringGenerator(() => expectedResult);
             var stringRequest = typeof(string);
             // Act

--- a/Src/AutoFixtureUnitTest/StringSeedRelayTest.cs
+++ b/Src/AutoFixtureUnitTest/StringSeedRelayTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -52,7 +52,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonSeed, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -66,7 +66,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonStringRequestSeed, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -80,7 +80,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonStringSeed, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -90,11 +90,11 @@ namespace AutoFixtureUnitTest
             // Arrange
             var sut = new StringSeedRelay();
             var stringSeed = new SeededRequest(typeof(string), "Anonymous value");
-            var unableContainer = new DelegatingSpecimenContext { OnResolve = r => new NoSpecimen() };
+            var unableContainer = new DelegatingSpecimenContext { OnResolve = r => NoSpecimen.Instance };
             // Act
             var result = sut.Create(stringSeed, unableContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/TypeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/TypeGeneratorTest.cs
@@ -34,7 +34,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
 

--- a/Src/AutoFixtureUnitTest/UInt16SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt16SequenceGeneratorTest.cs
@@ -48,7 +48,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonUInt16Request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/UInt32SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt32SequenceGeneratorTest.cs
@@ -48,7 +48,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonUInt32Request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/UInt64SequenceGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UInt64SequenceGeneratorTest.cs
@@ -48,7 +48,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContainer);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace AutoFixtureUnitTest
             var dummyContainer = new DelegatingSpecimenContext();
             var result = sut.Create(nonUInt64Request, dummyContainer);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/UnwrapMemberRequestTest.cs
+++ b/Src/AutoFixtureUnitTest/UnwrapMemberRequestTest.cs
@@ -66,7 +66,7 @@ namespace AutoFixtureUnitTest
             var expectedResult = new object();
             var innerBuilder = new DelegatingSpecimenBuilder
             {
-                OnCreate = (r, c) => memberType.Equals(r) ? expectedResult : new NoSpecimen()
+                OnCreate = (r, c) => memberType.Equals(r) ? expectedResult : NoSpecimen.Instance
             };
 
             var sut = new UnwrapMemberRequest(innerBuilder)
@@ -109,7 +109,7 @@ namespace AutoFixtureUnitTest
             var result = sut.Create(nonMemberRequest, ctx);
 
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/UriGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UriGeneratorTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -62,12 +62,12 @@ namespace AutoFixtureUnitTest
             object expectedValue = null;
             var context = new DelegatingSpecimenContext
             {
-                OnResolve = r => typeof(UriScheme).Equals(r) ? expectedValue : new NoSpecimen()
+                OnResolve = r => typeof(UriScheme).Equals(r) ? expectedValue : NoSpecimen.Instance
             };
             var sut = new UriGenerator();
             // Act & assert
             var result = sut.Create(request, context);
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -91,13 +91,13 @@ namespace AutoFixtureUnitTest
                         return expectedValue;
                     }
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
             var sut = new UriGenerator();
             // Act & assert
             var result = sut.Create(request, context);
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -121,7 +121,7 @@ namespace AutoFixtureUnitTest
                         return Guid.NewGuid().ToString();
                     }
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
             var sut = new UriGenerator();
@@ -151,7 +151,7 @@ namespace AutoFixtureUnitTest
                         return expectedAuthority;
                     }
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
             var sut = new UriGenerator();
@@ -182,7 +182,7 @@ namespace AutoFixtureUnitTest
                         return expectedAuthority;
                     }
 
-                    return new NoSpecimen();
+                    return NoSpecimen.Instance;
                 }
             };
             var sut = new UriGenerator();

--- a/Src/AutoFixtureUnitTest/UriSchemeGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/UriSchemeGeneratorTest.cs
@@ -26,7 +26,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(null, dummyContext);
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace AutoFixtureUnitTest
             var dummyContext = new DelegatingSpecimenContext();
             var result = sut.Create(dummyRequest, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 

--- a/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/Utf8EncodingGeneratorTest.cs
@@ -46,7 +46,7 @@ namespace AutoFixtureUnitTest
             var result = sut.Create(null, new DelegatingSpecimenContext());
 
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace AutoFixtureUnitTest
             // Act
             var result = sut.Create(new object(), new DelegatingSpecimenContext());
             // Assert
-            Assert.Equal(new NoSpecimen(), result);
+            Assert.Equal(NoSpecimen.Instance, result);
         }
     }
 }

--- a/Src/AutoMoq/MockPostprocessor.cs
+++ b/Src/AutoMoq/MockPostprocessor.cs
@@ -43,7 +43,7 @@ namespace AutoFixture.AutoMoq
             var t = request as Type;
             if (!t.IsMock())
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var specimen = this.Builder.Create(request, context);
@@ -53,13 +53,13 @@ namespace AutoFixture.AutoMoq
             var m = specimen as Mock;
             if (m == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var mockType = t.GetMockedType();
             if (m.GetType().GetMockedType() != mockType)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var configurator = (IMockConfigurator)Activator.CreateInstance(typeof(MockConfigurator<>).MakeGenericType(mockType));

--- a/Src/AutoMoq/MockRelay.cs
+++ b/Src/AutoMoq/MockRelay.cs
@@ -64,11 +64,11 @@ namespace AutoFixture.AutoMoq
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             if (!this.MockableSpecification.IsSatisfiedBy(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var t = request as Type;
             if (t == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var result = ResolveMock(t, context);
 
@@ -78,7 +78,7 @@ namespace AutoFixture.AutoMoq
 
             var m = result as Mock;
             if (m == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return m.Object;
         }

--- a/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
+++ b/Src/AutoMoqUnitTest/MockPostprocessorTest.cs
@@ -56,7 +56,7 @@ namespace AutoFixture.AutoMoq.UnitTest
             var dummyContext = new Mock<ISpecimenContext>().Object;
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -112,7 +112,7 @@ namespace AutoFixture.AutoMoq.UnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
     }

--- a/Src/AutoMoqUnitTest/MockRelayTest.cs
+++ b/Src/AutoMoqUnitTest/MockRelayTest.cs
@@ -76,7 +76,7 @@ namespace AutoFixture.AutoMoq.UnitTest
             // Act
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -113,7 +113,7 @@ namespace AutoFixture.AutoMoq.UnitTest
             // Act
             var result = sut.Create(request, contextStub.Object);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
 
@@ -180,7 +180,7 @@ namespace AutoFixture.AutoMoq.UnitTest
             var dummyContext = new Mock<ISpecimenContext>().Object;
             var actual = sut.Create(request, dummyContext);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, actual);
         }
     }

--- a/Src/AutoMoqUnitTest/MockTypeTest.cs
+++ b/Src/AutoMoqUnitTest/MockTypeTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using AutoFixture.AutoMoq.UnitTest.TestTypes;
 using AutoFixture.Kernel;
@@ -103,23 +104,28 @@ namespace AutoFixture.AutoMoq.UnitTest
                 ex.Message);
         }
 
+        public static TheoryData<object> UnexpectedSpecimens =>
+           new TheoryData<object>
+           {
+                new OmitSpecimen(),
+                NoSpecimen.Instance,
+                new object(),
+                new StringBuilder()
+           };
+
         [Theory]
-        [InlineData(typeof(OmitSpecimen))]
-        [InlineData(typeof(NoSpecimen))]
-        [InlineData(typeof(object))]
-        [InlineData(typeof(StringBuilder))]
-        public void ReturnsUsingFixture_Throws_WhenContextReturnsUnexpectedSpecimen(Type specimenType)
+        [MemberData(nameof(UnexpectedSpecimens))]
+        public void ReturnsUsingFixture_Throws_WhenContextReturnsUnexpectedSpecimen(object specimen)
         {
             // Arrange
             var mock = new Mock<IInterfaceWithProperty>();
-            var specimen = Activator.CreateInstance(specimenType);
             var fixture = new Mock<ISpecimenBuilder>();
             fixture.Setup(f => f.Create(typeof(string), It.IsAny<ISpecimenContext>()))
                 .Returns(specimen);
             var expectedExceptionMessage =
                 string.Format(
                     "Tried to setup a member with a return type of System.String, but an instance of {0} was found instead.",
-                    specimenType.FullName);
+                    specimen.GetType().FullName);
 
             // Act
             mock.Setup(x => x.Property).ReturnsUsingFixture(fixture.Object);

--- a/Src/AutoMoqUnitTest/ValidNonMockSpecimens.cs
+++ b/Src/AutoMoqUnitTest/ValidNonMockSpecimens.cs
@@ -8,7 +8,7 @@ namespace AutoFixture.AutoMoq.UnitTest
     {
         public IEnumerator<object[]> GetEnumerator()
         {
-            yield return new object[] { new NoSpecimen() };
+            yield return new object[] { NoSpecimen.Instance };
             yield return new object[] { new OmitSpecimen() };
             yield return new object[] { null };
         }

--- a/Src/AutoNSubstitute/NSubstituteBuilder.cs
+++ b/Src/AutoNSubstitute/NSubstituteBuilder.cs
@@ -61,11 +61,11 @@ namespace AutoFixture.AutoNSubstitute
         public object Create(object request, ISpecimenContext context)
         {
             if (!this.SubstitutionSpecification.IsSatisfiedBy(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var substitute = this.Builder.Create(request, context);
             if (substitute == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             return substitute;
         }

--- a/Src/AutoNSubstitute/SubstituteAttributeRelay.cs
+++ b/Src/AutoNSubstitute/SubstituteAttributeRelay.cs
@@ -28,14 +28,14 @@ namespace AutoFixture.AutoNSubstitute
             var customAttributeProvider = request as ICustomAttributeProvider;
             if (customAttributeProvider == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var attribute = customAttributeProvider.GetCustomAttributes(typeof(SubstituteAttribute), true)
                     .OfType<SubstituteAttribute>().FirstOrDefault();
             if (attribute == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             object substituteRequest = CreateSubstituteRequest(customAttributeProvider, attribute);

--- a/Src/AutoNSubstitute/SubstituteRelay.cs
+++ b/Src/AutoNSubstitute/SubstituteRelay.cs
@@ -50,11 +50,11 @@ namespace AutoFixture.AutoNSubstitute
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             if (!this.Specification.IsSatisfiedBy(request))
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             var requestedType = request as Type;
             if (requestedType == null)
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
 
             object substitute = context.Resolve(new SubstituteRequest(requestedType));
 

--- a/Src/AutoNSubstitute/SubstituteRequestHandler.cs
+++ b/Src/AutoNSubstitute/SubstituteRequestHandler.cs
@@ -45,7 +45,7 @@ namespace AutoFixture.AutoNSubstitute
             var substituteRequest = request as SubstituteRequest;
             if (substituteRequest == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return this.SubstituteFactory.Create(substituteRequest.TargetType, context);

--- a/Src/AutoNSubstituteUnitTest/NSubstituteBuilderTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteBuilderTest.cs
@@ -82,7 +82,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
 
@@ -114,7 +114,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
 
@@ -131,7 +131,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             var result = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
     }

--- a/Src/AutoNSubstituteUnitTest/SubstituteAttributeRelayTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteAttributeRelayTest.cs
@@ -27,7 +27,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             object specimen = sut.Create(null, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, specimen);
         }
 
@@ -41,7 +41,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             object specimen = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, specimen);
         }
 
@@ -56,7 +56,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             object specimen = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, specimen);
         }
 

--- a/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteRelayTest.cs
@@ -63,7 +63,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             object result = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
 
@@ -77,7 +77,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             object result = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
 

--- a/Src/AutoNSubstituteUnitTest/SubstituteRequestHandlerTest.cs
+++ b/Src/AutoNSubstituteUnitTest/SubstituteRequestHandlerTest.cs
@@ -49,7 +49,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
             // Act
             object result = sut.Create(request, context);
             // Assert
-            var expected = new NoSpecimen();
+            var expected = NoSpecimen.Instance;
             Assert.Equal(expected, result);
         }
 

--- a/Src/AutoRhinoMock/RhinoMockAroundAdvice.cs
+++ b/Src/AutoRhinoMock/RhinoMockAroundAdvice.cs
@@ -58,14 +58,14 @@ namespace AutoFixture.AutoRhinoMock
         {
             if (!request.IsMockable())
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             var built = this.Builder.Create(request, context);
             var m = built as IMockedObject;
             if (m == null)
             {
-                return new NoSpecimen();
+                return NoSpecimen.Instance;
             }
 
             return m;

--- a/Src/AutoRhinoMockUnitTest/RhinoMockAroundAdviceTest.cs
+++ b/Src/AutoRhinoMockUnitTest/RhinoMockAroundAdviceTest.cs
@@ -53,7 +53,7 @@ namespace AutoFixture.AutoRhinoMock.UnitTest
             var dummyContext = MockRepository.GenerateMock<ISpecimenContext>();
             var result = sut.Create(request, dummyContext);
             // Assert
-            var expectedResult = new NoSpecimen();
+            var expectedResult = NoSpecimen.Instance;
             Assert.Equal(expectedResult, result);
         }
     }


### PR DESCRIPTION
### Description
This is a performance change that saves memory by avoiding creation of a large number of NoSpecimen instances.

### Closed issues
#1489

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
