### PR TITLE
fix: update version System.Text.RegularExpressions from 4.3.0 to 4.3.1

### DIFF
--- a/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy3UnitTest/AutoFakeItEasy.FakeItEasy3UnitTest.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="[3.0.0]" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy4UnitTest/AutoFakeItEasy.FakeItEasy4UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy4UnitTest/AutoFakeItEasy.FakeItEasy4UnitTest.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="FakeItEasy" Version="[4.0.0]" Condition=" '$(TargetFramework)'=='net452' " />
     <PackageReference Include="FakeItEasy" Version="[4.0.0]" Condition=" '$(TargetFramework)'=='netcoreapp1.1' " />
     <PackageReference Include="FakeItEasy" Version="[4.9.0]" Condition=" '$(TargetFramework)'=='netcoreapp2.0' " />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy5UnitTest/AutoFakeItEasy.FakeItEasy5UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy5UnitTest/AutoFakeItEasy.FakeItEasy5UnitTest.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="[5.0.0]" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy6UnitTest/AutoFakeItEasy.FakeItEasy6UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy6UnitTest/AutoFakeItEasy.FakeItEasy6UnitTest.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="[6.2.1]" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFakeItEasy.FakeItEasy7UnitTest/AutoFakeItEasy.FakeItEasy7UnitTest.csproj
+++ b/Src/AutoFakeItEasy.FakeItEasy7UnitTest/AutoFakeItEasy.FakeItEasy7UnitTest.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
+++ b/Src/AutoFakeItEasy/AutoFakeItEasy.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="FakeItEasy" Version="[1.7.4109.1,9.0.0)" Condition=" '$(TargetFramework)'=='net462' " />
     <PackageReference Include="FakeItEasy" Version="[3.0.0,7.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.6' " />
     <PackageReference Include="FakeItEasy" Version="[4.9.0,9.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoFixture.NUnit3.UnitTest.csproj
@@ -14,8 +14,9 @@
     <PackageReference Include="NUnit" Version="[3.7.0]" Condition=" '$(TargetFramework)'=='netcoreapp1.1' " />
     <PackageReference Include="NUnit" Version="[3.10.1]" Condition=" '$(TargetFramework)'=='netcoreapp2.1' " />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
+++ b/Src/AutoFixture.NUnit3/AutoFixture.NUnit3.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="NUnit" Version="[3.0.1,4.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
     <PackageReference Include="NUnit" Version="[3.7.0,4.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <PackageReference Include="NUnit" Version="[3.7.0,4.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFixture.SeedExtensions.UnitTest/AutoFixture.SeedExtensions.UnitTest.csproj
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/AutoFixture.SeedExtensions.UnitTest.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture.SeedExtensions\AutoFixture.SeedExtensions.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
   </ItemGroup>

--- a/Src/AutoFixture.SeedExtensions/AutoFixture.SeedExtensions.csproj
+++ b/Src/AutoFixture.SeedExtensions/AutoFixture.SeedExtensions.csproj
@@ -15,6 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
   </ItemGroup>
 </Project>

--- a/Src/AutoFixture.xUnit2.UnitTest/AutoFixture.xUnit2.UnitTest.csproj
+++ b/Src/AutoFixture.xUnit2.UnitTest/AutoFixture.xUnit2.UnitTest.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\AutoFixture.xUnit2\AutoFixture.xUnit2.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />

--- a/Src/AutoFixture.xUnit2/AutoFixture.xUnit2.csproj
+++ b/Src/AutoFixture.xUnit2/AutoFixture.xUnit2.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit.extensibility.core" Version="[2.0.0,3.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
     <PackageReference Include="xunit.extensibility.core" Version="[2.2.0,3.0.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <PackageReference Include="xunit.extensibility.core" Version="[2.2.0,3.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />

--- a/Src/AutoFixture/AutoFixture.csproj
+++ b/Src/AutoFixture/AutoFixture.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Fare" Version="[2.1.1,3.0.0)" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' Or '$(TargetFramework)'=='netstandard2.0' " />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <Reference Include="System.ComponentModel.DataAnnotations" Condition=" '$(TargetFramework)'=='net452' " />
   </ItemGroup>
 </Project>

--- a/Src/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
+++ b/Src/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\AutoFixture.SeedExtensions\AutoFixture.SeedExtensions.csproj" />
   </ItemGroup>

--- a/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/Src/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />
     <Reference Condition=" '$(TargetFramework)'=='net452' " Include="System.ComponentModel.DataAnnotations" />
     <PackageReference Condition=" '$(TargetFramework)'=='netcoreapp1.1' " Include="System.Linq.Parallel" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoFoq/AutoFoq.fsproj
+++ b/Src/AutoFoq/AutoFoq.fsproj
@@ -42,6 +42,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
   </ItemGroup>
 

--- a/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
+++ b/Src/AutoFoqUnitTest/AutoFoqUnitTest.fsproj
@@ -33,6 +33,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\AutoFoq\AutoFoq.fsproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />

--- a/Src/AutoMoq/AutoMoq.csproj
+++ b/Src/AutoMoq/AutoMoq.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Moq" Version="[4.1.1308.2120,5.0.0)" Condition=" '$(TargetFramework)'=='net452' " />
     <PackageReference Include="Moq" Version="[4.7.0,4.11.0)" Condition=" '$(TargetFramework)'=='netstandard1.5' " />
     <PackageReference Include="Moq" Version="[4.7.0,5.0.0)" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/Src/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -18,6 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\AutoMoq\AutoMoq.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />

--- a/Src/AutoNSubstitute.NSubstitute3UnitTest/AutoNSubstitute.NSubstitute3UnitTest.csproj
+++ b/Src/AutoNSubstitute.NSubstitute3UnitTest/AutoNSubstitute.NSubstitute3UnitTest.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="[3.0.1]" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 

--- a/Src/AutoNSubstitute.NSubstitute4UnitTest/AutoNSubstitute.NSubstitute4UnitTest.csproj
+++ b/Src/AutoNSubstitute.NSubstitute4UnitTest/AutoNSubstitute.NSubstitute4UnitTest.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="[4.0.0]" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 

--- a/Src/AutoNSubstitute.NSubstitute5UnitTest/AutoNSubstitute.NSubstitute5UnitTest.csproj
+++ b/Src/AutoNSubstitute.NSubstitute5UnitTest/AutoNSubstitute.NSubstitute5UnitTest.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="[5.0.0]" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 

--- a/Src/AutoNSubstitute/AutoNSubstitute.csproj
+++ b/Src/AutoNSubstitute/AutoNSubstitute.csproj
@@ -24,6 +24,7 @@
 
     <PackageReference Include="NSubstitute" Version="[2.0.3,6.0.0)" Condition="'$(TargetFramework)'=='net452'" />
     <PackageReference Include="NSubstitute" Version="[2.0.3,6.0.0)" Condition="'$(TargetFramework)'=='netstandard2.0'" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
+++ b/Src/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 

--- a/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
+++ b/Src/Idioms.FsCheck.FsCheck2UnitTest/Idioms.FsCheck.FsCheck2UnitTest.fsproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Unquote" Version="4.0.0" />
   </ItemGroup>
 

--- a/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
+++ b/Src/Idioms.FsCheck/Idioms.FsCheck.fsproj
@@ -40,6 +40,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\Idioms\Idioms.csproj" />
   </ItemGroup>

--- a/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
+++ b/Src/Idioms.FsCheckUnitTest/Idioms.FsCheckUnitTest.fsproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Unquote" Version="4.0.0" />
     <PackageReference Include="FSharp.Core" Version="[4.2.3]" PrivateAssets="All" />
   </ItemGroup>

--- a/Src/Idioms/Idioms.csproj
+++ b/Src/Idioms/Idioms.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\Common.props"/>
+  <Import Project="..\Common.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
@@ -15,12 +15,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Albedo" Version="[2.0.0,3.0.0)"/>
+    <PackageReference Include="Albedo" Version="[2.0.0,3.0.0)" />
 
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard2.0' "/>
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" Condition=" '$(TargetFramework)'=='netstandard2.0' " />
+
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj"/>
+    <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
   </ItemGroup>
 </Project>

--- a/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/Src/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AutoFixture\AutoFixture.csproj" />
     <ProjectReference Include="..\Idioms\Idioms.csproj" />
     <ProjectReference Include="..\TestTypeFoundation\TestTypeFoundation.csproj" />

--- a/Src/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/Src/TestTypeFoundation/TestTypeFoundation.csproj
@@ -7,6 +7,10 @@
     <AssemblyTitle>TestTypeFoundation</AssemblyTitle>
     <AssemblyName>TestTypeFoundation</AssemblyName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
  
 </Project>
 


### PR DESCRIPTION
### Description
Update version of System.Text.RegularExpressions from 4.3.0(vulnerable) to 4.3.1

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->
#1484

### Checklist

- [x] Reviewed the [contribution guidelines](https://github.com/AutoFixture/AutoFixture/blob/master/CONTRIBUTING.md)
- [x] Linked the issue(s) the PR closes
- [ ] Implemented automated tests and checked coverage
- [ ] Provided inline documentation comments for new public API
- [x] Ran the full solution [build and validation](https://github.com/AutoFixture/AutoFixture#build) locally
