### PR TITLE
Migrate project to not use this. keyword

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,10 +10,11 @@ indent_style = space
 
 [*.cs]
 # Disallow "this." keyword qualification in code
-dotnet_style_qualification_for_field = false:warning
-dotnet_style_qualification_for_property = false:warning
-dotnet_style_qualification_for_method = false:warning
-dotnet_style_qualification_for_event = false:warning
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error
+
 
 # Require "_" prefix for private instance fields
 dotnet_naming_symbols.private_instance_fields.applicable_kinds = field
@@ -22,7 +23,16 @@ dotnet_naming_style.private_instance_fields_underscore.required_prefix = _
 dotnet_naming_style.private_instance_fields_underscore.capitalization = camel_case
 dotnet_naming_rule.private_instance_fields_should_be_underscored.symbols = private_instance_fields
 dotnet_naming_rule.private_instance_fields_should_be_underscored.style = private_instance_fields_underscore
-dotnet_naming_rule.private_instance_fields_should_be_underscored.severity = warning
+dotnet_naming_rule.private_instance_fields_should_be_underscored.severity = error
+
+# Require PascalCase for private constants
+dotnet_naming_symbols.private_constants.applicable_kinds = field
+dotnet_naming_symbols.private_constants.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants.required_modifiers = const
+dotnet_naming_style.private_constants_pascal_case.capitalization = pascal_case
+dotnet_naming_rule.private_constants_should_be_pascal_case.symbols = private_constants
+dotnet_naming_rule.private_constants_should_be_pascal_case.style = private_constants_pascal_case
+dotnet_naming_rule.private_constants_should_be_pascal_case.severity = error
 
 # Require "s_" prefix for private static fields
 dotnet_naming_symbols.private_static_fields.applicable_kinds = field
@@ -32,7 +42,7 @@ dotnet_naming_style.private_static_fields_prefixed.required_prefix = s_
 dotnet_naming_style.private_static_fields_prefixed.capitalization = camel_case
 dotnet_naming_rule.private_static_fields_should_be_prefixed.symbols = private_static_fields
 dotnet_naming_rule.private_static_fields_should_be_prefixed.style = private_static_fields_prefixed
-dotnet_naming_rule.private_static_fields_should_be_prefixed.severity = warning
+dotnet_naming_rule.private_static_fields_should_be_prefixed.severity = suggestion
 
 # Require properties to start with uppercase
 dotnet_naming_symbols.properties.applicable_kinds = property
@@ -40,7 +50,7 @@ dotnet_naming_symbols.properties.applicable_accessibilities = *
 dotnet_naming_style.properties_pascal_case.capitalization = pascal_case
 dotnet_naming_rule.properties_should_be_pascal_case.symbols = properties
 dotnet_naming_rule.properties_should_be_pascal_case.style = properties_pascal_case
-dotnet_naming_rule.properties_should_be_pascal_case.severity = warning
+dotnet_naming_rule.properties_should_be_pascal_case.severity = error
 
-[Src/AutoFixtureUnitTest/UseCultureAttribute.cs]
-dotnet_diagnostic.IDE1006.severity = none
+# Enable code style warnings
+dotnet_diagnostic.IDE1006.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,38 @@ indent_size = 2
 indent_style = space
 
 [*.cs]
-# Require "this." keyword qualification in code
-dotnet_style_qualification_for_field = true:suggestion
-dotnet_style_qualification_for_property = true:suggestion
-dotnet_style_qualification_for_method = true:suggestion
-dotnet_style_qualification_for_event = true:suggestion
+# Disallow "this." keyword qualification in code
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# Require "_" prefix for private instance fields
+dotnet_naming_symbols.private_instance_fields.applicable_kinds = field
+dotnet_naming_symbols.private_instance_fields.applicable_accessibilities = private
+dotnet_naming_style.private_instance_fields_underscore.required_prefix = _
+dotnet_naming_style.private_instance_fields_underscore.capitalization = camel_case
+dotnet_naming_rule.private_instance_fields_should_be_underscored.symbols = private_instance_fields
+dotnet_naming_rule.private_instance_fields_should_be_underscored.style = private_instance_fields_underscore
+dotnet_naming_rule.private_instance_fields_should_be_underscored.severity = warning
+
+# Require "s_" prefix for private static fields
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+dotnet_naming_style.private_static_fields_prefixed.required_prefix = s_
+dotnet_naming_style.private_static_fields_prefixed.capitalization = camel_case
+dotnet_naming_rule.private_static_fields_should_be_prefixed.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_be_prefixed.style = private_static_fields_prefixed
+dotnet_naming_rule.private_static_fields_should_be_prefixed.severity = warning
+
+# Require properties to start with uppercase
+dotnet_naming_symbols.properties.applicable_kinds = property
+dotnet_naming_symbols.properties.applicable_accessibilities = *
+dotnet_naming_style.properties_pascal_case.capitalization = pascal_case
+dotnet_naming_rule.properties_should_be_pascal_case.symbols = properties
+dotnet_naming_rule.properties_should_be_pascal_case.style = properties_pascal_case
+dotnet_naming_rule.properties_should_be_pascal_case.severity = warning
+
+[Src/AutoFixtureUnitTest/UseCultureAttribute.cs]
+dotnet_diagnostic.IDE1006.severity = none

--- a/AutoFixture.globalconfig
+++ b/AutoFixture.globalconfig
@@ -26,6 +26,7 @@ dotnet_diagnostic.CA5394.severity = none	# CA5394: Do not use insecure randomnes
 
 ## StyleCop Analyzers ##
 
+dotnet_diagnostic.SA1101.severity = none # SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1116.severity = none # SA1116: The parameters should begin on the line after the declaration, whenever the parameter span across multiple line
 dotnet_diagnostic.SA1117.severity = none # SA1117: The parameters should all be placed on the same line or each parameter should be placed on its own line.
 dotnet_diagnostic.SA1118.severity = none # SA1118: The parameter spans multiple lines
@@ -35,6 +36,9 @@ dotnet_diagnostic.SA1202.severity = none # SA1202: 'public' members should come 
 dotnet_diagnostic.SA1203.severity = none # SA1203: Constant fields should appear before non-constant fields
 dotnet_diagnostic.SA1204.severity = none # SA1204: Static members should appear before non-static members
 dotnet_diagnostic.SA1214.severity = none # SA1214: Readonly fields should appear before non-readonly fields
+dotnet_diagnostic.SA1308.severity = none # SA1308: Variable names should not be prefixed
+dotnet_diagnostic.SA1309.severity = none # SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1311.severity = none # SA1311: Static readonly fields should begin with upper-case letter
 dotnet_diagnostic.SA1413.severity = none # SA1413: Use trailing comma in multi-line initializers
 dotnet_diagnostic.SA1501.severity = none # SA1501: Statement should not be on a single line
 dotnet_diagnostic.SA1503.severity = none # SA1503: Braces should not be omitted

--- a/Common.props
+++ b/Common.props
@@ -17,6 +17,8 @@
 
     <Deterministic>true</Deterministic>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
     <!-- NETSDK1138: Ignore .NET SDK deprecation notice -->
     <NoWarn>$(NoWarn);NETSDK1138;NU1902;NU1903</NoWarn>
 

--- a/Src/AutoFakeItEasy/AutoFakeItEasyCustomization.cs
+++ b/Src/AutoFakeItEasy/AutoFakeItEasyCustomization.cs
@@ -13,7 +13,7 @@ namespace AutoFixture.AutoFakeItEasy;
 /// </remarks>
 public class AutoFakeItEasyCustomization : ICustomization
 {
-    private ISpecimenBuilder relay;
+    private ISpecimenBuilder _relay;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AutoFakeItEasyCustomization"/> class.
@@ -39,7 +39,7 @@ public class AutoFakeItEasyCustomization : ICustomization
               "Please use the AutoFakeItEasyCustomization() overload (without arguments) instead and set the Relay property.")]
     public AutoFakeItEasyCustomization(ISpecimenBuilder relay)
     {
-        this.Relay = relay ?? throw new ArgumentNullException(nameof(relay));
+        Relay = relay ?? throw new ArgumentNullException(nameof(relay));
     }
 
     /// <summary>
@@ -48,8 +48,8 @@ public class AutoFakeItEasyCustomization : ICustomization
     /// </summary>
     public ISpecimenBuilder Relay
     {
-        get => this.relay;
-        set => this.relay = value ?? throw new ArgumentNullException(nameof(value));
+        get => _relay;
+        set => _relay = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -70,14 +70,14 @@ public class AutoFakeItEasyCustomization : ICustomization
     {
         if (fixture is null) throw new ArgumentNullException(nameof(fixture));
 
-        if (this.GenerateDelegates)
+        if (GenerateDelegates)
         {
             fixture.Customizations.Add(new FakeItEasyRelay(new DelegateSpecification()));
         }
 
         ISpecimenBuilder fakeBuilder = new FakeItEasyBuilder(new MethodInvoker(new FakeItEasyMethodQuery()));
 
-        if (this.ConfigureMembers)
+        if (ConfigureMembers)
         {
             fakeBuilder = new Postprocessor(
                 builder: fakeBuilder,
@@ -87,6 +87,6 @@ public class AutoFakeItEasyCustomization : ICustomization
         }
 
         fixture.Customizations.Add(fakeBuilder);
-        fixture.ResidueCollectors.Add(this.Relay);
+        fixture.ResidueCollectors.Add(Relay);
     }
 }

--- a/Src/AutoFakeItEasy/CallResultCache.cs
+++ b/Src/AutoFakeItEasy/CallResultCache.cs
@@ -5,16 +5,16 @@ namespace AutoFixture.AutoFakeItEasy;
 
 internal class CallResultCache
 {
-    private readonly ConcurrentDictionary<MethodCall, MethodCallResult> cachedResults =
+    private readonly ConcurrentDictionary<MethodCall, MethodCallResult> _cachedResults =
         new ConcurrentDictionary<MethodCall, MethodCallResult>();
 
     public MethodCallResult GetOrAdd(MethodCall methodCall, Func<MethodCallResult> resultFactory)
     {
-        return this.cachedResults.GetOrAdd(methodCall, key => resultFactory());
+        return _cachedResults.GetOrAdd(methodCall, key => resultFactory());
     }
 
     public void Put(MethodCall methodCall, MethodCallResult methodCallResult)
     {
-        this.cachedResults[methodCall] = methodCallResult;
+        _cachedResults[methodCall] = methodCallResult;
     }
 }

--- a/Src/AutoFakeItEasy/ConfigureSealedMembersCommand.cs
+++ b/Src/AutoFakeItEasy/ConfigureSealedMembersCommand.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.AutoFakeItEasy;
 /// </summary>
 public class ConfigureSealedMembersCommand : ISpecimenCommand
 {
-    private readonly ISpecimenCommand autoPropertiesCommand =
+    private readonly ISpecimenCommand _autoPropertiesCommand =
         new AutoPropertiesCommand(new FieldOrSealedPropertySpecification());
 
     /// <summary>
@@ -25,7 +25,7 @@ public class ConfigureSealedMembersCommand : ISpecimenCommand
         var fake = specimen.GetType().GetProperty("FakedObject")?.GetValue(specimen, null);
         if (fake is null) return;
 
-        this.autoPropertiesCommand.Execute(fake, context);
+        _autoPropertiesCommand.Execute(fake, context);
     }
 
     /// <summary>

--- a/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyBuilder.cs
@@ -23,7 +23,7 @@ public class FakeItEasyBuilder : ISpecimenBuilder
     /// <seealso cref="Builder" />
     public FakeItEasyBuilder(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public class FakeItEasyBuilder : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        var fake = this.Builder.Create(request, context);
+        var fake = Builder.Create(request, context);
 
         return type.IsInstanceOfType(fake) ? fake : NoSpecimen.Instance;
     }

--- a/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyMethodQuery.cs
@@ -13,7 +13,7 @@ namespace AutoFixture.AutoFakeItEasy;
 /// </summary>
 public class FakeItEasyMethodQuery : IMethodQuery
 {
-    private static readonly DelegateSpecification DelegateSpecification = new DelegateSpecification();
+    private static readonly DelegateSpecification s_delegateSpecification = new DelegateSpecification();
 
     /// <summary>
     /// Selects constructors for the supplied type.
@@ -38,7 +38,7 @@ public class FakeItEasyMethodQuery : IMethodQuery
         }
 
         var fakeType = type.GetFakedType();
-        if (fakeType.GetTypeInfo().IsInterface || DelegateSpecification.IsSatisfiedBy(fakeType))
+        if (fakeType.GetTypeInfo().IsInterface || s_delegateSpecification.IsSatisfiedBy(fakeType))
         {
             return new[] { new ConstructorMethod(type.GetDefaultConstructor()) };
         }
@@ -65,7 +65,7 @@ public class FakeItEasyMethodQuery : IMethodQuery
     {
         public FakeMethod(IEnumerable<ParameterInfo> parameters)
         {
-            this.Parameters = parameters;
+            Parameters = parameters;
         }
 
         public IEnumerable<ParameterInfo> Parameters { get; }

--- a/Src/AutoFakeItEasy/FakeItEasyRelay.cs
+++ b/Src/AutoFakeItEasy/FakeItEasyRelay.cs
@@ -28,7 +28,7 @@ public class FakeItEasyRelay : ISpecimenBuilder
     /// </param>
     public FakeItEasyRelay(IRequestSpecification fakeableSpecification)
     {
-        this.FakeableSpecification = fakeableSpecification ?? throw new ArgumentNullException(nameof(fakeableSpecification));
+        FakeableSpecification = fakeableSpecification ?? throw new ArgumentNullException(nameof(fakeableSpecification));
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class FakeItEasyRelay : ISpecimenBuilder
     {
         if (context is null) throw new ArgumentNullException(nameof(context));
 
-        if (!this.FakeableSpecification.IsSatisfiedBy(request))
+        if (!FakeableSpecification.IsSatisfiedBy(request))
             return NoSpecimen.Instance;
 
         if (request is not Type type)

--- a/Src/AutoFakeItEasy/MethodCall.cs
+++ b/Src/AutoFakeItEasy/MethodCall.cs
@@ -8,39 +8,39 @@ namespace AutoFixture.AutoFakeItEasy;
 
 internal class MethodCall
 {
-    private readonly Type declaringType;
-    private readonly string methodName;
-    private readonly IList<Type> parameterTypes;
-    private readonly IList<object> arguments;
+    private readonly Type _declaringType;
+    private readonly string _methodName;
+    private readonly IList<Type> _parameterTypes;
+    private readonly IList<object> _arguments;
 
     public MethodCall(Type declaringType, string methodName, IEnumerable<ParameterInfo> parameters, IEnumerable<object> arguments)
     {
-        this.declaringType = declaringType;
-        this.methodName = methodName;
+        _declaringType = declaringType;
+        _methodName = methodName;
         var parametersList = parameters.ToList();
-        this.parameterTypes = parametersList.Select(p => p.ParameterType).ToList();
-        this.arguments = ExpandParamsArgument(parametersList, arguments).ToList();
+        _parameterTypes = parametersList.Select(p => p.ParameterType).ToList();
+        _arguments = ExpandParamsArgument(parametersList, arguments).ToList();
     }
 
     public override bool Equals(object obj)
     {
         return obj is MethodCall call
-               && this.declaringType == call.declaringType
-               && this.methodName.Equals(call.methodName, StringComparison.Ordinal)
-               && this.parameterTypes.SequenceEqual(call.parameterTypes)
-               && this.arguments.SequenceEqual(call.arguments);
+               && _declaringType == call._declaringType
+               && _methodName.Equals(call._methodName, StringComparison.Ordinal)
+               && _parameterTypes.SequenceEqual(call._parameterTypes)
+               && _arguments.SequenceEqual(call._arguments);
     }
 
     public override int GetHashCode()
     {
         var hashCode = default(HashCode);
-        hashCode.Add(this.declaringType);
-        hashCode.Add(this.methodName);
-        foreach (var argument in this.arguments)
+        hashCode.Add(_declaringType);
+        hashCode.Add(_methodName);
+        foreach (var argument in _arguments)
         {
             hashCode.Add(argument);
         }
-        foreach (var argumentType in this.parameterTypes)
+        foreach (var argumentType in _parameterTypes)
         {
             hashCode.Add(argumentType);
         }

--- a/Src/AutoFakeItEasy/MethodCallResult.cs
+++ b/Src/AutoFakeItEasy/MethodCallResult.cs
@@ -5,20 +5,20 @@ namespace AutoFixture.AutoFakeItEasy;
 
 internal class MethodCallResult
 {
-    private List<PositionedValue> outAndRefValues;
-    private readonly object returnValue;
+    private List<PositionedValue> _outAndRefValues;
+    private readonly object _returnValue;
 
     public MethodCallResult(object returnValue)
     {
-        this.returnValue = returnValue;
+        _returnValue = returnValue;
     }
 
     public void ApplyToCall(IInterceptedFakeObjectCall fakeObjectCall)
     {
-        fakeObjectCall.SetReturnValue(this.returnValue);
-        if (this.outAndRefValues is null) return;
+        fakeObjectCall.SetReturnValue(_returnValue);
+        if (_outAndRefValues is null) return;
 
-        foreach (var positionedValue in this.outAndRefValues)
+        foreach (var positionedValue in _outAndRefValues)
         {
             fakeObjectCall.SetArgumentValue(positionedValue.Position, positionedValue.Value);
         }
@@ -26,16 +26,16 @@ internal class MethodCallResult
 
     public void AddOutOrRefValue(int position, object value)
     {
-        this.outAndRefValues ??= new List<PositionedValue>();
-        this.outAndRefValues.Add(new PositionedValue(position, value));
+        _outAndRefValues ??= new List<PositionedValue>();
+        _outAndRefValues.Add(new PositionedValue(position, value));
     }
 
     private class PositionedValue
     {
         public PositionedValue(int position, object value)
         {
-            this.Position = position;
-            this.Value = value;
+            Position = position;
+            Value = value;
         }
 
         public int Position { get; }

--- a/Src/AutoFakeItEasy/MethodRule.cs
+++ b/Src/AutoFakeItEasy/MethodRule.cs
@@ -11,13 +11,13 @@ namespace AutoFixture.AutoFakeItEasy;
 /// </summary>
 internal class MethodRule : IFakeObjectCallRule
 {
-    private readonly ISpecimenContext context;
-    private readonly CallResultCache resultSource;
+    private readonly ISpecimenContext _context;
+    private readonly CallResultCache _resultSource;
 
     public MethodRule(ISpecimenContext context, CallResultCache resultSource)
     {
-        this.context = context;
-        this.resultSource = resultSource;
+        _context = context;
+        _resultSource = resultSource;
     }
 
     /// <summary>
@@ -44,9 +44,9 @@ internal class MethodRule : IFakeObjectCallRule
     {
         if (fakeObjectCall is null) throw new ArgumentNullException(nameof(fakeObjectCall));
 
-        this.resultSource.GetOrAdd(
+        _resultSource.GetOrAdd(
                 CreateMethodCall(fakeObjectCall),
-                () => this.CreateMethodCallResult(fakeObjectCall))
+                () => CreateMethodCallResult(fakeObjectCall))
             .ApplyToCall(fakeObjectCall);
     }
 
@@ -58,15 +58,15 @@ internal class MethodRule : IFakeObjectCallRule
 
     private MethodCallResult CreateMethodCallResult(IFakeObjectCall fakeObjectCall)
     {
-        var result = new MethodCallResult(this.ResolveReturnValue(fakeObjectCall));
-        this.AddOutAndRefValues(result, fakeObjectCall);
+        var result = new MethodCallResult(ResolveReturnValue(fakeObjectCall));
+        AddOutAndRefValues(result, fakeObjectCall);
         return result;
     }
 
     private object ResolveReturnValue(IFakeObjectCall fakeObjectCall)
     {
         var methodReturnType = fakeObjectCall.Method.ReturnType;
-        return methodReturnType == typeof(void) ? null : this.context.Resolve(methodReturnType);
+        return methodReturnType == typeof(void) ? null : _context.Resolve(methodReturnType);
     }
 
     private void AddOutAndRefValues(MethodCallResult result, IFakeObjectCall fakeObjectCall)
@@ -77,7 +77,7 @@ internal class MethodRule : IFakeObjectCallRule
             var parameterParameterType = parameters[index].ParameterType;
             if (parameterParameterType.IsByRef)
             {
-                var value = this.context.Resolve(parameterParameterType.GetElementType());
+                var value = _context.Resolve(parameterParameterType.GetElementType());
                 result.AddOutOrRefValue(index, value);
             }
         }

--- a/Src/AutoFakeItEasy/PropertySetterRule.cs
+++ b/Src/AutoFakeItEasy/PropertySetterRule.cs
@@ -11,11 +11,11 @@ namespace AutoFixture.AutoFakeItEasy;
 /// </summary>
 internal class PropertySetterRule : IFakeObjectCallRule
 {
-    private readonly CallResultCache resultCache;
+    private readonly CallResultCache _resultCache;
 
     public PropertySetterRule(CallResultCache resultCache)
     {
-        this.resultCache = resultCache;
+        _resultCache = resultCache;
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ internal class PropertySetterRule : IFakeObjectCallRule
         if (fakeObjectCall is null) throw new ArgumentNullException(nameof(fakeObjectCall));
 
         var methodCall = CreateMethodCallForGetter(fakeObjectCall);
-        this.resultCache.Put(methodCall, new MethodCallResult(fakeObjectCall.Arguments.Last()));
+        _resultCache.Put(methodCall, new MethodCallResult(fakeObjectCall.Arguments.Last()));
     }
 
     private static bool IsSetter(MethodInfo method) =>

--- a/Src/AutoFakeItEasyUnitTest/DependencyConstraints.cs
+++ b/Src/AutoFakeItEasyUnitTest/DependencyConstraints.cs
@@ -26,7 +26,7 @@ namespace AutoFixture.AutoFakeItEasy.UnitTest
         {
             // Arrange
             // Act
-            var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+            var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
             // Assert
             Assert.DoesNotContain(references, an => an.Name == assemblyName);
         }

--- a/Src/AutoFakeItEasyUnitTest/TestTypes/TypeWithPrivateField.cs
+++ b/Src/AutoFakeItEasyUnitTest/TestTypes/TypeWithPrivateField.cs
@@ -2,11 +2,11 @@
 {
     public class TypeWithPrivateField
     {
-        private string field = string.Empty;
+        private string _field = string.Empty;
 
         public string GetPrivateField()
         {
-            return this.field;
+            return _field;
         }
     }
 }

--- a/Src/AutoFixture.NUnit2.UnitTest/AutoDataProviderTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/AutoDataProviderTest.cs
@@ -7,11 +7,11 @@ namespace AutoFixture.NUnit2.UnitTest;
 [TestFixture]
 public class AutoDataProviderTest
 {
-    private readonly MethodInfo method;
+    private readonly MethodInfo _method;
 
     public AutoDataProviderTest()
     {
-        this.method = typeof(FakeAutoDataFixture).GetMethod("DoSomething");
+        _method = typeof(FakeAutoDataFixture).GetMethod("DoSomething");
     }
 
     [Test]
@@ -20,7 +20,7 @@ public class AutoDataProviderTest
         // Arrange
         // Act
         var sut = new AutoDataProvider();
-        var actual = sut.HasTestCasesFor(this.method);
+        var actual = sut.HasTestCasesFor(_method);
         // Assert
         Assert.True(actual);
     }
@@ -31,7 +31,7 @@ public class AutoDataProviderTest
         // Arrange
         // Act
         var sut = new AutoDataProvider();
-        var actual = sut.GetTestCasesFor(this.method);
+        var actual = sut.GetTestCasesFor(_method);
         // Assert
         Assert.NotNull(actual);
     }

--- a/Src/AutoFixture.NUnit2.UnitTest/CompositeDataAttributeInsufficientArgumentsTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/CompositeDataAttributeInsufficientArgumentsTest.cs
@@ -12,11 +12,11 @@ namespace AutoFixture.NUnit2.UnitTest;
 [TestFixture]
 public class CompositeDataAttributeInsufficientArgumentsTest : IEnumerable<object[]>
 {
-    private readonly MethodInfo method;
+    private readonly MethodInfo _method;
 
     public CompositeDataAttributeInsufficientArgumentsTest()
     {
-        this.method = typeof(TypeWithOverloadedMembers)
+        _method = typeof(TypeWithOverloadedMembers)
             .GetMethod("DoSomething", new[] { typeof(object), typeof(object), typeof(object) });
     }
 
@@ -26,7 +26,7 @@ public class CompositeDataAttributeInsufficientArgumentsTest : IEnumerable<objec
         // Arrange
         // Act & Assert
         Assert.Throws<InvalidOperationException>(
-            () => { new CompositeDataAttribute(attributes).GetData(this.method).ToList(); });
+            () => { new CompositeDataAttribute(attributes).GetData(_method).ToList(); });
     }
 
     public IEnumerator<object[]> GetEnumerator()
@@ -35,53 +35,53 @@ public class CompositeDataAttributeInsufficientArgumentsTest : IEnumerable<objec
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3, 4 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3, 4 } })
             });
 
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1    } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1    } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3 } })
             });
 
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1    } }),
-                new FakeDataAttribute(this.method, new[] { new object[] {      } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1    } }),
+                new FakeDataAttribute(_method, new[] { new object[] {      } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3 } })
             });
 
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3 } })
             });
 
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] {  new object[] { 1, 2    },  new object[] {  3,  4     }, new object[] { 5, 6 } }),
-                new FakeDataAttribute(this.method, new[] {  new object[] { 7, 8, 9 },  new object[] { 10, 11, 12 }                        })
+                new FakeDataAttribute(_method, new[] {  new object[] { 1, 2    },  new object[] {  3,  4     }, new object[] { 5, 6 } }),
+                new FakeDataAttribute(_method, new[] {  new object[] { 7, 8, 9 },  new object[] { 10, 11, 12 }                        })
             });
 
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] {  1,  2     }, new object[] {  3,  4     }, new object[] { 5, 6 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] {  7,  8,  9 }, new object[] { 10, 11, 12 }                        }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 13, 14, 15 }                                                     })
+                new FakeDataAttribute(_method, new[] { new object[] {  1,  2     }, new object[] {  3,  4     }, new object[] { 5, 6 } }),
+                new FakeDataAttribute(_method, new[] { new object[] {  7,  8,  9 }, new object[] { 10, 11, 12 }                        }),
+                new FakeDataAttribute(_method, new[] { new object[] { 13, 14, 15 }                                                     })
             });
 #pragma warning restore SA1025 // Code should not contain multiple whitespace in a row
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     private static object[] CreateTestCase(object[] data)

--- a/Src/AutoFixture.NUnit2.UnitTest/CompositeDataAttributeSufficientArgumentsTest.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/CompositeDataAttributeSufficientArgumentsTest.cs
@@ -11,11 +11,11 @@ namespace AutoFixture.NUnit2.UnitTest;
 [TestFixture]
 public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[]>
 {
-    private readonly MethodInfo method;
+    private readonly MethodInfo _method;
 
     public CompositeDataAttributeSufficientArgumentsTest()
     {
-        this.method = typeof(TypeWithOverloadedMembers)
+        _method = typeof(TypeWithOverloadedMembers)
             .GetMethod("DoSomething", new[] { typeof(object), typeof(object), typeof(object) });
     }
 
@@ -24,7 +24,7 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
     {
         // Arrange
         // Act
-        var result = new CompositeDataAttribute(attributes).GetData(this.method).ToList();
+        var result = new CompositeDataAttribute(attributes).GetData(_method).ToList();
         // Assert
         Assert.True(expectedResult.SequenceEqual(result, new TheoryComparer()));
     }
@@ -35,7 +35,7 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } })
             },
             expected: new[]
             {
@@ -45,8 +45,8 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -56,7 +56,7 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3, 4 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3, 4 } })
             },
             expected: new[]
             {
@@ -66,8 +66,8 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1       } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3, 4 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1       } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3, 4 } })
             },
             expected: new[]
             {
@@ -77,8 +77,8 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2    } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3, 4, 5 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2    } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3, 4, 5 } })
             },
             expected: new[]
             {
@@ -88,7 +88,7 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -98,8 +98,8 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4,  5, 6 }                          }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 7, 8    }, new object[] { 9, 10    }, new object[] { 11, 12 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4,  5, 6 }                          }),
+                new FakeDataAttribute(_method, new[] { new object[] { 7, 8    }, new object[] { 9, 10    }, new object[] { 11, 12 } })
             },
             expected: new[]
             {
@@ -109,8 +109,8 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2    }, new object[] {  3,  4     }, new object[] {  5,  6     } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 7, 8, 9 }, new object[] { 10, 11, 12 }, new object[] { 13, 14, 15 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2    }, new object[] {  3,  4     }, new object[] {  5,  6     } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 7, 8, 9 }, new object[] { 10, 11, 12 }, new object[] { 13, 14, 15 } })
             },
             expected: new[]
             {
@@ -121,7 +121,7 @@ public class CompositeDataAttributeSufficientArgumentsTest : IEnumerable<object[
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     private static object[] CreateTestCase(object[] data, object[] expected)

--- a/Src/AutoFixture.NUnit2.UnitTest/CustomizedFixture.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/CustomizedFixture.cs
@@ -6,6 +6,6 @@ internal class CustomizedFixture : Fixture
 {
     public CustomizedFixture()
     {
-        this.Customize<PropertyHolder<string>>(c => c.With(x => x.Property, "Ploeh"));
+        Customize<PropertyHolder<string>>(c => c.With(x => x.Property, "Ploeh"));
     }
 }

--- a/Src/AutoFixture.NUnit2.UnitTest/DelegatingCustomization.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/DelegatingCustomization.cs
@@ -6,12 +6,12 @@ internal class DelegatingCustomization : ICustomization
 {
     internal DelegatingCustomization()
     {
-        this.OnCustomize = f => { };
+        OnCustomize = f => { };
     }
 
     public void Customize(IFixture fixture)
     {
-        this.OnCustomize(fixture);
+        OnCustomize(fixture);
     }
 
     internal Action<IFixture> OnCustomize { get; set; }

--- a/Src/AutoFixture.NUnit2.UnitTest/DelegatingCustomizeAttribute.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/DelegatingCustomizeAttribute.cs
@@ -7,12 +7,12 @@ internal class DelegatingCustomizeAttribute : CustomizeAttribute
 {
     internal DelegatingCustomizeAttribute()
     {
-        this.OnGetCustomization = p => new DelegatingCustomization();
+        OnGetCustomization = p => new DelegatingCustomization();
     }
 
     public override ICustomization GetCustomization(ParameterInfo parameter)
     {
-        return this.OnGetCustomization(parameter);
+        return OnGetCustomization(parameter);
     }
 
     internal Func<ParameterInfo, ICustomization> OnGetCustomization { get; set; }

--- a/Src/AutoFixture.NUnit2.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/DelegatingFixture.cs
@@ -7,14 +7,14 @@ namespace AutoFixture.NUnit2.UnitTest;
 
 internal class DelegatingFixture : IFixture
 {
-    private readonly List<ISpecimenBuilder> customizations;
-    private readonly List<ISpecimenBuilder> residueCollectors;
+    private readonly List<ISpecimenBuilder> _customizations;
+    private readonly List<ISpecimenBuilder> _residueCollectors;
 
     public DelegatingFixture()
     {
-        this.customizations = new List<ISpecimenBuilder>();
-        this.residueCollectors = new List<ISpecimenBuilder>();
-        this.OnCreate = (r, s) => new object();
+        _customizations = new List<ISpecimenBuilder>();
+        _residueCollectors = new List<ISpecimenBuilder>();
+        OnCreate = (r, s) => new object();
     }
 
     public IList<ISpecimenBuilderTransformation> Behaviors
@@ -24,7 +24,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> Customizations
     {
-        get { return this.customizations; }
+        get { return _customizations; }
     }
 
     public bool OmitAutoProperties { get; set; }
@@ -33,7 +33,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> ResidueCollectors
     {
-        get { return this.residueCollectors; }
+        get { return _residueCollectors; }
     }
 
     public void AddManyTo<T>(ICollection<T> collection, Func<T> creator)
@@ -58,7 +58,7 @@ internal class DelegatingFixture : IFixture
 
     public IFixture Customize(ICustomization customization)
     {
-        return this.OnCustomize(customization);
+        return OnCustomize(customization);
     }
 
     public void Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -98,7 +98,7 @@ internal class DelegatingFixture : IFixture
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixture.NUnit2.UnitTest/DelegatingSpecimenBuilder.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/DelegatingSpecimenBuilder.cs
@@ -7,12 +7,12 @@ internal class DelegatingSpecimenBuilder : ISpecimenBuilder
 {
     public DelegatingSpecimenBuilder()
     {
-        this.OnCreate = (r, c) => new object();
+        OnCreate = (r, c) => new object();
     }
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixture.NUnit2.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/DependencyConstraints.cs
@@ -23,7 +23,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().Assembly.GetReferencedAssemblies();
+        var references = GetType().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.False(references.Any(an => an.Name == assemblyName));
     }

--- a/Src/AutoFixture.NUnit2.UnitTest/FakeDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2.UnitTest/FakeDataAttribute.cs
@@ -7,19 +7,19 @@ namespace AutoFixture.NUnit2.UnitTest;
 
 public class FakeDataAttribute : DataAttribute
 {
-    private readonly MethodInfo expectedMethod;
-    private readonly IEnumerable<object[]> output;
+    private readonly MethodInfo _expectedMethod;
+    private readonly IEnumerable<object[]> _output;
 
     public FakeDataAttribute(MethodInfo expectedMethod, IEnumerable<object[]> output)
     {
-        this.expectedMethod = expectedMethod;
-        this.output = output;
+        _expectedMethod = expectedMethod;
+        _output = output;
     }
 
     public override IEnumerable<object[]> GetData(MethodInfo method)
     {
-        Assert.AreEqual(this.expectedMethod, method);
+        Assert.AreEqual(_expectedMethod, method);
 
-        return this.output;
+        return _output;
     }
 }

--- a/Src/AutoFixture.NUnit2/Addins/Builders/AutoDataProvider.cs
+++ b/Src/AutoFixture.NUnit2/Addins/Builders/AutoDataProvider.cs
@@ -29,7 +29,7 @@ public class AutoDataProvider : ITestCaseProvider2
     /// <returns></returns>
     public IEnumerable GetTestCasesFor(MethodInfo method)
     {
-        return this.GetTestCasesFor(method, null);
+        return GetTestCasesFor(method, null);
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public class AutoDataProvider : ITestCaseProvider2
     /// <returns>True if any cases are available, otherwise false.</returns>
     public bool HasTestCasesFor(MethodInfo method, Test suite)
     {
-        return this.HasTestCasesFor(method);
+        return HasTestCasesFor(method);
     }
 
     /// <summary>

--- a/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2/AutoDataAttribute.cs
@@ -18,7 +18,7 @@ namespace AutoFixture.NUnit2;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
 public class AutoDataAttribute : DataAttribute
 {
-    private readonly Lazy<IFixture> fixtureLazy;
+    private readonly Lazy<IFixture> _fixtureLazy;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AutoDataAttribute"/> class.
@@ -60,7 +60,7 @@ public class AutoDataAttribute : DataAttribute
     {
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-        this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        _fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ public class AutoDataAttribute : DataAttribute
     {
         if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
 
-        this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
+        _fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public class AutoDataAttribute : DataAttribute
     /// </summary>
     [Obsolete("Fixture is created lazily for the performance efficiency, so this property is deprecated as it activates the fixture immediately. " +
               "If you need to customize the fixture, do that in the factory method passed to the constructor.")]
-    public IFixture Fixture => this.fixtureLazy.Value;
+    public IFixture Fixture => _fixtureLazy.Value;
 
     /// <summary>
     /// Gets the type of <see cref="Fixture"/>.
@@ -90,7 +90,7 @@ public class AutoDataAttribute : DataAttribute
     public Type FixtureType
     {
 #pragma warning disable 618
-        get { return this.Fixture.GetType(); }
+        get { return Fixture.GetType(); }
 #pragma warning restore 618
     }
 
@@ -106,9 +106,9 @@ public class AutoDataAttribute : DataAttribute
         var specimens = new List<object>();
         foreach (var p in method.GetParameters())
         {
-            this.CustomizeFixture(p);
+            CustomizeFixture(p);
 
-            var specimen = this.Resolve(p);
+            var specimen = Resolve(p);
             specimens.Add(specimen);
         }
 
@@ -125,7 +125,7 @@ public class AutoDataAttribute : DataAttribute
         {
             var c = ca.GetCustomization(p);
 #pragma warning disable 618
-            this.Fixture.Customize(c);
+            Fixture.Customize(c);
 #pragma warning restore 618
         }
     }
@@ -133,7 +133,7 @@ public class AutoDataAttribute : DataAttribute
     private object Resolve(ParameterInfo p)
     {
 #pragma warning disable 618
-        var context = new SpecimenContext(this.Fixture);
+        var context = new SpecimenContext(Fixture);
 #pragma warning restore 618
         return context.Resolve(p);
     }

--- a/Src/AutoFixture.NUnit2/CompositeDataAttribute.cs
+++ b/Src/AutoFixture.NUnit2/CompositeDataAttribute.cs
@@ -33,7 +33,7 @@ public class CompositeDataAttribute : DataAttribute
     /// </param>
     public CompositeDataAttribute(params DataAttribute[] attributes)
     {
-        this.Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class CompositeDataAttribute : DataAttribute
 
         do
         {
-            foreach (var attribute in this.Attributes)
+            foreach (var attribute in Attributes)
             {
                 var attributeData = attribute.GetData(method).ToArray();
 

--- a/Src/AutoFixture.NUnit2/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit2/FrozenAttribute.cs
@@ -14,7 +14,7 @@ namespace AutoFixture.NUnit2;
 public sealed class FrozenAttribute : CustomizeAttribute
 {
     [Obsolete("The As property is deprecated.")]
-    private Type @as;
+    private Type _as;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
@@ -38,7 +38,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
     /// </param>
     public FrozenAttribute(Matching by)
     {
-        this.By = by;
+        By = by;
     }
 
     /// <summary>
@@ -48,8 +48,8 @@ public sealed class FrozenAttribute : CustomizeAttribute
     [Obsolete("The ability to map a frozen object to a specific type is deprecated and will likely be removed in the future. If you wish to map a frozen type to its implemented interfaces, use [Frozen(Matching.ImplementedInterfaces)]. If you instead wish to map it to its direct base type, use [Frozen(Matching.DirectBaseType)].", true)]
     public Type As
     {
-        get => this.@as;
-        set => this.@as = value;
+        get => _as;
+        set => _as = value;
     }
 
     /// <summary>
@@ -75,15 +75,15 @@ public sealed class FrozenAttribute : CustomizeAttribute
     {
         if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
-        return this.ShouldMatchBySpecificType()
-            ? this.FreezeAsType(parameter.ParameterType)
-            : this.FreezeByCriteria(parameter);
+        return ShouldMatchBySpecificType()
+            ? FreezeAsType(parameter.ParameterType)
+            : FreezeByCriteria(parameter);
     }
 
     private bool ShouldMatchBySpecificType()
     {
 #pragma warning disable 618
-        return this.@as != null;
+        return _as != null;
 #pragma warning restore 618
     }
 
@@ -92,7 +92,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
         return new FreezingCustomization(
             type,
 #pragma warning disable 618
-            this.@as ?? type);
+            _as ?? type);
 #pragma warning restore 618
     }
 
@@ -102,12 +102,12 @@ public sealed class FrozenAttribute : CustomizeAttribute
         var name = parameter.Name;
 
         var filter = new Filter(ByEqual(parameter))
-            .Or(this.ByExactType(type))
-            .Or(this.ByBaseType(type))
-            .Or(this.ByImplementedInterfaces(type))
-            .Or(this.ByPropertyName(type, name))
-            .Or(this.ByParameterName(type, name))
-            .Or(this.ByFieldName(type, name));
+            .Or(ByExactType(type))
+            .Or(ByBaseType(type))
+            .Or(ByImplementedInterfaces(type))
+            .Or(ByPropertyName(type, name))
+            .Or(ByParameterName(type, name))
+            .Or(ByFieldName(type, name));
 
         return new FreezeOnMatchCustomization(parameter, filter);
     }
@@ -119,7 +119,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByExactType(Type type)
     {
-        return this.ShouldMatchBy(Matching.ExactType)
+        return ShouldMatchBy(Matching.ExactType)
             ? new OrRequestSpecification(
                 new ExactTypeSpecification(type),
                 new SeedRequestSpecification(type))
@@ -128,7 +128,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByBaseType(Type type)
     {
-        return this.ShouldMatchBy(Matching.DirectBaseType)
+        return ShouldMatchBy(Matching.DirectBaseType)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -138,7 +138,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByImplementedInterfaces(Type type)
     {
-        return this.ShouldMatchBy(Matching.ImplementedInterfaces)
+        return ShouldMatchBy(Matching.ImplementedInterfaces)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -148,7 +148,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByParameterName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.ParameterName)
+        return ShouldMatchBy(Matching.ParameterName)
             ? new ParameterSpecification(
                 new ParameterTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -158,7 +158,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByPropertyName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.PropertyName)
+        return ShouldMatchBy(Matching.PropertyName)
             ? new PropertySpecification(
                 new PropertyTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -168,7 +168,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByFieldName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.FieldName)
+        return ShouldMatchBy(Matching.FieldName)
             ? new FieldSpecification(
                 new FieldTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -178,7 +178,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private bool ShouldMatchBy(Matching criteria)
     {
-        return this.By.HasFlag(criteria);
+        return By.HasFlag(criteria);
     }
 
     private static IRequestSpecification NoMatch()
@@ -202,24 +202,24 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private class Filter : IRequestSpecification
     {
-        private readonly IRequestSpecification criteria;
+        private readonly IRequestSpecification _criteria;
 
         public Filter(IRequestSpecification criteria)
         {
-            this.criteria = criteria;
+            _criteria = criteria;
         }
 
         public Filter Or(IRequestSpecification condition)
         {
             return new Filter(
                 new OrRequestSpecification(
-                    this.criteria,
+                    _criteria,
                     condition));
         }
 
         public bool IsSatisfiedBy(object request)
         {
-            return this.criteria.IsSatisfiedBy(request);
+            return _criteria.IsSatisfiedBy(request);
         }
     }
 

--- a/Src/AutoFixture.NUnit3.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/AutoDataAttributeTest.cs
@@ -64,7 +64,7 @@ public class AutoDataAttributeTest
     {
         // Arrange
         var autoDataAttribute = new AutoDataAttribute();
-        var fixtureType = this.GetType();
+        var fixtureType = GetType();
 
         var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod("DummyTestMethod"));
         var testSuite = new TestSuite(fixtureType);
@@ -89,8 +89,8 @@ public class AutoDataAttributeTest
         });
         sut.TestMethodBuilder = new TestMethodBuilderWithoutParametersUsage();
 
-        var methodWrapper = new MethodWrapper(this.GetType(), nameof(this.DummyTestMethod));
-        var testSuite = new TestSuite(this.GetType());
+        var methodWrapper = new MethodWrapper(GetType(), nameof(DummyTestMethod));
+        var testSuite = new TestSuite(GetType());
 
         // Act
         var dummy = sut.BuildFrom(methodWrapper, testSuite).ToArray();
@@ -123,7 +123,7 @@ public class AutoDataAttributeTest
         // DummyFixture is set up to throw DummyException when invoked by AutoDataAttribute
         var autoDataAttributeStub = new AutoDataAttributeStub(() => new ThrowingStubFixture());
 
-        var fixtureType = this.GetType();
+        var fixtureType = GetType();
 
         var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod("DummyTestMethod"));
         var testSuite = new TestSuite(fixtureType);
@@ -163,7 +163,7 @@ public class AutoDataAttributeTest
         };
         var sut = new AutoDataAttributeStub(() => fixture);
         // Assert
-        sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
+        sut.BuildFrom(method, new TestSuite(GetType())).Single();
         // Assert
         Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
         Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
@@ -218,7 +218,7 @@ public class AutoDataAttributeTest
         var sut = new AutoDataAttributeStub(() => fixture);
 
         // Assert
-        sut.BuildFrom(method, new TestSuite(this.GetType())).ToArray();
+        sut.BuildFrom(method, new TestSuite(GetType())).ToArray();
         // Assert
         Assert.True(customizationLog[0] is TypeWithIParameterCustomizationSourceUsage.Customization);
     }

--- a/Src/AutoFixture.NUnit3.UnitTest/DelegatingCustomization.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/DelegatingCustomization.cs
@@ -6,12 +6,12 @@ internal class DelegatingCustomization : ICustomization
 {
     internal DelegatingCustomization()
     {
-        this.OnCustomize = f => { };
+        OnCustomize = f => { };
     }
 
     public void Customize(IFixture fixture)
     {
-        this.OnCustomize(fixture);
+        OnCustomize(fixture);
     }
 
     internal Action<IFixture> OnCustomize { get; set; }

--- a/Src/AutoFixture.NUnit3.UnitTest/DelegatingCustomizeAttribute.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/DelegatingCustomizeAttribute.cs
@@ -7,12 +7,12 @@ internal class DelegatingCustomizeAttribute : CustomizeAttribute
 {
     internal DelegatingCustomizeAttribute()
     {
-        this.OnGetCustomization = p => new DelegatingCustomization();
+        OnGetCustomization = p => new DelegatingCustomization();
     }
 
     public override ICustomization GetCustomization(ParameterInfo parameter)
     {
-        return this.OnGetCustomization(parameter);
+        return OnGetCustomization(parameter);
     }
 
     internal Func<ParameterInfo, ICustomization> OnGetCustomization { get; set; }

--- a/Src/AutoFixture.NUnit3.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/DelegatingFixture.cs
@@ -7,14 +7,14 @@ namespace AutoFixture.NUnit3.UnitTest;
 
 internal class DelegatingFixture : IFixture
 {
-    private readonly List<ISpecimenBuilder> customizations;
-    private readonly List<ISpecimenBuilder> residueCollectors;
+    private readonly List<ISpecimenBuilder> _customizations;
+    private readonly List<ISpecimenBuilder> _residueCollectors;
 
     public DelegatingFixture()
     {
-        this.customizations = new List<ISpecimenBuilder>();
-        this.residueCollectors = new List<ISpecimenBuilder>();
-        this.OnCreate = (r, s) => new object();
+        _customizations = new List<ISpecimenBuilder>();
+        _residueCollectors = new List<ISpecimenBuilder>();
+        OnCreate = (r, s) => new object();
     }
 
     public IList<ISpecimenBuilderTransformation> Behaviors
@@ -24,7 +24,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> Customizations
     {
-        get { return this.customizations; }
+        get { return _customizations; }
     }
 
     public bool OmitAutoProperties { get; set; }
@@ -33,7 +33,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> ResidueCollectors
     {
-        get { return this.residueCollectors; }
+        get { return _residueCollectors; }
     }
 
     public void AddManyTo<T>(ICollection<T> collection, Func<T> creator)
@@ -58,7 +58,7 @@ internal class DelegatingFixture : IFixture
 
     public IFixture Customize(ICustomization customization)
     {
-        return this.OnCustomize(customization);
+        return OnCustomize(customization);
     }
 
     public void Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -98,7 +98,7 @@ internal class DelegatingFixture : IFixture
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixture.NUnit3.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/DependencyConstraints.cs
@@ -39,7 +39,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+        var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.False(references.Any(an => an.Name == assemblyName));
     }

--- a/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/InlineAutoDataAttributeTest.cs
@@ -53,9 +53,9 @@ public class InlineAutoDataAttributeTest
         // DummyFixture is set up to throw DummyException when invoked by AutoDataAttribute
         var inlineAutoDataAttributeStub = new InlineAutoDataAttributeStub(() => new ThrowingStubFixture());
 
-        var fixtureType = this.GetType();
+        var fixtureType = GetType();
 
-        var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod(nameof(this.DummyTestMethod)));
+        var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod(nameof(DummyTestMethod)));
         var testSuite = new TestSuite(fixtureType);
 
         // Act
@@ -81,8 +81,8 @@ public class InlineAutoDataAttributeTest
         });
         sut.TestMethodBuilder = new TestMethodBuilderWithoutParametersUsage();
 
-        var methodWrapper = new MethodWrapper(this.GetType(), nameof(this.DummyTestMethod));
-        var testSuite = new TestSuite(this.GetType());
+        var methodWrapper = new MethodWrapper(GetType(), nameof(DummyTestMethod));
+        var testSuite = new TestSuite(GetType());
 
         // Assert
         var dummy = sut.BuildFrom(methodWrapper, testSuite).ToArray();
@@ -140,7 +140,7 @@ public class InlineAutoDataAttributeTest
         };
         var sut = new InlineAutoDataAttributeStub(() => fixture);
         // Act
-        sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
+        sut.BuildFrom(method, new TestSuite(GetType())).Single();
         // Assert
         Assert.False(customizationLog[0] is FreezeOnMatchCustomization);
         Assert.True(customizationLog[1] is FreezeOnMatchCustomization);
@@ -202,7 +202,7 @@ public class InlineAutoDataAttributeTest
         var sut = new InlineAutoDataAttributeStub(() => fixture, new[] { 42 });
 
         // Act
-        sut.BuildFrom(method, new TestSuite(this.GetType())).ToArray();
+        sut.BuildFrom(method, new TestSuite(GetType())).ToArray();
         // Assert
         Assert.True(customizationLog[0] is TypeWithIParameterCustomizationSourceUsage.Customization);
     }

--- a/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesFixture.cs
+++ b/Src/AutoFixture.NUnit3.UnitTest/TestNameStrategiesFixture.cs
@@ -15,7 +15,7 @@ public class TestNameStrategiesFixture
     {
         public AutoDataFixedNameAttribute()
         {
-            this.TestMethodBuilder = new FixedNameTestMethodBuilder();
+            TestMethodBuilder = new FixedNameTestMethodBuilder();
         }
     }
 
@@ -24,7 +24,7 @@ public class TestNameStrategiesFixture
         public AutoDataVolatileNameAttribute()
             : base(CreateFixtureWithInjectedValues)
         {
-            this.TestMethodBuilder = new VolatileNameTestMethodBuilder();
+            TestMethodBuilder = new VolatileNameTestMethodBuilder();
         }
     }
 
@@ -33,7 +33,7 @@ public class TestNameStrategiesFixture
         public InlineAutoDataFixedNameAttribute(params object[] arguments)
             : base(arguments)
         {
-            this.TestMethodBuilder = new FixedNameTestMethodBuilder();
+            TestMethodBuilder = new FixedNameTestMethodBuilder();
         }
     }
 
@@ -42,7 +42,7 @@ public class TestNameStrategiesFixture
         public InlineAutoDataVolatileNameAttribute(params object[] arguments)
             : base(CreateFixtureWithInjectedValues, arguments)
         {
-            this.TestMethodBuilder = new VolatileNameTestMethodBuilder();
+            TestMethodBuilder = new VolatileNameTestMethodBuilder();
         }
     }
 

--- a/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/AutoDataAttribute.cs
@@ -18,19 +18,19 @@ namespace AutoFixture.NUnit3;
 [AttributeUsage(AttributeTargets.Method)]
 public class AutoDataAttribute : Attribute, ITestBuilder
 {
-    private readonly Lazy<IFixture> fixtureLazy;
+    private readonly Lazy<IFixture> _fixtureLazy;
 
-    private IFixture Fixture => this.fixtureLazy.Value;
+    private IFixture Fixture => _fixtureLazy.Value;
 
-    private ITestMethodBuilder testMethodBuilder = new FixedNameTestMethodBuilder();
+    private ITestMethodBuilder _testMethodBuilder = new FixedNameTestMethodBuilder();
 
     /// <summary>
     /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.
     /// </summary>
     public ITestMethodBuilder TestMethodBuilder
     {
-        get => this.testMethodBuilder;
-        set => this.testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
+        get => _testMethodBuilder;
+        set => _testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public class AutoDataAttribute : Attribute, ITestBuilder
             throw new ArgumentNullException(nameof(fixture));
         }
 
-        this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        _fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class AutoDataAttribute : Attribute, ITestBuilder
     {
         if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
 
-        this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
+        _fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
     }
 
     /// <summary>
@@ -80,21 +80,21 @@ public class AutoDataAttribute : Attribute, ITestBuilder
     {
         if (method == null) throw new ArgumentNullException(nameof(method));
 
-        var test = this.TestMethodBuilder.Build(method, suite, this.GetParameterValues(method), 0);
+        var test = TestMethodBuilder.Build(method, suite, GetParameterValues(method), 0);
 
         yield return test;
     }
 
     private IEnumerable<object> GetParameterValues(IMethodInfo method)
     {
-        return method.GetParameters().Select(this.Resolve);
+        return method.GetParameters().Select(Resolve);
     }
 
     private object Resolve(IParameterInfo parameterInfo)
     {
-        this.CustomizeFixtureByParameter(parameterInfo);
+        CustomizeFixtureByParameter(parameterInfo);
 
-        return new SpecimenContext(this.Fixture)
+        return new SpecimenContext(Fixture)
             .Resolve(parameterInfo.ParameterInfo);
     }
 
@@ -107,7 +107,7 @@ public class AutoDataAttribute : Attribute, ITestBuilder
         foreach (var ca in customizeAttributes)
         {
             var customization = ca.GetCustomization(parameter.ParameterInfo);
-            this.Fixture.Customize(customization);
+            Fixture.Customize(customization);
         }
     }
 }

--- a/Src/AutoFixture.NUnit3/FixedNameTestMethodBuilder.cs
+++ b/Src/AutoFixture.NUnit3/FixedNameTestMethodBuilder.cs
@@ -85,12 +85,12 @@ public class FixedNameTestMethodBuilder : ITestMethodBuilder
 
         public TypeNameRenderer(Type type)
         {
-            this.Type = type ?? throw new ArgumentNullException(nameof(type));
+            Type = type ?? throw new ArgumentNullException(nameof(type));
         }
 
         public override string ToString()
         {
-            return "auto<" + this.Type.Name + ">";
+            return "auto<" + Type.Name + ">";
         }
     }
 }

--- a/Src/AutoFixture.NUnit3/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit3/FrozenAttribute.cs
@@ -35,7 +35,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
     /// </param>
     public FrozenAttribute(Matching by)
     {
-        this.By = by;
+        By = by;
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
     {
         if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
-        return this.FreezeByCriteria(parameter);
+        return FreezeByCriteria(parameter);
     }
 
     private ICustomization FreezeByCriteria(ParameterInfo parameter)
@@ -70,12 +70,12 @@ public sealed class FrozenAttribute : CustomizeAttribute
         var name = parameter.Name;
 
         var filter = new Filter(ByEqual(parameter))
-            .Or(this.ByExactType(type))
-            .Or(this.ByBaseType(type))
-            .Or(this.ByImplementedInterfaces(type))
-            .Or(this.ByPropertyName(type, name))
-            .Or(this.ByParameterName(type, name))
-            .Or(this.ByFieldName(type, name));
+            .Or(ByExactType(type))
+            .Or(ByBaseType(type))
+            .Or(ByImplementedInterfaces(type))
+            .Or(ByPropertyName(type, name))
+            .Or(ByParameterName(type, name))
+            .Or(ByFieldName(type, name));
 
         return new FreezeOnMatchCustomization(parameter, filter);
     }
@@ -87,7 +87,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByExactType(Type type)
     {
-        return this.ShouldMatchBy(Matching.ExactType)
+        return ShouldMatchBy(Matching.ExactType)
             ? new OrRequestSpecification(
                 new ExactTypeSpecification(type),
                 new SeedRequestSpecification(type))
@@ -96,7 +96,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByBaseType(Type type)
     {
-        return this.ShouldMatchBy(Matching.DirectBaseType)
+        return ShouldMatchBy(Matching.DirectBaseType)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -106,7 +106,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByImplementedInterfaces(Type type)
     {
-        return this.ShouldMatchBy(Matching.ImplementedInterfaces)
+        return ShouldMatchBy(Matching.ImplementedInterfaces)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -116,7 +116,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByParameterName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.ParameterName)
+        return ShouldMatchBy(Matching.ParameterName)
             ? new ParameterSpecification(
                 new ParameterTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -126,7 +126,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByPropertyName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.PropertyName)
+        return ShouldMatchBy(Matching.PropertyName)
             ? new PropertySpecification(
                 new PropertyTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -136,7 +136,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByFieldName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.FieldName)
+        return ShouldMatchBy(Matching.FieldName)
             ? new FieldSpecification(
                 new FieldTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -146,7 +146,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private bool ShouldMatchBy(Matching criteria)
     {
-        return this.By.HasFlag(criteria);
+        return By.HasFlag(criteria);
     }
 
     private static IRequestSpecification NoMatch()
@@ -170,24 +170,24 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private class Filter : IRequestSpecification
     {
-        private readonly IRequestSpecification criteria;
+        private readonly IRequestSpecification _criteria;
 
         public Filter(IRequestSpecification criteria)
         {
-            this.criteria = criteria;
+            _criteria = criteria;
         }
 
         public Filter Or(IRequestSpecification condition)
         {
             return new Filter(
                 new OrRequestSpecification(
-                    this.criteria,
+                    _criteria,
                     condition));
         }
 
         public bool IsSatisfiedBy(object request)
         {
-            return this.criteria.IsSatisfiedBy(request);
+            return _criteria.IsSatisfiedBy(request);
         }
     }
 

--- a/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit3/InlineAutoDataAttribute.cs
@@ -18,20 +18,20 @@ namespace AutoFixture.NUnit3;
 [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
 public class InlineAutoDataAttribute : Attribute, ITestBuilder
 {
-    private readonly object[] existingParameterValues;
-    private readonly Lazy<IFixture> fixtureLazy;
+    private readonly object[] _existingParameterValues;
+    private readonly Lazy<IFixture> _fixtureLazy;
 
-    private IFixture Fixture => this.fixtureLazy.Value;
+    private IFixture Fixture => _fixtureLazy.Value;
 
-    private ITestMethodBuilder testMethodBuilder = new FixedNameTestMethodBuilder();
+    private ITestMethodBuilder _testMethodBuilder = new FixedNameTestMethodBuilder();
 
     /// <summary>
     /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.
     /// </summary>
     public ITestMethodBuilder TestMethodBuilder
     {
-        get => this.testMethodBuilder;
-        set => this.testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
+        get => _testMethodBuilder;
+        set => _testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -52,8 +52,8 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-        this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
-        this.existingParameterValues = arguments ?? new object[] { null };
+        _fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        _existingParameterValues = arguments ?? new object[] { null };
     }
 
     /// <summary>
@@ -65,14 +65,14 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
 
-        this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
-        this.existingParameterValues = arguments ?? new object[] { null };
+        _fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
+        _existingParameterValues = arguments ?? new object[] { null };
     }
 
     /// <summary>
     /// Gets the parameter values for the test method.
     /// </summary>
-    public IEnumerable<object> Arguments => this.existingParameterValues;
+    public IEnumerable<object> Arguments => _existingParameterValues;
 
     /// <summary>
     ///     Construct one or more TestMethods from a given MethodInfo,
@@ -85,8 +85,8 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         if (method == null) throw new ArgumentNullException(nameof(method));
 
-        var test = this.TestMethodBuilder.Build(
-            method, suite, this.GetParameterValues(method), this.existingParameterValues.Length);
+        var test = TestMethodBuilder.Build(
+            method, suite, GetParameterValues(method), _existingParameterValues.Length);
 
         yield return test;
     }
@@ -97,14 +97,14 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     private IEnumerable<object> GetParameterValues(IMethodInfo method)
     {
         var parameters = method.GetParameters();
-        return this.existingParameterValues.Concat(this.GetMissingValues(parameters));
+        return _existingParameterValues.Concat(GetMissingValues(parameters));
     }
 
     private IEnumerable<object> GetMissingValues(IEnumerable<IParameterInfo> parameters)
     {
-        var parametersWithoutValues = parameters.Skip(this.existingParameterValues.Length);
+        var parametersWithoutValues = parameters.Skip(_existingParameterValues.Length);
 
-        return parametersWithoutValues.Select(this.GetValueForParameter);
+        return parametersWithoutValues.Select(GetValueForParameter);
     }
 
     /// <summary>
@@ -112,9 +112,9 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     /// </summary>
     private object GetValueForParameter(IParameterInfo parameterInfo)
     {
-        this.CustomizeFixtureByParameter(parameterInfo);
+        CustomizeFixtureByParameter(parameterInfo);
 
-        return new SpecimenContext(this.Fixture)
+        return new SpecimenContext(Fixture)
             .Resolve(parameterInfo.ParameterInfo);
     }
 
@@ -127,7 +127,7 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
         foreach (var ca in customizeAttributes)
         {
             var customization = ca.GetCustomization(parameter.ParameterInfo);
-            this.Fixture.Customize(customization);
+            Fixture.Customize(customization);
         }
     }
 }

--- a/Src/AutoFixture.NUnit4.UnitTest/AutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit4.UnitTest/AutoDataAttributeTest.cs
@@ -65,7 +65,7 @@ public class AutoDataAttributeTest
     {
         // Arrange
         var autoDataAttribute = new AutoDataAttribute();
-        var fixtureType = this.GetType();
+        var fixtureType = GetType();
 
         var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod("DummyTestMethod"));
         var testSuite = new TestSuite(fixtureType);
@@ -90,8 +90,8 @@ public class AutoDataAttributeTest
         });
         sut.TestMethodBuilder = new TestMethodBuilderWithoutParametersUsage();
 
-        var methodWrapper = new MethodWrapper(this.GetType(), nameof(this.DummyTestMethod));
-        var testSuite = new TestSuite(this.GetType());
+        var methodWrapper = new MethodWrapper(GetType(), nameof(DummyTestMethod));
+        var testSuite = new TestSuite(GetType());
 
         // Act
         var dummy = sut.BuildFrom(methodWrapper, testSuite).ToArray();
@@ -124,7 +124,7 @@ public class AutoDataAttributeTest
         // DummyFixture is set up to throw DummyException when invoked by AutoDataAttribute
         var autoDataAttributeStub = new AutoDataAttributeStub(() => new ThrowingStubFixture());
 
-        var fixtureType = this.GetType();
+        var fixtureType = GetType();
 
         var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod("DummyTestMethod"));
         var testSuite = new TestSuite(fixtureType);
@@ -164,7 +164,7 @@ public class AutoDataAttributeTest
         };
         var sut = new AutoDataAttributeStub(() => fixture);
         // Assert
-        sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
+        sut.BuildFrom(method, new TestSuite(GetType())).Single();
         // Assert
         ClassicAssert.False(customizationLog[0] is FreezeOnMatchCustomization);
         ClassicAssert.True(customizationLog[1] is FreezeOnMatchCustomization);
@@ -219,7 +219,7 @@ public class AutoDataAttributeTest
         var sut = new AutoDataAttributeStub(() => fixture);
 
         // Assert
-        sut.BuildFrom(method, new TestSuite(this.GetType())).ToArray();
+        sut.BuildFrom(method, new TestSuite(GetType())).ToArray();
         // Assert
         ClassicAssert.True(customizationLog[0] is TypeWithIParameterCustomizationSourceUsage.Customization);
     }

--- a/Src/AutoFixture.NUnit4.UnitTest/DelegatingCustomization.cs
+++ b/Src/AutoFixture.NUnit4.UnitTest/DelegatingCustomization.cs
@@ -6,12 +6,12 @@ internal class DelegatingCustomization : ICustomization
 {
     internal DelegatingCustomization()
     {
-        this.OnCustomize = f => { };
+        OnCustomize = f => { };
     }
 
     public void Customize(IFixture fixture)
     {
-        this.OnCustomize(fixture);
+        OnCustomize(fixture);
     }
 
     internal Action<IFixture> OnCustomize { get; set; }

--- a/Src/AutoFixture.NUnit4.UnitTest/DelegatingCustomizeAttribute.cs
+++ b/Src/AutoFixture.NUnit4.UnitTest/DelegatingCustomizeAttribute.cs
@@ -7,12 +7,12 @@ internal class DelegatingCustomizeAttribute : CustomizeAttribute
 {
     internal DelegatingCustomizeAttribute()
     {
-        this.OnGetCustomization = p => new DelegatingCustomization();
+        OnGetCustomization = p => new DelegatingCustomization();
     }
 
     public override ICustomization GetCustomization(ParameterInfo parameter)
     {
-        return this.OnGetCustomization(parameter);
+        return OnGetCustomization(parameter);
     }
 
     internal Func<ParameterInfo, ICustomization> OnGetCustomization { get; set; }

--- a/Src/AutoFixture.NUnit4.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.NUnit4.UnitTest/DelegatingFixture.cs
@@ -7,14 +7,14 @@ namespace AutoFixture.NUnit4.UnitTest;
 
 internal class DelegatingFixture : IFixture
 {
-    private readonly List<ISpecimenBuilder> customizations;
-    private readonly List<ISpecimenBuilder> residueCollectors;
+    private readonly List<ISpecimenBuilder> _customizations;
+    private readonly List<ISpecimenBuilder> _residueCollectors;
 
     public DelegatingFixture()
     {
-        this.customizations = new List<ISpecimenBuilder>();
-        this.residueCollectors = new List<ISpecimenBuilder>();
-        this.OnCreate = (r, s) => new object();
+        _customizations = new List<ISpecimenBuilder>();
+        _residueCollectors = new List<ISpecimenBuilder>();
+        OnCreate = (r, s) => new object();
     }
 
     public IList<ISpecimenBuilderTransformation> Behaviors
@@ -24,7 +24,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> Customizations
     {
-        get { return this.customizations; }
+        get { return _customizations; }
     }
 
     public bool OmitAutoProperties { get; set; }
@@ -33,7 +33,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> ResidueCollectors
     {
-        get { return this.residueCollectors; }
+        get { return _residueCollectors; }
     }
 
     public void AddManyTo<T>(ICollection<T> collection, Func<T> creator)
@@ -58,7 +58,7 @@ internal class DelegatingFixture : IFixture
 
     public IFixture Customize(ICustomization customization)
     {
-        return this.OnCustomize(customization);
+        return OnCustomize(customization);
     }
 
     public void Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -98,7 +98,7 @@ internal class DelegatingFixture : IFixture
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixture.NUnit4.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.NUnit4.UnitTest/DependencyConstraints.cs
@@ -40,7 +40,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+        var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
         // Assert
         ClassicAssert.False(references.Any(an => an.Name == assemblyName));
     }

--- a/Src/AutoFixture.NUnit4.UnitTest/InlineAutoDataAttributeTest.cs
+++ b/Src/AutoFixture.NUnit4.UnitTest/InlineAutoDataAttributeTest.cs
@@ -54,9 +54,9 @@ public class InlineAutoDataAttributeTest
         // DummyFixture is set up to throw DummyException when invoked by AutoDataAttribute
         var inlineAutoDataAttributeStub = new InlineAutoDataAttributeStub(() => new ThrowingStubFixture());
 
-        var fixtureType = this.GetType();
+        var fixtureType = GetType();
 
-        var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod(nameof(this.DummyTestMethod)));
+        var methodWrapper = new MethodWrapper(fixtureType, fixtureType.GetMethod(nameof(DummyTestMethod)));
         var testSuite = new TestSuite(fixtureType);
 
         // Act
@@ -82,8 +82,8 @@ public class InlineAutoDataAttributeTest
         });
         sut.TestMethodBuilder = new TestMethodBuilderWithoutParametersUsage();
 
-        var methodWrapper = new MethodWrapper(this.GetType(), nameof(this.DummyTestMethod));
-        var testSuite = new TestSuite(this.GetType());
+        var methodWrapper = new MethodWrapper(GetType(), nameof(DummyTestMethod));
+        var testSuite = new TestSuite(GetType());
 
         // Assert
         var dummy = sut.BuildFrom(methodWrapper, testSuite).ToArray();
@@ -141,7 +141,7 @@ public class InlineAutoDataAttributeTest
         };
         var sut = new InlineAutoDataAttributeStub(() => fixture);
         // Act
-        sut.BuildFrom(method, new TestSuite(this.GetType())).Single();
+        sut.BuildFrom(method, new TestSuite(GetType())).Single();
         // Assert
         ClassicAssert.False(customizationLog[0] is FreezeOnMatchCustomization);
         ClassicAssert.True(customizationLog[1] is FreezeOnMatchCustomization);
@@ -203,7 +203,7 @@ public class InlineAutoDataAttributeTest
         var sut = new InlineAutoDataAttributeStub(() => fixture, new[] { 42 });
 
         // Act
-        sut.BuildFrom(method, new TestSuite(this.GetType())).ToArray();
+        sut.BuildFrom(method, new TestSuite(GetType())).ToArray();
         // Assert
         ClassicAssert.True(customizationLog[0] is TypeWithIParameterCustomizationSourceUsage.Customization);
     }

--- a/Src/AutoFixture.NUnit4.UnitTest/TestNameStrategiesFixture.cs
+++ b/Src/AutoFixture.NUnit4.UnitTest/TestNameStrategiesFixture.cs
@@ -15,7 +15,7 @@ public class TestNameStrategiesFixture
     {
         public AutoDataFixedNameAttribute()
         {
-            this.TestMethodBuilder = new FixedNameTestMethodBuilder();
+            TestMethodBuilder = new FixedNameTestMethodBuilder();
         }
     }
 
@@ -24,7 +24,7 @@ public class TestNameStrategiesFixture
         public AutoDataVolatileNameAttribute()
             : base(CreateFixtureWithInjectedValues)
         {
-            this.TestMethodBuilder = new VolatileNameTestMethodBuilder();
+            TestMethodBuilder = new VolatileNameTestMethodBuilder();
         }
     }
 
@@ -33,7 +33,7 @@ public class TestNameStrategiesFixture
         public InlineAutoDataFixedNameAttribute(params object[] arguments)
             : base(arguments)
         {
-            this.TestMethodBuilder = new FixedNameTestMethodBuilder();
+            TestMethodBuilder = new FixedNameTestMethodBuilder();
         }
     }
 
@@ -42,7 +42,7 @@ public class TestNameStrategiesFixture
         public InlineAutoDataVolatileNameAttribute(params object[] arguments)
             : base(CreateFixtureWithInjectedValues, arguments)
         {
-            this.TestMethodBuilder = new VolatileNameTestMethodBuilder();
+            TestMethodBuilder = new VolatileNameTestMethodBuilder();
         }
     }
 

--- a/Src/AutoFixture.NUnit4/AutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit4/AutoDataAttribute.cs
@@ -18,19 +18,19 @@ namespace AutoFixture.NUnit4;
 [AttributeUsage(AttributeTargets.Method)]
 public class AutoDataAttribute : Attribute, ITestBuilder
 {
-    private readonly Lazy<IFixture> fixtureLazy;
+    private readonly Lazy<IFixture> _fixtureLazy;
 
-    private IFixture Fixture => this.fixtureLazy.Value;
+    private IFixture Fixture => _fixtureLazy.Value;
 
-    private ITestMethodBuilder testMethodBuilder = new FixedNameTestMethodBuilder();
+    private ITestMethodBuilder _testMethodBuilder = new FixedNameTestMethodBuilder();
 
     /// <summary>
     /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.
     /// </summary>
     public ITestMethodBuilder TestMethodBuilder
     {
-        get => this.testMethodBuilder;
-        set => this.testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
+        get => _testMethodBuilder;
+        set => _testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public class AutoDataAttribute : Attribute, ITestBuilder
             throw new ArgumentNullException(nameof(fixture));
         }
 
-        this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        _fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class AutoDataAttribute : Attribute, ITestBuilder
     {
         if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
 
-        this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
+        _fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
     }
 
     /// <summary>
@@ -80,21 +80,21 @@ public class AutoDataAttribute : Attribute, ITestBuilder
     {
         if (method == null) throw new ArgumentNullException(nameof(method));
 
-        var test = this.TestMethodBuilder.Build(method, suite, this.GetParameterValues(method), 0);
+        var test = TestMethodBuilder.Build(method, suite, GetParameterValues(method), 0);
 
         yield return test;
     }
 
     private IEnumerable<object> GetParameterValues(IMethodInfo method)
     {
-        return method.GetParameters().Select(this.Resolve);
+        return method.GetParameters().Select(Resolve);
     }
 
     private object Resolve(IParameterInfo parameterInfo)
     {
-        this.CustomizeFixtureByParameter(parameterInfo);
+        CustomizeFixtureByParameter(parameterInfo);
 
-        return new SpecimenContext(this.Fixture)
+        return new SpecimenContext(Fixture)
             .Resolve(parameterInfo.ParameterInfo);
     }
 
@@ -107,7 +107,7 @@ public class AutoDataAttribute : Attribute, ITestBuilder
         foreach (var ca in customizeAttributes)
         {
             var customization = ca.GetCustomization(parameter.ParameterInfo);
-            this.Fixture.Customize(customization);
+            Fixture.Customize(customization);
         }
     }
 }

--- a/Src/AutoFixture.NUnit4/FixedNameTestMethodBuilder.cs
+++ b/Src/AutoFixture.NUnit4/FixedNameTestMethodBuilder.cs
@@ -85,12 +85,12 @@ public class FixedNameTestMethodBuilder : ITestMethodBuilder
 
         public TypeNameRenderer(Type type)
         {
-            this.Type = type ?? throw new ArgumentNullException(nameof(type));
+            Type = type ?? throw new ArgumentNullException(nameof(type));
         }
 
         public override string ToString()
         {
-            return "auto<" + this.Type.Name + ">";
+            return "auto<" + Type.Name + ">";
         }
     }
 }

--- a/Src/AutoFixture.NUnit4/FrozenAttribute.cs
+++ b/Src/AutoFixture.NUnit4/FrozenAttribute.cs
@@ -35,7 +35,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
     /// </param>
     public FrozenAttribute(Matching by)
     {
-        this.By = by;
+        By = by;
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
     {
         if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
-        return this.FreezeByCriteria(parameter);
+        return FreezeByCriteria(parameter);
     }
 
     private ICustomization FreezeByCriteria(ParameterInfo parameter)
@@ -70,12 +70,12 @@ public sealed class FrozenAttribute : CustomizeAttribute
         var name = parameter.Name;
 
         var filter = new Filter(ByEqual(parameter))
-            .Or(this.ByExactType(type))
-            .Or(this.ByBaseType(type))
-            .Or(this.ByImplementedInterfaces(type))
-            .Or(this.ByPropertyName(type, name))
-            .Or(this.ByParameterName(type, name))
-            .Or(this.ByFieldName(type, name));
+            .Or(ByExactType(type))
+            .Or(ByBaseType(type))
+            .Or(ByImplementedInterfaces(type))
+            .Or(ByPropertyName(type, name))
+            .Or(ByParameterName(type, name))
+            .Or(ByFieldName(type, name));
 
         return new FreezeOnMatchCustomization(parameter, filter);
     }
@@ -87,7 +87,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByExactType(Type type)
     {
-        return this.ShouldMatchBy(Matching.ExactType)
+        return ShouldMatchBy(Matching.ExactType)
             ? new OrRequestSpecification(
                 new ExactTypeSpecification(type),
                 new SeedRequestSpecification(type))
@@ -96,7 +96,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByBaseType(Type type)
     {
-        return this.ShouldMatchBy(Matching.DirectBaseType)
+        return ShouldMatchBy(Matching.DirectBaseType)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -106,7 +106,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByImplementedInterfaces(Type type)
     {
-        return this.ShouldMatchBy(Matching.ImplementedInterfaces)
+        return ShouldMatchBy(Matching.ImplementedInterfaces)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -116,7 +116,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByParameterName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.ParameterName)
+        return ShouldMatchBy(Matching.ParameterName)
             ? new ParameterSpecification(
                 new ParameterTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -126,7 +126,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByPropertyName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.PropertyName)
+        return ShouldMatchBy(Matching.PropertyName)
             ? new PropertySpecification(
                 new PropertyTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -136,7 +136,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByFieldName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.FieldName)
+        return ShouldMatchBy(Matching.FieldName)
             ? new FieldSpecification(
                 new FieldTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -146,7 +146,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private bool ShouldMatchBy(Matching criteria)
     {
-        return this.By.HasFlag(criteria);
+        return By.HasFlag(criteria);
     }
 
     private static IRequestSpecification NoMatch()
@@ -170,24 +170,24 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private class Filter : IRequestSpecification
     {
-        private readonly IRequestSpecification criteria;
+        private readonly IRequestSpecification _criteria;
 
         public Filter(IRequestSpecification criteria)
         {
-            this.criteria = criteria;
+            _criteria = criteria;
         }
 
         public Filter Or(IRequestSpecification condition)
         {
             return new Filter(
                 new OrRequestSpecification(
-                    this.criteria,
+                    _criteria,
                     condition));
         }
 
         public bool IsSatisfiedBy(object request)
         {
-            return this.criteria.IsSatisfiedBy(request);
+            return _criteria.IsSatisfiedBy(request);
         }
     }
 

--- a/Src/AutoFixture.NUnit4/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.NUnit4/InlineAutoDataAttribute.cs
@@ -18,20 +18,20 @@ namespace AutoFixture.NUnit4;
 [SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes", Justification = "This attribute is the root of a potential attribute hierarchy.")]
 public class InlineAutoDataAttribute : Attribute, ITestBuilder
 {
-    private readonly object[] existingParameterValues;
-    private readonly Lazy<IFixture> fixtureLazy;
+    private readonly object[] _existingParameterValues;
+    private readonly Lazy<IFixture> _fixtureLazy;
 
-    private IFixture Fixture => this.fixtureLazy.Value;
+    private IFixture Fixture => _fixtureLazy.Value;
 
-    private ITestMethodBuilder testMethodBuilder = new FixedNameTestMethodBuilder();
+    private ITestMethodBuilder _testMethodBuilder = new FixedNameTestMethodBuilder();
 
     /// <summary>
     /// Gets or sets the current <see cref="ITestMethodBuilder"/> strategy.
     /// </summary>
     public ITestMethodBuilder TestMethodBuilder
     {
-        get => this.testMethodBuilder;
-        set => this.testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
+        get => _testMethodBuilder;
+        set => _testMethodBuilder = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -52,8 +52,8 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-        this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
-        this.existingParameterValues = arguments ?? new object[] { null };
+        _fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        _existingParameterValues = arguments ?? new object[] { null };
     }
 
     /// <summary>
@@ -65,14 +65,14 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
 
-        this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
-        this.existingParameterValues = arguments ?? new object[] { null };
+        _fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
+        _existingParameterValues = arguments ?? new object[] { null };
     }
 
     /// <summary>
     /// Gets the parameter values for the test method.
     /// </summary>
-    public IEnumerable<object> Arguments => this.existingParameterValues;
+    public IEnumerable<object> Arguments => _existingParameterValues;
 
     /// <summary>
     ///     Construct one or more TestMethods from a given MethodInfo,
@@ -85,8 +85,8 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     {
         if (method == null) throw new ArgumentNullException(nameof(method));
 
-        var test = this.TestMethodBuilder.Build(
-            method, suite, this.GetParameterValues(method), this.existingParameterValues.Length);
+        var test = TestMethodBuilder.Build(
+            method, suite, GetParameterValues(method), _existingParameterValues.Length);
 
         yield return test;
     }
@@ -97,14 +97,14 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     private IEnumerable<object> GetParameterValues(IMethodInfo method)
     {
         var parameters = method.GetParameters();
-        return this.existingParameterValues.Concat(this.GetMissingValues(parameters));
+        return _existingParameterValues.Concat(GetMissingValues(parameters));
     }
 
     private IEnumerable<object> GetMissingValues(IEnumerable<IParameterInfo> parameters)
     {
-        var parametersWithoutValues = parameters.Skip(this.existingParameterValues.Length);
+        var parametersWithoutValues = parameters.Skip(_existingParameterValues.Length);
 
-        return parametersWithoutValues.Select(this.GetValueForParameter);
+        return parametersWithoutValues.Select(GetValueForParameter);
     }
 
     /// <summary>
@@ -112,9 +112,9 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
     /// </summary>
     private object GetValueForParameter(IParameterInfo parameterInfo)
     {
-        this.CustomizeFixtureByParameter(parameterInfo);
+        CustomizeFixtureByParameter(parameterInfo);
 
-        return new SpecimenContext(this.Fixture)
+        return new SpecimenContext(Fixture)
             .Resolve(parameterInfo.ParameterInfo);
     }
 
@@ -127,7 +127,7 @@ public class InlineAutoDataAttribute : Attribute, ITestBuilder
         foreach (var ca in customizeAttributes)
         {
             var customization = ca.GetCustomization(parameter.ParameterInfo);
-            this.Fixture.Customize(customization);
+            Fixture.Customize(customization);
         }
     }
 }

--- a/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenBuilder.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenBuilder.cs
@@ -7,12 +7,12 @@ internal class DelegatingSpecimenBuilder : ISpecimenBuilder
 {
     public DelegatingSpecimenBuilder()
     {
-        this.OnCreate = (r, c) => null;
+        OnCreate = (r, c) => null;
     }
 
     public object Create(object request, ISpecimenContext container)
     {
-        return this.OnCreate(request, container);
+        return OnCreate(request, container);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenContext.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/DelegatingSpecimenContext.cs
@@ -7,12 +7,12 @@ internal class DelegatingSpecimenContext : ISpecimenContext
 {
     public DelegatingSpecimenContext()
     {
-        this.OnResolve = r => null;
+        OnResolve = r => null;
     }
 
     public object Resolve(object request)
     {
-        return this.OnResolve(request);
+        return OnResolve(request);
     }
 
     internal Func<object, object> OnResolve { get; set; }

--- a/Src/AutoFixture.SeedExtensions.UnitTest/TextGuidRegex.cs
+++ b/Src/AutoFixture.SeedExtensions.UnitTest/TextGuidRegex.cs
@@ -11,11 +11,11 @@ internal class TextGuidRegex : Regex
 
     internal string GetGuid(string s)
     {
-        return this.Match(s).Groups["guid"].Value;
+        return Match(s).Groups["guid"].Value;
     }
 
     internal string GetText(string s)
     {
-        return this.Match(s).Groups["text"].Value;
+        return Match(s).Groups["text"].Value;
     }
 }

--- a/Src/AutoFixture.xUnit.UnitTest/CompositeDataAttributeSufficientDataTest.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/CompositeDataAttributeSufficientDataTest.cs
@@ -11,15 +11,15 @@ namespace AutoFixture.Xunit.UnitTest;
 
 public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
 {
-    private readonly MethodInfo method;
-    private readonly Type[] parameterTypes;
+    private readonly MethodInfo _method;
+    private readonly Type[] _parameterTypes;
 
     public CompositeDataAttributeSufficientDataTest()
     {
-        this.method = typeof(TypeWithOverloadedMembers)
+        _method = typeof(TypeWithOverloadedMembers)
             .GetMethod("DoSomething", new[] { typeof(object), typeof(object), typeof(object) });
-        var parameters = this.method.GetParameters();
-        this.parameterTypes = (from pi in parameters
+        var parameters = _method.GetParameters();
+        _parameterTypes = (from pi in parameters
             select pi.ParameterType).ToArray();
     }
 
@@ -29,7 +29,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
     {
         // Arrange
         // Act
-        var result = new CompositeDataAttribute(attributes).GetData(this.method, this.parameterTypes).ToList();
+        var result = new CompositeDataAttribute(attributes).GetData(_method, _parameterTypes).ToList();
         // Assert
         Assert.True(expectedResult.SequenceEqual(result, new TheoryComparer()));
     }
@@ -40,7 +40,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2, 3 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2, 3 } })
             },
             expected: new[]
             {
@@ -50,8 +50,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2, 3 } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2, 3 } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -61,8 +61,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1       } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 2, 3, 4 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1       } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 2, 3, 4 } })
             },
             expected: new[]
             {
@@ -72,8 +72,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2    } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 3, 4, 5 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2    } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 3, 4, 5 } })
             },
             expected: new[]
             {
@@ -83,7 +83,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -93,8 +93,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2, 3 }, new object[] { 4,  5, 6 }                          }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 7, 8    }, new object[] { 9, 10    }, new object[] { 11, 12 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2, 3 }, new object[] { 4,  5, 6 }                          }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 7, 8    }, new object[] { 9, 10    }, new object[] { 11, 12 } })
             },
             expected: new[]
             {
@@ -104,8 +104,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2    }, new object[] {  3,  4     }, new object[] {  5,  6     } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 7, 8, 9 }, new object[] { 10, 11, 12 }, new object[] { 13, 14, 15 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2    }, new object[] {  3,  4     }, new object[] {  5,  6     } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 7, 8, 9 }, new object[] { 10, 11, 12 }, new object[] { 13, 14, 15 } })
             },
             expected: new[]
             {
@@ -116,8 +116,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 7, 8, 9 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 7, 8, 9 } })
             },
             expected: new[]
             {
@@ -128,8 +128,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2, 3 } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 4, 5, 6 }, new object[] { 7, 8, 9 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2, 3 } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 4, 5, 6 }, new object[] { 7, 8, 9 } })
             },
             expected: new[]
             {
@@ -141,8 +141,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2 } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 3, 4 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2 } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 3, 4 } })
             },
             expected: new[]
             {
@@ -152,8 +152,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1    } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1    } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 2, 3 } })
             },
             expected: new[]
             {
@@ -163,9 +163,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1    } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] {      } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1    } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] {      } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 2, 3 } })
             },
             expected: new[]
             {
@@ -175,9 +175,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 2 } }),
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 3 } })
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 2 } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 3 } })
             },
             expected: new[]
             {
@@ -187,7 +187,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestCase(
             data: new[]
             {
-                new FakeDataAttribute(this.method, this.parameterTypes, new[] { new object[] { 1, 2, 3, 4 } }),
+                new FakeDataAttribute(_method, _parameterTypes, new[] { new object[] { 1, 2, 3, 4 } }),
             },
             expected: new[]
             {
@@ -198,7 +198,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     private static object[] CreateTestCase(object[] data, object[] expected)

--- a/Src/AutoFixture.xUnit.UnitTest/CustomizedFixture.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/CustomizedFixture.cs
@@ -6,6 +6,6 @@ internal class CustomizedFixture : Fixture
 {
     public CustomizedFixture()
     {
-        this.Customize<PropertyHolder<string>>(c => c.With(x => x.Property, "Ploeh"));
+        Customize<PropertyHolder<string>>(c => c.With(x => x.Property, "Ploeh"));
     }
 }

--- a/Src/AutoFixture.xUnit.UnitTest/DelegatingCustomization.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/DelegatingCustomization.cs
@@ -6,12 +6,12 @@ internal class DelegatingCustomization : ICustomization
 {
     internal DelegatingCustomization()
     {
-        this.OnCustomize = f => { };
+        OnCustomize = f => { };
     }
 
     public void Customize(IFixture fixture)
     {
-        this.OnCustomize(fixture);
+        OnCustomize(fixture);
     }
 
     internal Action<IFixture> OnCustomize { get; set; }

--- a/Src/AutoFixture.xUnit.UnitTest/DelegatingCustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/DelegatingCustomizeAttribute.cs
@@ -7,12 +7,12 @@ internal class DelegatingCustomizeAttribute : CustomizeAttribute
 {
     internal DelegatingCustomizeAttribute()
     {
-        this.OnGetCustomization = p => new DelegatingCustomization();
+        OnGetCustomization = p => new DelegatingCustomization();
     }
 
     public override ICustomization GetCustomization(ParameterInfo parameter)
     {
-        return this.OnGetCustomization(parameter);
+        return OnGetCustomization(parameter);
     }
 
     internal Func<ParameterInfo, ICustomization> OnGetCustomization { get; set; }

--- a/Src/AutoFixture.xUnit.UnitTest/DelegatingFixture.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/DelegatingFixture.cs
@@ -7,14 +7,14 @@ namespace AutoFixture.Xunit.UnitTest;
 
 internal class DelegatingFixture : IFixture
 {
-    private readonly List<ISpecimenBuilder> customizations;
-    private readonly List<ISpecimenBuilder> residueCollectors;
+    private readonly List<ISpecimenBuilder> _customizations;
+    private readonly List<ISpecimenBuilder> _residueCollectors;
 
     public DelegatingFixture()
     {
-        this.customizations = new List<ISpecimenBuilder>();
-        this.residueCollectors = new List<ISpecimenBuilder>();
-        this.OnCreate = (r, s) => new object();
+        _customizations = new List<ISpecimenBuilder>();
+        _residueCollectors = new List<ISpecimenBuilder>();
+        OnCreate = (r, s) => new object();
     }
 
     public IList<ISpecimenBuilderTransformation> Behaviors
@@ -24,7 +24,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> Customizations
     {
-        get { return this.customizations; }
+        get { return _customizations; }
     }
 
     public bool OmitAutoProperties { get; set; }
@@ -33,7 +33,7 @@ internal class DelegatingFixture : IFixture
 
     public IList<ISpecimenBuilder> ResidueCollectors
     {
-        get { return this.residueCollectors; }
+        get { return _residueCollectors; }
     }
 
     public void AddManyTo<T>(ICollection<T> collection, Func<T> creator)
@@ -58,7 +58,7 @@ internal class DelegatingFixture : IFixture
 
     public IFixture Customize(ICustomization customization)
     {
-        return this.OnCustomize(customization);
+        return OnCustomize(customization);
     }
 
     public void Customize<T>(Func<ICustomizationComposer<T>, ISpecimenBuilder> composerTransformation)
@@ -98,7 +98,7 @@ internal class DelegatingFixture : IFixture
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixture.xUnit.UnitTest/DelegatingSpecimenBuilder.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/DelegatingSpecimenBuilder.cs
@@ -7,12 +7,12 @@ internal class DelegatingSpecimenBuilder : ISpecimenBuilder
 {
     public DelegatingSpecimenBuilder()
     {
-        this.OnCreate = (r, c) => new object();
+        OnCreate = (r, c) => new object();
     }
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixture.xUnit.UnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/DependencyConstraints.cs
@@ -25,7 +25,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().Assembly.GetReferencedAssemblies();
+        var references = GetType().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.False(references.Any(an => an.Name == assemblyName));
     }

--- a/Src/AutoFixture.xUnit.UnitTest/FakeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit.UnitTest/FakeDataAttribute.cs
@@ -9,23 +9,23 @@ namespace AutoFixture.Xunit.UnitTest;
 
 public class FakeDataAttribute : DataAttribute
 {
-    private readonly MethodInfo expectedMethod;
-    private readonly Type[] expectedTypes;
-    private readonly IEnumerable<object[]> output;
+    private readonly MethodInfo _expectedMethod;
+    private readonly Type[] _expectedTypes;
+    private readonly IEnumerable<object[]> _output;
 
     public FakeDataAttribute(MethodInfo expectedMethod,
         Type[] expectedTypes, IEnumerable<object[]> output)
     {
-        this.expectedMethod = expectedMethod;
-        this.expectedTypes = expectedTypes;
-        this.output = output;
+        _expectedMethod = expectedMethod;
+        _expectedTypes = expectedTypes;
+        _output = output;
     }
 
     public override IEnumerable<object[]> GetData(MethodInfo methodUnderTest, Type[] parameterTypes)
     {
-        Assert.Equal(this.expectedMethod, methodUnderTest);
-        Assert.True(this.expectedTypes.SequenceEqual(parameterTypes));
+        Assert.Equal(_expectedMethod, methodUnderTest);
+        Assert.True(_expectedTypes.SequenceEqual(parameterTypes));
 
-        return this.output;
+        return _output;
     }
 }

--- a/Src/AutoFixture.xUnit/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit/AutoDataAttribute.cs
@@ -19,7 +19,7 @@ namespace AutoFixture.Xunit;
     Justification = "This attribute is the root of a potential attribute hierarchy.")]
 public class AutoDataAttribute : DataAttribute
 {
-    private readonly Lazy<IFixture> fixtureLazy;
+    private readonly Lazy<IFixture> _fixtureLazy;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AutoDataAttribute"/> class.
@@ -61,7 +61,7 @@ public class AutoDataAttribute : DataAttribute
     {
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-        this.fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
+        _fixtureLazy = new Lazy<IFixture>(() => fixture, LazyThreadSafetyMode.None);
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public class AutoDataAttribute : DataAttribute
     {
         if (fixtureFactory == null) throw new ArgumentNullException(nameof(fixtureFactory));
 
-        this.fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
+        _fixtureLazy = new Lazy<IFixture>(fixtureFactory, LazyThreadSafetyMode.PublicationOnly);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public class AutoDataAttribute : DataAttribute
     /// </summary>
     [Obsolete("Fixture is created lazily for the performance efficiency, so this property is deprecated as it activates the fixture immediately. " +
               "If you need to customize the fixture, do that in the factory method passed to the constructor.")]
-    public IFixture Fixture => this.fixtureLazy.Value;
+    public IFixture Fixture => _fixtureLazy.Value;
 
     /// <summary>
     /// Gets the type of <see cref="Fixture"/>.
@@ -91,7 +91,7 @@ public class AutoDataAttribute : DataAttribute
     public Type FixtureType
     {
 #pragma warning disable 618
-        get { return this.Fixture.GetType(); }
+        get { return Fixture.GetType(); }
 #pragma warning restore 618
     }
 
@@ -108,9 +108,9 @@ public class AutoDataAttribute : DataAttribute
         var specimens = new List<object>();
         foreach (var p in methodUnderTest.GetParameters())
         {
-            this.CustomizeFixture(p);
+            CustomizeFixture(p);
 
-            var specimen = this.Resolve(p);
+            var specimen = Resolve(p);
             specimens.Add(specimen);
         }
 
@@ -127,7 +127,7 @@ public class AutoDataAttribute : DataAttribute
         {
             var c = ca.GetCustomization(p);
 #pragma warning disable 618
-            this.Fixture.Customize(c);
+            Fixture.Customize(c);
 #pragma warning restore 618
         }
     }
@@ -135,7 +135,7 @@ public class AutoDataAttribute : DataAttribute
     private object Resolve(ParameterInfo p)
     {
 #pragma warning disable 618
-        var context = new SpecimenContext(this.Fixture);
+        var context = new SpecimenContext(Fixture);
 #pragma warning restore 618
         return context.Resolve(p);
     }

--- a/Src/AutoFixture.xUnit/CompositeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit/CompositeDataAttribute.cs
@@ -32,7 +32,7 @@ public class CompositeDataAttribute : DataAttribute
     /// </param>
     public CompositeDataAttribute(params DataAttribute[] attributes)
     {
-        this.Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
 
     /// <summary>
@@ -58,7 +58,7 @@ public class CompositeDataAttribute : DataAttribute
         if (methodUnderTest == null) throw new ArgumentNullException(nameof(methodUnderTest));
         if (parameterTypes == null) throw new ArgumentNullException(nameof(parameterTypes));
 
-        return this.Attributes
+        return Attributes
             .Select(attr => attr.GetData(methodUnderTest, parameterTypes))
             .Zip(dataSets => dataSets.Collapse().ToArray());
     }

--- a/Src/AutoFixture.xUnit/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit/FrozenAttribute.cs
@@ -14,7 +14,7 @@ namespace AutoFixture.Xunit;
 public sealed class FrozenAttribute : CustomizeAttribute
 {
     [Obsolete("The As property is deprecated.")]
-    private Type @as;
+    private Type _as;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FrozenAttribute"/> class.
@@ -38,7 +38,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
     /// </param>
     public FrozenAttribute(Matching by)
     {
-        this.By = by;
+        By = by;
     }
 
     /// <summary>
@@ -50,8 +50,8 @@ public sealed class FrozenAttribute : CustomizeAttribute
               "If you instead wish to map it to its direct base type, use [Frozen(Matching.DirectBaseType)].", true)]
     public Type As
     {
-        get => this.@as;
-        set => this.@as = value;
+        get => _as;
+        set => _as = value;
     }
 
     /// <summary>
@@ -77,15 +77,15 @@ public sealed class FrozenAttribute : CustomizeAttribute
     {
         if (parameter == null) throw new ArgumentNullException(nameof(parameter));
 
-        return this.ShouldMatchBySpecificType()
-            ? this.FreezeAsType(parameter.ParameterType)
-            : this.FreezeByCriteria(parameter);
+        return ShouldMatchBySpecificType()
+            ? FreezeAsType(parameter.ParameterType)
+            : FreezeByCriteria(parameter);
     }
 
     private bool ShouldMatchBySpecificType()
     {
 #pragma warning disable 0618
-        return this.@as != null;
+        return _as != null;
 #pragma warning restore 0618
     }
 
@@ -94,7 +94,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
         return new FreezingCustomization(
             type,
 #pragma warning disable 0618
-            this.@as ?? type);
+            _as ?? type);
 #pragma warning restore 0618
     }
 
@@ -104,12 +104,12 @@ public sealed class FrozenAttribute : CustomizeAttribute
         var name = parameter.Name;
 
         var filter = new Filter(ByEqual(parameter))
-            .Or(this.ByExactType(type))
-            .Or(this.ByBaseType(type))
-            .Or(this.ByImplementedInterfaces(type))
-            .Or(this.ByPropertyName(type, name))
-            .Or(this.ByParameterName(type, name))
-            .Or(this.ByFieldName(type, name));
+            .Or(ByExactType(type))
+            .Or(ByBaseType(type))
+            .Or(ByImplementedInterfaces(type))
+            .Or(ByPropertyName(type, name))
+            .Or(ByParameterName(type, name))
+            .Or(ByFieldName(type, name));
 
         return new FreezeOnMatchCustomization(parameter, filter);
     }
@@ -121,7 +121,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByExactType(Type type)
     {
-        return this.ShouldMatchBy(Matching.ExactType)
+        return ShouldMatchBy(Matching.ExactType)
             ? new OrRequestSpecification(
                 new ExactTypeSpecification(type),
                 new SeedRequestSpecification(type))
@@ -130,7 +130,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByBaseType(Type type)
     {
-        return this.ShouldMatchBy(Matching.DirectBaseType)
+        return ShouldMatchBy(Matching.DirectBaseType)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -140,7 +140,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByImplementedInterfaces(Type type)
     {
-        return this.ShouldMatchBy(Matching.ImplementedInterfaces)
+        return ShouldMatchBy(Matching.ImplementedInterfaces)
             ? new AndRequestSpecification(
                 new InverseRequestSpecification(
                     new ExactTypeSpecification(type)),
@@ -150,7 +150,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByParameterName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.ParameterName)
+        return ShouldMatchBy(Matching.ParameterName)
             ? new ParameterSpecification(
                 new ParameterTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -160,7 +160,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByPropertyName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.PropertyName)
+        return ShouldMatchBy(Matching.PropertyName)
             ? new PropertySpecification(
                 new PropertyTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -170,7 +170,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private IRequestSpecification ByFieldName(Type type, string name)
     {
-        return this.ShouldMatchBy(Matching.FieldName)
+        return ShouldMatchBy(Matching.FieldName)
             ? new FieldSpecification(
                 new FieldTypeAndNameCriterion(
                     DerivesFrom(type),
@@ -180,7 +180,7 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private bool ShouldMatchBy(Matching criteria)
     {
-        return this.By.HasFlag(criteria);
+        return By.HasFlag(criteria);
     }
 
     private static IRequestSpecification NoMatch()
@@ -204,24 +204,24 @@ public sealed class FrozenAttribute : CustomizeAttribute
 
     private class Filter : IRequestSpecification
     {
-        private readonly IRequestSpecification criteria;
+        private readonly IRequestSpecification _criteria;
 
         public Filter(IRequestSpecification criteria)
         {
-            this.criteria = criteria;
+            _criteria = criteria;
         }
 
         public Filter Or(IRequestSpecification condition)
         {
             return new Filter(
                 new OrRequestSpecification(
-                    this.criteria,
+                    _criteria,
                     condition));
         }
 
         public bool IsSatisfiedBy(object request)
         {
-            return this.criteria.IsSatisfiedBy(request);
+            return _criteria.IsSatisfiedBy(request);
         }
     }
 

--- a/Src/AutoFixture.xUnit/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit/InlineAutoDataAttribute.cs
@@ -91,7 +91,7 @@ public class InlineAutoDataAttribute : CompositeDataAttribute
     protected InlineAutoDataAttribute(DataAttribute autoDataAttribute, params object[] values)
         : base(new InlineDataAttribute(values), autoDataAttribute)
     {
-        this.AutoDataAttribute = autoDataAttribute;
-        this.Values = values;
+        AutoDataAttribute = autoDataAttribute;
+        Values = values;
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/ClassAutoDataAttributeTests.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/ClassAutoDataAttributeTests.cs
@@ -288,7 +288,7 @@ public class ClassAutoDataAttributeTests
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/CompositeDataAttributeSufficientDataTest.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/CompositeDataAttributeSufficientDataTest.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.Xunit2.UnitTest;
 
 public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
 {
-    private readonly MethodInfo method = typeof(TypeWithOverloadedMembers)
+    private readonly MethodInfo _method = typeof(TypeWithOverloadedMembers)
         .GetMethod(nameof(TypeWithOverloadedMembers.DoSomething),
             new[] { typeof(object), typeof(object), typeof(object) });
 
@@ -22,7 +22,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
     {
         // Arrange
         // Act
-        var result = new CompositeDataAttribute(attributes.ToArray()).GetData(this.method).ToList();
+        var result = new CompositeDataAttribute(attributes.ToArray()).GetData(_method).ToList();
 
         // Assert
         Assert.True(expectedResult.SequenceEqual(result, new TheoryComparer()));
@@ -33,7 +33,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } })
             },
             expected: new[]
             {
@@ -43,8 +43,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -54,8 +54,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3, 4 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3, 4 } })
             },
             expected: new[]
             {
@@ -65,8 +65,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3, 4, 5 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3, 4, 5 } })
             },
             expected: new[]
             {
@@ -76,7 +76,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -86,8 +86,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
-                new FakeDataAttribute(this.method,
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
+                new FakeDataAttribute(_method,
                     new[] { new object[] { 7, 8 }, new object[] { 9, 10 }, new object[] { 11, 12 } })
             },
             expected: new[]
@@ -98,9 +98,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method,
+                new FakeDataAttribute(_method,
                     new[] { new object[] { 1, 2 }, new object[] { 3, 4 }, new object[] { 5, 6 } }),
-                new FakeDataAttribute(this.method,
+                new FakeDataAttribute(_method,
                     new[] { new object[] { 7, 8, 9 }, new object[] { 10, 11, 12 }, new object[] { 13, 14, 15 } })
             },
             expected: new[]
@@ -112,8 +112,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 7, 8, 9 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 7, 8, 9 } })
             },
             expected: new[]
             {
@@ -124,8 +124,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 4, 5, 6 }, new object[] { 7, 8, 9 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 4, 5, 6 }, new object[] { 7, 8, 9 } })
             },
             expected: new[]
             {
@@ -137,8 +137,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3, 4 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3, 4 } })
             },
             expected: new[]
             {
@@ -148,8 +148,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3 } })
             },
             expected: new[]
             {
@@ -159,9 +159,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3 } })
             },
             expected: new[]
             {
@@ -171,9 +171,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3 } })
             },
             expected: new[]
             {
@@ -183,7 +183,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3, 4 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3, 4 } }),
             },
             expected: new[]
             {
@@ -193,7 +193,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     private static object[] CreateTestData(DataAttribute[] data, object[][] expected)

--- a/Src/AutoFixture.xUnit2.UnitTest/DependencyConstraintsTests.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/DependencyConstraintsTests.cs
@@ -40,7 +40,7 @@ public class DependencyConstraintsTests
     {
         // Arrange
         // Act
-        var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+        var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.DoesNotContain(references, an => an.Name == assemblyName);
     }

--- a/Src/AutoFixture.xUnit2.UnitTest/Internal/ClassDataSourceTests.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/Internal/ClassDataSourceTests.cs
@@ -105,7 +105,7 @@ public class ClassDataSourceTests
             yield return new object[] { "Han", 3, new RecordType<string>("Solo") };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     [Fact]

--- a/Src/AutoFixture.xUnit2.UnitTest/Internal/MethodDataSourceTests.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/Internal/MethodDataSourceTests.cs
@@ -22,7 +22,7 @@ public class MethodDataSourceTests
     {
         // Arrange
         var methodInfo = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.SutIsTestDataSource));
+            .GetMethod(nameof(SutIsTestDataSource));
 
         // Act
         var sut = new MethodDataSource(methodInfo);
@@ -44,7 +44,7 @@ public class MethodDataSourceTests
     {
         // Arrange
         var methodInfo = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.SutIsTestDataSource));
+            .GetMethod(nameof(SutIsTestDataSource));
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
@@ -56,7 +56,7 @@ public class MethodDataSourceTests
     {
         // Arrange
         var methodInfo = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.SutIsTestDataSource));
+            .GetMethod(nameof(SutIsTestDataSource));
         var arguments = new[] { new object() };
 
         // Act
@@ -78,7 +78,7 @@ public class MethodDataSourceTests
             new object[] { "Han", 3, new RecordType<string>("Solo") }
         };
         var testDataSource = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.GetTestDataFieldWithMixedValues));
+            .GetMethod(nameof(GetTestDataFieldWithMixedValues));
         var testData = typeof(SampleTestType)
             .GetMethod(nameof(SampleTestType.TestMethodWithReferenceTypeParameter));
         var sut = new MethodDataSource(testDataSource);

--- a/Src/AutoFixture.xUnit2.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/Scenario.cs
@@ -528,7 +528,7 @@ public class Scenario
             yield return new object[] { "dim", "sum", "dimsum" };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     public class MixedDataClass : IEnumerable<object[]>
@@ -540,27 +540,27 @@ public class Scenario
             yield return new object[] { 20, "otherValue", new PropertyHolder<string> { Property = "testValue1" } };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     public class ParameterizedDataClass : IEnumerable<object[]>
     {
-        private readonly int p1;
-        private readonly string p2;
-        private readonly double p3;
+        private readonly int _p1;
+        private readonly string _p2;
+        private readonly double _p3;
 
         public ParameterizedDataClass(int p1, string p2, double p3)
         {
-            this.p1 = p1;
-            this.p2 = p2;
-            this.p3 = p3;
+            _p1 = p1;
+            _p2 = p2;
+            _p3 = p3;
         }
 
         public IEnumerator<object[]> GetEnumerator()
         {
-            yield return new object[] { this.p1, this.p2, this.p3 };
+            yield return new object[] { _p1, _p2, _p3 };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ClassWithEmptyTestData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ClassWithEmptyTestData.cs
@@ -12,5 +12,5 @@ public class ClassWithEmptyTestData : IEnumerable<object[]>
         yield return new object[] { };
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ClassWithNullTestData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ClassWithNullTestData.cs
@@ -12,5 +12,5 @@ public class ClassWithNullTestData : IEnumerable<object[]>
         yield return null;
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/CompositeTypeWithOverloadedConstructors.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/CompositeTypeWithOverloadedConstructors.cs
@@ -6,17 +6,17 @@ public class CompositeTypeWithOverloadedConstructors<T>
 {
     public CompositeTypeWithOverloadedConstructors(IEnumerable<T> items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public CompositeTypeWithOverloadedConstructors(params T[] items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public CompositeTypeWithOverloadedConstructors(IList<T> items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public IEnumerable<T> Items { get; }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingCustomization.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingCustomization.cs
@@ -6,12 +6,12 @@ internal class DelegatingCustomization : ICustomization
 {
     internal DelegatingCustomization()
     {
-        this.OnCustomize = _ => { };
+        OnCustomize = _ => { };
     }
 
     public void Customize(IFixture fixture)
     {
-        this.OnCustomize(fixture);
+        OnCustomize(fixture);
     }
 
     internal Action<IFixture> OnCustomize { get; set; }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingCustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingCustomizeAttribute.cs
@@ -7,12 +7,12 @@ internal class DelegatingCustomizeAttribute : CustomizeAttribute
 {
     public DelegatingCustomizeAttribute()
     {
-        this.OnGetCustomization = p => new DelegatingCustomization();
+        OnGetCustomization = p => new DelegatingCustomization();
     }
 
     public override ICustomization GetCustomization(ParameterInfo parameter)
     {
-        return this.OnGetCustomization(parameter);
+        return OnGetCustomization(parameter);
     }
 
     public Func<ParameterInfo, ICustomization> OnGetCustomization { get; set; }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingDataSource.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingDataSource.cs
@@ -10,6 +10,6 @@ public class DelegatingDataSource : DataSource
 
     protected override IEnumerable<object[]> GetData()
     {
-        return this.TestData;
+        return TestData;
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingFixture.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingFixture.cs
@@ -7,18 +7,18 @@ namespace AutoFixture.Xunit2.UnitTest.TestTypes;
 
 internal class DelegatingFixture : IFixture
 {
-    private readonly List<ISpecimenBuilder> customizations = new();
-    private readonly List<ISpecimenBuilder> residueCollectors = new();
+    private readonly List<ISpecimenBuilder> _customizations = new();
+    private readonly List<ISpecimenBuilder> _residueCollectors = new();
 
     public IList<ISpecimenBuilderTransformation> Behaviors => throw new InvalidOperationException();
 
-    public IList<ISpecimenBuilder> Customizations => this.customizations;
+    public IList<ISpecimenBuilder> Customizations => _customizations;
 
     public bool OmitAutoProperties { get; set; }
 
     public int RepeatCount { get; set; }
 
-    public IList<ISpecimenBuilder> ResidueCollectors => this.residueCollectors;
+    public IList<ISpecimenBuilder> ResidueCollectors => _residueCollectors;
 
     public void AddManyTo<T>(ICollection<T> collection, Func<T> creator)
     {
@@ -42,7 +42,7 @@ internal class DelegatingFixture : IFixture
 
     public IFixture Customize(ICustomization customization)
     {
-        this.OnCustomize?.Invoke(customization);
+        OnCustomize?.Invoke(customization);
         return this;
     }
 
@@ -83,7 +83,7 @@ internal class DelegatingFixture : IFixture
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; } = (_, _) => new object();

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingMemberDataSource.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingMemberDataSource.cs
@@ -10,5 +10,5 @@ public class DelegatingMemberDataSource : MemberDataSource
     {
     }
 
-    public DataSource GetSource() => this.Source;
+    public DataSource GetSource() => Source;
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingSpecimenBuilder.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingSpecimenBuilder.cs
@@ -7,7 +7,7 @@ internal class DelegatingSpecimenBuilder : ISpecimenBuilder
 {
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; } = (_, _) => new object();

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingTestData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/DelegatingTestData.cs
@@ -6,19 +6,19 @@ namespace AutoFixture.Xunit2.UnitTest.TestTypes;
 
 public class DelegatingTestData : IEnumerable<object[]>
 {
-    private readonly List<object[]> data;
+    private readonly List<object[]> _data;
 
     public DelegatingTestData(params object[][] data)
     {
-        this.data = data.ToList();
+        _data = data.ToList();
     }
 
     public DelegatingTestData(IEnumerable<object[]> data)
     {
-        this.data = data as List<object[]> ?? data.ToList();
+        _data = data as List<object[]> ?? data.ToList();
     }
 
-    public IEnumerator<object[]> GetEnumerator() => this.data.GetEnumerator();
+    public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/EmptyClassData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/EmptyClassData.cs
@@ -10,5 +10,5 @@ public class EmptyClassData : IEnumerable<object[]>
         yield break;
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/FakeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/FakeDataAttribute.cs
@@ -7,19 +7,19 @@ namespace AutoFixture.Xunit2.UnitTest.TestTypes;
 
 public class FakeDataAttribute : DataAttribute
 {
-    private readonly MethodInfo expectedMethod;
-    private readonly IEnumerable<object[]> output;
+    private readonly MethodInfo _expectedMethod;
+    private readonly IEnumerable<object[]> _output;
 
     public FakeDataAttribute(MethodInfo expectedMethod, IEnumerable<object[]> output)
     {
-        this.expectedMethod = expectedMethod;
-        this.output = output;
+        _expectedMethod = expectedMethod;
+        _output = output;
     }
 
     public override IEnumerable<object[]> GetData(MethodInfo methodUnderTest)
     {
-        Assert.Equal(this.expectedMethod, methodUnderTest);
+        Assert.Equal(_expectedMethod, methodUnderTest);
 
-        return this.output;
+        return _output;
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/InlineAttributeTestData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/InlineAttributeTestData.cs
@@ -54,5 +54,5 @@ internal abstract class InlineAttributeTestData : IEnumerable<object[]>
     }
 
     public abstract IEnumerator<object[]> GetEnumerator();
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/MixedTypeClassData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/MixedTypeClassData.cs
@@ -16,5 +16,5 @@ public class MixedTypeClassData : IEnumerable<object[]>
         yield return new object[] { -95, "test-92", EnumType.Second, new Tuple<string, int>("myValue", 5) };
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ParameterNameCriterion.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ParameterNameCriterion.cs
@@ -13,7 +13,7 @@ internal class ParameterNameCriterion : IEquatable<ParameterInfo>
 
     public ParameterNameCriterion(IEquatable<string> nameCriterion)
     {
-        this.NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
+        NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
     }
 
     /// <summary>
@@ -24,6 +24,6 @@ internal class ParameterNameCriterion : IEquatable<ParameterInfo>
     public bool Equals(ParameterInfo other)
     {
         return other is not null
-               && this.NameCriterion.Equals(other.Name);
+               && NameCriterion.Equals(other.Name);
     }
 }

--- a/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ParameterizedClassData.cs
+++ b/Src/AutoFixture.xUnit2.UnitTest/TestTypes/ParameterizedClassData.cs
@@ -6,22 +6,22 @@ namespace AutoFixture.Xunit2.UnitTest.TestTypes;
 
 public class ParameterizedClassData : IEnumerable<object[]>
 {
-    private readonly int p1;
-    private readonly string p2;
-    private readonly EnumType p3;
+    private readonly int _p1;
+    private readonly string _p2;
+    private readonly EnumType _p3;
 
     public ParameterizedClassData(int p1, string p2, EnumType p3)
     {
-        this.p1 = p1;
-        this.p2 = p2;
-        this.p3 = p3;
+        _p1 = p1;
+        _p2 = p2;
+        _p3 = p3;
     }
 
     public IEnumerator<object[]> GetEnumerator()
     {
-        yield return new object[] { this.p1, this.p2, this.p3 };
-        yield return new object[] { this.p1, this.p2, this.p3 };
+        yield return new object[] { _p1, _p2, _p3 };
+        yield return new object[] { _p1, _p2, _p3 };
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit2/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit2/AutoDataAttribute.cs
@@ -42,7 +42,7 @@ public class AutoDataAttribute : DataAttribute
     /// <param name="fixtureFactory">The fixture factory used to construct the fixture.</param>
     protected AutoDataAttribute(Func<IFixture> fixtureFactory)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public class AutoDataAttribute : DataAttribute
     {
         if (testMethod is null) throw new ArgumentNullException(nameof(testMethod));
 
-        return new AutoDataSource(this.FixtureFactory)
+        return new AutoDataSource(FixtureFactory)
             .GetData(testMethod);
     }
 }

--- a/Src/AutoFixture.xUnit2/ClassAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit2/ClassAutoDataAttribute.cs
@@ -79,9 +79,9 @@ public class ClassAutoDataAttribute : DataAttribute
     /// </example>
     protected ClassAutoDataAttribute(Func<IFixture> fixtureFactory, Type sourceType, params object[] parameters)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
-        this.SourceType = sourceType ?? throw new ArgumentNullException(nameof(sourceType));
-        this.Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        SourceType = sourceType ?? throw new ArgumentNullException(nameof(sourceType));
+        Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
     }
 
     /// <summary>
@@ -103,8 +103,8 @@ public class ClassAutoDataAttribute : DataAttribute
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
         var source = new AutoDataSource(
-            this.FixtureFactory,
-            new ClassDataSource(this.SourceType, this.Parameters));
+            FixtureFactory,
+            new ClassDataSource(SourceType, Parameters));
 
         return source.GetData(testMethod);
     }

--- a/Src/AutoFixture.xUnit2/CompositeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit2/CompositeDataAttribute.cs
@@ -17,7 +17,7 @@ namespace AutoFixture.Xunit2;
     Justification = "This attribute is the root of a potential attribute hierarchy.")]
 public class CompositeDataAttribute : DataAttribute
 {
-    private readonly DataAttribute[] attributes;
+    private readonly DataAttribute[] _attributes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CompositeDataAttribute"/> class.
@@ -34,13 +34,13 @@ public class CompositeDataAttribute : DataAttribute
     /// <param name="attributes">The attributes representing a data source for a data theory.</param>
     public CompositeDataAttribute(params DataAttribute[] attributes)
     {
-        this.attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        _attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
 
     /// <summary>
     /// Gets the attributes supplied through one of the constructors.
     /// </summary>
-    public IReadOnlyList<DataAttribute> Attributes => Array.AsReadOnly(this.attributes);
+    public IReadOnlyList<DataAttribute> Attributes => Array.AsReadOnly(_attributes);
 
     /// <summary>
     /// Returns the composition of data to be used to test the theory. Favors the data returned
@@ -57,7 +57,7 @@ public class CompositeDataAttribute : DataAttribute
     {
         if (testMethod is null) throw new ArgumentNullException(nameof(testMethod));
 
-        return this.attributes
+        return _attributes
             .Select(attr => attr.GetData(testMethod))
             .Zip(dataSets => dataSets.Collapse().ToArray());
     }

--- a/Src/AutoFixture.xUnit2/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit2/FrozenAttribute.cs
@@ -37,7 +37,7 @@ public class FrozenAttribute : CustomizeAttribute
     /// </param>
     public FrozenAttribute(Matching by)
     {
-        this.By = by;
+        By = by;
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class FrozenAttribute : CustomizeAttribute
     {
         if (parameter is null) throw new ArgumentNullException(nameof(parameter));
 
-        var matcher = new ParameterMatcherBuilder(parameter).SetFlags(this.By).Build();
+        var matcher = new ParameterMatcherBuilder(parameter).SetFlags(By).Build();
         return new FreezeOnMatchCustomization(parameter, matcher);
     }
 }

--- a/Src/AutoFixture.xUnit2/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit2/InlineAutoDataAttribute.cs
@@ -37,8 +37,8 @@ public class InlineAutoDataAttribute : DataAttribute
     /// <exception cref="ArgumentNullException"></exception>
     protected InlineAutoDataAttribute(Func<IFixture> fixtureFactory, params object[] values)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
-        this.Values = values ?? throw new ArgumentNullException(nameof(values));
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        Values = values ?? throw new ArgumentNullException(nameof(values));
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class InlineAutoDataAttribute : DataAttribute
     /// <inheritdoc />
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var source = new AutoDataSource(this.FixtureFactory, new InlineDataSource(this.Values));
+        var source = new AutoDataSource(FixtureFactory, new InlineDataSource(Values));
 
         return source.GetData(testMethod);
     }

--- a/Src/AutoFixture.xUnit2/Internal/Argument.cs
+++ b/Src/AutoFixture.xUnit2/Internal/Argument.cs
@@ -6,13 +6,13 @@ internal class Argument
 {
     public Argument(TestParameter parameter, object value)
     {
-        this.Parameter = parameter ?? throw new ArgumentNullException(nameof(parameter));
-        this.Value = value;
+        Parameter = parameter ?? throw new ArgumentNullException(nameof(parameter));
+        Value = value;
     }
 
     public TestParameter Parameter { get; }
 
     public object Value { get; }
 
-    public ICustomization GetCustomization() => this.Parameter.GetCustomization(this.Value);
+    public ICustomization GetCustomization() => Parameter.GetCustomization(Value);
 }

--- a/Src/AutoFixture.xUnit2/Internal/AutoDataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/AutoDataSource.cs
@@ -21,8 +21,8 @@ public class AutoDataSource : IDataSource
     /// </exception>
     public AutoDataSource(Func<IFixture> createFixture, IDataSource? source = default)
     {
-        this.CreateFixture = createFixture ?? throw new ArgumentNullException(nameof(createFixture));
-        this.Source = source;
+        CreateFixture = createFixture ?? throw new ArgumentNullException(nameof(createFixture));
+        Source = source;
     }
 
     /// <summary>
@@ -42,15 +42,15 @@ public class AutoDataSource : IDataSource
     /// <returns>Returns a sequence of argument collections.</returns>
     public IEnumerable<object[]> GetData(MethodInfo method)
     {
-        return this.Source is null
-            ? this.GenerateValues(method)
-            : this.CombineValues(method, this.Source);
+        return Source is null
+            ? GenerateValues(method)
+            : CombineValues(method, Source);
     }
 
     private IEnumerable<object[]> GenerateValues(MethodBase methodInfo)
     {
         var parameters = Array.ConvertAll(methodInfo.GetParameters(), TestParameter.From);
-        var fixture = this.CreateFixture();
+        var fixture = CreateFixture();
         yield return Array.ConvertAll(parameters, parameter => GenerateAutoValue(parameter, fixture));
     }
 
@@ -65,7 +65,7 @@ public class AutoDataSource : IDataSource
                 .Select(argument => argument.GetCustomization())
                 .Where(x => x is not NullCustomization);
 
-            var fixture = this.CreateFixture();
+            var fixture = CreateFixture();
             foreach (var customization in customizations)
             {
                 fixture.Customize(customization);

--- a/Src/AutoFixture.xUnit2/Internal/ClassDataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/ClassDataSource.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.Xunit2.Internal;
     Justification = "Type is not a collection.")]
 public class ClassDataSource : DataSource
 {
-    private readonly object[] parameters;
+    private readonly object[] _parameters;
 
     /// <summary>
     /// Creates an instance of type <see cref="ClassDataSource" />.
@@ -21,8 +21,8 @@ public class ClassDataSource : DataSource
     /// <exception cref="ArgumentNullException">Thrown when arguments are <see langword="null" />.</exception>
     public ClassDataSource(Type type, object[] parameters)
     {
-        this.Type = type ?? throw new ArgumentNullException(nameof(type));
-        this.parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
     }
 
     /// <summary>
@@ -33,14 +33,14 @@ public class ClassDataSource : DataSource
     /// <summary>
     /// Gets the constructor parameters for test data source type.
     /// </summary>
-    public IReadOnlyList<object> Parameters => Array.AsReadOnly(this.parameters);
+    public IReadOnlyList<object> Parameters => Array.AsReadOnly(_parameters);
 
     /// <inheritdoc />
     protected override IEnumerable<object[]> GetData()
     {
-        var instance = Activator.CreateInstance(type: this.Type, args: this.parameters);
+        var instance = Activator.CreateInstance(type: Type, args: _parameters);
         if (instance is not IEnumerable<object[]> enumerable)
-            throw new InvalidOperationException($"Data source type \"{this.Type}\" should implement the \"{typeof(IEnumerable<object>)}\" interface.");
+            throw new InvalidOperationException($"Data source type \"{Type}\" should implement the \"{typeof(IEnumerable<object>)}\" interface.");
 
         return enumerable;
     }

--- a/Src/AutoFixture.xUnit2/Internal/DataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/DataSource.cs
@@ -41,7 +41,7 @@ public abstract class DataSource : IDataSource
                 yield break;
             }
 
-            var enumerable = this.GetData()
+            var enumerable = GetData()
                              ?? throw new InvalidOperationException("The source member yielded no test data.");
 
             foreach (var testData in enumerable)

--- a/Src/AutoFixture.xUnit2/Internal/FieldDataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/FieldDataSource.cs
@@ -21,7 +21,7 @@ public class FieldDataSource : DataSource
     /// </exception>
     public FieldDataSource(FieldInfo fieldInfo)
     {
-        this.FieldInfo = fieldInfo ?? throw new ArgumentNullException(nameof(fieldInfo));
+        FieldInfo = fieldInfo ?? throw new ArgumentNullException(nameof(fieldInfo));
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public class FieldDataSource : DataSource
     /// </exception>
     protected override IEnumerable<object[]> GetData()
     {
-        var value = this.FieldInfo.GetValue(null);
+        var value = FieldInfo.GetValue(null);
         if (value is not IEnumerable<object[]> enumerable)
             throw new InvalidCastException("Member does not return an enumerable value.");
 

--- a/Src/AutoFixture.xUnit2/Internal/FrozenValueCustomization.cs
+++ b/Src/AutoFixture.xUnit2/Internal/FrozenValueCustomization.cs
@@ -6,20 +6,20 @@ namespace AutoFixture.Xunit2.Internal;
 
 internal class FrozenValueCustomization : ICustomization
 {
-    private readonly IRequestSpecification specification;
-    private readonly object? value;
+    private readonly IRequestSpecification _specification;
+    private readonly object? _value;
 
     public FrozenValueCustomization(IRequestSpecification specification, object? value)
     {
-        this.specification = specification ?? throw new ArgumentNullException(nameof(specification));
-        this.value = value;
+        _specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        _value = value;
     }
 
     public void Customize(IFixture fixture)
     {
         var builder = new FilteringSpecimenBuilder(
-            builder: new FixedBuilder(this.value),
-            specification: this.specification);
+            builder: new FixedBuilder(_value),
+            specification: _specification);
 
         fixture.Customizations.Insert(0, builder);
     }

--- a/Src/AutoFixture.xUnit2/Internal/InlineDataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/InlineDataSource.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.Xunit2.Internal;
     Justification = "Type is not a collection.")]
 public sealed class InlineDataSource : IDataSource
 {
-    private readonly object[] values;
+    private readonly object[] _values;
 
     /// <summary>
     /// Creates an instance of type <see cref="InlineDataSource" />.
@@ -23,13 +23,13 @@ public sealed class InlineDataSource : IDataSource
     /// </exception>
     public InlineDataSource(object[] values)
     {
-        this.values = values ?? throw new ArgumentNullException(nameof(values));
+        _values = values ?? throw new ArgumentNullException(nameof(values));
     }
 
     /// <summary>
     /// The collection of inline values.
     /// </summary>
-    public IReadOnlyList<object> Values => Array.AsReadOnly(this.values);
+    public IReadOnlyList<object> Values => Array.AsReadOnly(_values);
 
     /// <inheritdoc />
     public IEnumerable<object[]> GetData(MethodInfo method)
@@ -37,12 +37,12 @@ public sealed class InlineDataSource : IDataSource
         if (method is null) throw new ArgumentNullException(nameof(method));
 
         var parameters = method.GetParameters();
-        if (this.values.Length > parameters.Length)
+        if (_values.Length > parameters.Length)
         {
             throw new InvalidOperationException(
                 "The number of arguments provided exceeds the number of parameters.");
         }
 
-        return new[] { this.values };
+        return new[] { _values };
     }
 }

--- a/Src/AutoFixture.xUnit2/Internal/MemberDataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/MemberDataSource.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.Xunit2.Internal;
 /// </summary>
 public class MemberDataSource : IDataSource
 {
-    private readonly object[] arguments;
+    private readonly object[] _arguments;
 
     /// <summary>
     /// Creates an instance of type <see cref="MemberDataSource" />.
@@ -23,10 +23,10 @@ public class MemberDataSource : IDataSource
     /// <exception cref="ArgumentNullException">Thrown when arguments are <see langref="null" />.</exception>
     public MemberDataSource(Type type, string name, params object[] arguments)
     {
-        this.Type = type ?? throw new ArgumentNullException(nameof(type));
-        this.Name = name ?? throw new ArgumentNullException(nameof(name));
-        this.arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
-        this.Source = this.GetTestDataSource();
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        Source = GetTestDataSource();
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ public class MemberDataSource : IDataSource
     /// <summary>
     /// Gets the arguments provided to the member.
     /// </summary>
-    public IReadOnlyList<object> Arguments => Array.AsReadOnly(this.arguments);
+    public IReadOnlyList<object> Arguments => Array.AsReadOnly(_arguments);
 
     /// <summary>
     /// Gets the test data source.
@@ -52,12 +52,12 @@ public class MemberDataSource : IDataSource
     /// <inheritdoc />
     public IEnumerable<object[]> GetData(MethodInfo method)
     {
-        return this.Source.GetData(method);
+        return Source.GetData(method);
     }
 
     private DataSource GetTestDataSource()
     {
-        var sourceMember = this.Type.GetMember(this.Name,
+        var sourceMember = Type.GetMember(Name,
                 MemberTypes.Method | MemberTypes.Field | MemberTypes.Property,
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy)
             .FirstOrDefault();
@@ -67,7 +67,7 @@ public class MemberDataSource : IDataSource
             var message = string.Format(
                 CultureInfo.CurrentCulture,
                 "Could not find public static member (property, field, or method) named '{0}' on {1}",
-                this.Name, this.Type.FullName);
+                Name, Type.FullName);
             throw new ArgumentException(message);
         }
 
@@ -77,7 +77,7 @@ public class MemberDataSource : IDataSource
             var message = string.Format(
                 CultureInfo.CurrentCulture,
                 "Member {0} on {1} does not return IEnumerable<object[]>",
-                this.Name, this.Type.FullName);
+                Name, Type.FullName);
             throw new ArgumentException(message);
         }
 
@@ -85,7 +85,7 @@ public class MemberDataSource : IDataSource
         {
             FieldInfo fieldInfo => new FieldDataSource(fieldInfo),
             PropertyInfo propertyInfo => new PropertyDataSource(propertyInfo),
-            MethodInfo methodInfo => new MethodDataSource(methodInfo, this.arguments),
+            MethodInfo methodInfo => new MethodDataSource(methodInfo, _arguments),
             _ => throw new InvalidOperationException("Unsupported member type.")
         };
     }

--- a/Src/AutoFixture.xUnit2/Internal/MethodDataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/MethodDataSource.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.Xunit2.Internal;
     Justification = "Type is not a collection.")]
 public class MethodDataSource : DataSource
 {
-    private readonly object[] arguments;
+    private readonly object[] _arguments;
 
     /// <summary>
     /// Creates an instance of type <see cref="MethodDataSource" />.
@@ -21,8 +21,8 @@ public class MethodDataSource : DataSource
     /// <param name="arguments">The source method arguments.</param>
     public MethodDataSource(MethodInfo methodInfo, params object[] arguments)
     {
-        this.MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
-        this.arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+        _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
     }
 
     /// <summary>
@@ -33,12 +33,12 @@ public class MethodDataSource : DataSource
     /// <summary>
     /// Gets the source method arguments.
     /// </summary>
-    public IReadOnlyList<object> Arguments => Array.AsReadOnly(this.arguments);
+    public IReadOnlyList<object> Arguments => Array.AsReadOnly(_arguments);
 
     /// <inheritdoc />
     protected override IEnumerable<object[]> GetData()
     {
-        var value = this.MethodInfo.Invoke(null, this.arguments);
+        var value = MethodInfo.Invoke(null, _arguments);
         if (value is not IEnumerable<object[]> enumerable)
             throw new InvalidCastException("Member does not return an enumerable value.");
 

--- a/Src/AutoFixture.xUnit2/Internal/NullCustomization.cs
+++ b/Src/AutoFixture.xUnit2/Internal/NullCustomization.cs
@@ -9,10 +9,10 @@ internal sealed class NullCustomization : ICustomization
         // prevent external instantiation
     }
 
-    private static readonly Lazy<NullCustomization> LazyInstance = new(
+    private static readonly Lazy<NullCustomization> s_lazyInstance = new(
         () => new NullCustomization(), isThreadSafe: true);
 
-    public static NullCustomization Instance => LazyInstance.Value;
+    public static NullCustomization Instance => s_lazyInstance.Value;
 
     public void Customize(IFixture fixture)
     {

--- a/Src/AutoFixture.xUnit2/Internal/ParameterFilter.cs
+++ b/Src/AutoFixture.xUnit2/Internal/ParameterFilter.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.Xunit2.Internal;
 /// </summary>
 internal class ParameterFilter : IRequestSpecification
 {
-    private readonly IRequestSpecification matcherSpecification;
+    private readonly IRequestSpecification _matcherSpecification;
 
     /// <summary>
     /// Creates an instance of type <see cref="ParameterFilter"/>.
@@ -19,10 +19,10 @@ internal class ParameterFilter : IRequestSpecification
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameterInfo"/> is null.</exception>
     public ParameterFilter(ParameterInfo parameterInfo, Matching flags)
     {
-        this.ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
-        this.Flags = flags;
-        this.matcherSpecification = new ParameterMatcherBuilder(this.ParameterInfo)
-            .SetFlags(this.Flags).Build();
+        ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
+        Flags = flags;
+        _matcherSpecification = new ParameterMatcherBuilder(ParameterInfo)
+            .SetFlags(Flags).Build();
     }
 
     /// <summary>
@@ -38,6 +38,6 @@ internal class ParameterFilter : IRequestSpecification
     /// <inheritdoc />
     public bool IsSatisfiedBy(object request)
     {
-        return this.matcherSpecification.IsSatisfiedBy(request);
+        return _matcherSpecification.IsSatisfiedBy(request);
     }
 }

--- a/Src/AutoFixture.xUnit2/Internal/ParameterMatcherBuilder.cs
+++ b/Src/AutoFixture.xUnit2/Internal/ParameterMatcherBuilder.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.Xunit2.Internal;
 /// </summary>
 public class ParameterMatcherBuilder
 {
-    private readonly ParameterInfo parameterInfo;
+    private readonly ParameterInfo _parameterInfo;
 
     /// <summary>
     /// Creates an instance of type <see cref="ParameterMatcherBuilder"/>.
@@ -22,7 +22,7 @@ public class ParameterMatcherBuilder
     /// </exception>
     public ParameterMatcherBuilder(ParameterInfo parameterInfo)
     {
-        this.parameterInfo = parameterInfo
+        _parameterInfo = parameterInfo
                              ?? throw new ArgumentNullException(nameof(parameterInfo));
     }
 
@@ -73,12 +73,12 @@ public class ParameterMatcherBuilder
     /// <returns>The current <see cref="ParameterMatcherBuilder"/> instance.</returns>
     public ParameterMatcherBuilder SetFlags(Matching flags)
     {
-        this.MatchExactType = flags.HasFlag(Matching.ExactType);
-        this.MatchDirectBaseType = flags.HasFlag(Matching.DirectBaseType);
-        this.MatchImplementedInterfaces = flags.HasFlag(Matching.ImplementedInterfaces);
-        this.MatchParameter = flags.HasFlag(Matching.ParameterName);
-        this.MatchProperty = flags.HasFlag(Matching.PropertyName);
-        this.MatchField = flags.HasFlag(Matching.FieldName);
+        MatchExactType = flags.HasFlag(Matching.ExactType);
+        MatchDirectBaseType = flags.HasFlag(Matching.DirectBaseType);
+        MatchImplementedInterfaces = flags.HasFlag(Matching.ImplementedInterfaces);
+        MatchParameter = flags.HasFlag(Matching.ParameterName);
+        MatchProperty = flags.HasFlag(Matching.PropertyName);
+        MatchField = flags.HasFlag(Matching.FieldName);
         return this;
     }
 
@@ -91,26 +91,26 @@ public class ParameterMatcherBuilder
     public IRequestSpecification Build()
     {
         var specifications = new List<IRequestSpecification>(7);
-        if (this.MatchExactRequest)
-            specifications.Add(this.AsExactRequest());
+        if (MatchExactRequest)
+            specifications.Add(AsExactRequest());
 
-        if (this.MatchExactType)
-            specifications.Add(this.AsExactType());
+        if (MatchExactType)
+            specifications.Add(AsExactType());
 
-        if (this.MatchDirectBaseType)
-            specifications.Add(this.AsDirectBaseType());
+        if (MatchDirectBaseType)
+            specifications.Add(AsDirectBaseType());
 
-        if (this.MatchImplementedInterfaces)
-            specifications.Add(this.AsImplementedInterfaces());
+        if (MatchImplementedInterfaces)
+            specifications.Add(AsImplementedInterfaces());
 
-        if (this.MatchProperty)
-            specifications.Add(this.AsProperty());
+        if (MatchProperty)
+            specifications.Add(AsProperty());
 
-        if (this.MatchParameter)
-            specifications.Add(this.AsParameter());
+        if (MatchParameter)
+            specifications.Add(AsParameter());
 
-        if (this.MatchField)
-            specifications.Add(this.AsField());
+        if (MatchField)
+            specifications.Add(AsField());
 
         return specifications.Count == 1
             ? specifications[0]
@@ -119,54 +119,54 @@ public class ParameterMatcherBuilder
 
     private IRequestSpecification AsExactRequest()
     {
-        return new EqualRequestSpecification(this.parameterInfo);
+        return new EqualRequestSpecification(_parameterInfo);
     }
 
     private IRequestSpecification AsExactType()
     {
         return new OrRequestSpecification(
-            new ExactTypeSpecification(this.parameterInfo.ParameterType),
-            new SeedRequestSpecification(this.parameterInfo.ParameterType));
+            new ExactTypeSpecification(_parameterInfo.ParameterType),
+            new SeedRequestSpecification(_parameterInfo.ParameterType));
     }
 
     private IRequestSpecification AsDirectBaseType()
     {
         return new AndRequestSpecification(
             new InverseRequestSpecification(
-                new ExactTypeSpecification(this.parameterInfo.ParameterType)),
-            new DirectBaseTypeSpecification(this.parameterInfo.ParameterType));
+                new ExactTypeSpecification(_parameterInfo.ParameterType)),
+            new DirectBaseTypeSpecification(_parameterInfo.ParameterType));
     }
 
     private IRequestSpecification AsImplementedInterfaces()
     {
         return new AndRequestSpecification(
             new InverseRequestSpecification(
-                new ExactTypeSpecification(this.parameterInfo.ParameterType)),
-            new ImplementedInterfaceSpecification(this.parameterInfo.ParameterType));
+                new ExactTypeSpecification(_parameterInfo.ParameterType)),
+            new ImplementedInterfaceSpecification(_parameterInfo.ParameterType));
     }
 
     private IRequestSpecification AsParameter()
     {
         return new ParameterSpecification(
             new ParameterTypeAndNameCriterion(
-                new Criterion<Type>(this.parameterInfo.ParameterType, new DerivesFromTypeComparer()),
-                new Criterion<string>(this.parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
+                new Criterion<Type>(_parameterInfo.ParameterType, new DerivesFromTypeComparer()),
+                new Criterion<string>(_parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
     }
 
     private IRequestSpecification AsProperty()
     {
         return new PropertySpecification(
             new PropertyTypeAndNameCriterion(
-                new Criterion<Type>(this.parameterInfo.ParameterType, new DerivesFromTypeComparer()),
-                new Criterion<string>(this.parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
+                new Criterion<Type>(_parameterInfo.ParameterType, new DerivesFromTypeComparer()),
+                new Criterion<string>(_parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
     }
 
     private IRequestSpecification AsField()
     {
         return new FieldSpecification(
             new FieldTypeAndNameCriterion(
-                new Criterion<Type>(this.parameterInfo.ParameterType, new DerivesFromTypeComparer()),
-                new Criterion<string>(this.parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
+                new Criterion<Type>(_parameterInfo.ParameterType, new DerivesFromTypeComparer()),
+                new Criterion<string>(_parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
     }
 
     private class DerivesFromTypeComparer : IEqualityComparer<Type>

--- a/Src/AutoFixture.xUnit2/Internal/PropertyDataSource.cs
+++ b/Src/AutoFixture.xUnit2/Internal/PropertyDataSource.cs
@@ -19,7 +19,7 @@ public class PropertyDataSource : DataSource
     /// <exception cref="ArgumentNullException"></exception>
     public PropertyDataSource(PropertyInfo propertyInfo)
     {
-        this.PropertyInfo = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
+        PropertyInfo = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public class PropertyDataSource : DataSource
     /// <inheritdoc />
     protected override IEnumerable<object[]> GetData()
     {
-        var value = this.PropertyInfo.GetValue(null);
+        var value = PropertyInfo.GetValue(null);
         if (value is not IEnumerable<object[]> enumerable)
             throw new InvalidCastException("Member does not return an enumerable value.");
 

--- a/Src/AutoFixture.xUnit2/Internal/TestParameter.cs
+++ b/Src/AutoFixture.xUnit2/Internal/TestParameter.cs
@@ -6,33 +6,33 @@ namespace AutoFixture.Xunit2.Internal;
 
 internal class TestParameter
 {
-    private readonly Lazy<ICustomization> lazyCustomization;
-    private readonly Lazy<FrozenAttribute> lazyFrozenAttribute;
+    private readonly Lazy<ICustomization> _lazyCustomization;
+    private readonly Lazy<FrozenAttribute> _lazyFrozenAttribute;
 
     public TestParameter(ParameterInfo parameterInfo)
     {
-        this.ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
+        ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
 
-        this.lazyCustomization = new Lazy<ICustomization>(
+        _lazyCustomization = new Lazy<ICustomization>(
             () => GetCustomization(parameterInfo));
-        this.lazyFrozenAttribute = new Lazy<FrozenAttribute>(
+        _lazyFrozenAttribute = new Lazy<FrozenAttribute>(
             () => parameterInfo.GetCustomAttributes()
                 .OfType<FrozenAttribute>().FirstOrDefault());
     }
 
     public ParameterInfo ParameterInfo { get; }
 
-    public ICustomization GetCustomization() => this.lazyCustomization.Value;
+    public ICustomization GetCustomization() => _lazyCustomization.Value;
 
     public ICustomization GetCustomization(object value)
     {
-        var frozenAttribute = this.lazyFrozenAttribute.Value;
+        var frozenAttribute = _lazyFrozenAttribute.Value;
 
         if (frozenAttribute is null)
             return NullCustomization.Instance;
 
         return new FrozenValueCustomization(
-            new ParameterFilter(this.ParameterInfo, frozenAttribute.By),
+            new ParameterFilter(ParameterInfo, frozenAttribute.By),
             value);
     }
 

--- a/Src/AutoFixture.xUnit2/MemberAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit2/MemberAutoDataAttribute.cs
@@ -67,10 +67,10 @@ public class MemberAutoDataAttribute : DataAttribute
     /// <exception cref="ArgumentNullException">Thrown when arguments are null.</exception>
     protected MemberAutoDataAttribute(Func<IFixture> fixtureFactory, Type? memberType, string memberName, params object[] parameters)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
-        this.MemberName = memberName ?? throw new ArgumentNullException(nameof(memberName));
-        this.Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
-        this.MemberType = memberType;
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        MemberName = memberName ?? throw new ArgumentNullException(nameof(memberName));
+        Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        MemberType = memberType;
     }
 
     /// <summary>
@@ -98,15 +98,15 @@ public class MemberAutoDataAttribute : DataAttribute
     {
         if (testMethod is null) throw new ArgumentNullException(nameof(testMethod));
 
-        var sourceType = this.MemberType ?? testMethod.DeclaringType
+        var sourceType = MemberType ?? testMethod.DeclaringType
             ?? throw new InvalidOperationException("Source type cannot be null.");
 
         var source = new AutoDataSource(
-            createFixture: this.FixtureFactory,
+            createFixture: FixtureFactory,
             source: new MemberDataSource(
                 type: sourceType,
-                name: this.MemberName,
-                arguments: this.Parameters));
+                name: MemberName,
+                arguments: Parameters));
 
         return source.GetData(testMethod);
     }

--- a/Src/AutoFixture.xUnit3.UnitTest/ClassAutoDataAttributeTests.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/ClassAutoDataAttributeTests.cs
@@ -306,7 +306,7 @@ public class ClassAutoDataAttributeTests
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
     }
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/CompositeDataAttributeSufficientDataTest.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/CompositeDataAttributeSufficientDataTest.cs
@@ -13,7 +13,7 @@ namespace AutoFixture.Xunit3.UnitTest;
 
 public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
 {
-    private readonly MethodInfo method = typeof(TypeWithOverloadedMembers)
+    private readonly MethodInfo _method = typeof(TypeWithOverloadedMembers)
         .GetMethod(nameof(TypeWithOverloadedMembers.DoSomething),
             new[] { typeof(object), typeof(object), typeof(object) });
 
@@ -26,7 +26,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         var attribute = new CompositeDataAttribute(attributes.ToArray());
 
         // Act
-        var result = (await attribute.GetData(this.method!, new DisposalTracker()))
+        var result = (await attribute.GetData(_method!, new DisposalTracker()))
             .Select(x => x.GetData()).ToArray();
 
         // Assert
@@ -38,7 +38,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } })
             },
             expected: new[]
             {
@@ -48,8 +48,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -59,8 +59,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3, 4 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3, 4 } })
             },
             expected: new[]
             {
@@ -70,8 +70,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3, 4, 5 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3, 4, 5 } })
             },
             expected: new[]
             {
@@ -81,7 +81,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } })
             },
             expected: new[]
             {
@@ -91,8 +91,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
-                new FakeDataAttribute(this.method,
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
+                new FakeDataAttribute(_method,
                     new[] { new object[] { 7, 8 }, new object[] { 9, 10 }, new object[] { 11, 12 } })
             },
             expected: new[]
@@ -103,9 +103,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method,
+                new FakeDataAttribute(_method,
                     new[] { new object[] { 1, 2 }, new object[] { 3, 4 }, new object[] { 5, 6 } }),
-                new FakeDataAttribute(this.method,
+                new FakeDataAttribute(_method,
                     new[] { new object[] { 7, 8, 9 }, new object[] { 10, 11, 12 }, new object[] { 13, 14, 15 } })
             },
             expected: new[]
@@ -117,8 +117,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 7, 8, 9 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 }, new object[] { 4, 5, 6 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 7, 8, 9 } })
             },
             expected: new[]
             {
@@ -129,8 +129,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 4, 5, 6 }, new object[] { 7, 8, 9 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 4, 5, 6 }, new object[] { 7, 8, 9 } })
             },
             expected: new[]
             {
@@ -142,8 +142,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3, 4 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3, 4 } })
             },
             expected: new[]
             {
@@ -153,8 +153,8 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3 } })
             },
             expected: new[]
             {
@@ -164,9 +164,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2, 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2, 3 } })
             },
             expected: new[]
             {
@@ -176,9 +176,9 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 2 } }),
-                new FakeDataAttribute(this.method, new[] { new object[] { 3 } })
+                new FakeDataAttribute(_method, new[] { new object[] { 1 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 2 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 3 } })
             },
             expected: new[]
             {
@@ -188,7 +188,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
         yield return CreateTestData(
             data: new DataAttribute[]
             {
-                new FakeDataAttribute(this.method, new[] { new object[] { 1, 2, 3, 4 } }),
+                new FakeDataAttribute(_method, new[] { new object[] { 1, 2, 3, 4 } }),
             },
             expected: new[]
             {
@@ -198,7 +198,7 @@ public class CompositeDataAttributeSufficientDataTest : IEnumerable<object[]>
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     private static object[] CreateTestData(DataAttribute[] data, object[][] expected)

--- a/Src/AutoFixture.xUnit3.UnitTest/DependencyConstraintsTests.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/DependencyConstraintsTests.cs
@@ -40,7 +40,7 @@ public class DependencyConstraintsTests
     {
         // Arrange
         // Act
-        var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+        var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.DoesNotContain(references, an => an.Name == assemblyName);
     }

--- a/Src/AutoFixture.xUnit3.UnitTest/Internal/ClassDataSourceTests.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/Internal/ClassDataSourceTests.cs
@@ -105,7 +105,7 @@ public class ClassDataSourceTests
             yield return new object[] { "Han", 3, new RecordType<string>("Solo") };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     [Fact]

--- a/Src/AutoFixture.xUnit3.UnitTest/Internal/MethodDataSourceTests.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/Internal/MethodDataSourceTests.cs
@@ -22,7 +22,7 @@ public class MethodDataSourceTests
     {
         // Arrange
         var methodInfo = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.SutIsTestDataSource));
+            .GetMethod(nameof(SutIsTestDataSource));
 
         // Act
         var sut = new MethodDataSource(methodInfo);
@@ -44,7 +44,7 @@ public class MethodDataSourceTests
     {
         // Arrange
         var methodInfo = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.SutIsTestDataSource));
+            .GetMethod(nameof(SutIsTestDataSource));
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
@@ -56,7 +56,7 @@ public class MethodDataSourceTests
     {
         // Arrange
         var methodInfo = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.SutIsTestDataSource));
+            .GetMethod(nameof(SutIsTestDataSource));
         var arguments = new[] { new object() };
 
         // Act
@@ -78,7 +78,7 @@ public class MethodDataSourceTests
             new object[] { "Han", 3, new RecordType<string>("Solo") }
         };
         var testDataSource = typeof(MethodDataSourceTests)
-            .GetMethod(nameof(this.GetTestDataFieldWithMixedValues));
+            .GetMethod(nameof(GetTestDataFieldWithMixedValues));
         var testData = typeof(SampleTestType)
             .GetMethod(nameof(SampleTestType.TestMethodWithReferenceTypeParameter));
         var sut = new MethodDataSource(testDataSource);

--- a/Src/AutoFixture.xUnit3.UnitTest/Scenario.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/Scenario.cs
@@ -528,7 +528,7 @@ public class Scenario
             yield return new object[] { "dim", "sum", "dimsum" };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     public class MixedDataClass : IEnumerable<object[]>
@@ -540,27 +540,27 @@ public class Scenario
             yield return new object[] { 20, "otherValue", new PropertyHolder<string> { Property = "testValue1" } };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     public class ParameterizedDataClass : IEnumerable<object[]>
     {
-        private readonly int p1;
-        private readonly string p2;
-        private readonly double p3;
+        private readonly int _p1;
+        private readonly string _p2;
+        private readonly double _p3;
 
         public ParameterizedDataClass(int p1, string p2, double p3)
         {
-            this.p1 = p1;
-            this.p2 = p2;
-            this.p3 = p3;
+            _p1 = p1;
+            _p2 = p2;
+            _p3 = p3;
         }
 
         public IEnumerator<object[]> GetEnumerator()
         {
-            yield return new object[] { this.p1, this.p2, this.p3 };
+            yield return new object[] { _p1, _p2, _p3 };
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ClassWithEmptyTestData.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ClassWithEmptyTestData.cs
@@ -12,5 +12,5 @@ public class ClassWithEmptyTestData : IEnumerable<object[]>
         yield return new object[] { };
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ClassWithNullTestData.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ClassWithNullTestData.cs
@@ -12,5 +12,5 @@ public class ClassWithNullTestData : IEnumerable<object[]>
         yield return null;
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/CompositeTypeWithOverloadedConstructors.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/CompositeTypeWithOverloadedConstructors.cs
@@ -6,17 +6,17 @@ public class CompositeTypeWithOverloadedConstructors<T>
 {
     public CompositeTypeWithOverloadedConstructors(IEnumerable<T> items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public CompositeTypeWithOverloadedConstructors(params T[] items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public CompositeTypeWithOverloadedConstructors(IList<T> items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public IEnumerable<T> Items { get; }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingCustomization.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingCustomization.cs
@@ -6,12 +6,12 @@ internal class DelegatingCustomization : ICustomization
 {
     internal DelegatingCustomization()
     {
-        this.OnCustomize = _ => { };
+        OnCustomize = _ => { };
     }
 
     public void Customize(IFixture fixture)
     {
-        this.OnCustomize(fixture);
+        OnCustomize(fixture);
     }
 
     internal Action<IFixture> OnCustomize { get; set; }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingCustomizeAttribute.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingCustomizeAttribute.cs
@@ -7,12 +7,12 @@ internal class DelegatingCustomizeAttribute : CustomizeAttribute
 {
     public DelegatingCustomizeAttribute()
     {
-        this.OnGetCustomization = p => new DelegatingCustomization();
+        OnGetCustomization = p => new DelegatingCustomization();
     }
 
     public override ICustomization GetCustomization(ParameterInfo parameter)
     {
-        return this.OnGetCustomization(parameter);
+        return OnGetCustomization(parameter);
     }
 
     public Func<ParameterInfo, ICustomization> OnGetCustomization { get; set; }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingDataSource.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingDataSource.cs
@@ -10,6 +10,6 @@ public class DelegatingDataSource : DataSource
 
     protected override IEnumerable<object[]> GetData()
     {
-        return this.TestData;
+        return TestData;
     }
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingFixture.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingFixture.cs
@@ -7,18 +7,18 @@ namespace AutoFixture.Xunit3.UnitTest.TestTypes;
 
 internal class DelegatingFixture : IFixture
 {
-    private readonly List<ISpecimenBuilder> customizations = new();
-    private readonly List<ISpecimenBuilder> residueCollectors = new();
+    private readonly List<ISpecimenBuilder> _customizations = new();
+    private readonly List<ISpecimenBuilder> _residueCollectors = new();
 
     public IList<ISpecimenBuilderTransformation> Behaviors => throw new InvalidOperationException();
 
-    public IList<ISpecimenBuilder> Customizations => this.customizations;
+    public IList<ISpecimenBuilder> Customizations => _customizations;
 
     public bool OmitAutoProperties { get; set; }
 
     public int RepeatCount { get; set; }
 
-    public IList<ISpecimenBuilder> ResidueCollectors => this.residueCollectors;
+    public IList<ISpecimenBuilder> ResidueCollectors => _residueCollectors;
 
     public void AddManyTo<T>(ICollection<T> collection, Func<T> creator)
     {
@@ -42,7 +42,7 @@ internal class DelegatingFixture : IFixture
 
     public IFixture Customize(ICustomization customization)
     {
-        this.OnCustomize?.Invoke(customization);
+        OnCustomize?.Invoke(customization);
         return this;
     }
 
@@ -83,7 +83,7 @@ internal class DelegatingFixture : IFixture
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; } = (_, _) => new object();

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingMemberDataSource.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingMemberDataSource.cs
@@ -10,5 +10,5 @@ public class DelegatingMemberDataSource : MemberDataSource
     {
     }
 
-    public DataSource GetSource() => this.Source;
+    public DataSource GetSource() => Source;
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingSpecimenBuilder.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingSpecimenBuilder.cs
@@ -7,7 +7,7 @@ internal class DelegatingSpecimenBuilder : ISpecimenBuilder
 {
     public object Create(object request, ISpecimenContext context)
     {
-        return this.OnCreate(request, context);
+        return OnCreate(request, context);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; } = (_, _) => new object();

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingTestData.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/DelegatingTestData.cs
@@ -6,19 +6,19 @@ namespace AutoFixture.Xunit3.UnitTest.TestTypes;
 
 public class DelegatingTestData : IEnumerable<object[]>
 {
-    private readonly List<object[]> data;
+    private readonly List<object[]> _data;
 
     public DelegatingTestData(params object[][] data)
     {
-        this.data = data.ToList();
+        _data = data.ToList();
     }
 
     public DelegatingTestData(IEnumerable<object[]> data)
     {
-        this.data = data as List<object[]> ?? data.ToList();
+        _data = data as List<object[]> ?? data.ToList();
     }
 
-    public IEnumerator<object[]> GetEnumerator() => this.data.GetEnumerator();
+    public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/EmptyClassData.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/EmptyClassData.cs
@@ -10,5 +10,5 @@ public class EmptyClassData : IEnumerable<object[]>
         yield break;
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/FakeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/FakeDataAttribute.cs
@@ -10,19 +10,19 @@ namespace AutoFixture.Xunit3.UnitTest.TestTypes;
 
 public class FakeDataAttribute : DataAttribute
 {
-    private readonly MethodInfo expectedMethod;
-    private readonly IEnumerable<object[]> output;
+    private readonly MethodInfo _expectedMethod;
+    private readonly IEnumerable<object[]> _output;
 
     public FakeDataAttribute(MethodInfo expectedMethod, IEnumerable<object[]> output)
     {
-        this.expectedMethod = expectedMethod;
-        this.output = output;
+        _expectedMethod = expectedMethod;
+        _output = output;
     }
 
     public override ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(MethodInfo testMethod, DisposalTracker disposalTracker)
     {
-        Assert.Same(this.expectedMethod, testMethod);
-        return this.output.Select(row => new TheoryDataRow(row))
+        Assert.Same(_expectedMethod, testMethod);
+        return _output.Select(row => new TheoryDataRow(row))
             .Cast<ITheoryDataRow>().AsReadOnlyCollection()
             .ToValueTask();
     }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/InlineAttributeTestData.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/InlineAttributeTestData.cs
@@ -54,5 +54,5 @@ internal abstract class InlineAttributeTestData : IEnumerable<object[]>
     }
 
     public abstract IEnumerator<object[]> GetEnumerator();
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/MixedTypeClassData.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/MixedTypeClassData.cs
@@ -16,5 +16,5 @@ public class MixedTypeClassData : IEnumerable<object[]>
         yield return new object[] { -95, "test-92", EnumType.Second, new Tuple<string, int>("myValue", 5) };
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ParameterNameCriterion.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ParameterNameCriterion.cs
@@ -13,7 +13,7 @@ internal class ParameterNameCriterion : IEquatable<ParameterInfo>
 
     public ParameterNameCriterion(IEquatable<string> nameCriterion)
     {
-        this.NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
+        NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
     }
 
     /// <summary>
@@ -24,6 +24,6 @@ internal class ParameterNameCriterion : IEquatable<ParameterInfo>
     public bool Equals(ParameterInfo other)
     {
         return other is not null
-               && this.NameCriterion.Equals(other.Name);
+               && NameCriterion.Equals(other.Name);
     }
 }

--- a/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ParameterizedClassData.cs
+++ b/Src/AutoFixture.xUnit3.UnitTest/TestTypes/ParameterizedClassData.cs
@@ -6,22 +6,22 @@ namespace AutoFixture.Xunit3.UnitTest.TestTypes;
 
 public class ParameterizedClassData : IEnumerable<object[]>
 {
-    private readonly int p1;
-    private readonly string p2;
-    private readonly EnumType p3;
+    private readonly int _p1;
+    private readonly string _p2;
+    private readonly EnumType _p3;
 
     public ParameterizedClassData(int p1, string p2, EnumType p3)
     {
-        this.p1 = p1;
-        this.p2 = p2;
-        this.p3 = p3;
+        _p1 = p1;
+        _p2 = p2;
+        _p3 = p3;
     }
 
     public IEnumerator<object[]> GetEnumerator()
     {
-        yield return new object[] { this.p1, this.p2, this.p3 };
-        yield return new object[] { this.p1, this.p2, this.p3 };
+        yield return new object[] { _p1, _p2, _p3 };
+        yield return new object[] { _p1, _p2, _p3 };
     }
 
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture.xUnit3/AutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit3/AutoDataAttribute.cs
@@ -43,7 +43,7 @@ public class AutoDataAttribute : DataAttribute
     /// <param name="fixtureFactory">The fixture factory used to construct the fixture.</param>
     protected AutoDataAttribute(Func<IFixture> fixtureFactory)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class AutoDataAttribute : DataAttribute
     {
         if (testMethod is null) throw new ArgumentNullException(nameof(testMethod));
 
-        var source = new AutoDataSource(this.FixtureFactory);
+        var source = new AutoDataSource(FixtureFactory);
 
         return source.GetData(testMethod)
             .Select(x => new TheoryDataRow(x))

--- a/Src/AutoFixture.xUnit3/ClassAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit3/ClassAutoDataAttribute.cs
@@ -80,9 +80,9 @@ public class ClassAutoDataAttribute : DataAttribute
     /// </example>
     protected ClassAutoDataAttribute(Func<IFixture> fixtureFactory, Type sourceType, params object[] parameters)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
-        this.SourceType = sourceType ?? throw new ArgumentNullException(nameof(sourceType));
-        this.Parameters = parameters ?? new object[] { null };
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        SourceType = sourceType ?? throw new ArgumentNullException(nameof(sourceType));
+        Parameters = parameters ?? new object[] { null };
     }
 
     /// <summary>
@@ -105,8 +105,8 @@ public class ClassAutoDataAttribute : DataAttribute
         MethodInfo testMethod, DisposalTracker disposalTracker)
     {
         var source = new AutoDataSource(
-            this.FixtureFactory,
-            new ClassDataSource(this.SourceType, this.Parameters));
+            FixtureFactory,
+            new ClassDataSource(SourceType, Parameters));
 
         return source.GetData(testMethod)
             .Select(row => new TheoryDataRow(row))

--- a/Src/AutoFixture.xUnit3/CompositeDataAttribute.cs
+++ b/Src/AutoFixture.xUnit3/CompositeDataAttribute.cs
@@ -20,7 +20,7 @@ namespace AutoFixture.Xunit3;
     Justification = "This attribute is the root of a potential attribute hierarchy.")]
 public class CompositeDataAttribute : DataAttribute
 {
-    private readonly DataAttribute[] attributes;
+    private readonly DataAttribute[] _attributes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CompositeDataAttribute"/> class.
@@ -37,13 +37,13 @@ public class CompositeDataAttribute : DataAttribute
     /// <param name="attributes">The attributes representing a data source for a data theory.</param>
     public CompositeDataAttribute(params DataAttribute[] attributes)
     {
-        this.attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+        _attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
     }
 
     /// <summary>
     /// Gets the attributes supplied through one of the constructors.
     /// </summary>
-    public IReadOnlyList<DataAttribute> Attributes => Array.AsReadOnly(this.attributes);
+    public IReadOnlyList<DataAttribute> Attributes => Array.AsReadOnly(_attributes);
 
     /// <inheritdoc />
     public override async ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(
@@ -51,7 +51,7 @@ public class CompositeDataAttribute : DataAttribute
     {
         if (testMethod is null) throw new ArgumentNullException(nameof(testMethod));
 
-        var dataRowSources = this.attributes
+        var dataRowSources = _attributes
             .Select(attr => attr.GetData(testMethod, disposalTracker).AsTask())
             .ToArray();
         var results = await Task.WhenAll(dataRowSources);

--- a/Src/AutoFixture.xUnit3/FrozenAttribute.cs
+++ b/Src/AutoFixture.xUnit3/FrozenAttribute.cs
@@ -37,7 +37,7 @@ public class FrozenAttribute : CustomizeAttribute
     /// </param>
     public FrozenAttribute(Matching by)
     {
-        this.By = by;
+        By = by;
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class FrozenAttribute : CustomizeAttribute
     {
         if (parameter is null) throw new ArgumentNullException(nameof(parameter));
 
-        var matcher = new ParameterMatcherBuilder(parameter).SetFlags(this.By).Build();
+        var matcher = new ParameterMatcherBuilder(parameter).SetFlags(By).Build();
         return new FreezeOnMatchCustomization(parameter, matcher);
     }
 }

--- a/Src/AutoFixture.xUnit3/InlineAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit3/InlineAutoDataAttribute.cs
@@ -38,8 +38,8 @@ public class InlineAutoDataAttribute : DataAttribute
     /// <exception cref="ArgumentNullException"></exception>
     protected InlineAutoDataAttribute(Func<IFixture> fixtureFactory, params object[] values)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
-        this.Values = values ?? new object[] { null };
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        Values = values ?? new object[] { null };
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class InlineAutoDataAttribute : DataAttribute
     public override ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(
         MethodInfo testMethod, DisposalTracker disposalTracker)
     {
-        return new AutoDataSource(this.FixtureFactory, new InlineDataSource(this.Values))
+        return new AutoDataSource(FixtureFactory, new InlineDataSource(Values))
             .GetData(testMethod).Select(row => new TheoryDataRow(row))
             .Cast<ITheoryDataRow>().ToArray()
             .AsReadOnlyCollection().ToValueTask();

--- a/Src/AutoFixture.xUnit3/Internal/Argument.cs
+++ b/Src/AutoFixture.xUnit3/Internal/Argument.cs
@@ -6,13 +6,13 @@ internal class Argument
 {
     public Argument(TestParameter parameter, object value)
     {
-        this.Parameter = parameter ?? throw new ArgumentNullException(nameof(parameter));
-        this.Value = value;
+        Parameter = parameter ?? throw new ArgumentNullException(nameof(parameter));
+        Value = value;
     }
 
     public TestParameter Parameter { get; }
 
     public object Value { get; }
 
-    public ICustomization GetCustomization() => this.Parameter.GetCustomization(this.Value);
+    public ICustomization GetCustomization() => Parameter.GetCustomization(Value);
 }

--- a/Src/AutoFixture.xUnit3/Internal/AutoDataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/AutoDataSource.cs
@@ -21,8 +21,8 @@ public class AutoDataSource : IDataSource
     /// </exception>
     public AutoDataSource(Func<IFixture> createFixture, IDataSource? source = default)
     {
-        this.CreateFixture = createFixture ?? throw new ArgumentNullException(nameof(createFixture));
-        this.Source = source;
+        CreateFixture = createFixture ?? throw new ArgumentNullException(nameof(createFixture));
+        Source = source;
     }
 
     /// <summary>
@@ -42,15 +42,15 @@ public class AutoDataSource : IDataSource
     /// <returns>Returns a sequence of argument collections.</returns>
     public IEnumerable<object[]> GetData(MethodInfo method)
     {
-        return this.Source is null
-            ? this.GenerateValues(method)
-            : this.CombineValues(method, this.Source);
+        return Source is null
+            ? GenerateValues(method)
+            : CombineValues(method, Source);
     }
 
     private IEnumerable<object[]> GenerateValues(MethodBase methodInfo)
     {
         var parameters = Array.ConvertAll(methodInfo.GetParameters(), TestParameter.From);
-        var fixture = this.CreateFixture();
+        var fixture = CreateFixture();
         yield return Array.ConvertAll(parameters, parameter => GenerateAutoValue(parameter, fixture));
     }
 
@@ -65,7 +65,7 @@ public class AutoDataSource : IDataSource
                 .Select(argument => argument.GetCustomization())
                 .Where(x => x is not NullCustomization);
 
-            var fixture = this.CreateFixture();
+            var fixture = CreateFixture();
             foreach (var customization in customizations)
             {
                 fixture.Customize(customization);

--- a/Src/AutoFixture.xUnit3/Internal/ClassDataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/ClassDataSource.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.Xunit3.Internal;
     Justification = "Type is not a collection.")]
 public class ClassDataSource : DataSource
 {
-    private readonly object[] parameters;
+    private readonly object[] _parameters;
 
     /// <summary>
     /// Creates an instance of type <see cref="ClassDataSource" />.
@@ -21,8 +21,8 @@ public class ClassDataSource : DataSource
     /// <exception cref="ArgumentNullException">Thrown when arguments are <see langword="null" />.</exception>
     public ClassDataSource(Type type, params object[] parameters)
     {
-        this.Type = type ?? throw new ArgumentNullException(nameof(type));
-        this.parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
     }
 
     /// <summary>
@@ -33,14 +33,14 @@ public class ClassDataSource : DataSource
     /// <summary>
     /// Gets the constructor parameters for test data source type.
     /// </summary>
-    public IReadOnlyList<object> Parameters => Array.AsReadOnly(this.parameters);
+    public IReadOnlyList<object> Parameters => Array.AsReadOnly(_parameters);
 
     /// <inheritdoc />
     protected override IEnumerable<object[]> GetData()
     {
-        var instance = Activator.CreateInstance(type: this.Type, args: this.parameters);
+        var instance = Activator.CreateInstance(type: Type, args: _parameters);
         if (instance is not IEnumerable<object[]> enumerable)
-            throw new InvalidOperationException($"Data source type \"{this.Type}\" should implement the \"{typeof(IEnumerable<object>)}\" interface.");
+            throw new InvalidOperationException($"Data source type \"{Type}\" should implement the \"{typeof(IEnumerable<object>)}\" interface.");
 
         return enumerable;
     }

--- a/Src/AutoFixture.xUnit3/Internal/DataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/DataSource.cs
@@ -41,7 +41,7 @@ public abstract class DataSource : IDataSource
                 yield break;
             }
 
-            var enumerable = this.GetData()
+            var enumerable = GetData()
                              ?? throw new InvalidOperationException("The source member yielded no test data.");
 
             foreach (var testData in enumerable)

--- a/Src/AutoFixture.xUnit3/Internal/FieldDataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/FieldDataSource.cs
@@ -21,7 +21,7 @@ public class FieldDataSource : DataSource
     /// </exception>
     public FieldDataSource(FieldInfo fieldInfo)
     {
-        this.FieldInfo = fieldInfo ?? throw new ArgumentNullException(nameof(fieldInfo));
+        FieldInfo = fieldInfo ?? throw new ArgumentNullException(nameof(fieldInfo));
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public class FieldDataSource : DataSource
     /// </exception>
     protected override IEnumerable<object[]> GetData()
     {
-        var value = this.FieldInfo.GetValue(null);
+        var value = FieldInfo.GetValue(null);
         if (value is not IEnumerable<object[]> enumerable)
             throw new InvalidCastException("Member does not return an enumerable value.");
 

--- a/Src/AutoFixture.xUnit3/Internal/FrozenValueCustomization.cs
+++ b/Src/AutoFixture.xUnit3/Internal/FrozenValueCustomization.cs
@@ -6,20 +6,20 @@ namespace AutoFixture.Xunit3.Internal;
 
 internal class FrozenValueCustomization : ICustomization
 {
-    private readonly IRequestSpecification specification;
-    private readonly object? value;
+    private readonly IRequestSpecification _specification;
+    private readonly object? _value;
 
     public FrozenValueCustomization(IRequestSpecification specification, object? value)
     {
-        this.specification = specification ?? throw new ArgumentNullException(nameof(specification));
-        this.value = value;
+        _specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        _value = value;
     }
 
     public void Customize(IFixture fixture)
     {
         var builder = new FilteringSpecimenBuilder(
-            builder: new FixedBuilder(this.value),
-            specification: this.specification);
+            builder: new FixedBuilder(_value),
+            specification: _specification);
 
         fixture.Customizations.Insert(0, builder);
     }

--- a/Src/AutoFixture.xUnit3/Internal/InlineDataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/InlineDataSource.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.Xunit3.Internal;
     Justification = "Type is not a collection.")]
 public sealed class InlineDataSource : IDataSource
 {
-    private readonly object[] values;
+    private readonly object[] _values;
 
     /// <summary>
     /// Creates an instance of type <see cref="InlineDataSource" />.
@@ -23,13 +23,13 @@ public sealed class InlineDataSource : IDataSource
     /// </exception>
     public InlineDataSource(object[] values)
     {
-        this.values = values ?? throw new ArgumentNullException(nameof(values));
+        _values = values ?? throw new ArgumentNullException(nameof(values));
     }
 
     /// <summary>
     /// The collection of inline values.
     /// </summary>
-    public IReadOnlyList<object> Values => Array.AsReadOnly(this.values);
+    public IReadOnlyList<object> Values => Array.AsReadOnly(_values);
 
     /// <inheritdoc />
     public IEnumerable<object[]> GetData(MethodInfo method)
@@ -37,12 +37,12 @@ public sealed class InlineDataSource : IDataSource
         if (method is null) throw new ArgumentNullException(nameof(method));
 
         var parameters = method.GetParameters();
-        if (this.values.Length > parameters.Length)
+        if (_values.Length > parameters.Length)
         {
             throw new InvalidOperationException(
                 "The number of arguments provided exceeds the number of parameters.");
         }
 
-        return new[] { this.values };
+        return new[] { _values };
     }
 }

--- a/Src/AutoFixture.xUnit3/Internal/MemberDataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/MemberDataSource.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.Xunit3.Internal;
 /// </summary>
 public class MemberDataSource : IDataSource
 {
-    private readonly object[] arguments;
+    private readonly object[] _arguments;
 
     /// <summary>
     /// Creates an instance of type <see cref="MemberDataSource" />.
@@ -23,10 +23,10 @@ public class MemberDataSource : IDataSource
     /// <exception cref="ArgumentNullException">Thrown when arguments are <see langref="null" />.</exception>
     public MemberDataSource(Type type, string name, params object[] arguments)
     {
-        this.Type = type ?? throw new ArgumentNullException(nameof(type));
-        this.Name = name ?? throw new ArgumentNullException(nameof(name));
-        this.arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
-        this.Source = this.GetTestDataSource();
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        Source = GetTestDataSource();
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ public class MemberDataSource : IDataSource
     /// <summary>
     /// Gets the arguments provided to the member.
     /// </summary>
-    public IReadOnlyList<object> Arguments => Array.AsReadOnly(this.arguments);
+    public IReadOnlyList<object> Arguments => Array.AsReadOnly(_arguments);
 
     /// <summary>
     /// Gets the test data source.
@@ -52,12 +52,12 @@ public class MemberDataSource : IDataSource
     /// <inheritdoc />
     public IEnumerable<object[]> GetData(MethodInfo method)
     {
-        return this.Source.GetData(method);
+        return Source.GetData(method);
     }
 
     private DataSource GetTestDataSource()
     {
-        var sourceMember = this.Type.GetMember(this.Name,
+        var sourceMember = Type.GetMember(Name,
                 MemberTypes.Method | MemberTypes.Field | MemberTypes.Property,
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy)
             .FirstOrDefault();
@@ -67,7 +67,7 @@ public class MemberDataSource : IDataSource
             var message = string.Format(
                 CultureInfo.CurrentCulture,
                 "Could not find public static member (property, field, or method) named '{0}' on {1}",
-                this.Name, this.Type.FullName);
+                Name, Type.FullName);
             throw new ArgumentException(message);
         }
 
@@ -77,7 +77,7 @@ public class MemberDataSource : IDataSource
             var message = string.Format(
                 CultureInfo.CurrentCulture,
                 "Member {0} on {1} does not return IEnumerable<object[]>",
-                this.Name, this.Type.FullName);
+                Name, Type.FullName);
             throw new ArgumentException(message);
         }
 
@@ -85,7 +85,7 @@ public class MemberDataSource : IDataSource
         {
             FieldInfo fieldInfo => new FieldDataSource(fieldInfo),
             PropertyInfo propertyInfo => new PropertyDataSource(propertyInfo),
-            MethodInfo methodInfo => new MethodDataSource(methodInfo, this.arguments),
+            MethodInfo methodInfo => new MethodDataSource(methodInfo, _arguments),
             _ => throw new InvalidOperationException("Unsupported member type.")
         };
     }

--- a/Src/AutoFixture.xUnit3/Internal/MethodDataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/MethodDataSource.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.Xunit3.Internal;
     Justification = "Type is not a collection.")]
 public class MethodDataSource : DataSource
 {
-    private readonly object[] arguments;
+    private readonly object[] _arguments;
 
     /// <summary>
     /// Creates an instance of type <see cref="MethodDataSource" />.
@@ -21,8 +21,8 @@ public class MethodDataSource : DataSource
     /// <param name="arguments">The source method arguments.</param>
     public MethodDataSource(MethodInfo methodInfo, params object[] arguments)
     {
-        this.MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
-        this.arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+        _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
     }
 
     /// <summary>
@@ -33,12 +33,12 @@ public class MethodDataSource : DataSource
     /// <summary>
     /// Gets the source method arguments.
     /// </summary>
-    public IReadOnlyList<object> Arguments => Array.AsReadOnly(this.arguments);
+    public IReadOnlyList<object> Arguments => Array.AsReadOnly(_arguments);
 
     /// <inheritdoc />
     protected override IEnumerable<object[]> GetData()
     {
-        var value = this.MethodInfo.Invoke(null, this.arguments);
+        var value = MethodInfo.Invoke(null, _arguments);
         if (value is not IEnumerable<object[]> enumerable)
             throw new InvalidCastException("Member does not return an enumerable value.");
 

--- a/Src/AutoFixture.xUnit3/Internal/NullCustomization.cs
+++ b/Src/AutoFixture.xUnit3/Internal/NullCustomization.cs
@@ -9,10 +9,10 @@ internal sealed class NullCustomization : ICustomization
         // prevent external instantiation
     }
 
-    private static readonly Lazy<NullCustomization> LazyInstance = new(
+    private static readonly Lazy<NullCustomization> s_lazyInstance = new(
         () => new NullCustomization(), isThreadSafe: true);
 
-    public static NullCustomization Instance => LazyInstance.Value;
+    public static NullCustomization Instance => s_lazyInstance.Value;
 
     public void Customize(IFixture fixture)
     {

--- a/Src/AutoFixture.xUnit3/Internal/ParameterFilter.cs
+++ b/Src/AutoFixture.xUnit3/Internal/ParameterFilter.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.Xunit3.Internal;
 /// </summary>
 internal class ParameterFilter : IRequestSpecification
 {
-    private readonly IRequestSpecification matcherSpecification;
+    private readonly IRequestSpecification _matcherSpecification;
 
     /// <summary>
     /// Creates an instance of type <see cref="ParameterFilter"/>.
@@ -19,10 +19,10 @@ internal class ParameterFilter : IRequestSpecification
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameterInfo"/> is null.</exception>
     public ParameterFilter(ParameterInfo parameterInfo, Matching flags)
     {
-        this.ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
-        this.Flags = flags;
-        this.matcherSpecification = new ParameterMatcherBuilder(this.ParameterInfo)
-            .SetFlags(this.Flags).Build();
+        ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
+        Flags = flags;
+        _matcherSpecification = new ParameterMatcherBuilder(ParameterInfo)
+            .SetFlags(Flags).Build();
     }
 
     /// <summary>
@@ -38,6 +38,6 @@ internal class ParameterFilter : IRequestSpecification
     /// <inheritdoc />
     public bool IsSatisfiedBy(object request)
     {
-        return this.matcherSpecification.IsSatisfiedBy(request);
+        return _matcherSpecification.IsSatisfiedBy(request);
     }
 }

--- a/Src/AutoFixture.xUnit3/Internal/ParameterMatcherBuilder.cs
+++ b/Src/AutoFixture.xUnit3/Internal/ParameterMatcherBuilder.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.Xunit3.Internal;
 /// </summary>
 public class ParameterMatcherBuilder
 {
-    private readonly ParameterInfo parameterInfo;
+    private readonly ParameterInfo _parameterInfo;
 
     /// <summary>
     /// Creates an instance of type <see cref="ParameterMatcherBuilder"/>.
@@ -22,7 +22,7 @@ public class ParameterMatcherBuilder
     /// </exception>
     public ParameterMatcherBuilder(ParameterInfo parameterInfo)
     {
-        this.parameterInfo = parameterInfo
+        _parameterInfo = parameterInfo
                              ?? throw new ArgumentNullException(nameof(parameterInfo));
     }
 
@@ -73,12 +73,12 @@ public class ParameterMatcherBuilder
     /// <returns>The current <see cref="ParameterMatcherBuilder"/> instance.</returns>
     public ParameterMatcherBuilder SetFlags(Matching flags)
     {
-        this.MatchExactType = flags.HasFlag(Matching.ExactType);
-        this.MatchDirectBaseType = flags.HasFlag(Matching.DirectBaseType);
-        this.MatchImplementedInterfaces = flags.HasFlag(Matching.ImplementedInterfaces);
-        this.MatchParameter = flags.HasFlag(Matching.ParameterName);
-        this.MatchProperty = flags.HasFlag(Matching.PropertyName);
-        this.MatchField = flags.HasFlag(Matching.FieldName);
+        MatchExactType = flags.HasFlag(Matching.ExactType);
+        MatchDirectBaseType = flags.HasFlag(Matching.DirectBaseType);
+        MatchImplementedInterfaces = flags.HasFlag(Matching.ImplementedInterfaces);
+        MatchParameter = flags.HasFlag(Matching.ParameterName);
+        MatchProperty = flags.HasFlag(Matching.PropertyName);
+        MatchField = flags.HasFlag(Matching.FieldName);
         return this;
     }
 
@@ -91,26 +91,26 @@ public class ParameterMatcherBuilder
     public IRequestSpecification Build()
     {
         var specifications = new List<IRequestSpecification>(7);
-        if (this.MatchExactRequest)
-            specifications.Add(this.AsExactRequest());
+        if (MatchExactRequest)
+            specifications.Add(AsExactRequest());
 
-        if (this.MatchExactType)
-            specifications.Add(this.AsExactType());
+        if (MatchExactType)
+            specifications.Add(AsExactType());
 
-        if (this.MatchDirectBaseType)
-            specifications.Add(this.AsDirectBaseType());
+        if (MatchDirectBaseType)
+            specifications.Add(AsDirectBaseType());
 
-        if (this.MatchImplementedInterfaces)
-            specifications.Add(this.AsImplementedInterfaces());
+        if (MatchImplementedInterfaces)
+            specifications.Add(AsImplementedInterfaces());
 
-        if (this.MatchProperty)
-            specifications.Add(this.AsProperty());
+        if (MatchProperty)
+            specifications.Add(AsProperty());
 
-        if (this.MatchParameter)
-            specifications.Add(this.AsParameter());
+        if (MatchParameter)
+            specifications.Add(AsParameter());
 
-        if (this.MatchField)
-            specifications.Add(this.AsField());
+        if (MatchField)
+            specifications.Add(AsField());
 
         return specifications.Count == 1
             ? specifications[0]
@@ -119,54 +119,54 @@ public class ParameterMatcherBuilder
 
     private IRequestSpecification AsExactRequest()
     {
-        return new EqualRequestSpecification(this.parameterInfo);
+        return new EqualRequestSpecification(_parameterInfo);
     }
 
     private IRequestSpecification AsExactType()
     {
         return new OrRequestSpecification(
-            new ExactTypeSpecification(this.parameterInfo.ParameterType),
-            new SeedRequestSpecification(this.parameterInfo.ParameterType));
+            new ExactTypeSpecification(_parameterInfo.ParameterType),
+            new SeedRequestSpecification(_parameterInfo.ParameterType));
     }
 
     private IRequestSpecification AsDirectBaseType()
     {
         return new AndRequestSpecification(
             new InverseRequestSpecification(
-                new ExactTypeSpecification(this.parameterInfo.ParameterType)),
-            new DirectBaseTypeSpecification(this.parameterInfo.ParameterType));
+                new ExactTypeSpecification(_parameterInfo.ParameterType)),
+            new DirectBaseTypeSpecification(_parameterInfo.ParameterType));
     }
 
     private IRequestSpecification AsImplementedInterfaces()
     {
         return new AndRequestSpecification(
             new InverseRequestSpecification(
-                new ExactTypeSpecification(this.parameterInfo.ParameterType)),
-            new ImplementedInterfaceSpecification(this.parameterInfo.ParameterType));
+                new ExactTypeSpecification(_parameterInfo.ParameterType)),
+            new ImplementedInterfaceSpecification(_parameterInfo.ParameterType));
     }
 
     private IRequestSpecification AsParameter()
     {
         return new ParameterSpecification(
             new ParameterTypeAndNameCriterion(
-                new Criterion<Type>(this.parameterInfo.ParameterType, new DerivesFromTypeComparer()),
-                new Criterion<string>(this.parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
+                new Criterion<Type>(_parameterInfo.ParameterType, new DerivesFromTypeComparer()),
+                new Criterion<string>(_parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
     }
 
     private IRequestSpecification AsProperty()
     {
         return new PropertySpecification(
             new PropertyTypeAndNameCriterion(
-                new Criterion<Type>(this.parameterInfo.ParameterType, new DerivesFromTypeComparer()),
-                new Criterion<string>(this.parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
+                new Criterion<Type>(_parameterInfo.ParameterType, new DerivesFromTypeComparer()),
+                new Criterion<string>(_parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
     }
 
     private IRequestSpecification AsField()
     {
         return new FieldSpecification(
             new FieldTypeAndNameCriterion(
-                new Criterion<Type>(this.parameterInfo.ParameterType, new DerivesFromTypeComparer()),
-                new Criterion<string>(this.parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
+                new Criterion<Type>(_parameterInfo.ParameterType, new DerivesFromTypeComparer()),
+                new Criterion<string>(_parameterInfo.Name, StringComparer.OrdinalIgnoreCase)));
     }
 
     private class DerivesFromTypeComparer : IEqualityComparer<Type>

--- a/Src/AutoFixture.xUnit3/Internal/PropertyDataSource.cs
+++ b/Src/AutoFixture.xUnit3/Internal/PropertyDataSource.cs
@@ -19,7 +19,7 @@ public class PropertyDataSource : DataSource
     /// <exception cref="ArgumentNullException"></exception>
     public PropertyDataSource(PropertyInfo propertyInfo)
     {
-        this.PropertyInfo = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
+        PropertyInfo = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public class PropertyDataSource : DataSource
     /// <inheritdoc />
     protected override IEnumerable<object[]> GetData()
     {
-        var value = this.PropertyInfo.GetValue(null);
+        var value = PropertyInfo.GetValue(null);
         if (value is not IEnumerable<object[]> enumerable)
             throw new InvalidCastException("Member does not return an enumerable value.");
 

--- a/Src/AutoFixture.xUnit3/Internal/TestParameter.cs
+++ b/Src/AutoFixture.xUnit3/Internal/TestParameter.cs
@@ -6,33 +6,33 @@ namespace AutoFixture.Xunit3.Internal;
 
 internal class TestParameter
 {
-    private readonly Lazy<ICustomization> lazyCustomization;
-    private readonly Lazy<FrozenAttribute> lazyFrozenAttribute;
+    private readonly Lazy<ICustomization> _lazyCustomization;
+    private readonly Lazy<FrozenAttribute> _lazyFrozenAttribute;
 
     public TestParameter(ParameterInfo parameterInfo)
     {
-        this.ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
+        ParameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
 
-        this.lazyCustomization = new Lazy<ICustomization>(
+        _lazyCustomization = new Lazy<ICustomization>(
             () => GetCustomization(parameterInfo));
-        this.lazyFrozenAttribute = new Lazy<FrozenAttribute>(
+        _lazyFrozenAttribute = new Lazy<FrozenAttribute>(
             () => parameterInfo.GetCustomAttributes()
                 .OfType<FrozenAttribute>().FirstOrDefault());
     }
 
     public ParameterInfo ParameterInfo { get; }
 
-    public ICustomization GetCustomization() => this.lazyCustomization.Value;
+    public ICustomization GetCustomization() => _lazyCustomization.Value;
 
     public ICustomization GetCustomization(object value)
     {
-        var frozenAttribute = this.lazyFrozenAttribute.Value;
+        var frozenAttribute = _lazyFrozenAttribute.Value;
 
         if (frozenAttribute is null)
             return NullCustomization.Instance;
 
         return new FrozenValueCustomization(
-            new ParameterFilter(this.ParameterInfo, frozenAttribute.By),
+            new ParameterFilter(ParameterInfo, frozenAttribute.By),
             value);
     }
 

--- a/Src/AutoFixture.xUnit3/MemberAutoDataAttribute.cs
+++ b/Src/AutoFixture.xUnit3/MemberAutoDataAttribute.cs
@@ -68,10 +68,10 @@ public class MemberAutoDataAttribute : DataAttribute
     /// <exception cref="ArgumentNullException">Thrown when arguments are null.</exception>
     protected MemberAutoDataAttribute(Func<IFixture> fixtureFactory, Type? memberType, string memberName, params object[]? parameters)
     {
-        this.FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
-        this.MemberName = memberName ?? throw new ArgumentNullException(nameof(memberName));
-        this.Parameters = parameters ?? new object[] { null! };
-        this.MemberType = memberType;
+        FixtureFactory = fixtureFactory ?? throw new ArgumentNullException(nameof(fixtureFactory));
+        MemberName = memberName ?? throw new ArgumentNullException(nameof(memberName));
+        Parameters = parameters ?? new object[] { null! };
+        MemberType = memberType;
     }
 
     /// <summary>
@@ -100,12 +100,12 @@ public class MemberAutoDataAttribute : DataAttribute
     {
         if (testMethod is null) throw new ArgumentNullException(nameof(testMethod));
 
-        var sourceType = this.MemberType ?? testMethod.DeclaringType
+        var sourceType = MemberType ?? testMethod.DeclaringType
             ?? throw new InvalidOperationException("Source type cannot be null.");
 
         var source = new AutoDataSource(
-            createFixture: this.FixtureFactory,
-            source: new MemberDataSource(sourceType, this.MemberName, this.Parameters));
+            createFixture: FixtureFactory,
+            source: new MemberDataSource(sourceType, MemberName, Parameters));
 
         return source.GetData(testMethod)
             .Select(row => new TheoryDataRow(row))

--- a/Src/AutoFixture/AutoPropertiesTarget.cs
+++ b/Src/AutoFixture/AutoPropertiesTarget.cs
@@ -33,7 +33,7 @@ public class AutoPropertiesTarget : ISpecimenBuilderNode
     /// <seealso cref="Builder"/>
     public AutoPropertiesTarget(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>Composes the supplied builders.</summary>
@@ -70,7 +70,7 @@ public class AutoPropertiesTarget : ISpecimenBuilderNode
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Builder.Create(request, context);
+        return Builder.Create(request, context);
     }
 
     /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -78,7 +78,7 @@ public class AutoPropertiesTarget : ISpecimenBuilderNode
     /// <seealso cref="Builder" />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public class AutoPropertiesTarget : ISpecimenBuilderNode
     /// <seealso cref="GetEnumerator()" />
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     /// <summary>Gets the builder decorated by this instance.</summary>

--- a/Src/AutoFixture/BehaviorRoot.cs
+++ b/Src/AutoFixture/BehaviorRoot.cs
@@ -33,7 +33,7 @@ public class BehaviorRoot : ISpecimenBuilderNode
     /// <seealso cref="Builder" />
     public BehaviorRoot(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>Composes the supplied builders.</summary>
@@ -70,7 +70,7 @@ public class BehaviorRoot : ISpecimenBuilderNode
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Builder.Create(request, context);
+        return Builder.Create(request, context);
     }
 
     /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -78,7 +78,7 @@ public class BehaviorRoot : ISpecimenBuilderNode
     /// <seealso cref="Builder" />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public class BehaviorRoot : ISpecimenBuilderNode
     /// <seealso cref="GetEnumerator()" />
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     /// <summary>Gets the builder decorated by this instance.</summary>

--- a/Src/AutoFixture/BooleanSwitch.cs
+++ b/Src/AutoFixture/BooleanSwitch.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class BooleanSwitch : ISpecimenBuilder
 {
-    private bool b;
-    private readonly object syncRoot;
+    private bool _b;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BooleanSwitch"/> class.
     /// </summary>
     public BooleanSwitch()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -29,10 +29,10 @@ public class BooleanSwitch : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public bool Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            this.b = !this.b;
-            return this.b;
+            _b = !_b;
+            return _b;
         }
     }
 
@@ -48,7 +48,7 @@ public class BooleanSwitch : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public bool CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public class BooleanSwitch : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/ByteSequenceGenerator.cs
+++ b/Src/AutoFixture/ByteSequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class ByteSequenceGenerator : ISpecimenBuilder
 {
-    private byte b;
-    private readonly object syncRoot;
+    private byte _b;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ByteSequenceGenerator"/> class.
     /// </summary>
     public ByteSequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -26,9 +26,9 @@ public class ByteSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public byte Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.b;
+            return ++_b;
         }
     }
 
@@ -40,7 +40,7 @@ public class ByteSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public byte CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public class ByteSequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/CharSequenceGenerator.cs
+++ b/Src/AutoFixture/CharSequenceGenerator.cs
@@ -7,15 +7,15 @@ namespace AutoFixture;
 /// </summary>
 public class CharSequenceGenerator : ISpecimenBuilder
 {
-    private char c = '!';
-    private readonly object syncRoot;
+    private char _c = '!';
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CharSequenceGenerator"/> class.
     /// </summary>
     public CharSequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -33,19 +33,19 @@ public class CharSequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        return this.Create();
+        return Create();
     }
 
     private char Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            if (this.c > 126)
+            if (_c > 126)
             {
-                this.c = '!';
+                _c = '!';
             }
 
-            return this.c++;
+            return _c++;
         }
     }
 }

--- a/Src/AutoFixture/CompositeCustomization.cs
+++ b/Src/AutoFixture/CompositeCustomization.cs
@@ -24,7 +24,7 @@ public class CompositeCustomization : ICustomization
     /// <param name="customizations">The customizations.</param>
     public CompositeCustomization(params ICustomization[] customizations)
     {
-        this.Customizations = customizations ?? throw new ArgumentNullException(nameof(customizations));
+        Customizations = customizations ?? throw new ArgumentNullException(nameof(customizations));
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public class CompositeCustomization : ICustomization
     /// <param name="fixture">The fixture to customize.</param>
     public void Customize(IFixture fixture)
     {
-        foreach (var c in this.Customizations)
+        foreach (var c in Customizations)
         {
             c.Customize(fixture);
         }

--- a/Src/AutoFixture/ConstructorCustomization.cs
+++ b/Src/AutoFixture/ConstructorCustomization.cs
@@ -21,8 +21,8 @@ public class ConstructorCustomization : ICustomization
     /// </param>
     public ConstructorCustomization(Type targetType, IMethodQuery query)
     {
-        this.TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
-        this.Query = query ?? throw new ArgumentNullException(nameof(query));
+        TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+        Query = query ?? throw new ArgumentNullException(nameof(query));
     }
 
     /// <summary>
@@ -45,9 +45,9 @@ public class ConstructorCustomization : ICustomization
     {
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-        var factory = new MethodInvoker(this.Query);
+        var factory = new MethodInvoker(Query);
         var builder = SpecimenBuilderNodeFactory.CreateTypedNode(
-            this.TargetType,
+            TargetType,
             factory);
 
         fixture.Customizations.Insert(0, builder);

--- a/Src/AutoFixture/CustomizationExtensions.cs
+++ b/Src/AutoFixture/CustomizationExtensions.cs
@@ -21,18 +21,18 @@ public static class CustomizationExtensions
 
     private class InsertCustomization : ICustomization
     {
-        private readonly ISpecimenBuilder builder;
+        private readonly ISpecimenBuilder _builder;
 
         public InsertCustomization(ISpecimenBuilder builder)
         {
-            this.builder = builder;
+            _builder = builder;
         }
 
         public void Customize(IFixture fixture)
         {
             if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-            fixture.Customizations.Insert(0, this.builder);
+            fixture.Customizations.Insert(0, _builder);
         }
     }
 }

--- a/Src/AutoFixture/CustomizationNode.cs
+++ b/Src/AutoFixture/CustomizationNode.cs
@@ -36,7 +36,7 @@ public class CustomizationNode : ISpecimenBuilderNode
         if (builder == null)
             throw new ArgumentNullException(nameof(builder));
 
-        this.Builder = builder;
+        Builder = builder;
     }
 
     /// <summary>Composes the supplied builders.</summary>
@@ -74,7 +74,7 @@ public class CustomizationNode : ISpecimenBuilderNode
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Builder.Create(request, context);
+        return Builder.Create(request, context);
     }
 
     /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -82,7 +82,7 @@ public class CustomizationNode : ISpecimenBuilderNode
     /// <seealso cref="Builder" />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ public class CustomizationNode : ISpecimenBuilderNode
     /// <seealso cref="GetEnumerator()" />
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     /// <summary>Gets the builder decorated by this instance.</summary>

--- a/Src/AutoFixture/DataAnnotations/DataAnnotationsSupportNode.cs
+++ b/Src/AutoFixture/DataAnnotations/DataAnnotationsSupportNode.cs
@@ -28,13 +28,13 @@ public class DataAnnotationsSupportNode : ISpecimenBuilderNode
     /// <param name="builder">Builder that handles all the data annotation related requests.</param>
     public DataAnnotationsSupportNode(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <inheritdoc />
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Builder.Create(request, context);
+        return Builder.Create(request, context);
     }
 
     /// <inheritdoc />
@@ -48,9 +48,9 @@ public class DataAnnotationsSupportNode : ISpecimenBuilderNode
     /// <inheritdoc />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     /// <inheritdoc />
-    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/EnumDataTypeAttributeRelay.cs
@@ -11,8 +11,8 @@ namespace AutoFixture.DataAnnotations;
 /// </summary>
 public class EnumDataTypeAttributeRelay : ISpecimenBuilder
 {
-    private readonly ISpecimenBuilder enumGenerator;
-    private IRequestMemberTypeResolver requestMemberTypeResolver = new RequestMemberTypeResolver();
+    private readonly ISpecimenBuilder _enumGenerator;
+    private IRequestMemberTypeResolver _requestMemberTypeResolver = new RequestMemberTypeResolver();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EnumDataTypeAttributeRelay" /> class.
@@ -28,7 +28,7 @@ public class EnumDataTypeAttributeRelay : ISpecimenBuilder
     /// <param name="enumGenerator">The <see langword="enum" /> value builder.</param>
     public EnumDataTypeAttributeRelay(ISpecimenBuilder enumGenerator)
     {
-        this.enumGenerator = enumGenerator
+        _enumGenerator = enumGenerator
                              ?? throw new ArgumentNullException(nameof(enumGenerator));
     }
 
@@ -37,8 +37,8 @@ public class EnumDataTypeAttributeRelay : ISpecimenBuilder
     /// </summary>
     public IRequestMemberTypeResolver RequestMemberTypeResolver
     {
-        get => this.requestMemberTypeResolver;
-        set => this.requestMemberTypeResolver = value
+        get => _requestMemberTypeResolver;
+        set => _requestMemberTypeResolver = value
                                                 ?? throw new ArgumentNullException(nameof(value));
     }
 
@@ -57,10 +57,10 @@ public class EnumDataTypeAttributeRelay : ISpecimenBuilder
         var attribute = TypeEnvy.GetAttribute<EnumDataTypeAttribute>(request);
         if (attribute == null || !attribute.EnumType.GetTypeInfo().IsEnum) return NoSpecimen.Instance;
 
-        var enumValue = this.enumGenerator.Create(attribute.EnumType, context);
+        var enumValue = _enumGenerator.Create(attribute.EnumType, context);
         if (enumValue is NoSpecimen) return enumValue;
 
-        if (!this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
+        if (!RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
         {
             return NoSpecimen.Instance;
         }

--- a/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/MinAndMaxLengthAttributeRelay.cs
@@ -10,15 +10,15 @@ namespace AutoFixture.DataAnnotations;
 /// </summary>
 public class MinAndMaxLengthAttributeRelay : ISpecimenBuilder
 {
-    private IRequestMemberTypeResolver requestMemberTypeResolver = new RequestMemberTypeResolver();
+    private IRequestMemberTypeResolver _requestMemberTypeResolver = new RequestMemberTypeResolver();
 
     /// <summary>
     /// Gets or sets the current IRequestMemberTypeResolver.
     /// </summary>
     public IRequestMemberTypeResolver RequestMemberTypeResolver
     {
-        get => this.requestMemberTypeResolver;
-        set => this.requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
+        get => _requestMemberTypeResolver;
+        set => _requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public class MinAndMaxLengthAttributeRelay : ISpecimenBuilder
     {
         if (context is null) throw new ArgumentNullException(nameof(context));
 
-        if (!this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
+        if (!RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
         {
             return NoSpecimen.Instance;
         }
@@ -72,9 +72,9 @@ public class MinAndMaxLengthAttributeRelay : ISpecimenBuilder
 
         public Range(int? min, int? max)
         {
-            this.Min = min;
-            this.Max = max;
-            this.IsConstrained = min.HasValue || max.HasValue;
+            Min = min;
+            Max = max;
+            IsConstrained = min.HasValue || max.HasValue;
         }
 
         public int? Min { get; }
@@ -85,8 +85,8 @@ public class MinAndMaxLengthAttributeRelay : ISpecimenBuilder
 
         public ConstrainedStringRequest ToStringRequest()
         {
-            var min = this.Min ?? 0;
-            var max = this.Max ?? min * 2;
+            var min = Min ?? 0;
+            var max = Max ?? min * 2;
             min = min == 0 && max != 0 ? FallbackMin : min;
             max = max < 0 ? int.MaxValue : max;
             return new ConstrainedStringRequest(min, max);
@@ -94,8 +94,8 @@ public class MinAndMaxLengthAttributeRelay : ISpecimenBuilder
 
         public RangedSequenceRequest ToSequenceRequest(Type elementType)
         {
-            var min = this.Min ?? 0;
-            var max = this.Max ?? min * 2;
+            var min = Min ?? 0;
+            var max = Max ?? min * 2;
             min = min == 0 && max != 0 ? FallbackMin : min;
             const int fallbackMax = 3;
             max = max < 0 ? fallbackMax : max;

--- a/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/RangeAttributeRelay.cs
@@ -9,15 +9,15 @@ namespace AutoFixture.DataAnnotations;
 /// </summary>
 public class RangeAttributeRelay : ISpecimenBuilder
 {
-    private IRequestMemberTypeResolver requestMemberTypeResolver = new RequestMemberTypeResolver();
+    private IRequestMemberTypeResolver _requestMemberTypeResolver = new RequestMemberTypeResolver();
 
     /// <summary>
     /// Gets or sets the current IRequestMemberTypeResolver.
     /// </summary>
     public IRequestMemberTypeResolver RequestMemberTypeResolver
     {
-        get => this.requestMemberTypeResolver;
-        set => this.requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
+        get => _requestMemberTypeResolver;
+        set => _requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public class RangeAttributeRelay : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        var memberType = this.GetMemberType(rangeAttribute, request);
+        var memberType = GetMemberType(rangeAttribute, request);
         var rangedRequest = new RangedRequest(
             memberType,
             rangeAttribute.OperandType,
@@ -52,7 +52,7 @@ public class RangeAttributeRelay : ISpecimenBuilder
 
     private Type GetMemberType(RangeAttribute rangeAttribute, object request)
     {
-        if (this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
+        if (RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
         {
             return memberType;
         }

--- a/Src/AutoFixture/DataAnnotations/RangedRequest.cs
+++ b/Src/AutoFixture/DataAnnotations/RangedRequest.cs
@@ -21,10 +21,10 @@ public class RangedRequest : IEquatable<RangedRequest>
     /// <param name="maximum">The maximum.</param>
     public RangedRequest(Type memberType, Type operandType, object minimum, object maximum)
     {
-        this.MemberType = memberType ?? throw new ArgumentNullException(nameof(memberType));
-        this.OperandType = operandType ?? throw new ArgumentNullException(nameof(operandType));
-        this.Minimum = minimum ?? throw new ArgumentNullException(nameof(minimum));
-        this.Maximum = maximum ?? throw new ArgumentNullException(nameof(maximum));
+        MemberType = memberType ?? throw new ArgumentNullException(nameof(memberType));
+        OperandType = operandType ?? throw new ArgumentNullException(nameof(operandType));
+        Minimum = minimum ?? throw new ArgumentNullException(nameof(minimum));
+        Maximum = maximum ?? throw new ArgumentNullException(nameof(maximum));
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class RangedRequest : IEquatable<RangedRequest>
     {
         if (obj is RangedRequest other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
 
         return false;
@@ -68,10 +68,10 @@ public class RangedRequest : IEquatable<RangedRequest>
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
 
-        return this.MemberType == other.MemberType &&
-               this.OperandType == other.OperandType &&
-               Equals(this.Minimum, other.Minimum) &&
-               Equals(this.Maximum, other.Maximum);
+        return MemberType == other.MemberType &&
+               OperandType == other.OperandType &&
+               Equals(Minimum, other.Minimum) &&
+               Equals(Maximum, other.Maximum);
     }
 
     /// <inheritdoc />
@@ -79,10 +79,10 @@ public class RangedRequest : IEquatable<RangedRequest>
     {
         unchecked
         {
-            var hashCode = this.MemberType.GetHashCode();
-            hashCode = (hashCode * 397) ^ this.OperandType.GetHashCode();
-            hashCode = (hashCode * 397) ^ this.Minimum.GetHashCode();
-            hashCode = (hashCode * 397) ^ this.Maximum.GetHashCode();
+            var hashCode = MemberType.GetHashCode();
+            hashCode = (hashCode * 397) ^ OperandType.GetHashCode();
+            hashCode = (hashCode * 397) ^ Minimum.GetHashCode();
+            hashCode = (hashCode * 397) ^ Maximum.GetHashCode();
             return hashCode;
         }
     }
@@ -94,7 +94,7 @@ public class RangedRequest : IEquatable<RangedRequest>
     {
         if (targetType == null) throw new ArgumentNullException(nameof(targetType));
 
-        return GetConvertedRangeBoundary(this.Minimum, targetType);
+        return GetConvertedRangeBoundary(Minimum, targetType);
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public class RangedRequest : IEquatable<RangedRequest>
     {
         if (targetType == null) throw new ArgumentNullException(nameof(targetType));
 
-        return GetConvertedRangeBoundary(this.Maximum, targetType);
+        return GetConvertedRangeBoundary(Maximum, targetType);
     }
 
     /// <inheritdoc />
@@ -113,12 +113,12 @@ public class RangedRequest : IEquatable<RangedRequest>
         return string.Format(
             CultureInfo.CurrentCulture,
             "RangedRequest (MemberType: {0}, OperandType: {1} Minimum: [{2}] {3}, Maximum: [{4}] {5})",
-            this.MemberType.FullName,
-            this.OperandType.FullName,
-            this.Minimum.GetType().Name,
-            this.Minimum,
-            this.Maximum.GetType().Name,
-            this.Maximum);
+            MemberType.FullName,
+            OperandType.FullName,
+            Minimum.GetType().Name,
+            Minimum,
+            Maximum.GetType().Name,
+            Maximum);
     }
 
     private static object GetConvertedRangeBoundary(object attributeValue, Type conversionType)

--- a/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
+++ b/Src/AutoFixture/DataAnnotations/StringLengthAttributeRelay.cs
@@ -9,15 +9,15 @@ namespace AutoFixture.DataAnnotations;
 /// </summary>
 public class StringLengthAttributeRelay : ISpecimenBuilder
 {
-    private IRequestMemberTypeResolver requestMemberTypeResolver = new RequestMemberTypeResolver();
+    private IRequestMemberTypeResolver _requestMemberTypeResolver = new RequestMemberTypeResolver();
 
     /// <summary>
     /// Gets or sets the current IRequestMemberTypeResolver.
     /// </summary>
     public IRequestMemberTypeResolver RequestMemberTypeResolver
     {
-        get => this.requestMemberTypeResolver;
-        set => this.requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
+        get => _requestMemberTypeResolver;
+        set => _requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ public class StringLengthAttributeRelay : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        if (!this.RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
+        if (!RequestMemberTypeResolver.TryGetMemberType(request, out var memberType))
         {
             return NoSpecimen.Instance;
         }

--- a/Src/AutoFixture/DecimalSequenceGenerator.cs
+++ b/Src/AutoFixture/DecimalSequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class DecimalSequenceGenerator : ISpecimenBuilder
 {
-    private decimal d;
-    private readonly object syncRoot;
+    private decimal _d;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Int64SequenceGenerator"/> class.
     /// </summary>
     public DecimalSequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -25,9 +25,9 @@ public class DecimalSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public decimal Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.d;
+            return ++_d;
         }
     }
 
@@ -37,7 +37,7 @@ public class DecimalSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public decimal CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <inheritdoc />
@@ -49,7 +49,7 @@ public class DecimalSequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/DefaultEngineParts.cs
+++ b/Src/AutoFixture/DefaultEngineParts.cs
@@ -12,7 +12,7 @@ namespace AutoFixture;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "This is not a 'collection' - it can't be modified.")]
 public class DefaultEngineParts : DefaultRelays
 {
-    private readonly IEnumerable<ISpecimenBuilder> primitiveBuilders;
+    private readonly IEnumerable<ISpecimenBuilder> _primitiveBuilders;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultEngineParts"/> class with
@@ -49,7 +49,7 @@ public class DefaultEngineParts : DefaultRelays
             throw new ArgumentNullException(nameof(primitiveBuilders));
         }
 
-        this.primitiveBuilders = primitiveBuilders;
+        _primitiveBuilders = primitiveBuilders;
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class DefaultEngineParts : DefaultRelays
     /// </returns>
     public override IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        var l = this.primitiveBuilders.ToList();
+        var l = _primitiveBuilders.ToList();
         var be = base.GetEnumerator();
         while (be.MoveNext())
         {

--- a/Src/AutoFixture/DefaultPrimitiveBuilders.cs
+++ b/Src/AutoFixture/DefaultPrimitiveBuilders.cs
@@ -58,6 +58,6 @@ public class DefaultPrimitiveBuilders : IEnumerable<ISpecimenBuilder>
     /// </returns>
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixture/DefaultRelays.cs
+++ b/Src/AutoFixture/DefaultRelays.cs
@@ -44,6 +44,6 @@ public class DefaultRelays : IEnumerable<ISpecimenBuilder>
     /// </returns>
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixture/DisposableTrackingCustomization.cs
+++ b/Src/AutoFixture/DisposableTrackingCustomization.cs
@@ -16,21 +16,21 @@ namespace AutoFixture;
 /// <seealso cref="DisposableTrackingBehavior"/>
 public class DisposableTrackingCustomization : ICustomization, IDisposable
 {
-    private readonly DisposableTrackingBehavior behavior;
+    private readonly DisposableTrackingBehavior _behavior;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DisposableTrackingCustomization"/> class.
     /// </summary>
     public DisposableTrackingCustomization()
     {
-        this.behavior = new DisposableTrackingBehavior();
+        _behavior = new DisposableTrackingBehavior();
     }
 
     /// <summary>
     /// Gets the behavior that this customization adds to <see cref="IFixture"/> instances.
     /// </summary>
     /// <seealso cref="DisposableTrackingBehavior"/>
-    public DisposableTrackingBehavior Behavior => this.behavior;
+    public DisposableTrackingBehavior Behavior => _behavior;
 
     /// <summary>
     /// Customizes the specified fixture by applying <see cref="Behavior"/>.
@@ -40,7 +40,7 @@ public class DisposableTrackingCustomization : ICustomization, IDisposable
     {
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-        fixture.Behaviors.Add(this.Behavior);
+        fixture.Behaviors.Add(Behavior);
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public class DisposableTrackingCustomization : ICustomization, IDisposable
     /// </summary>
     public void Dispose()
     {
-        this.Dispose(true);
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
@@ -63,7 +63,7 @@ public class DisposableTrackingCustomization : ICustomization, IDisposable
     {
         if (disposing)
         {
-            this.behavior.Dispose();
+            _behavior.Dispose();
         }
     }
 }

--- a/Src/AutoFixture/DomainName.cs
+++ b/Src/AutoFixture/DomainName.cs
@@ -13,7 +13,7 @@ public class DomainName
     /// </summary>
     public DomainName(string domainName)
     {
-        this.Domain = domainName ?? throw new ArgumentNullException(nameof(domainName));
+        Domain = domainName ?? throw new ArgumentNullException(nameof(domainName));
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ public class DomainName
     /// </returns>
     public override string ToString()
     {
-        return this.Domain;
+        return Domain;
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public class DomainName
     {
         if (obj is DomainName other)
         {
-            return this.Domain.Equals(other.Domain, StringComparison.Ordinal);
+            return Domain.Equals(other.Domain, StringComparison.Ordinal);
         }
         return base.Equals(obj);
     }
@@ -62,6 +62,6 @@ public class DomainName
     /// </returns>
     public override int GetHashCode()
     {
-        return HashCode.Combine(this.Domain);
+        return HashCode.Combine(Domain);
     }
 }

--- a/Src/AutoFixture/DomainNameGenerator.cs
+++ b/Src/AutoFixture/DomainNameGenerator.cs
@@ -8,7 +8,7 @@ namespace AutoFixture;
 /// </summary>
 public class DomainNameGenerator : ISpecimenBuilder
 {
-    private readonly ElementsBuilder<string> fictitiousDomainBuilder = new ElementsBuilder<string>(
+    private readonly ElementsBuilder<string> _fictitiousDomainBuilder = new ElementsBuilder<string>(
         "example.com",
         "example.net",
         "example.org");
@@ -21,7 +21,7 @@ public class DomainNameGenerator : ISpecimenBuilder
         if (request == null || !typeof(DomainName).Equals(request))
             return NoSpecimen.Instance;
 
-        var domainName = this.fictitiousDomainBuilder.Create(typeof(string), context) as string;
+        var domainName = _fictitiousDomainBuilder.Create(typeof(string), context) as string;
         if (domainName == null)
             return NoSpecimen.Instance;
 

--- a/Src/AutoFixture/DoubleSequenceGenerator.cs
+++ b/Src/AutoFixture/DoubleSequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class DoubleSequenceGenerator : ISpecimenBuilder
 {
-    private double d;
-    private readonly object syncRoot;
+    private double _d;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DoubleSequenceGenerator"/> class.
     /// </summary>
     public DoubleSequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -25,9 +25,9 @@ public class DoubleSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public double Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.d;
+            return ++_d;
         }
     }
 
@@ -37,7 +37,7 @@ public class DoubleSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public double CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <inheritdoc />
@@ -49,7 +49,7 @@ public class DoubleSequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -47,7 +47,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromSeed(Func<T, T> factory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromSeed(factory),
             when: n => n is NodeComposer<T>);
@@ -56,7 +56,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -65,7 +65,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory(Func<T> factory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -74,7 +74,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -83,7 +83,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -93,7 +93,7 @@ public class CompositeNodeComposer<T> :
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(
         Func<TInput1, TInput2, TInput3, T> factory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -103,7 +103,7 @@ public class CompositeNodeComposer<T> :
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(
         Func<TInput1, TInput2, TInput3, TInput4, T> factory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -122,7 +122,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> Do(Action<T> action)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).Do(action),
             when: n => n is NodeComposer<T>);
@@ -131,7 +131,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> OmitAutoProperties()
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).OmitAutoProperties(),
             when: n => n is NodeComposer<T>);
@@ -140,7 +140,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker),
             when: n => n is NodeComposer<T>);
@@ -149,7 +149,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, value),
             when: n => n is NodeComposer<T>);
@@ -158,7 +158,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueFactory),
             when: n => n is NodeComposer<T>);
@@ -167,7 +167,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueFactory),
             when: n => n is NodeComposer<T>);
@@ -176,7 +176,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, builder),
             when: n => n is NodeComposer<T>);
@@ -185,7 +185,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> WithAutoProperties()
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).WithAutoProperties(),
             when: n => n is NodeComposer<T>);
@@ -194,7 +194,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
     {
-        return (CompositeNodeComposer<T>)ReplaceNodes(
+        return (CompositeNodeComposer<T>)this.ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).Without(propertyPicker),
             when: n => n is NodeComposer<T>);

--- a/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositeNodeComposer.cs
@@ -41,13 +41,13 @@ public class CompositeNodeComposer<T> :
     /// <seealso cref="Node" />
     public CompositeNodeComposer(ISpecimenBuilderNode node)
     {
-        this.Node = node ?? throw new ArgumentNullException(nameof(node));
+        Node = node ?? throw new ArgumentNullException(nameof(node));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromSeed(Func<T, T> factory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromSeed(factory),
             when: n => n is NodeComposer<T>);
@@ -56,7 +56,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -65,7 +65,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory(Func<T> factory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -74,7 +74,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -83,7 +83,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -93,7 +93,7 @@ public class CompositeNodeComposer<T> :
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(
         Func<TInput1, TInput2, TInput3, T> factory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -103,7 +103,7 @@ public class CompositeNodeComposer<T> :
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(
         Func<TInput1, TInput2, TInput3, TInput4, T> factory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).FromFactory(factory),
             when: n => n is NodeComposer<T>);
@@ -122,7 +122,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> Do(Action<T> action)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).Do(action),
             when: n => n is NodeComposer<T>);
@@ -131,7 +131,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> OmitAutoProperties()
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).OmitAutoProperties(),
             when: n => n is NodeComposer<T>);
@@ -140,7 +140,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker),
             when: n => n is NodeComposer<T>);
@@ -149,7 +149,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, value),
             when: n => n is NodeComposer<T>);
@@ -158,7 +158,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueFactory),
             when: n => n is NodeComposer<T>);
@@ -167,7 +167,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, valueFactory),
             when: n => n is NodeComposer<T>);
@@ -176,7 +176,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).With(propertyPicker, builder),
             when: n => n is NodeComposer<T>);
@@ -185,7 +185,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> WithAutoProperties()
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).WithAutoProperties(),
             when: n => n is NodeComposer<T>);
@@ -194,7 +194,7 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
     {
-        return (CompositeNodeComposer<T>)this.ReplaceNodes(
+        return (CompositeNodeComposer<T>)ReplaceNodes(
             with: n =>
                 (NodeComposer<T>)((NodeComposer<T>)n).Without(propertyPicker),
             when: n => n is NodeComposer<T>);
@@ -219,15 +219,15 @@ public class CompositeNodeComposer<T> :
     /// <inheritdoc />
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Node.Create(request, context);
+        return Node.Create(request, context);
     }
 
     /// <inheritdoc />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Node;
+        yield return Node;
     }
 
     /// <inheritdoc />
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
+++ b/Src/AutoFixture/Dsl/CompositePostprocessComposer.cs
@@ -31,7 +31,7 @@ public class CompositePostprocessComposer<T> : IPostprocessComposer<T>
     /// <param name="composers">The composers to aggregate.</param>
     public CompositePostprocessComposer(params IPostprocessComposer<T>[] composers)
     {
-        this.Composers = composers ?? throw new ArgumentNullException(nameof(composers));
+        Composers = composers ?? throw new ArgumentNullException(nameof(composers));
     }
 
     /// <summary>
@@ -42,70 +42,70 @@ public class CompositePostprocessComposer<T> : IPostprocessComposer<T>
     /// <inheritdoc />
     public IPostprocessComposer<T> Do(Action<T> action)
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.Do(action));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> OmitAutoProperties()
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.OmitAutoProperties());
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.With(propertyPicker));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value)
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.With(propertyPicker, value));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.With(propertyPicker, valueFactory));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.With(propertyPicker, valueFactory));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.With(propertyPicker, builder));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> WithAutoProperties()
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.WithAutoProperties());
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker)
     {
-        return new CompositePostprocessComposer<T>(from c in this.Composers
+        return new CompositePostprocessComposer<T>(from c in Composers
             select c.Without(propertyPicker));
     }
 
     /// <inheritdoc />
     public object Create(object request, ISpecimenContext context)
     {
-        return new CompositeSpecimenBuilder(this.Composers)
+        return new CompositeSpecimenBuilder(Composers)
             .Create(request, context);
     }
 }

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -39,49 +39,49 @@ public class NodeComposer<T> :
     /// <seealso cref="Builder" />
     public NodeComposer(ISpecimenBuilder builder)
     {
-        this.Builder = builder;
+        Builder = builder;
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromSeed(Func<T, T> factory)
     {
-        return this.WithFactory(new SeededFactory<T>(factory));
+        return WithFactory(new SeededFactory<T>(factory));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory)
     {
-        return this.WithFactory(factory);
+        return WithFactory(factory);
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory(Func<T> factory)
     {
-        return this.WithFactory(new SpecimenFactory<T>(factory));
+        return WithFactory(new SpecimenFactory<T>(factory));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory)
     {
-        return this.WithFactory(new SpecimenFactory<TInput, T>(factory));
+        return WithFactory(new SpecimenFactory<TInput, T>(factory));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory)
     {
-        return this.WithFactory(new SpecimenFactory<TInput1, TInput2, T>(factory));
+        return WithFactory(new SpecimenFactory<TInput1, TInput2, T>(factory));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(Func<TInput1, TInput2, TInput3, T> factory)
     {
-        return this.WithFactory(new SpecimenFactory<TInput1, TInput2, TInput3, T>(factory));
+        return WithFactory(new SpecimenFactory<TInput1, TInput2, TInput3, T>(factory));
     }
 
     /// <inheritdoc />
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(Func<TInput1, TInput2, TInput3, TInput4, T> factory)
     {
-        return this.WithFactory(new SpecimenFactory<TInput1, TInput2, TInput3, TInput4, T>(factory));
+        return WithFactory(new SpecimenFactory<TInput1, TInput2, TInput3, TInput4, T>(factory));
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public class NodeComposer<T> :
         // If user later decide to enable properties population, we'll need this information
         // (e.g. if user does smth like fixture.Build().Without(x => x.P).OmitAutoProperties().WithAutoProperties()
         // the information from "Without" should not be missed)
-        return (NodeComposer<T>)this.ReplaceNodes(
+        return (NodeComposer<T>)ReplaceNodes(
             with: n => new Postprocessor(
                 autoPropertiesNode.Builder,
                 autoPropertiesNode.Command,
@@ -159,7 +159,7 @@ public class NodeComposer<T> :
     public IPostprocessComposer<T> With<TProperty>(
         Expression<Func<T, TProperty>> propertyPicker)
     {
-        return this.WithCommand(
+        return WithCommand(
             propertyPicker,
             new BindingCommand<T, TProperty>(propertyPicker));
     }
@@ -168,7 +168,7 @@ public class NodeComposer<T> :
     public IPostprocessComposer<T> With<TProperty>(
         Expression<Func<T, TProperty>> propertyPicker, TProperty value)
     {
-        return this.WithCommand(
+        return WithCommand(
             propertyPicker,
             new BindingCommand<T, TProperty>(propertyPicker, value));
     }
@@ -176,7 +176,7 @@ public class NodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory)
     {
-        return this.WithCommand(
+        return WithCommand(
             propertyPicker,
             new BindingCommand<T, TProperty>(propertyPicker, _ => valueFactory.Invoke()));
     }
@@ -184,7 +184,7 @@ public class NodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory)
     {
-        return this.WithCommand(
+        return WithCommand(
             propertyPicker,
             new BindingCommand<T, TProperty>(propertyPicker, context =>
             {
@@ -196,7 +196,7 @@ public class NodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder)
     {
-        return this.WithCommand(
+        return WithCommand(
             propertyPicker,
             new BindingCommand<T, TProperty>(propertyPicker,
                 c => (TProperty)builder.Create(typeof(TProperty), c)));
@@ -206,7 +206,7 @@ public class NodeComposer<T> :
     {
         ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);
 
-        var graphWithAutoPropertiesNode = this.GetGraphWithAutoPropertiesNode();
+        var graphWithAutoPropertiesNode = GetGraphWithAutoPropertiesNode();
         var graphWithoutSeedIgnoringRelay = WithoutSeedIgnoringRelay(graphWithAutoPropertiesNode);
 
         var container = FindContainer(graphWithoutSeedIgnoringRelay);
@@ -230,7 +230,7 @@ public class NodeComposer<T> :
     /// <inheritdoc />
     public IPostprocessComposer<T> WithAutoProperties()
     {
-        var g = this.GetGraphWithAutoPropertiesNode();
+        var g = GetGraphWithAutoPropertiesNode();
         var autoProperties = FindAutoPropertiesNode(g);
 
         return (NodeComposer<T>)g.ReplaceNodes(
@@ -249,7 +249,7 @@ public class NodeComposer<T> :
         ExpressionReflector.VerifyIsNonNestedWritableMemberExpression(propertyPicker);
 
         var member = propertyPicker.GetWritableMember().Member;
-        var graphWithAutoPropertiesNode = this.GetGraphWithAutoPropertiesNode();
+        var graphWithAutoPropertiesNode = GetGraphWithAutoPropertiesNode();
 
         return (NodeComposer<T>)ExcludeMemberFromAutoProperties(member, graphWithAutoPropertiesNode);
     }
@@ -268,14 +268,14 @@ public class NodeComposer<T> :
     public NodeComposer<T> WithAutoProperties(bool enable)
     {
         if (!enable)
-            return (NodeComposer<T>)this.OmitAutoProperties();
+            return (NodeComposer<T>)OmitAutoProperties();
 
-        return (NodeComposer<T>)this.WithAutoProperties();
+        return (NodeComposer<T>)WithAutoProperties();
     }
 
     private NodeComposer<T> WithFactory(ISpecimenBuilder factory)
     {
-        return (NodeComposer<T>)this.ReplaceNodes(
+        return (NodeComposer<T>)ReplaceNodes(
             with: n => n.Compose(new[] { factory }),
             when: n => n is NoSpecimenOutputGuard);
     }
@@ -300,17 +300,17 @@ public class NodeComposer<T> :
     /// <inheritdoc />
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Builder.Create(request, context);
+        return Builder.Create(request, context);
     }
 
     /// <inheritdoc />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     /// <inheritdoc />
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>
     /// Looks for the AutoProperties postprocessor in the current graph.

--- a/Src/AutoFixture/Dsl/NodeComposer.cs
+++ b/Src/AutoFixture/Dsl/NodeComposer.cs
@@ -147,7 +147,7 @@ public class NodeComposer<T> :
         // If user later decide to enable properties population, we'll need this information
         // (e.g. if user does smth like fixture.Build().Without(x => x.P).OmitAutoProperties().WithAutoProperties()
         // the information from "Without" should not be missed)
-        return (NodeComposer<T>)ReplaceNodes(
+        return (NodeComposer<T>)this.ReplaceNodes(
             with: n => new Postprocessor(
                 autoPropertiesNode.Builder,
                 autoPropertiesNode.Command,
@@ -275,7 +275,7 @@ public class NodeComposer<T> :
 
     private NodeComposer<T> WithFactory(ISpecimenBuilder factory)
     {
-        return (NodeComposer<T>)ReplaceNodes(
+        return (NodeComposer<T>)this.ReplaceNodes(
             with: n => n.Compose(new[] { factory }),
             when: n => n is NoSpecimenOutputGuard);
     }

--- a/Src/AutoFixture/Dsl/NullComposer.cs
+++ b/Src/AutoFixture/Dsl/NullComposer.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.Dsl;
 /// <typeparam name="T"></typeparam>
 public class NullComposer<T> : ICustomizationComposer<T>
 {
-    private readonly Func<ISpecimenBuilder> compose;
+    private readonly Func<ISpecimenBuilder> _compose;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NullComposer&lt;T&gt;"/> class.
@@ -30,7 +30,7 @@ public class NullComposer<T> : ICustomizationComposer<T>
     {
         if (builder == null) throw new ArgumentNullException(nameof(builder));
 
-        this.compose = () => builder;
+        _compose = () => builder;
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public class NullComposer<T> : ICustomizationComposer<T>
     /// </summary>
     public NullComposer(Func<ISpecimenBuilder> factory)
     {
-        this.compose = factory ?? throw new ArgumentNullException(nameof(factory));
+        _compose = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
     /// <inheritdoc />
@@ -101,12 +101,12 @@ public class NullComposer<T> : ICustomizationComposer<T>
     /// </remarks>
     public ISpecimenBuilder Compose()
     {
-        return this.compose();
+        return _compose();
     }
 
     /// <inheritdoc />
     public object Create(object request, ISpecimenContext context)
     {
-        return this.compose().Create(request, context);
+        return _compose().Create(request, context);
     }
 }

--- a/Src/AutoFixture/ElementsBuilder.cs
+++ b/Src/AutoFixture/ElementsBuilder.cs
@@ -10,8 +10,8 @@ namespace AutoFixture;
 /// </summary>
 public sealed class ElementsBuilder<T> : ISpecimenBuilder
 {
-    private readonly T[] elements;
-    private readonly RandomNumericSequenceGenerator sequence;
+    private readonly T[] _elements;
+    private readonly RandomNumericSequenceGenerator _sequence;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ElementsBuilder{T}"/> class.
@@ -28,9 +28,9 @@ public sealed class ElementsBuilder<T> : ISpecimenBuilder
     {
         if (elements == null) throw new ArgumentNullException(nameof(elements));
 
-        this.elements = elements.ToArray();
+        _elements = elements.ToArray();
 
-        if (this.elements.Length < 1)
+        if (_elements.Length < 1)
         {
             throw new ArgumentException(
                 "The supplied collection of elements must contain at least one element. " +
@@ -40,8 +40,8 @@ public sealed class ElementsBuilder<T> : ISpecimenBuilder
         }
 
         // The RandomNumericSequenceGenerator is only created for collections of minimum 2 elements
-        if (this.elements.Length > 1)
-            this.sequence = new RandomNumericSequenceGenerator(0, this.elements.Length - 1);
+        if (_elements.Length > 1)
+            _sequence = new RandomNumericSequenceGenerator(0, _elements.Length - 1);
     }
 
     /// <summary>
@@ -58,14 +58,14 @@ public sealed class ElementsBuilder<T> : ISpecimenBuilder
         if (!typeof(T).Equals(request))
             return NoSpecimen.Instance;
 
-        return this.elements[this.GetNextIndex()];
+        return _elements[GetNextIndex()];
     }
 
     private int GetNextIndex()
     {
-        if (this.elements.Length == 1)
+        if (_elements.Length == 1)
             return 0;
         else
-            return (int)this.sequence.Create(typeof(int));
+            return (int)_sequence.Create(typeof(int));
     }
 }

--- a/Src/AutoFixture/EmailAddressLocalPart.cs
+++ b/Src/AutoFixture/EmailAddressLocalPart.cs
@@ -26,7 +26,7 @@ public class EmailAddressLocalPart
         if (localPart == null) throw new ArgumentNullException(nameof(localPart));
         if (localPart.Length == 0) throw new ArgumentException("Value cannot be empty", nameof(localPart));
 
-        this.LocalPart = localPart;
+        LocalPart = localPart;
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class EmailAddressLocalPart
     {
         if (obj is EmailAddressLocalPart other)
         {
-            return this.LocalPart.Equals(other.LocalPart, StringComparison.Ordinal);
+            return LocalPart.Equals(other.LocalPart, StringComparison.Ordinal);
         }
 
         return base.Equals(obj);
@@ -65,7 +65,7 @@ public class EmailAddressLocalPart
     /// </returns>
     public override int GetHashCode()
     {
-        return HashCode.Combine(this.LocalPart);
+        return HashCode.Combine(LocalPart);
     }
 
     /// <summary>
@@ -76,6 +76,6 @@ public class EmailAddressLocalPart
     /// </returns>
     public override string ToString()
     {
-        return this.LocalPart;
+        return LocalPart;
     }
 }

--- a/Src/AutoFixture/EnumGenerator.cs
+++ b/Src/AutoFixture/EnumGenerator.cs
@@ -13,16 +13,16 @@ namespace AutoFixture;
 /// </summary>
 public class EnumGenerator : ISpecimenBuilder
 {
-    private readonly Dictionary<Type, IEnumerator> enumerators;
-    private readonly object syncRoot;
+    private readonly Dictionary<Type, IEnumerator> _enumerators;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EnumGenerator"/> class.
     /// </summary>
     public EnumGenerator()
     {
-        this.syncRoot = new object();
-        this.enumerators = new Dictionary<Type, IEnumerator>();
+        _syncRoot = new object();
+        _enumerators = new Dictionary<Type, IEnumerator>();
     }
 
     /// <summary>
@@ -52,15 +52,15 @@ public class EnumGenerator : ISpecimenBuilder
         if (!type.GetTypeInfo().IsEnum)
             return NoSpecimen.Instance;
 
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return this.CreateValue(type);
+            return CreateValue(type);
         }
     }
 
     private object CreateValue(Type t)
     {
-        var generator = this.EnsureGenerator(t);
+        var generator = EnsureGenerator(t);
         generator.MoveNext();
         return generator.Current;
     }
@@ -68,10 +68,10 @@ public class EnumGenerator : ISpecimenBuilder
     private IEnumerator EnsureGenerator(Type t)
     {
         IEnumerator enumerator = null;
-        if (!this.enumerators.TryGetValue(t, out enumerator))
+        if (!_enumerators.TryGetValue(t, out enumerator))
         {
             enumerator = new RoundRobinEnumEnumerable(t).GetEnumerator();
-            this.enumerators.Add(t, enumerator);
+            _enumerators.Add(t, enumerator);
         }
         return enumerator;
     }
@@ -80,7 +80,7 @@ public class EnumGenerator : ISpecimenBuilder
         Justification = "This is not a usual enumerable and for our purpose generic interface is not required.")]
     private class RoundRobinEnumEnumerable : IEnumerable
     {
-        private readonly IEnumerable<object> values;
+        private readonly IEnumerable<object> _values;
 
         internal RoundRobinEnumEnumerable(Type enumType)
         {
@@ -89,9 +89,9 @@ public class EnumGenerator : ISpecimenBuilder
                 throw new ArgumentNullException(nameof(enumType));
             }
 
-            this.values = Enum.GetValues(enumType).Cast<object>();
+            _values = Enum.GetValues(enumType).Cast<object>();
 
-            if (!this.values.Any())
+            if (!_values.Any())
             {
                 throw new ObjectCreationException(
                     string.Format(
@@ -106,7 +106,7 @@ public class EnumGenerator : ISpecimenBuilder
         {
             while (true)
             {
-                foreach (var obj in this.values)
+                foreach (var obj in _values)
                 {
                     yield return obj;
                 }

--- a/Src/AutoFixture/EnumerableExtensions.cs
+++ b/Src/AutoFixture/EnumerableExtensions.cs
@@ -9,7 +9,7 @@ namespace AutoFixture;
 
 internal static class EnumerableExtensions
 {
-    private static readonly MethodInfo BuildTypedArrayMethodInfo =
+    private static readonly MethodInfo s_buildTypedArrayMethodInfo =
         typeof(EnumerableExtensions).GetTypeInfo().GetMethod(
             nameof(BuildTypedArray),
             BindingFlags.Static | BindingFlags.NonPublic);
@@ -51,7 +51,7 @@ internal static class EnumerableExtensions
 
     public static object ToTypedArray(this IEnumerable items, Type elementType)
     {
-        return BuildTypedArrayMethodInfo.MakeGenericMethod(elementType).Invoke(null, new object[] { items });
+        return s_buildTypedArrayMethodInfo.MakeGenericMethod(elementType).Invoke(null, new object[] { items });
     }
 
     private static object BuildTypedArray<TElementType>(IEnumerable items)

--- a/Src/AutoFixture/Fixture.cs
+++ b/Src/AutoFixture/Fixture.cs
@@ -23,13 +23,13 @@ namespace AutoFixture;
                     "Besides, fixing this CA error would be a breaking change.")]
 public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
 {
-    private readonly MultipleRelay multiple;
+    private readonly MultipleRelay _multiple;
 
-    private ISpecimenBuilderNode graph;
+    private ISpecimenBuilderNode _graph;
 
-    private SingletonSpecimenBuilderNodeStackAdapterCollection behaviors;
-    private SpecimenBuilderNodeAdapterCollection customizer;
-    private SpecimenBuilderNodeAdapterCollection residueCollector;
+    private SingletonSpecimenBuilderNodeStackAdapterCollection _behaviors;
+    private SpecimenBuilderNodeAdapterCollection _customizer;
+    private SpecimenBuilderNodeAdapterCollection _residueCollector;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Fixture"/> class.
@@ -61,8 +61,8 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
         Justification = "This is the Façade that binds everything else together, so being coupled to many other types must follow.")]
     public Fixture(ISpecimenBuilder engine, MultipleRelay multiple)
     {
-        this.Engine = engine ?? throw new ArgumentNullException(nameof(engine));
-        this.multiple = multiple ?? throw new ArgumentNullException(nameof(multiple));
+        Engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _multiple = multiple ?? throw new ArgumentNullException(nameof(multiple));
 
         ISpecimenBuilderNode newGraph =
             new BehaviorRoot(
@@ -174,16 +174,16 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
                             new ValueTypeSpecification(),
                             new NoConstructorsSpecification())))));
 
-        this.UpdateGraphAndSetupAdapters(newGraph, Enumerable.Empty<ISpecimenBuilderTransformation>());
+        UpdateGraphAndSetupAdapters(newGraph, Enumerable.Empty<ISpecimenBuilderTransformation>());
 
-        this.Behaviors.Add(new ThrowingRecursionBehavior());
+        Behaviors.Add(new ThrowingRecursionBehavior());
     }
 
     /// <inheritdoc />
-    public IList<ISpecimenBuilderTransformation> Behaviors => this.behaviors;
+    public IList<ISpecimenBuilderTransformation> Behaviors => _behaviors;
 
     /// <inheritdoc />
-    public IList<ISpecimenBuilder> Customizations => this.customizer;
+    public IList<ISpecimenBuilder> Customizations => _customizer;
 
     /// <summary>
     /// Gets the core engine of the <see cref="Fixture"/> instance.
@@ -203,14 +203,14 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
     /// <inheritdoc />
     public bool OmitAutoProperties
     {
-        get => this.FindAutoPropertiesPostProcessor().Specification is FalseRequestSpecification;
+        get => FindAutoPropertiesPostProcessor().Specification is FalseRequestSpecification;
         set
         {
             IRequestSpecification newSpecification = value
                 ? new FalseRequestSpecification()
                 : new AnyTypeSpecification();
 
-            var existingPostProcessor = this.FindAutoPropertiesPostProcessor();
+            var existingPostProcessor = FindAutoPropertiesPostProcessor();
 
             // Optimization. Do nothing if no change is required (i.e. you set property to its current value).
             if (existingPostProcessor.Specification.GetType() == newSpecification.GetType())
@@ -221,11 +221,11 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
                 existingPostProcessor.Command,
                 newSpecification);
 
-            var updatedGraph = this.graph.ReplaceNodes(
+            var updatedGraph = _graph.ReplaceNodes(
                 with: updatedPostProcessor,
                 when: existingPostProcessor.Equals);
 
-            this.UpdateGraphAndSetupAdapters(updatedGraph);
+            UpdateGraphAndSetupAdapters(updatedGraph);
         }
     }
 
@@ -236,21 +236,21 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
     /// </summary>
     public int RepeatCount
     {
-        get => this.multiple.Count;
-        set => this.multiple.Count = value;
+        get => _multiple.Count;
+        set => _multiple.Count = value;
     }
 
     /// <inheritdoc />
-    public IList<ISpecimenBuilder> ResidueCollectors => this.residueCollector;
+    public IList<ISpecimenBuilder> ResidueCollectors => _residueCollector;
 
     /// <inheritdoc />
     [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter",
         Justification = "This method is required to be generic by design, so there is no way to refactor it.")]
     public ICustomizationComposer<T> Build<T>()
     {
-        var g = this.graph.ReplaceNodes(
+        var g = _graph.ReplaceNodes(
             with: n => new CompositeSpecimenBuilder(
-                SpecimenBuilderNodeFactory.CreateComposer<T>().WithAutoProperties(this.EnableAutoProperties),
+                SpecimenBuilderNodeFactory.CreateComposer<T>().WithAutoProperties(EnableAutoProperties),
                 n),
             when: n => n is BehaviorRoot);
 
@@ -271,8 +271,8 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
     {
         if (composerTransformation == null) throw new ArgumentNullException(nameof(composerTransformation));
 
-        var c = composerTransformation(SpecimenBuilderNodeFactory.CreateComposer<T>().WithAutoProperties(this.EnableAutoProperties));
-        this.customizer.Insert(0, c);
+        var c = composerTransformation(SpecimenBuilderNodeFactory.CreateComposer<T>().WithAutoProperties(EnableAutoProperties));
+        _customizer.Insert(0, c);
     }
 
     /// <inheritdoc />
@@ -281,7 +281,7 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
         if (request == null) throw new ArgumentNullException(nameof(request));
         if (context == null) throw new ArgumentNullException(nameof(context));
 
-        return this.graph.Create(request, context);
+        return _graph.Create(request, context);
     }
 
     /// <summary>
@@ -292,66 +292,66 @@ public class Fixture : IFixture, IEnumerable<ISpecimenBuilder>
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.graph;
+        yield return _graph;
     }
 
     /// <inheritdoc />
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 
-    private bool EnableAutoProperties => !this.OmitAutoProperties;
+    private bool EnableAutoProperties => !OmitAutoProperties;
 
     private void UpdateGraphAndSetupAdapters(ISpecimenBuilderNode newGraph)
     {
-        if (this.Behaviors == null)
+        if (Behaviors == null)
         {
             throw new InvalidOperationException(
                 "Behaviors should be already initialized. Please verify the method invocation logic to fix that.");
         }
 
-        this.UpdateGraphAndSetupAdapters(newGraph, this.Behaviors);
+        UpdateGraphAndSetupAdapters(newGraph, Behaviors);
     }
 
     private void UpdateGraphAndSetupAdapters(
         ISpecimenBuilderNode newGraph, IEnumerable<ISpecimenBuilderTransformation> existingBehaviors)
     {
-        this.graph = newGraph;
+        _graph = newGraph;
 
-        this.UpdateCustomizer();
-        this.UpdateResidueCollector();
-        this.UpdateBehaviors(existingBehaviors.ToArray());
+        UpdateCustomizer();
+        UpdateResidueCollector();
+        UpdateBehaviors(existingBehaviors.ToArray());
     }
 
     private void UpdateCustomizer()
     {
-        this.customizer =
+        _customizer =
             new SpecimenBuilderNodeAdapterCollection(
-                this.graph,
+                _graph,
                 n => n is CustomizationNode);
-        this.customizer.GraphChanged += (_, args) => this.UpdateGraphAndSetupAdapters(args.Graph);
+        _customizer.GraphChanged += (_, args) => UpdateGraphAndSetupAdapters(args.Graph);
     }
 
     private void UpdateResidueCollector()
     {
-        this.residueCollector =
+        _residueCollector =
             new SpecimenBuilderNodeAdapterCollection(
-                this.graph,
+                _graph,
                 n => n is ResidueCollectorNode);
-        this.residueCollector.GraphChanged += (_, args) => this.UpdateGraphAndSetupAdapters(args.Graph);
+        _residueCollector.GraphChanged += (_, args) => UpdateGraphAndSetupAdapters(args.Graph);
     }
 
     private void UpdateBehaviors(ISpecimenBuilderTransformation[] existingTransformations)
     {
-        this.behaviors =
+        _behaviors =
             new SingletonSpecimenBuilderNodeStackAdapterCollection(
-                this.graph,
+                _graph,
                 n => n is BehaviorRoot,
                 existingTransformations);
-        this.behaviors.GraphChanged += (_, args) => this.UpdateGraphAndSetupAdapters(args.Graph);
+        _behaviors.GraphChanged += (_, args) => UpdateGraphAndSetupAdapters(args.Graph);
     }
 
     private Postprocessor FindAutoPropertiesPostProcessor()
     {
-        var postprocessorHolder = (AutoPropertiesTarget)this.graph.FindFirstNode(b => b is AutoPropertiesTarget);
+        var postprocessorHolder = (AutoPropertiesTarget)_graph.FindFirstNode(b => b is AutoPropertiesTarget);
         return (Postprocessor)postprocessorHolder.Builder;
     }
 

--- a/Src/AutoFixture/FreezeOnMatchCustomization.cs
+++ b/Src/AutoFixture/FreezeOnMatchCustomization.cs
@@ -26,8 +26,8 @@ public class FreezeOnMatchCustomization : ICustomization
     /// </exception>
     public FreezeOnMatchCustomization(object request)
     {
-        this.Request = request ?? throw new ArgumentNullException(nameof(request));
-        this.Matcher = new EqualRequestSpecification(request);
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        Matcher = new EqualRequestSpecification(request);
     }
 
     /// <summary>
@@ -45,15 +45,15 @@ public class FreezeOnMatchCustomization : ICustomization
         object request,
         IRequestSpecification matcher)
     {
-        this.Request = request ?? throw new ArgumentNullException(nameof(request));
-        this.Matcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        Matcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
     }
 
     /// <summary>
     /// The <see cref="Type"/> of the frozen specimen.
     /// </summary>
     [Obsolete("Please use the Request property instead.")]
-    public Type TargetType => this.Request as Type;
+    public Type TargetType => Request as Type;
 
     /// <summary>
     /// The request used to resolve specimens. By default that is TargetType.
@@ -74,7 +74,7 @@ public class FreezeOnMatchCustomization : ICustomization
     {
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
-        this.FreezeSpecimenForMatchingRequests(fixture);
+        FreezeSpecimenForMatchingRequests(fixture);
     }
 
     private void FreezeSpecimenForMatchingRequests(IFixture fixture)
@@ -82,14 +82,14 @@ public class FreezeOnMatchCustomization : ICustomization
         fixture.Customizations.Insert(
             0,
             new FilteringSpecimenBuilder(
-                this.FreezeSpecimen(fixture),
-                this.Matcher));
+                FreezeSpecimen(fixture),
+                Matcher));
     }
 
     private ISpecimenBuilder FreezeSpecimen(IFixture fixture)
     {
         var context = new SpecimenContext(fixture);
-        var specimen = context.Resolve(this.Request);
+        var specimen = context.Resolve(Request);
         return new FixedBuilder(specimen);
     }
 }

--- a/Src/AutoFixture/FreezingCustomization.cs
+++ b/Src/AutoFixture/FreezingCustomization.cs
@@ -51,8 +51,8 @@ public class FreezingCustomization : ICustomization
             throw new ArgumentException(message);
         }
 
-        this.TargetType = targetType;
-        this.RegisteredType = registeredType;
+        TargetType = targetType;
+        RegisteredType = registeredType;
     }
 
     /// <summary>
@@ -78,13 +78,13 @@ public class FreezingCustomization : ICustomization
         if (fixture == null) throw new ArgumentNullException(nameof(fixture));
 
         var specimen = fixture.Create(
-            this.TargetType);
+            TargetType);
         var fixedBuilder = new FixedBuilder(specimen);
 
         var types = new[]
         {
-            this.TargetType,
-            this.RegisteredType
+            TargetType,
+            RegisteredType
         };
 
         var builder = new CompositeSpecimenBuilder(

--- a/Src/AutoFixture/Generator.cs
+++ b/Src/AutoFixture/Generator.cs
@@ -21,7 +21,7 @@ namespace AutoFixture;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "A Generator is (or ought to be) a generally known concept, based on the Iterator design pattern.")]
 public class Generator<T> : IEnumerable<T>
 {
-    private readonly ISpecimenBuilder builder;
+    private readonly ISpecimenBuilder _builder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Generator{T}" />
@@ -35,7 +35,7 @@ public class Generator<T> : IEnumerable<T>
     /// </exception>
     public Generator(ISpecimenBuilder builder)
     {
-        this.builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        _builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public class Generator<T> : IEnumerable<T>
     public IEnumerator<T> GetEnumerator()
     {
         while (true)
-            yield return this.builder.Create<T>();
+            yield return _builder.Create<T>();
     }
 
     /// <summary>
@@ -55,6 +55,6 @@ public class Generator<T> : IEnumerable<T>
     /// </returns>
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixture/Int16SequenceGenerator.cs
+++ b/Src/AutoFixture/Int16SequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class Int16SequenceGenerator : ISpecimenBuilder
 {
-    private short s;
-    private readonly object syncRoot;
+    private short _s;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Int16SequenceGenerator"/> class.
     /// </summary>
     public Int16SequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -26,9 +26,9 @@ public class Int16SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public short Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.s;
+            return ++_s;
         }
     }
 
@@ -40,7 +40,7 @@ public class Int16SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public short CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public class Int16SequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/Int32SequenceGenerator.cs
+++ b/Src/AutoFixture/Int32SequenceGenerator.cs
@@ -9,7 +9,7 @@ namespace AutoFixture;
 /// </summary>
 public class Int32SequenceGenerator : ISpecimenBuilder
 {
-    private int i;
+    private int _i;
 
     /// <summary>
     /// Creates an anonymous number.
@@ -18,7 +18,7 @@ public class Int32SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public int Create()
     {
-        return Interlocked.Increment(ref this.i);
+        return Interlocked.Increment(ref _i);
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ public class Int32SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public int CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class Int32SequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/Int64SequenceGenerator.cs
+++ b/Src/AutoFixture/Int64SequenceGenerator.cs
@@ -9,7 +9,7 @@ namespace AutoFixture;
 /// </summary>
 public class Int64SequenceGenerator : ISpecimenBuilder
 {
-    private long l;
+    private long _l;
 
     /// <summary>
     /// Creates an anonymous number.
@@ -18,7 +18,7 @@ public class Int64SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public long Create()
     {
-        return Interlocked.Increment(ref this.l);
+        return Interlocked.Increment(ref _l);
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ public class Int64SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public long CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class Int64SequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/InvariantCultureGenerator.cs
+++ b/Src/AutoFixture/InvariantCultureGenerator.cs
@@ -11,7 +11,7 @@ namespace AutoFixture;
 [Obsolete("Please use a 'AutoFixture.Kernel.FilteringSpecimenBuilder' instead.", true)]
 public class InvariantCultureGenerator : ISpecimenBuilder
 {
-    private readonly ExactTypeSpecification cultureTypeSpecification
+    private readonly ExactTypeSpecification _cultureTypeSpecification
         = new ExactTypeSpecification(typeof(CultureInfo));
 
     /// <summary>
@@ -30,7 +30,7 @@ public class InvariantCultureGenerator : ISpecimenBuilder
         if (request == null)
             return NoSpecimen.Instance;
 
-        if (!this.cultureTypeSpecification.IsSatisfiedBy(request))
+        if (!_cultureTypeSpecification.IsSatisfiedBy(request))
             return NoSpecimen.Instance;
 
         return CultureInfo.InvariantCulture;

--- a/Src/AutoFixture/Kernel/ActionSpecimenCommand.cs
+++ b/Src/AutoFixture/Kernel/ActionSpecimenCommand.cs
@@ -10,7 +10,7 @@ namespace AutoFixture.Kernel;
 /// </typeparam>
 public class ActionSpecimenCommand<T> : ISpecimenCommand
 {
-    private readonly Action<T, ISpecimenContext> action;
+    private readonly Action<T, ISpecimenContext> _action;
 
     /// <summary>
     /// Initializes a new instance of the
@@ -22,7 +22,7 @@ public class ActionSpecimenCommand<T> : ISpecimenCommand
     /// <seealso cref="ActionSpecimenCommand(Action{T, ISpecimenContext})" />
     public ActionSpecimenCommand(Action<T> action)
     {
-        this.action = (s, c) => action(s);
+        _action = (s, c) => action(s);
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public class ActionSpecimenCommand<T> : ISpecimenCommand
     /// <seealso cref="ActionSpecimenCommand(Action{T})" />
     public ActionSpecimenCommand(Action<T, ISpecimenContext> action)
     {
-        this.action = action;
+        _action = action;
     }
 
     /// <summary>Invokes the adapted action on the specimen.</summary>
@@ -54,6 +54,6 @@ public class ActionSpecimenCommand<T> : ISpecimenCommand
     /// <seealso cref="ActionSpecimenCommand(Action{T, ISpecimenContext})" />
     public void Execute(object specimen, ISpecimenContext context)
     {
-        this.action((T)specimen, context);
+        _action((T)specimen, context);
     }
 }

--- a/Src/AutoFixture/Kernel/AndPropertyQuery.cs
+++ b/Src/AutoFixture/Kernel/AndPropertyQuery.cs
@@ -18,7 +18,7 @@ public class AndPropertyQuery : IPropertyQuery
     /// <param name="queries">The queries that should be used to select properties.</param>
     public AndPropertyQuery(params IPropertyQuery[] queries)
     {
-        this.Queries = queries;
+        Queries = queries;
     }
 
     /// <summary>
@@ -33,9 +33,9 @@ public class AndPropertyQuery : IPropertyQuery
     /// <returns>Properties belonging to <paramref name="type"/> that meet <see cref="Queries"/>.</returns>
     public IEnumerable<PropertyInfo> SelectProperties(Type type)
     {
-        var properties = new HashSet<PropertyInfo>(this.Queries.First().SelectProperties(type));
+        var properties = new HashSet<PropertyInfo>(Queries.First().SelectProperties(type));
 
-        foreach (var query in this.Queries.Skip(1))
+        foreach (var query in Queries.Skip(1))
         {
             properties.IntersectWith(query.SelectProperties(type));
         }

--- a/Src/AutoFixture/Kernel/AndRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/AndRequestSpecification.cs
@@ -16,7 +16,7 @@ public class AndRequestSpecification : IRequestSpecification
     /// <param name="specifications">An array of <see cref="IRequestSpecification"/>.</param>
     public AndRequestSpecification(params IRequestSpecification[] specifications)
     {
-        this.Specifications = specifications ?? throw new ArgumentNullException(nameof(specifications));
+        Specifications = specifications ?? throw new ArgumentNullException(nameof(specifications));
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public class AndRequestSpecification : IRequestSpecification
     /// </returns>
     public bool IsSatisfiedBy(object request)
     {
-        return this.Specifications
+        return Specifications
             .Select(s => s.IsSatisfiedBy(request))
             .DefaultIfEmpty(false)
             .All(b => b);

--- a/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
+++ b/Src/AutoFixture/Kernel/ArrayFavoringConstructorQuery.cs
@@ -47,14 +47,14 @@ public class ArrayFavoringConstructorQuery : IMethodQuery
 
     private class ArrayParameterScore : IComparable<ArrayParameterScore>
     {
-        private readonly int score;
+        private readonly int _score;
 
         public ArrayParameterScore(IEnumerable<ParameterInfo> parameters)
         {
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));
 
-            this.score = CalculateScore(parameters);
+            _score = CalculateScore(parameters);
         }
 
         public int CompareTo(ArrayParameterScore other)
@@ -64,7 +64,7 @@ public class ArrayFavoringConstructorQuery : IMethodQuery
                 return 1;
             }
 
-            return this.score.CompareTo(other.score);
+            return _score.CompareTo(other._score);
         }
 
         private static int CalculateScore(IEnumerable<ParameterInfo> parameters)

--- a/Src/AutoFixture/Kernel/AsyncEnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/AsyncEnumerableRelay.cs
@@ -46,18 +46,18 @@ public class AsyncEnumerableRelay : ISpecimenBuilder
         Justification = "It's activated via reflection.")]
     private class SynchronousAsyncEnumerable<T> : IAsyncEnumerable<T>
     {
-        private readonly IEnumerable<T> enumerable;
+        private readonly IEnumerable<T> _enumerable;
 
         public SynchronousAsyncEnumerable(IEnumerable<object> enumerable)
         {
             if (enumerable is null) throw new ArgumentNullException(nameof(enumerable));
 
-            this.enumerable = enumerable.OfType<T>().ToList();
+            _enumerable = enumerable.OfType<T>().ToList();
         }
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
-            return new SynchronousAsyncEnumerator<T>(this.enumerable.GetEnumerator());
+            return new SynchronousAsyncEnumerator<T>(_enumerable.GetEnumerator());
         }
     }
 
@@ -65,13 +65,13 @@ public class AsyncEnumerableRelay : ISpecimenBuilder
         Justification = "It's activated via reflection.")]
     private class SynchronousAsyncEnumerator<T> : IAsyncEnumerator<T>
     {
-        private readonly IEnumerator<T> enumerator;
+        private readonly IEnumerator<T> _enumerator;
 
-        public T Current => this.enumerator.Current;
+        public T Current => _enumerator.Current;
 
         public SynchronousAsyncEnumerator(IEnumerator<T> enumerator)
         {
-            this.enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
+            _enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
         }
 
         public ValueTask DisposeAsync()
@@ -81,7 +81,7 @@ public class AsyncEnumerableRelay : ISpecimenBuilder
 
         public ValueTask<bool> MoveNextAsync()
         {
-            return new ValueTask<bool>(Task.FromResult(this.enumerator.MoveNext()));
+            return new ValueTask<bool>(Task.FromResult(_enumerator.MoveNext()));
         }
     }
 }

--- a/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
+++ b/Src/AutoFixture/Kernel/AutoPropertiesCommand.cs
@@ -35,7 +35,7 @@ public class AutoPropertiesCommand : AutoPropertiesCommand<object>
     /// </remarks>
     public AutoPropertiesCommand()
     {
-        this.ExplicitSpecimenType = null;
+        ExplicitSpecimenType = null;
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ public class AutoPropertiesCommand : AutoPropertiesCommand<object>
     /// <param name="specimenType">The specimen type on which properties are assigned.</param>
     public AutoPropertiesCommand(Type specimenType)
     {
-        this.ExplicitSpecimenType = specimenType ?? throw new ArgumentNullException(nameof(specimenType));
+        ExplicitSpecimenType = specimenType ?? throw new ArgumentNullException(nameof(specimenType));
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public class AutoPropertiesCommand : AutoPropertiesCommand<object>
     public AutoPropertiesCommand(IRequestSpecification specification)
         : base(specification)
     {
-        this.ExplicitSpecimenType = null;
+        ExplicitSpecimenType = null;
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public class AutoPropertiesCommand : AutoPropertiesCommand<object>
     public AutoPropertiesCommand(Type specimenType, IRequestSpecification specification)
         : base(specification)
     {
-        this.ExplicitSpecimenType = specimenType ?? throw new ArgumentNullException(nameof(specimenType));
+        ExplicitSpecimenType = specimenType ?? throw new ArgumentNullException(nameof(specimenType));
     }
 
     /// <inheritdoc />
@@ -92,7 +92,7 @@ public class AutoPropertiesCommand : AutoPropertiesCommand<object>
     {
         if (specimen == null) throw new ArgumentNullException(nameof(specimen));
 
-        return this.ExplicitSpecimenType ?? specimen.GetType();
+        return ExplicitSpecimenType ?? specimen.GetType();
     }
 }
 
@@ -136,7 +136,7 @@ public class AutoPropertiesCommand<T> : ISpecimenCommand, ObsoletedMemberShims.I
             throw new ArgumentNullException(nameof(specification));
         }
 
-        this.Specification = specification;
+        Specification = specification;
     }
 
     /// <summary>
@@ -160,14 +160,14 @@ public class AutoPropertiesCommand<T> : ISpecimenCommand, ObsoletedMemberShims.I
             throw new ArgumentNullException(nameof(context));
         }
 
-        foreach (var pi in this.GetProperties(specimen))
+        foreach (var pi in GetProperties(specimen))
         {
             var propertyValue = context.Resolve(pi);
             if (!(propertyValue is OmitSpecimen))
                 pi.SetValue(specimen, propertyValue, null);
         }
 
-        foreach (var fi in this.GetFields(specimen))
+        foreach (var fi in GetFields(specimen))
         {
             var fieldValue = context.Resolve(fi);
             if (!(fieldValue is OmitSpecimen))
@@ -192,12 +192,12 @@ public class AutoPropertiesCommand<T> : ISpecimenCommand, ObsoletedMemberShims.I
             throw new ArgumentNullException(nameof(request));
         }
 
-        if (this.GetProperties(request).Any(pi => pi.Equals(request)))
+        if (GetProperties(request).Any(pi => pi.Equals(request)))
         {
             return true;
         }
 
-        if (this.GetFields(request).Any(fi => fi.Equals(request)))
+        if (GetFields(request).Any(fi => fi.Equals(request)))
         {
             return true;
         }
@@ -223,18 +223,18 @@ public class AutoPropertiesCommand<T> : ISpecimenCommand, ObsoletedMemberShims.I
 
     private IEnumerable<FieldInfo> GetFields(object specimen)
     {
-        return from fi in this.GetSpecimenType(specimen).GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance)
+        return from fi in GetSpecimenType(specimen).GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance)
             where !fi.IsInitOnly
-                  && this.Specification.IsSatisfiedBy(fi)
+                  && Specification.IsSatisfiedBy(fi)
             select fi;
     }
 
     private IEnumerable<PropertyInfo> GetProperties(object specimen)
     {
-        return from pi in this.GetSpecimenType(specimen).GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        return from pi in GetSpecimenType(specimen).GetTypeInfo().GetProperties(BindingFlags.Public | BindingFlags.Instance)
             where pi.GetSetMethod() != null
                   && pi.GetIndexParameters().Length == 0
-                  && this.Specification.IsSatisfiedBy(pi)
+                  && Specification.IsSatisfiedBy(pi)
             select pi;
     }
 
@@ -248,14 +248,14 @@ public class AutoPropertiesCommand<T> : ISpecimenCommand, ObsoletedMemberShims.I
         if (context == null)
             throw new ArgumentNullException(nameof(context));
 
-        foreach (var pi in this.GetProperties(specimen))
+        foreach (var pi in GetProperties(specimen))
         {
             var propertyValue = context.Resolve(pi);
             if (!(propertyValue is OmitSpecimen))
                 pi.SetValue(specimen, propertyValue, null);
         }
 
-        foreach (var fi in this.GetFields(specimen))
+        foreach (var fi in GetFields(specimen))
         {
             var fieldValue = context.Resolve(fi);
             if (!(fieldValue is OmitSpecimen))

--- a/Src/AutoFixture/Kernel/BindingCommand.cs
+++ b/Src/AutoFixture/Kernel/BindingCommand.cs
@@ -32,8 +32,8 @@ public class BindingCommand<T, TProperty> : ISpecimenCommand, ObsoletedMemberShi
     {
         if (propertyPicker is null) throw new ArgumentNullException(nameof(propertyPicker));
 
-        this.Member = propertyPicker.GetWritableMember().Member;
-        this.ValueCreator = this.CreateAnonymousValue;
+        Member = propertyPicker.GetWritableMember().Member;
+        ValueCreator = CreateAnonymousValue;
     }
 
     /// <summary>
@@ -65,8 +65,8 @@ public class BindingCommand<T, TProperty> : ISpecimenCommand, ObsoletedMemberShi
         if (propertyPicker is null) throw new ArgumentNullException(nameof(propertyPicker));
         if (valueCreator is null) throw new ArgumentNullException(nameof(valueCreator));
 
-        this.Member = propertyPicker.GetWritableMember().Member;
-        this.ValueCreator = valueCreator;
+        Member = propertyPicker.GetWritableMember().Member;
+        ValueCreator = valueCreator;
     }
 
     /// <summary>
@@ -104,14 +104,14 @@ public class BindingCommand<T, TProperty> : ISpecimenCommand, ObsoletedMemberShi
         if (specimen is null) throw new ArgumentNullException(nameof(specimen));
         if (context is null) throw new ArgumentNullException(nameof(context));
 
-        var bindingValue = this.ValueCreator(context);
+        var bindingValue = ValueCreator(context);
 
-        if (this.Member is PropertyInfo pi)
+        if (Member is PropertyInfo pi)
         {
             pi.SetValue(specimen, bindingValue, null);
         }
 
-        if (this.Member is FieldInfo fi)
+        if (Member is FieldInfo fi)
         {
             fi.SetValue(specimen, bindingValue);
         }
@@ -132,12 +132,12 @@ public class BindingCommand<T, TProperty> : ISpecimenCommand, ObsoletedMemberShi
         if (request is null) throw new ArgumentNullException(nameof(request));
 
         IEqualityComparer comparer = new MemberInfoEqualityComparer();
-        return comparer.Equals(this.Member, request);
+        return comparer.Equals(Member, request);
     }
 
     private TProperty CreateAnonymousValue(ISpecimenContext container)
     {
-        var bindingValue = container.Resolve(this.Member);
+        var bindingValue = container.Resolve(Member);
         if (bindingValue is not null and not TProperty)
         {
             throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
@@ -163,9 +163,9 @@ public class BindingCommand<T, TProperty> : ISpecimenCommand, ObsoletedMemberShi
         if (specimen is null) throw new ArgumentNullException(nameof(specimen));
         if (context is null) throw new ArgumentNullException(nameof(context));
 
-        var bindingValue = this.ValueCreator(context);
+        var bindingValue = ValueCreator(context);
 
-        if (this.Member is PropertyInfo pi)
+        if (Member is PropertyInfo pi)
         {
             TrySetValue(
                 specimen,
@@ -174,7 +174,7 @@ public class BindingCommand<T, TProperty> : ISpecimenCommand, ObsoletedMemberShi
                 (s, v) => pi.SetValue(s, v, null));
         }
 
-        if (this.Member is FieldInfo fi)
+        if (Member is FieldInfo fi)
         {
             TrySetValue(
                 specimen,

--- a/Src/AutoFixture/Kernel/CompositeMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/CompositeMethodQuery.cs
@@ -24,7 +24,7 @@ public class CompositeMethodQuery : IMethodQuery
     /// <param name="queries">The queries.</param>
     public CompositeMethodQuery(params IMethodQuery[] queries)
     {
-        this.Queries = queries ?? throw new ArgumentNullException(nameof(queries));
+        Queries = queries ?? throw new ArgumentNullException(nameof(queries));
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public class CompositeMethodQuery : IMethodQuery
     /// <returns>Methods for <paramref name="type"/>.</returns>
     public IEnumerable<IMethod> SelectMethods(Type type)
     {
-        return from q in this.Queries
+        return from q in Queries
             from m in q.SelectMethods(type)
             select m;
     }

--- a/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenBuilder.cs
@@ -10,7 +10,7 @@ namespace AutoFixture.Kernel;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
 public class CompositeSpecimenBuilder : ISpecimenBuilderNode
 {
-    private readonly ISpecimenBuilder[] composedBuilders;
+    private readonly ISpecimenBuilder[] _composedBuilders;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CompositeSpecimenBuilder"/> class with the
@@ -29,13 +29,13 @@ public class CompositeSpecimenBuilder : ISpecimenBuilderNode
     /// <param name="builders">The child builders.</param>
     public CompositeSpecimenBuilder(params ISpecimenBuilder[] builders)
     {
-        this.composedBuilders = builders ?? throw new ArgumentNullException(nameof(builders));
+        _composedBuilders = builders ?? throw new ArgumentNullException(nameof(builders));
     }
 
     /// <summary>
     /// Gets the child builders.
     /// </summary>
-    public IEnumerable<ISpecimenBuilder> Builders => this.composedBuilders;
+    public IEnumerable<ISpecimenBuilder> Builders => _composedBuilders;
 
     /// <summary>
     /// Creates a new specimen by delegating to <see cref="Builders"/>.
@@ -47,9 +47,9 @@ public class CompositeSpecimenBuilder : ISpecimenBuilderNode
     {
         // This is performance-sensitive code when used repeatedly over many requests.
         // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
-        for (int i = 0; i < this.composedBuilders.Length; i++)
+        for (int i = 0; i < _composedBuilders.Length; i++)
         {
-            var result = this.composedBuilders[i].Create(request, context);
+            var result = _composedBuilders[i].Create(request, context);
             if (!(result is NoSpecimen)) return result;
         }
 
@@ -76,7 +76,7 @@ public class CompositeSpecimenBuilder : ISpecimenBuilderNode
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        return this.composedBuilders.AsEnumerable().GetEnumerator();
+        return _composedBuilders.AsEnumerable().GetEnumerator();
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public class CompositeSpecimenBuilder : ISpecimenBuilderNode
     /// </returns>
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     internal static ISpecimenBuilder ComposeIfMultiple(IEnumerable<ISpecimenBuilder> builders)
@@ -142,10 +142,10 @@ public class CompositeSpecimenBuilder : ISpecimenBuilderNode
         var c = node as CompositeSpecimenBuilder;
         if (c == null)
             return node;
-        var isSingle = c.composedBuilders.Length == 1;
+        var isSingle = c._composedBuilders.Length == 1;
         if (isSingle)
         {
-            if (c.composedBuilders[0] is ISpecimenBuilderNode n)
+            if (c._composedBuilders[0] is ISpecimenBuilderNode n)
                 return n;
         }
         return node;

--- a/Src/AutoFixture/Kernel/CompositeSpecimenCommand.cs
+++ b/Src/AutoFixture/Kernel/CompositeSpecimenCommand.cs
@@ -10,7 +10,7 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class CompositeSpecimenCommand : ISpecimenCommand
 {
-    private readonly ISpecimenCommand[] commands;
+    private readonly ISpecimenCommand[] _commands;
 
     /// <summary>
     /// Initializes a new instance of <see cref="CompositeSpecimenCommand"/> class with the supplied set of commands.
@@ -27,13 +27,13 @@ public class CompositeSpecimenCommand : ISpecimenCommand
     /// <param name="commands">The child commands.</param>
     public CompositeSpecimenCommand(params ISpecimenCommand[] commands)
     {
-        this.commands = commands ?? throw new ArgumentNullException(nameof(commands));
+        _commands = commands ?? throw new ArgumentNullException(nameof(commands));
     }
 
     /// <summary>
     /// Gets the child commands.
     /// </summary>
-    public IEnumerable<ISpecimenCommand> Commands => this.commands;
+    public IEnumerable<ISpecimenCommand> Commands => _commands;
 
     /// <summary>
     /// Executes all child commands using a given specimen and context.
@@ -42,7 +42,7 @@ public class CompositeSpecimenCommand : ISpecimenCommand
     /// <param name="context">The context of <paramref name="specimen"/>.</param>
     public void Execute(object specimen, ISpecimenContext context)
     {
-        foreach (var command in this.commands)
+        foreach (var command in _commands)
         {
             command.Execute(specimen, context);
         }

--- a/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
+++ b/Src/AutoFixture/Kernel/ConstrainedStringRequest.cs
@@ -29,8 +29,8 @@ public class ConstrainedStringRequest : IEquatable<ConstrainedStringRequest>
             throw new ArgumentOutOfRangeException(nameof(maximumLength), "Maximum length must be equal or greater than Minimum length.");
         }
 
-        this.MinimumLength = minimumLength;
-        this.MaximumLength = maximumLength;
+        MinimumLength = minimumLength;
+        MaximumLength = maximumLength;
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class ConstrainedStringRequest : IEquatable<ConstrainedStringRequest>
     {
         if (obj is ConstrainedStringRequest other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
 
         return base.Equals(obj);
@@ -80,8 +80,8 @@ public class ConstrainedStringRequest : IEquatable<ConstrainedStringRequest>
     /// </returns>
     public override int GetHashCode()
     {
-        return this.MinimumLength.GetHashCode()
-               ^ this.MaximumLength.GetHashCode();
+        return MinimumLength.GetHashCode()
+               ^ MaximumLength.GetHashCode();
     }
 
     /// <summary>
@@ -98,7 +98,7 @@ public class ConstrainedStringRequest : IEquatable<ConstrainedStringRequest>
             return false;
         }
 
-        return this.MinimumLength == other.MinimumLength &&
-               this.MaximumLength == other.MaximumLength;
+        return MinimumLength == other.MinimumLength &&
+               MaximumLength == other.MaximumLength;
     }
 }

--- a/Src/AutoFixture/Kernel/ConstructorMethod.cs
+++ b/Src/AutoFixture/Kernel/ConstructorMethod.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class ConstructorMethod : IMethod, IEquatable<ConstructorMethod>
 {
-    private readonly ParameterInfo[] paramInfos;
+    private readonly ParameterInfo[] _paramInfos;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConstructorMethod"/> class.
@@ -19,8 +19,8 @@ public class ConstructorMethod : IMethod, IEquatable<ConstructorMethod>
     /// <param name="constructor">The constructor.</param>
     public ConstructorMethod(ConstructorInfo constructor)
     {
-        this.Constructor = constructor ?? throw new ArgumentNullException(nameof(constructor));
-        this.paramInfos = this.Constructor.GetParameters();
+        Constructor = constructor ?? throw new ArgumentNullException(nameof(constructor));
+        _paramInfos = Constructor.GetParameters();
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public class ConstructorMethod : IMethod, IEquatable<ConstructorMethod>
     {
         if (obj is ConstructorMethod other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
         return base.Equals(obj);
     }
@@ -54,13 +54,13 @@ public class ConstructorMethod : IMethod, IEquatable<ConstructorMethod>
     /// </returns>
     public override int GetHashCode()
     {
-        return this.Constructor.GetHashCode();
+        return Constructor.GetHashCode();
     }
 
     /// <summary>
     /// Gets information about the parameters of the method.
     /// </summary>
-    public IEnumerable<ParameterInfo> Parameters => this.paramInfos;
+    public IEnumerable<ParameterInfo> Parameters => _paramInfos;
 
     /// <summary>
     /// Invokes the method with the supplied parameters.
@@ -69,7 +69,7 @@ public class ConstructorMethod : IMethod, IEquatable<ConstructorMethod>
     /// <returns>The result of the method call.</returns>
     public object Invoke(IEnumerable<object> parameters)
     {
-        if (this.Constructor.DeclaringType.GetTypeInfo().IsAbstract && this.Constructor.IsPublic)
+        if (Constructor.DeclaringType.GetTypeInfo().IsAbstract && Constructor.IsPublic)
         {
             throw new ObjectCreationException(
                 string.Format(
@@ -86,9 +86,9 @@ fixture.Customizations.Add(
         typeof(TestDouble)));
 
 This will cause AutoFixture to create an instance of TestDouble every time AbstractClassWithPublicConstructor is requested. However, please keep in mind that this is only a workaround for the case where you can't address the root cause, which is that an abstract class has a public constructor.",
-                    this.Constructor.DeclaringType.Name));
+                    Constructor.DeclaringType.Name));
         }
-        return this.Constructor.Invoke(parameters.ToArray());
+        return Constructor.Invoke(parameters.ToArray());
     }
 
     /// <summary>
@@ -106,6 +106,6 @@ This will cause AutoFixture to create an instance of TestDouble every time Abstr
             return false;
         }
 
-        return this.Constructor.Equals(other.Constructor);
+        return Constructor.Equals(other.Constructor);
     }
 }

--- a/Src/AutoFixture/Kernel/Criterion.cs
+++ b/Src/AutoFixture/Kernel/Criterion.cs
@@ -44,8 +44,8 @@ public class Criterion<T> : IEquatable<T>
     /// <seealso cref="Comparer" />
     public Criterion(T target, IEqualityComparer<T> comparer)
     {
-        this.Target = target;
-        this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        Target = target;
+        Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ public class Criterion<T> : IEquatable<T>
     /// </remarks>
     public bool Equals(T other)
     {
-        return this.Comparer.Equals(this.Target, other);
+        return Comparer.Equals(Target, other);
     }
 
     /// <summary>
@@ -84,8 +84,8 @@ public class Criterion<T> : IEquatable<T>
     public override bool Equals(object obj)
     {
         if (obj is Criterion<T> other &&
-            Equals(this.Target, other.Target) &&
-            Equals(this.Comparer, other.Comparer))
+            Equals(Target, other.Target) &&
+            Equals(Comparer, other.Comparer))
         {
             return true;
         }
@@ -110,6 +110,6 @@ public class Criterion<T> : IEquatable<T>
     /// <returns>The hash code.</returns>
     public override int GetHashCode()
     {
-        return this.Target.GetHashCode() ^ this.Comparer.GetHashCode();
+        return Target.GetHashCode() ^ Comparer.GetHashCode();
     }
 }

--- a/Src/AutoFixture/Kernel/DelegateGenerator.cs
+++ b/Src/AutoFixture/Kernel/DelegateGenerator.cs
@@ -29,7 +29,7 @@ public class DelegateGenerator : ISpecimenBuilder
     /// </summary>
     public DelegateGenerator(IRequestSpecification delegateSpecification)
     {
-        this.Specification = delegateSpecification ?? throw new ArgumentNullException(nameof(delegateSpecification));
+        Specification = delegateSpecification ?? throw new ArgumentNullException(nameof(delegateSpecification));
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class DelegateGenerator : ISpecimenBuilder
         if (delegateType == null)
             return NoSpecimen.Instance;
 
-        if (!this.Specification.IsSatisfiedBy(delegateType))
+        if (!Specification.IsSatisfiedBy(delegateType))
             return NoSpecimen.Instance;
 
         var delegateMethod = delegateType.GetTypeInfo().GetMethod("Invoke");

--- a/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/DirectBaseTypeSpecification.cs
@@ -21,7 +21,7 @@ public class DirectBaseTypeSpecification : IRequestSpecification
     /// </exception>
     public DirectBaseTypeSpecification(Type targetType)
     {
-        this.TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+        TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public class DirectBaseTypeSpecification : IRequestSpecification
         if (request == null) throw new ArgumentNullException(nameof(request));
 
         return IsRequestForType(request) &&
-               this.IsTargetTypeOrItsDirectBase(request);
+               IsTargetTypeOrItsDirectBase(request);
     }
 
     private static bool IsRequestForType(object request)
@@ -53,17 +53,17 @@ public class DirectBaseTypeSpecification : IRequestSpecification
 
     private bool IsTargetTypeOrItsDirectBase(object request)
     {
-        return this.IsSameAsTargetType(request) ||
-               this.IsDirectBaseOfTargetType(request);
+        return IsSameAsTargetType(request) ||
+               IsDirectBaseOfTargetType(request);
     }
 
     private bool IsSameAsTargetType(object request)
     {
-        return (Type)request == this.TargetType;
+        return (Type)request == TargetType;
     }
 
     private bool IsDirectBaseOfTargetType(object request)
     {
-        return (Type)request == this.TargetType.GetTypeInfo().BaseType;
+        return (Type)request == TargetType.GetTypeInfo().BaseType;
     }
 }

--- a/Src/AutoFixture/Kernel/DisposableTracker.cs
+++ b/Src/AutoFixture/Kernel/DisposableTracker.cs
@@ -18,7 +18,7 @@ namespace AutoFixture.Kernel;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
 public class DisposableTracker : ISpecimenBuilderNode, IDisposable
 {
-    private readonly HashSet<IDisposable> disposables;
+    private readonly HashSet<IDisposable> _disposables;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DisposableTracker"/> class.
@@ -32,8 +32,8 @@ public class DisposableTracker : ISpecimenBuilderNode, IDisposable
     /// </remarks>
     public DisposableTracker(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.disposables = new HashSet<IDisposable>();
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        _disposables = new HashSet<IDisposable>();
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class DisposableTracker : ISpecimenBuilderNode, IDisposable
     /// method.
     /// </para>
     /// </remarks>
-    public IEnumerable<IDisposable> Disposables => this.disposables;
+    public IEnumerable<IDisposable> Disposables => _disposables;
 
     /// <summary>
     /// Creates a new specimen based on a request.
@@ -77,10 +77,10 @@ public class DisposableTracker : ISpecimenBuilderNode, IDisposable
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        var specimen = this.Builder.Create(request, context);
+        var specimen = Builder.Create(request, context);
         if (specimen is IDisposable d)
         {
-            this.disposables.Add(d);
+            _disposables.Add(d);
         }
         return specimen;
     }
@@ -97,7 +97,7 @@ public class DisposableTracker : ISpecimenBuilderNode, IDisposable
 
         var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
         var d = new DisposableTracker(composedBuilder);
-        this.disposables.Add(d);
+        _disposables.Add(d);
         return d;
     }
 
@@ -110,12 +110,12 @@ public class DisposableTracker : ISpecimenBuilderNode, IDisposable
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ public class DisposableTracker : ISpecimenBuilderNode, IDisposable
     /// </summary>
     public void Dispose()
     {
-        this.Dispose(true);
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
@@ -140,11 +140,11 @@ public class DisposableTracker : ISpecimenBuilderNode, IDisposable
     {
         if (disposing)
         {
-            foreach (var d in this.Disposables)
+            foreach (var d in Disposables)
             {
                 d.Dispose();
             }
-            this.disposables.Clear();
+            _disposables.Clear();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/DisposableTrackingBehavior.cs
+++ b/Src/AutoFixture/Kernel/DisposableTrackingBehavior.cs
@@ -10,14 +10,14 @@ namespace AutoFixture.Kernel;
 /// <seealso cref="DisposableTracker"/>
 public class DisposableTrackingBehavior : ISpecimenBuilderTransformation, IDisposable
 {
-    private readonly List<DisposableTracker> trackers;
+    private readonly List<DisposableTracker> _trackers;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DisposableTrackingBehavior"/> class.
     /// </summary>
     public DisposableTrackingBehavior()
     {
-        this.trackers = new List<DisposableTracker>();
+        _trackers = new List<DisposableTracker>();
     }
 
     /// <summary>
@@ -25,7 +25,7 @@ public class DisposableTrackingBehavior : ISpecimenBuilderTransformation, IDispo
     /// invoked, a new <see cref="DisposableTracker"/> instance is created and added to this
     /// list.
     /// </summary>
-    public IEnumerable<DisposableTracker> Trackers => this.trackers;
+    public IEnumerable<DisposableTracker> Trackers => _trackers;
 
     /// <summary>
     /// Decorates the supplied builder with a <see cref="DisposableTracker"/>.
@@ -43,7 +43,7 @@ public class DisposableTrackingBehavior : ISpecimenBuilderTransformation, IDispo
     public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
     {
         var tracker = new DisposableTracker(builder);
-        this.trackers.Add(tracker);
+        _trackers.Add(tracker);
         return tracker;
     }
 
@@ -52,7 +52,7 @@ public class DisposableTrackingBehavior : ISpecimenBuilderTransformation, IDispo
     /// </summary>
     public void Dispose()
     {
-        this.Dispose(true);
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
@@ -67,11 +67,11 @@ public class DisposableTrackingBehavior : ISpecimenBuilderTransformation, IDispo
     {
         if (disposing)
         {
-            foreach (var t in this.Trackers)
+            foreach (var t in Trackers)
             {
                 t.Dispose();
             }
-            this.trackers.Clear();
+            _trackers.Clear();
         }
     }
 }

--- a/Src/AutoFixture/Kernel/EnumerableRelay.cs
+++ b/Src/AutoFixture/Kernel/EnumerableRelay.cs
@@ -57,22 +57,22 @@ public class EnumerableRelay : ISpecimenBuilder
         Justification = "It's activated via reflection.")]
     private class ConvertedEnumerable<T> : IEnumerable<T>
     {
-        private readonly IEnumerable<object> enumerable;
+        private readonly IEnumerable<object> _enumerable;
 
         public ConvertedEnumerable(IEnumerable<object> enumerable)
         {
-            this.enumerable = enumerable ?? throw new ArgumentNullException(nameof(enumerable));
+            _enumerable = enumerable ?? throw new ArgumentNullException(nameof(enumerable));
         }
 
         public IEnumerator<T> GetEnumerator()
         {
-            foreach (var item in this.enumerable)
+            foreach (var item in _enumerable)
             {
                 if (item is T variable)
                     yield return variable;
             }
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/Src/AutoFixture/Kernel/EqualRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/EqualRequestSpecification.cs
@@ -22,8 +22,8 @@ public class EqualRequestSpecification : IRequestSpecification
     /// </summary>
     public EqualRequestSpecification(object target, IEqualityComparer comparer)
     {
-        this.Target = target ?? throw new ArgumentNullException(nameof(target));
-        this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        Target = target ?? throw new ArgumentNullException(nameof(target));
+        Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ public class EqualRequestSpecification : IRequestSpecification
     /// </summary>
     public bool IsSatisfiedBy(object request)
     {
-        return this.Comparer.Equals(this.Target, request);
+        return Comparer.Equals(Target, request);
     }
 
     /// <summary>

--- a/Src/AutoFixture/Kernel/ExactTypeSpecification.cs
+++ b/Src/AutoFixture/Kernel/ExactTypeSpecification.cs
@@ -15,7 +15,7 @@ public class ExactTypeSpecification : IRequestSpecification
     /// <param name="type">The target type.</param>
     public ExactTypeSpecification(Type type)
     {
-        this.TargetType = type ?? throw new ArgumentNullException(nameof(type));
+        TargetType = type ?? throw new ArgumentNullException(nameof(type));
     }
 
     /// <summary>
@@ -39,10 +39,10 @@ public class ExactTypeSpecification : IRequestSpecification
         if (typeRequest == null)
             return false;
 
-        if (this.TargetType == typeRequest)
+        if (TargetType == typeRequest)
             return true;
 
-        if (this.IsOpenGenericDefinitionEqual(typeRequest))
+        if (IsOpenGenericDefinitionEqual(typeRequest))
             return true;
 
         return false;
@@ -50,8 +50,8 @@ public class ExactTypeSpecification : IRequestSpecification
 
     private bool IsOpenGenericDefinitionEqual(Type request)
     {
-        return this.TargetType.GetTypeInfo().IsGenericTypeDefinition
+        return TargetType.GetTypeInfo().IsGenericTypeDefinition
                && request.GetTypeInfo().IsGenericType
-               && request.GetTypeInfo().GetGenericTypeDefinition() == this.TargetType;
+               && request.GetTypeInfo().GetGenericTypeDefinition() == TargetType;
     }
 }

--- a/Src/AutoFixture/Kernel/FieldSpecification.cs
+++ b/Src/AutoFixture/Kernel/FieldSpecification.cs
@@ -10,9 +10,9 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class FieldSpecification : IRequestSpecification
 {
-    private readonly Type targetType;
-    private readonly string targetName;
-    private readonly IEquatable<FieldInfo> target;
+    private readonly Type _targetType;
+    private readonly string _targetName;
+    private readonly IEquatable<FieldInfo> _target;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FieldSpecification"/> class.
@@ -32,8 +32,8 @@ public class FieldSpecification : IRequestSpecification
     public FieldSpecification(Type targetType, string targetName)
         : this(CreateDefaultTarget(targetType, targetName))
     {
-        this.targetType = targetType;
-        this.targetName = targetName;
+        _targetType = targetType;
+        _targetName = targetName;
     }
 
     private static IEquatable<FieldInfo> CreateDefaultTarget(
@@ -66,7 +66,7 @@ public class FieldSpecification : IRequestSpecification
     /// </exception>
     public FieldSpecification(IEquatable<FieldInfo> target)
     {
-        this.target = target ?? throw new ArgumentNullException(nameof(target));
+        _target = target ?? throw new ArgumentNullException(nameof(target));
     }
 
     /// <summary>
@@ -74,14 +74,14 @@ public class FieldSpecification : IRequestSpecification
     /// <see cref="FieldInfo"/> type should be compatible.
     /// </summary>
     [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", true)]
-    public Type TargetType => this.targetType;
+    public Type TargetType => _targetType;
 
     /// <summary>
     /// The name which the requested <see cref="FieldInfo"/> name
     /// should match exactly.
     /// </summary>
     [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", true)]
-    public string TargetName => this.targetName;
+    public string TargetName => _targetName;
 
     /// <summary>
     /// Evaluates a request for a specimen.
@@ -100,7 +100,7 @@ public class FieldSpecification : IRequestSpecification
         if (f == null)
             return false;
 
-        return this.target.Equals(f);
+        return _target.Equals(f);
     }
 
     private class DerivesFromTypeComparer : IEqualityComparer<Type>

--- a/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/FieldTypeAndNameCriterion.cs
@@ -38,8 +38,8 @@ public class FieldTypeAndNameCriterion : IEquatable<FieldInfo>
     /// </exception>
     public FieldTypeAndNameCriterion(IEquatable<Type> typeCriterion, IEquatable<string> nameCriterion)
     {
-        this.TypeCriterion = typeCriterion ?? throw new ArgumentNullException(nameof(typeCriterion));
-        this.NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
+        TypeCriterion = typeCriterion ?? throw new ArgumentNullException(nameof(typeCriterion));
+        NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
     }
 
     /// <summary>
@@ -67,8 +67,8 @@ public class FieldTypeAndNameCriterion : IEquatable<FieldInfo>
         if (other == null)
             return false;
 
-        return this.TypeCriterion.Equals(other.FieldType)
-               && this.NameCriterion.Equals(other.Name);
+        return TypeCriterion.Equals(other.FieldType)
+               && NameCriterion.Equals(other.Name);
     }
 
     /// <summary>
@@ -95,8 +95,8 @@ public class FieldTypeAndNameCriterion : IEquatable<FieldInfo>
         if (other == null)
             return base.Equals(obj);
 
-        return object.Equals(this.TypeCriterion, other.TypeCriterion)
-               && object.Equals(this.NameCriterion, other.NameCriterion);
+        return object.Equals(TypeCriterion, other.TypeCriterion)
+               && object.Equals(NameCriterion, other.NameCriterion);
     }
 
     /// <summary>
@@ -106,7 +106,7 @@ public class FieldTypeAndNameCriterion : IEquatable<FieldInfo>
     public override int GetHashCode()
     {
         return
-            this.TypeCriterion.GetHashCode() ^
-            this.NameCriterion.GetHashCode();
+            TypeCriterion.GetHashCode() ^
+            NameCriterion.GetHashCode();
     }
 }

--- a/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/FilteringSpecimenBuilder.cs
@@ -19,8 +19,8 @@ public class FilteringSpecimenBuilder : ISpecimenBuilderNode
     /// </param>
     public FilteringSpecimenBuilder(ISpecimenBuilder builder, IRequestSpecification specification)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.Specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Specification = specification ?? throw new ArgumentNullException(nameof(specification));
     }
 
     /// <summary>
@@ -45,12 +45,12 @@ public class FilteringSpecimenBuilder : ISpecimenBuilderNode
     /// </returns>
     public object Create(object request, ISpecimenContext context)
     {
-        if (!this.Specification.IsSatisfiedBy(request))
+        if (!Specification.IsSatisfiedBy(request))
         {
             return NoSpecimen.Instance;
         }
 
-        return this.Builder.Create(request, context);
+        return Builder.Create(request, context);
     }
 
     /// <summary>Composes the supplied builders.</summary>
@@ -64,7 +64,7 @@ public class FilteringSpecimenBuilder : ISpecimenBuilderNode
         if (builders == null) throw new ArgumentNullException(nameof(builders));
 
         var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-        return new FilteringSpecimenBuilder(composedBuilder, this.Specification);
+        return new FilteringSpecimenBuilder(composedBuilder, Specification);
     }
 
     /// <summary>
@@ -76,11 +76,11 @@ public class FilteringSpecimenBuilder : ISpecimenBuilderNode
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
+++ b/Src/AutoFixture/Kernel/FiniteSequenceRequest.cs
@@ -10,8 +10,8 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class FiniteSequenceRequest : IEquatable<FiniteSequenceRequest>
 {
-    private readonly object request;
-    private readonly int count;
+    private readonly object _request;
+    private readonly int _count;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FiniteSequenceRequest"/> class.
@@ -24,8 +24,8 @@ public class FiniteSequenceRequest : IEquatable<FiniteSequenceRequest>
         if (count < 0)
             throw new ArgumentOutOfRangeException(nameof(count), string.Format(CultureInfo.CurrentCulture, "The requested count must be a positive number (or zero), but was {0}.", count));
 
-        this.request = request;
-        this.count = count;
+        _request = request;
+        _count = count;
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public class FiniteSequenceRequest : IEquatable<FiniteSequenceRequest>
     {
         if (obj is FiniteSequenceRequest other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
         return base.Equals(obj);
     }
@@ -57,7 +57,7 @@ public class FiniteSequenceRequest : IEquatable<FiniteSequenceRequest>
     /// </returns>
     public override int GetHashCode()
     {
-        return this.request.GetHashCode() ^ this.count.GetHashCode();
+        return _request.GetHashCode() ^ _count.GetHashCode();
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class FiniteSequenceRequest : IEquatable<FiniteSequenceRequest>
     /// <returns>A number of similar requests.</returns>
     public IEnumerable<object> CreateRequests()
     {
-        return Enumerable.Repeat(this.request, this.count);
+        return Enumerable.Repeat(_request, _count);
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public class FiniteSequenceRequest : IEquatable<FiniteSequenceRequest>
             return false;
         }
 
-        return this.request.Equals(other.request)
-               && this.count == other.count;
+        return _request.Equals(other._request)
+               && _count == other._count;
     }
 }

--- a/Src/AutoFixture/Kernel/FixedBuilder.cs
+++ b/Src/AutoFixture/Kernel/FixedBuilder.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public class FixedBuilder : ISpecimenBuilder
 {
-    private readonly object specimen;
+    private readonly object _specimen;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FixedBuilder"/> class.
@@ -15,7 +15,7 @@ public class FixedBuilder : ISpecimenBuilder
     /// </param>
     public FixedBuilder(object specimen)
     {
-        this.specimen = specimen;
+        _specimen = specimen;
     }
 
     /// <summary>
@@ -31,6 +31,6 @@ public class FixedBuilder : ISpecimenBuilder
     /// <seealso cref="FixedBuilder(object)"/>
     public object Create(object request, ISpecimenContext context)
     {
-        return this.specimen;
+        return _specimen;
     }
 }

--- a/Src/AutoFixture/Kernel/GenericMethod.cs
+++ b/Src/AutoFixture/Kernel/GenericMethod.cs
@@ -10,7 +10,7 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class GenericMethod : IMethod
 {
-    private readonly ParameterInfo[] parametersInfo;
+    private readonly ParameterInfo[] _parametersInfo;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GenericMethod"/> class.
@@ -25,15 +25,15 @@ public class GenericMethod : IMethod
         if (method == null) throw new ArgumentNullException(nameof(method));
         if (factory == null) throw new ArgumentNullException(nameof(factory));
 
-        this.Method = method;
-        this.Factory = factory;
-        this.parametersInfo = method.GetParameters();
+        Method = method;
+        Factory = factory;
+        _parametersInfo = method.GetParameters();
     }
 
     /// <summary>
     /// Gets information about the parameters of the method.
     /// </summary>
-    public IEnumerable<ParameterInfo> Parameters => this.parametersInfo;
+    public IEnumerable<ParameterInfo> Parameters => _parametersInfo;
 
     /// <summary>
     /// Gets information about the method.
@@ -109,7 +109,7 @@ public class GenericMethod : IMethod
     public object Invoke(IEnumerable<object> parameters)
     {
         var arguments = parameters.ToArray();
-        return this.Factory.Create(InferMethodInfo(this.Method, arguments))
+        return Factory.Create(InferMethodInfo(Method, arguments))
             .Invoke(arguments);
     }
 }

--- a/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
+++ b/Src/AutoFixture/Kernel/ImplementedInterfaceSpecification.cs
@@ -22,7 +22,7 @@ public class ImplementedInterfaceSpecification : IRequestSpecification
     /// </exception>
     public ImplementedInterfaceSpecification(Type targetType)
     {
-        this.TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+        TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public class ImplementedInterfaceSpecification : IRequestSpecification
         if (request == null) throw new ArgumentNullException(nameof(request));
 
         return IsRequestForType(request) &&
-               this.IsTargetTypeOrImplementedInterface(request);
+               IsTargetTypeOrImplementedInterface(request);
     }
 
     private static bool IsRequestForType(object request)
@@ -54,18 +54,18 @@ public class ImplementedInterfaceSpecification : IRequestSpecification
 
     private bool IsTargetTypeOrImplementedInterface(object request)
     {
-        return this.IsSameAsTargetType(request) ||
-               this.IsInterfaceImplementedByTargetType(request);
+        return IsSameAsTargetType(request) ||
+               IsInterfaceImplementedByTargetType(request);
     }
 
     private bool IsSameAsTargetType(object request)
     {
-        return (Type)request == this.TargetType;
+        return (Type)request == TargetType;
     }
 
     private bool IsInterfaceImplementedByTargetType(object request)
     {
-        return this.TargetType
+        return TargetType
             .GetTypeInfo()
             .GetInterfaces()
             .Contains((Type)request);

--- a/Src/AutoFixture/Kernel/InstanceMethod.cs
+++ b/Src/AutoFixture/Kernel/InstanceMethod.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class InstanceMethod : IMethod, IEquatable<InstanceMethod>
 {
-    private readonly ParameterInfo[] paramInfos;
+    private readonly ParameterInfo[] _paramInfos;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InstanceMethod"/> class.
@@ -32,9 +32,9 @@ public class InstanceMethod : IMethod, IEquatable<InstanceMethod>
         if (instanceMethod == null) throw new ArgumentNullException(nameof(instanceMethod));
         if (owner == null) throw new ArgumentNullException(nameof(owner));
 
-        this.Method = instanceMethod;
-        this.paramInfos = instanceMethod.GetParameters();
-        this.Owner = owner;
+        Method = instanceMethod;
+        _paramInfos = instanceMethod.GetParameters();
+        Owner = owner;
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public class InstanceMethod : IMethod, IEquatable<InstanceMethod>
     {
         if (obj is InstanceMethod other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
         return base.Equals(obj);
     }
@@ -78,13 +78,13 @@ public class InstanceMethod : IMethod, IEquatable<InstanceMethod>
     /// </returns>
     public override int GetHashCode()
     {
-        return this.Method.GetHashCode() ^ this.Owner.GetHashCode();
+        return Method.GetHashCode() ^ Owner.GetHashCode();
     }
 
     /// <summary>
     /// Gets information about the parameters of the method.
     /// </summary>
-    public IEnumerable<ParameterInfo> Parameters => this.paramInfos;
+    public IEnumerable<ParameterInfo> Parameters => _paramInfos;
 
     /// <summary>
     /// Invokes the method with the supplied parameters.
@@ -93,7 +93,7 @@ public class InstanceMethod : IMethod, IEquatable<InstanceMethod>
     /// <returns>The result of the method call.</returns>
     public object Invoke(IEnumerable<object> parameters)
     {
-        return this.Method.Invoke(this.Owner, parameters.ToArray());
+        return Method.Invoke(Owner, parameters.ToArray());
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ public class InstanceMethod : IMethod, IEquatable<InstanceMethod>
             return false;
         }
 
-        return object.Equals(this.Method, other.Method)
-               && object.Equals(this.Owner, other.Owner);
+        return object.Equals(Method, other.Method)
+               && object.Equals(Owner, other.Owner);
     }
 }

--- a/Src/AutoFixture/Kernel/InstanceMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/InstanceMethodQuery.cs
@@ -17,8 +17,8 @@ public class InstanceMethodQuery : IMethodQuery
     /// <param name="methodName">The name of the method that should be selected.</param>
     public InstanceMethodQuery(object owner, string methodName)
     {
-        this.Owner = owner ?? throw new ArgumentNullException(nameof(owner));
-        this.MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
+        Owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
     }
 
     /// <summary>
@@ -39,10 +39,10 @@ public class InstanceMethodQuery : IMethodQuery
     /// returns an enumerable containing a single <see cref="InstanceMethod"/> otherwise.</returns>
     public IEnumerable<IMethod> SelectMethods(Type type = default)
     {
-        var method = this.Owner.GetType().GetTypeInfo().GetMethod(this.MethodName);
+        var method = Owner.GetType().GetTypeInfo().GetMethod(MethodName);
 
         return method == null
             ? new IMethod[0]
-            : new IMethod[] { new InstanceMethod(method, this.Owner) };
+            : new IMethod[] { new InstanceMethod(method, Owner) };
     }
 }

--- a/Src/AutoFixture/Kernel/InverseRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/InverseRequestSpecification.cs
@@ -16,7 +16,7 @@ public class InverseRequestSpecification : IRequestSpecification
     /// </param>
     public InverseRequestSpecification(IRequestSpecification specification)
     {
-        this.Specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        Specification = specification ?? throw new ArgumentNullException(nameof(specification));
     }
 
     /// <summary>
@@ -39,6 +39,6 @@ public class InverseRequestSpecification : IRequestSpecification
     /// </returns>
     public bool IsSatisfiedBy(object request)
     {
-        return !this.Specification.IsSatisfiedBy(request);
+        return !Specification.IsSatisfiedBy(request);
     }
 }

--- a/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
+++ b/Src/AutoFixture/Kernel/MemberInfoEqualityComparer.cs
@@ -101,7 +101,7 @@ public class MemberInfoEqualityComparer : IEqualityComparer<MemberInfo>, IEquali
             return false;
         }
 
-        return this.Equals(miX, miY);
+        return Equals(miX, miY);
     }
 
     int IEqualityComparer.GetHashCode(object obj)
@@ -110,7 +110,7 @@ public class MemberInfoEqualityComparer : IEqualityComparer<MemberInfo>, IEquali
 
         return obj switch
         {
-            MemberInfo mi => this.GetHashCode(mi),
+            MemberInfo mi => GetHashCode(mi),
             _ => obj.GetHashCode()
         };
     }

--- a/Src/AutoFixture/Kernel/MethodInvoker.cs
+++ b/Src/AutoFixture/Kernel/MethodInvoker.cs
@@ -19,7 +19,7 @@ public class MethodInvoker : ISpecimenBuilder
     /// </param>
     public MethodInvoker(IMethodQuery query)
     {
-        this.Query = query ?? throw new ArgumentNullException(nameof(query));
+        Query = query ?? throw new ArgumentNullException(nameof(query));
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public class MethodInvoker : ISpecimenBuilder
     {
         if (context == null) throw new ArgumentNullException(nameof(context));
 
-        foreach (var ci in this.GetConstructors(request))
+        foreach (var ci in GetConstructors(request))
         {
             var paramValues = (from pi in ci.Parameters
                 select context.Resolve(pi)).ToList();
@@ -70,7 +70,7 @@ public class MethodInvoker : ISpecimenBuilder
             return Enumerable.Empty<IMethod>();
         }
 
-        return this.Query.SelectMethods(requestedType);
+        return Query.SelectMethods(requestedType);
     }
 
     private static bool IsValueValid(object value)

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethod.cs
@@ -15,7 +15,7 @@ public class MissingParametersSupplyingMethod : IMethod, IEquatable<MissingParam
     /// </summary>
     public MissingParametersSupplyingMethod(IMethod method)
     {
-        this.Method = method ?? throw new ArgumentNullException(nameof(method));
+        Method = method ?? throw new ArgumentNullException(nameof(method));
     }
 
     /// <summary>
@@ -26,19 +26,19 @@ public class MissingParametersSupplyingMethod : IMethod, IEquatable<MissingParam
     /// <summary>
     /// Gets information about the parameters of the method.
     /// </summary>
-    public IEnumerable<ParameterInfo> Parameters => this.Method.Parameters;
+    public IEnumerable<ParameterInfo> Parameters => Method.Parameters;
 
     /// <inheritdoc />
     public override bool Equals(object obj)
     {
-        return obj is MissingParametersSupplyingMethod other && this.Equals(other);
+        return obj is MissingParametersSupplyingMethod other && Equals(other);
     }
 
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        return this.Method.GetHashCode()
-               ^ this.Parameters.Aggregate(0, (current, parameter) => current + parameter.GetHashCode());
+        return Method.GetHashCode()
+               ^ Parameters.Aggregate(0, (current, parameter) => current + parameter.GetHashCode());
     }
 
     /// <inheritdoc />
@@ -49,8 +49,8 @@ public class MissingParametersSupplyingMethod : IMethod, IEquatable<MissingParam
             return false;
         }
 
-        return this.Method.Equals(other.Method)
-               && this.Parameters.SequenceEqual(other.Parameters);
+        return Method.Equals(other.Method)
+               && Parameters.SequenceEqual(other.Parameters);
     }
 
     private static IEnumerable<object> GetArguments(IEnumerable<ParameterInfo> parameters, object[] arguments)
@@ -79,7 +79,7 @@ public class MissingParametersSupplyingMethod : IMethod, IEquatable<MissingParam
     /// <returns>The result of the method call.</returns>
     public object Invoke(IEnumerable<object> parameters)
     {
-        var arguments = GetArguments(this.Method.Parameters, parameters.ToArray());
-        return this.Method.Invoke(arguments);
+        var arguments = GetArguments(Method.Parameters, parameters.ToArray());
+        return Method.Invoke(arguments);
     }
 }

--- a/Src/AutoFixture/Kernel/MissingParametersSupplyingMethodFactory.cs
+++ b/Src/AutoFixture/Kernel/MissingParametersSupplyingMethodFactory.cs
@@ -16,7 +16,7 @@ public class MissingParametersSupplyingMethodFactory : IMethodFactory
     /// <param name="owner">The owner.</param>
     public MissingParametersSupplyingMethodFactory(object owner)
     {
-        this.Owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        Owner = owner ?? throw new ArgumentNullException(nameof(owner));
     }
 
     /// <summary>
@@ -33,6 +33,6 @@ public class MissingParametersSupplyingMethodFactory : IMethodFactory
     /// <returns>Method for <paramref name="methodInfo"/>.</returns>
     public IMethod Create(MethodInfo methodInfo)
     {
-        return new MissingParametersSupplyingMethod(new InstanceMethod(methodInfo, this.Owner));
+        return new MissingParametersSupplyingMethod(new InstanceMethod(methodInfo, Owner));
     }
 }

--- a/Src/AutoFixture/Kernel/MultipleRelay.cs
+++ b/Src/AutoFixture/Kernel/MultipleRelay.cs
@@ -8,14 +8,14 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class MultipleRelay : ISpecimenBuilder
 {
-    private int count;
+    private int _count;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MultipleRelay"/> class.
     /// </summary>
     public MultipleRelay()
     {
-        this.count = 3;
+        _count = 3;
     }
 
     /// <summary>
@@ -23,14 +23,14 @@ public class MultipleRelay : ISpecimenBuilder
     /// </summary>
     public int Count
     {
-        get => this.count;
+        get => _count;
         set
         {
             if (value < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(value), "Count cannot be negative.");
             }
-            this.count = value;
+            _count = value;
         }
     }
 
@@ -57,6 +57,6 @@ public class MultipleRelay : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        return context.Resolve(new FiniteSequenceRequest(manyRequest.Request, this.Count));
+        return context.Resolve(new FiniteSequenceRequest(manyRequest.Request, Count));
     }
 }

--- a/Src/AutoFixture/Kernel/MultipleRequest.cs
+++ b/Src/AutoFixture/Kernel/MultipleRequest.cs
@@ -26,7 +26,7 @@ public class MultipleRequest : IEquatable<MultipleRequest>
     /// <param name="request">A single request which will be multiplied.</param>
     public MultipleRequest(object request)
     {
-        this.Request = request ?? throw new ArgumentNullException(nameof(request));
+        Request = request ?? throw new ArgumentNullException(nameof(request));
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public class MultipleRequest : IEquatable<MultipleRequest>
     {
         if (obj is MultipleRequest other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
         return base.Equals(obj);
     }
@@ -62,7 +62,7 @@ public class MultipleRequest : IEquatable<MultipleRequest>
     /// </returns>
     public override int GetHashCode()
     {
-        return this.Request.GetHashCode();
+        return Request.GetHashCode();
     }
 
     /// <summary>
@@ -81,6 +81,6 @@ public class MultipleRequest : IEquatable<MultipleRequest>
             return false;
         }
 
-        return this.Request.Equals(other.Request);
+        return Request.Equals(other.Request);
     }
 }

--- a/Src/AutoFixture/Kernel/NoConstructorsSpecification.cs
+++ b/Src/AutoFixture/Kernel/NoConstructorsSpecification.cs
@@ -8,14 +8,14 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class NoConstructorsSpecification : IRequestSpecification
 {
-    private readonly IMethodQuery modestConstructorQuery;
+    private readonly IMethodQuery _modestConstructorQuery;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NoConstructorsSpecification"/> class.
     /// </summary>
     public NoConstructorsSpecification()
     {
-        this.modestConstructorQuery = new ModestConstructorQuery();
+        _modestConstructorQuery = new ModestConstructorQuery();
     }
 
     /// <summary>
@@ -31,6 +31,6 @@ public class NoConstructorsSpecification : IRequestSpecification
         if (request == null) throw new ArgumentNullException(nameof(request));
 
         var type = request as Type;
-        return type != null && !this.modestConstructorQuery.SelectMethods(type).Any();
+        return type != null && !_modestConstructorQuery.SelectMethods(type).Any();
     }
 }

--- a/Src/AutoFixture/Kernel/NoSpecimen.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimen.cs
@@ -44,7 +44,7 @@ public sealed class NoSpecimen : IEquatable<NoSpecimen>
     {
         if (obj is NoSpecimen other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
         return false;
     }

--- a/Src/AutoFixture/Kernel/NoSpecimenOutputGuard.cs
+++ b/Src/AutoFixture/Kernel/NoSpecimenOutputGuard.cs
@@ -30,8 +30,8 @@ public class NoSpecimenOutputGuard : ISpecimenBuilderNode
     /// <param name="specification">The specification.</param>
     public NoSpecimenOutputGuard(ISpecimenBuilder builder, IRequestSpecification specification)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.Specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Specification = specification ?? throw new ArgumentNullException(nameof(specification));
     }
 
     /// <summary>
@@ -67,9 +67,9 @@ public class NoSpecimenOutputGuard : ISpecimenBuilderNode
     /// </exception>
     public object Create(object request, ISpecimenContext context)
     {
-        var result = this.Builder.Create(request, context);
+        var result = Builder.Create(request, context);
         if (result is NoSpecimen
-            && this.Specification.IsSatisfiedBy(request))
+            && Specification.IsSatisfiedBy(request))
         {
             throw new ObjectCreationException(string.Format(CultureInfo.CurrentCulture, "The decorated ISpecimenBuilder could not create a specimen based on the request: {0}. This can happen if the request represents an interface or abstract class; if this is the case, register an ISpecimenBuilder that can create specimens based on the request. If this happens in a strongly typed Build<T> expression, try supplying a factory using one of the IFactoryComposer<T> methods.", request));
         }
@@ -87,7 +87,7 @@ public class NoSpecimenOutputGuard : ISpecimenBuilderNode
         if (builders == null) throw new ArgumentNullException(nameof(builders));
 
         var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-        return new NoSpecimenOutputGuard(composedBuilder, this.Specification);
+        return new NoSpecimenOutputGuard(composedBuilder, Specification);
     }
 
     /// <summary>
@@ -99,11 +99,11 @@ public class NoSpecimenOutputGuard : ISpecimenBuilderNode
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixture/Kernel/NullRecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/NullRecursionGuard.cs
@@ -52,6 +52,6 @@ public class NullRecursionGuard : RecursionGuard
         if (builders == null) throw new ArgumentNullException(nameof(builders));
 
         var builder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-        return new NullRecursionGuard(builder, this.Comparer);
+        return new NullRecursionGuard(builder, Comparer);
     }
 }

--- a/Src/AutoFixture/Kernel/OmitOnRecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/OmitOnRecursionGuard.cs
@@ -60,6 +60,6 @@ public class OmitOnRecursionGuard : RecursionGuard
         if (builders == null) throw new ArgumentNullException(nameof(builders));
 
         var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-        return new OmitOnRecursionGuard(composedBuilder, this.Comparer);
+        return new OmitOnRecursionGuard(composedBuilder, Comparer);
     }
 }

--- a/Src/AutoFixture/Kernel/OmitSpecimen.cs
+++ b/Src/AutoFixture/Kernel/OmitSpecimen.cs
@@ -36,7 +36,7 @@ public class OmitSpecimen : IEquatable<OmitSpecimen>
     public override bool Equals(object obj)
     {
         if (obj is OmitSpecimen other)
-            return this.Equals(other);
+            return Equals(other);
 
         return base.Equals(obj);
     }

--- a/Src/AutoFixture/Kernel/Omitter.cs
+++ b/Src/AutoFixture/Kernel/Omitter.cs
@@ -30,7 +30,7 @@ public class Omitter : ISpecimenBuilder
     /// <seealso cref="Specification" />
     public Omitter(IRequestSpecification specification)
     {
-        this.Specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        Specification = specification ?? throw new ArgumentNullException(nameof(specification));
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class Omitter : ISpecimenBuilder
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
 
-        if (this.Specification.IsSatisfiedBy(request))
+        if (Specification.IsSatisfiedBy(request))
             return new OmitSpecimen();
 
         return NoSpecimen.Instance;

--- a/Src/AutoFixture/Kernel/OrRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/OrRequestSpecification.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class OrRequestSpecification : IRequestSpecification
 {
-    private readonly IRequestSpecification[] specifications;
+    private readonly IRequestSpecification[] _specifications;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrRequestSpecification"/> class with the
@@ -18,7 +18,7 @@ public class OrRequestSpecification : IRequestSpecification
     /// <param name="specifications">An array of <see cref="IRequestSpecification"/>.</param>
     public OrRequestSpecification(params IRequestSpecification[] specifications)
     {
-        this.specifications = specifications ?? throw new ArgumentNullException(nameof(specifications));
+        _specifications = specifications ?? throw new ArgumentNullException(nameof(specifications));
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public class OrRequestSpecification : IRequestSpecification
     /// <summary>
     /// Gets the decorated specifications.
     /// </summary>
-    public IEnumerable<IRequestSpecification> Specifications => this.specifications;
+    public IEnumerable<IRequestSpecification> Specifications => _specifications;
 
     /// <summary>
     /// Evaluates a request for a specimen.
@@ -48,10 +48,10 @@ public class OrRequestSpecification : IRequestSpecification
     {
         // This is performance-sensitive code when used repeatedly over many requests.
         // See discussion at https://github.com/AutoFixture/AutoFixture/pull/218
-        if (this.specifications.Length == 0) return true;
-        for (int i = 0; i < this.specifications.Length; i++)
+        if (_specifications.Length == 0) return true;
+        for (int i = 0; i < _specifications.Length; i++)
         {
-            var satisfied = this.specifications[i].IsSatisfiedBy(request);
+            var satisfied = _specifications[i].IsSatisfiedBy(request);
             if (satisfied) return true;
         }
         return false;

--- a/Src/AutoFixture/Kernel/ParameterScore.cs
+++ b/Src/AutoFixture/Kernel/ParameterScore.cs
@@ -9,7 +9,7 @@ namespace AutoFixture.Kernel;
     Justification = "This type implements IComparable to be sortable. It's used in limited number of places, so operators overload is not needed.")]
 internal class ParameterScore : IComparable<ParameterScore>
 {
-    private readonly int score;
+    private readonly int _score;
 
     internal ParameterScore(Type parentType, Type targetType, IEnumerable<ParameterInfo> parameters)
     {
@@ -17,7 +17,7 @@ internal class ParameterScore : IComparable<ParameterScore>
         if (targetType == null) throw new ArgumentNullException(nameof(targetType));
         if (parameters == null) throw new ArgumentNullException(nameof(parameters));
 
-        this.score = CalculateScore(parentType, targetType, parameters);
+        _score = CalculateScore(parentType, targetType, parameters);
     }
 
     public int CompareTo(ParameterScore other)
@@ -27,17 +27,17 @@ internal class ParameterScore : IComparable<ParameterScore>
             return 1;
         }
 
-        return this.score.CompareTo(other.score);
+        return _score.CompareTo(other._score);
     }
 
     public override bool Equals(object obj)
     {
-        return this.CompareTo(obj as ParameterScore) == 0;
+        return CompareTo(obj as ParameterScore) == 0;
     }
 
     public override int GetHashCode()
     {
-        return this.score.GetHashCode();
+        return _score.GetHashCode();
     }
 
     private static int CalculateScore(Type parentType, Type targetType, IEnumerable<ParameterInfo> parameters)

--- a/Src/AutoFixture/Kernel/ParameterSpecification.cs
+++ b/Src/AutoFixture/Kernel/ParameterSpecification.cs
@@ -10,9 +10,9 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class ParameterSpecification : IRequestSpecification
 {
-    private readonly Type targetType;
-    private readonly string targetName;
-    private readonly IEquatable<ParameterInfo> target;
+    private readonly Type _targetType;
+    private readonly string _targetName;
+    private readonly IEquatable<ParameterInfo> _target;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ParameterSpecification"/> class.
@@ -32,8 +32,8 @@ public class ParameterSpecification : IRequestSpecification
     public ParameterSpecification(Type targetType, string targetName)
         : this(CreateDefaultTarget(targetType, targetName))
     {
-        this.targetType = targetType;
-        this.targetName = targetName;
+        _targetType = targetType;
+        _targetName = targetName;
     }
 
     private static IEquatable<ParameterInfo> CreateDefaultTarget(
@@ -67,7 +67,7 @@ public class ParameterSpecification : IRequestSpecification
     public ParameterSpecification(
         IEquatable<ParameterInfo> target)
     {
-        this.target = target ?? throw new ArgumentNullException(nameof(target));
+        _target = target ?? throw new ArgumentNullException(nameof(target));
     }
 
     /// <summary>
@@ -75,14 +75,14 @@ public class ParameterSpecification : IRequestSpecification
     /// <see cref="ParameterInfo"/> type should be compatible.
     /// </summary>
     [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", true)]
-    public Type TargetType => this.targetType;
+    public Type TargetType => _targetType;
 
     /// <summary>
     /// The name which the requested <see cref="ParameterInfo"/> name
     /// should match exactly.
     /// </summary>
     [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", true)]
-    public string TargetName => this.targetName;
+    public string TargetName => _targetName;
 
     /// <summary>
     /// Evaluates a request for a specimen.
@@ -101,7 +101,7 @@ public class ParameterSpecification : IRequestSpecification
         if (p == null)
             return false;
 
-        return this.target.Equals(p);
+        return _target.Equals(p);
     }
 
     private class DerivesFromTypeComparer : IEqualityComparer<Type>

--- a/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/ParameterTypeAndNameCriterion.cs
@@ -40,8 +40,8 @@ public class ParameterTypeAndNameCriterion : IEquatable<ParameterInfo>
         IEquatable<Type> typeCriterion,
         IEquatable<string> nameCriterion)
     {
-        this.TypeCriterion = typeCriterion ?? throw new ArgumentNullException(nameof(typeCriterion));
-        this.NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
+        TypeCriterion = typeCriterion ?? throw new ArgumentNullException(nameof(typeCriterion));
+        NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
     }
 
     /// <summary>
@@ -69,8 +69,8 @@ public class ParameterTypeAndNameCriterion : IEquatable<ParameterInfo>
         if (other == null)
             return false;
 
-        return this.TypeCriterion.Equals(other.ParameterType)
-               && this.NameCriterion.Equals(other.Name);
+        return TypeCriterion.Equals(other.ParameterType)
+               && NameCriterion.Equals(other.Name);
     }
 
     /// <summary>
@@ -97,8 +97,8 @@ public class ParameterTypeAndNameCriterion : IEquatable<ParameterInfo>
         if (other == null)
             return base.Equals(obj);
 
-        return object.Equals(this.TypeCriterion, other.TypeCriterion)
-               && object.Equals(this.NameCriterion, other.NameCriterion);
+        return object.Equals(TypeCriterion, other.TypeCriterion)
+               && object.Equals(NameCriterion, other.NameCriterion);
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public class ParameterTypeAndNameCriterion : IEquatable<ParameterInfo>
     public override int GetHashCode()
     {
         return
-            this.TypeCriterion.GetHashCode() ^
-            this.NameCriterion.GetHashCode();
+            TypeCriterion.GetHashCode() ^
+            NameCriterion.GetHashCode();
     }
 }

--- a/Src/AutoFixture/Kernel/Postprocessor.cs
+++ b/Src/AutoFixture/Kernel/Postprocessor.cs
@@ -101,7 +101,7 @@ public class Postprocessor : Postprocessor<object>
         if (builders == null) throw new ArgumentNullException(nameof(builders));
 
         var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-        var pp = new Postprocessor(composedBuilder, this.Command, this.Specification);
+        var pp = new Postprocessor(composedBuilder, Command, Specification);
 #pragma warning disable 618
         ObsoletedMemberShims.Postprocessor_SetAction(pp, ObsoletedMemberShims.Postprocessor_GetAction(this));
 #pragma warning restore 618
@@ -117,7 +117,7 @@ public class Postprocessor : Postprocessor<object>
 [Obsolete("The generic version of the Postprocessor is no longer used and will be removed in future versions. Please use the non-generic version of the Postprocessor type.")]
 public class Postprocessor<T> : ISpecimenBuilderNode
 {
-    private Action<T, ISpecimenContext> action;
+    private Action<T, ISpecimenContext> _action;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Postprocessor{T}"/> class with the
@@ -184,10 +184,10 @@ public class Postprocessor<T> : ISpecimenBuilderNode
             throw new ArgumentNullException(nameof(specification));
         }
 
-        this.Builder = builder;
-        this.action = action;
-        this.Command = new ActionSpecimenCommand<T>(this.action);
-        this.Specification = specification;
+        Builder = builder;
+        _action = action;
+        Command = new ActionSpecimenCommand<T>(_action);
+        Specification = specification;
     }
 
     /// <summary>
@@ -219,10 +219,10 @@ public class Postprocessor<T> : ISpecimenBuilderNode
         if (specification == null)
             throw new ArgumentNullException(nameof(specification));
 
-        this.Builder = builder;
-        this.Command = command;
-        this.Specification = specification;
-        this.action = (s, c) => this.Command.Execute(s, c);
+        Builder = builder;
+        Command = command;
+        Specification = specification;
+        _action = (s, c) => Command.Execute(s, c);
     }
 
     /// <summary>
@@ -231,8 +231,8 @@ public class Postprocessor<T> : ISpecimenBuilderNode
     [Obsolete("Use the Command property instead.", true)]
     public Action<T, ISpecimenContext> Action
     {
-        get => this.action;
-        internal set => this.action = value;
+        get => _action;
+        internal set => _action = value;
     }
 
     /// <summary>
@@ -268,7 +268,7 @@ public class Postprocessor<T> : ISpecimenBuilderNode
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        var specimen = this.Builder.Create(request, context);
+        var specimen = Builder.Create(request, context);
         if (specimen == null)
             return specimen;
 
@@ -276,7 +276,7 @@ public class Postprocessor<T> : ISpecimenBuilderNode
         if (ns != null)
             return ns;
 
-        if (!this.Specification.IsSatisfiedBy(request))
+        if (!Specification.IsSatisfiedBy(request))
             return specimen;
 
         if (!(specimen is T))
@@ -285,7 +285,7 @@ public class Postprocessor<T> : ISpecimenBuilderNode
                 "The specimen returned by the decorated ISpecimenBuilder is not compatible with {0}.", typeof(T)));
         }
 
-        this.Command.Execute(specimen, context);
+        Command.Execute(specimen, context);
         return specimen;
     }
 
@@ -300,8 +300,8 @@ public class Postprocessor<T> : ISpecimenBuilderNode
         if (builders == null) throw new ArgumentNullException(nameof(builders));
 
         var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-        var pp = new Postprocessor<T>(composedBuilder, this.Command, this.Specification);
-        pp.action = this.action;
+        var pp = new Postprocessor<T>(composedBuilder, Command, Specification);
+        pp._action = _action;
         return pp;
     }
 
@@ -314,12 +314,12 @@ public class Postprocessor<T> : ISpecimenBuilderNode
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }
 #pragma warning restore SA1402 // File may only contain a single type

--- a/Src/AutoFixture/Kernel/PropertySpecification.cs
+++ b/Src/AutoFixture/Kernel/PropertySpecification.cs
@@ -11,9 +11,9 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class PropertySpecification : IRequestSpecification
 {
-    private readonly Type targetType;
-    private readonly string targetName;
-    private readonly IEquatable<PropertyInfo> target;
+    private readonly Type _targetType;
+    private readonly string _targetName;
+    private readonly IEquatable<PropertyInfo> _target;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PropertySpecification"/> class.
@@ -33,8 +33,8 @@ public class PropertySpecification : IRequestSpecification
     public PropertySpecification(Type targetType, string targetName)
         : this(CreateDefaultTarget(targetType, targetName))
     {
-        this.targetType = targetType;
-        this.targetName = targetName;
+        _targetType = targetType;
+        _targetName = targetName;
     }
 
     private static IEquatable<PropertyInfo> CreateDefaultTarget(
@@ -68,7 +68,7 @@ public class PropertySpecification : IRequestSpecification
     /// </exception>
     public PropertySpecification(IEquatable<PropertyInfo> target)
     {
-        this.target = target ?? throw new ArgumentNullException(nameof(target));
+        _target = target ?? throw new ArgumentNullException(nameof(target));
     }
 
     /// <summary>
@@ -76,14 +76,14 @@ public class PropertySpecification : IRequestSpecification
     /// <see cref="PropertyInfo"/> type should be compatible.
     /// </summary>
     [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", true)]
-    public Type TargetType => this.targetType;
+    public Type TargetType => _targetType;
 
     /// <summary>
     /// The name which the requested <see cref="PropertyInfo"/> name
     /// should match exactly.
     /// </summary>
     [Obsolete("This value is only available if the constructor taking a target type and name is used. Otherwise, it'll be null. Use with caution. This property will be removed in a future version of AutoFixture.", true)]
-    public string TargetName => this.targetName;
+    public string TargetName => _targetName;
 
     /// <summary>
     /// Evaluates a request for a specimen.
@@ -102,7 +102,7 @@ public class PropertySpecification : IRequestSpecification
         if (p == null)
             return false;
 
-        return this.target.Equals(p);
+        return _target.Equals(p);
     }
 
     private class DerivesFromTypeComparer : IEqualityComparer<Type>

--- a/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
+++ b/Src/AutoFixture/Kernel/PropertyTypeAndNameCriterion.cs
@@ -40,8 +40,8 @@ public class PropertyTypeAndNameCriterion : IEquatable<PropertyInfo>
         IEquatable<Type> typeCriterion,
         IEquatable<string> nameCriterion)
     {
-        this.TypeCriterion = typeCriterion ?? throw new ArgumentNullException(nameof(typeCriterion));
-        this.NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
+        TypeCriterion = typeCriterion ?? throw new ArgumentNullException(nameof(typeCriterion));
+        NameCriterion = nameCriterion ?? throw new ArgumentNullException(nameof(nameCriterion));
     }
 
     /// <summary>
@@ -69,8 +69,8 @@ public class PropertyTypeAndNameCriterion : IEquatable<PropertyInfo>
         if (other == null)
             return false;
 
-        return this.TypeCriterion.Equals(other.PropertyType)
-               && this.NameCriterion.Equals(other.Name);
+        return TypeCriterion.Equals(other.PropertyType)
+               && NameCriterion.Equals(other.Name);
     }
 
     /// <summary>
@@ -87,8 +87,8 @@ public class PropertyTypeAndNameCriterion : IEquatable<PropertyInfo>
         if (other == null)
             return base.Equals(obj);
 
-        return object.Equals(this.TypeCriterion, other.TypeCriterion)
-               && object.Equals(this.NameCriterion, other.NameCriterion);
+        return object.Equals(TypeCriterion, other.TypeCriterion)
+               && object.Equals(NameCriterion, other.NameCriterion);
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public class PropertyTypeAndNameCriterion : IEquatable<PropertyInfo>
     public override int GetHashCode()
     {
         return
-            this.TypeCriterion.GetHashCode() ^
-            this.NameCriterion.GetHashCode();
+            TypeCriterion.GetHashCode() ^
+            NameCriterion.GetHashCode();
     }
 }

--- a/Src/AutoFixture/Kernel/RangedNumberRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedNumberRequest.cs
@@ -26,9 +26,9 @@ public class RangedNumberRequest : IEquatable<RangedNumberRequest>
             throw new ArgumentOutOfRangeException(nameof(minimum), "Minimum must be lower or equal Maximum.");
         }
 
-        this.OperandType = operandType;
-        this.Minimum = minimum;
-        this.Maximum = maximum;
+        OperandType = operandType;
+        Minimum = minimum;
+        Maximum = maximum;
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class RangedNumberRequest : IEquatable<RangedNumberRequest>
     {
         if (obj is RangedNumberRequest other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
 
         return base.Equals(obj);
@@ -77,9 +77,9 @@ public class RangedNumberRequest : IEquatable<RangedNumberRequest>
     /// </returns>
     public override int GetHashCode()
     {
-        return this.OperandType.GetHashCode()
-               ^ this.Minimum.GetHashCode()
-               ^ this.Maximum.GetHashCode();
+        return OperandType.GetHashCode()
+               ^ Minimum.GetHashCode()
+               ^ Maximum.GetHashCode();
     }
 
     /// <summary>
@@ -96,9 +96,9 @@ public class RangedNumberRequest : IEquatable<RangedNumberRequest>
             return false;
         }
 
-        return this.OperandType == other.OperandType
-               && object.Equals(this.Minimum, other.Minimum)
-               && object.Equals(this.Maximum, other.Maximum);
+        return OperandType == other.OperandType
+               && object.Equals(Minimum, other.Minimum)
+               && object.Equals(Maximum, other.Maximum);
     }
 
     /// <inheritdoc />
@@ -108,10 +108,10 @@ public class RangedNumberRequest : IEquatable<RangedNumberRequest>
         return string.Format(
             CultureInfo.CurrentCulture,
             "RangedNumberRequest (OperandType: {0}, Minimum: [{1}] {2}, Maximum: [{3}] {4})",
-            this.OperandType.FullName,
-            this.Minimum.GetType().Name,
-            this.Minimum,
-            this.Maximum.GetType().Name,
-            this.Maximum);
+            OperandType.FullName,
+            Minimum.GetType().Name,
+            Minimum,
+            Maximum.GetType().Name,
+            Maximum);
     }
 }

--- a/Src/AutoFixture/Kernel/RangedSequenceRequest.cs
+++ b/Src/AutoFixture/Kernel/RangedSequenceRequest.cs
@@ -35,9 +35,9 @@ public class RangedSequenceRequest : IEquatable<RangedSequenceRequest>
         if (maxLength < minLength)
             throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Max length cannot be less than min length.");
 
-        this.Request = request ?? throw new ArgumentNullException(nameof(request));
-        this.MinLength = minLength;
-        this.MaxLength = maxLength;
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        MinLength = minLength;
+        MaxLength = maxLength;
     }
 
     /// <inheritdoc />
@@ -46,15 +46,15 @@ public class RangedSequenceRequest : IEquatable<RangedSequenceRequest>
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
 
-        return this.Request.Equals(other.Request)
-               && this.MinLength == other.MinLength
-               && this.MaxLength == other.MaxLength;
+        return Request.Equals(other.Request)
+               && MinLength == other.MinLength
+               && MaxLength == other.MaxLength;
     }
 
     /// <inheritdoc />
     public override bool Equals(object obj)
     {
-        return obj is RangedSequenceRequest sequenceRequest && this.Equals(sequenceRequest);
+        return obj is RangedSequenceRequest sequenceRequest && Equals(sequenceRequest);
     }
 
     /// <inheritdoc />
@@ -62,9 +62,9 @@ public class RangedSequenceRequest : IEquatable<RangedSequenceRequest>
     {
         unchecked
         {
-            var hashCode = this.Request.GetHashCode();
-            hashCode = (hashCode * 397) ^ this.MinLength;
-            hashCode = (hashCode * 397) ^ this.MaxLength;
+            var hashCode = Request.GetHashCode();
+            hashCode = (hashCode * 397) ^ MinLength;
+            hashCode = (hashCode * 397) ^ MaxLength;
             return hashCode;
         }
     }

--- a/Src/AutoFixture/Kernel/ReadonlyCollectionPropertiesCommand.cs
+++ b/Src/AutoFixture/Kernel/ReadonlyCollectionPropertiesCommand.cs
@@ -27,7 +27,7 @@ public class ReadonlyCollectionPropertiesCommand : ISpecimenCommand
     /// <param name="propertyQuery">The query that will be applied to select readonly collection properties.</param>
     public ReadonlyCollectionPropertiesCommand(IPropertyQuery propertyQuery)
     {
-        this.PropertyQuery = propertyQuery;
+        PropertyQuery = propertyQuery;
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class ReadonlyCollectionPropertiesCommand : ISpecimenCommand
         if (context == null) throw new ArgumentNullException(nameof(context));
 
         var specimenType = specimen.GetType();
-        foreach (var pi in this.PropertyQuery.SelectProperties(specimenType))
+        foreach (var pi in PropertyQuery.SelectProperties(specimenType))
         {
             var addMethod = new InstanceMethodQuery(pi.GetValue(specimen), nameof(ICollection<object>.Add))
                 .SelectMethods()

--- a/Src/AutoFixture/Kernel/ReadonlyCollectionPropertiesSpecification.cs
+++ b/Src/AutoFixture/Kernel/ReadonlyCollectionPropertiesSpecification.cs
@@ -34,7 +34,7 @@ public class ReadonlyCollectionPropertiesSpecification : IRequestSpecification
     /// <param name="propertyQuery">The query that will be applied to select readonly collection properties.</param>
     public ReadonlyCollectionPropertiesSpecification(IPropertyQuery propertyQuery)
     {
-        this.PropertyQuery = propertyQuery;
+        PropertyQuery = propertyQuery;
     }
 
     /// <summary>
@@ -55,6 +55,6 @@ public class ReadonlyCollectionPropertiesSpecification : IRequestSpecification
     /// </returns>
     public bool IsSatisfiedBy(object request)
     {
-        return request is Type requestType && this.PropertyQuery.SelectProperties(requestType).Any();
+        return request is Type requestType && PropertyQuery.SelectProperties(requestType).Any();
     }
 }

--- a/Src/AutoFixture/Kernel/RecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/RecursionGuard.cs
@@ -16,10 +16,10 @@ namespace AutoFixture.Kernel;
     Justification = "Fixture doesn't support disposal, so we cannot dispose current builder somehow.")]
 public class RecursionGuard : ISpecimenBuilderNode
 {
-    private readonly ThreadLocal<Stack<object>> requestsByThread
+    private readonly ThreadLocal<Stack<object>> _requestsByThread
         = new ThreadLocal<Stack<object>>(() => new Stack<object>());
 
-    private Stack<object> GetMonitoredRequestsForCurrentThread() => this.requestsByThread.Value;
+    private Stack<object> GetMonitoredRequestsForCurrentThread() => _requestsByThread.Value;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RecursionGuard"/> class.
@@ -65,9 +65,9 @@ public class RecursionGuard : ISpecimenBuilderNode
     [Obsolete("This constructor overload is obsolete and will be removed in a future version of AutoFixture. Please use RecursionGuard(ISpecimenBuilder, IRecursionHandler, IEqualityComparer, int) instead.", true)]
     public RecursionGuard(ISpecimenBuilder builder, IEqualityComparer comparer)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-        this.RecursionDepth = 1;
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        RecursionDepth = 1;
     }
 
     /// <summary>
@@ -99,10 +99,10 @@ public class RecursionGuard : ISpecimenBuilderNode
         if (recursionDepth < 1)
             throw new ArgumentOutOfRangeException(nameof(recursionDepth), "Recursion depth must be greater than 0.");
 
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.RecursionHandler = recursionHandler ?? throw new ArgumentNullException(nameof(recursionHandler));
-        this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-        this.RecursionDepth = recursionDepth;
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        RecursionHandler = recursionHandler ?? throw new ArgumentNullException(nameof(recursionHandler));
+        Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        RecursionDepth = recursionDepth;
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ public class RecursionGuard : ISpecimenBuilderNode
     public IEqualityComparer Comparer { get; }
 
     /// <summary> Gets the recorded requests so far. </summary>
-    protected IEnumerable RecordedRequests => this.GetMonitoredRequestsForCurrentThread();
+    protected IEnumerable RecordedRequests => GetMonitoredRequestsForCurrentThread();
 
     /// <summary>
     /// Handles a request that would cause recursion.
@@ -132,15 +132,15 @@ public class RecursionGuard : ISpecimenBuilderNode
     [Obsolete("This method will be removed in a future version of AutoFixture. Use IRecursionHandler.HandleRecursiveRequest instead.", true)]
     public virtual object HandleRecursiveRequest(object request)
     {
-        return this.RecursionHandler.HandleRecursiveRequest(
+        return RecursionHandler.HandleRecursiveRequest(
             request,
-            this.GetMonitoredRequestsForCurrentThread());
+            GetMonitoredRequestsForCurrentThread());
     }
 
     /// <inheritdoc />
     public object Create(object request, ISpecimenContext context)
     {
-        var requestsForCurrentThread = this.GetMonitoredRequestsForCurrentThread();
+        var requestsForCurrentThread = GetMonitoredRequestsForCurrentThread();
         if (requestsForCurrentThread.Count > 0)
         {
             // This is performance-sensitive code when used repeatedly over many requests.
@@ -150,12 +150,12 @@ public class RecursionGuard : ISpecimenBuilderNode
             for (int i = 0; i < requestsArray.Length; i++)
             {
                 var existingRequest = requestsArray[i];
-                if (this.Comparer.Equals(existingRequest, request))
+                if (Comparer.Equals(existingRequest, request))
                 {
                     numRequestsSameAsThisOne++;
                 }
 
-                if (numRequestsSameAsThisOne >= this.RecursionDepth)
+                if (numRequestsSameAsThisOne >= RecursionDepth)
                 {
 #pragma warning disable 618
                     return ObsoletedMemberShims.RecursionGuard_HandleRecursiveRequest(this, request);
@@ -167,7 +167,7 @@ public class RecursionGuard : ISpecimenBuilderNode
         requestsForCurrentThread.Push(request);
         try
         {
-            return this.Builder.Create(request, context);
+            return Builder.Create(request, context);
         }
         finally
         {
@@ -183,20 +183,20 @@ public class RecursionGuard : ISpecimenBuilderNode
         var composedBuilder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
         return new RecursionGuard(
             composedBuilder,
-            this.RecursionHandler,
-            this.Comparer,
-            this.RecursionDepth);
+            RecursionHandler,
+            Comparer,
+            RecursionDepth);
     }
 
     /// <inheritdoc />
     public virtual IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     /// <inheritdoc />
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
+++ b/Src/AutoFixture/Kernel/RegularExpressionRequest.cs
@@ -13,7 +13,7 @@ public class RegularExpressionRequest : IEquatable<RegularExpressionRequest>
     /// <param name="pattern">The pattern.</param>
     public RegularExpressionRequest(string pattern)
     {
-        this.Pattern = pattern ?? throw new ArgumentNullException(nameof(pattern));
+        Pattern = pattern ?? throw new ArgumentNullException(nameof(pattern));
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public class RegularExpressionRequest : IEquatable<RegularExpressionRequest>
     {
         if (obj is RegularExpressionRequest other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
 
         return base.Equals(obj);
@@ -49,7 +49,7 @@ public class RegularExpressionRequest : IEquatable<RegularExpressionRequest>
     /// </returns>
     public override int GetHashCode()
     {
-        return HashCode.Combine(this.Pattern);
+        return HashCode.Combine(Pattern);
     }
 
     /// <summary>
@@ -66,6 +66,6 @@ public class RegularExpressionRequest : IEquatable<RegularExpressionRequest>
             return false;
         }
 
-        return string.Equals(this.Pattern, other.Pattern, StringComparison.Ordinal);
+        return string.Equals(Pattern, other.Pattern, StringComparison.Ordinal);
     }
 }

--- a/Src/AutoFixture/Kernel/RequestTraceEventArgs.cs
+++ b/Src/AutoFixture/Kernel/RequestTraceEventArgs.cs
@@ -17,8 +17,8 @@ public class RequestTraceEventArgs : EventArgs
     /// </param>
     public RequestTraceEventArgs(object request, int depth)
     {
-        this.Request = request;
-        this.Depth = depth;
+        Request = request;
+        Depth = depth;
     }
 
     /// <summary>

--- a/Src/AutoFixture/Kernel/SeedRequestSpecification.cs
+++ b/Src/AutoFixture/Kernel/SeedRequestSpecification.cs
@@ -13,7 +13,7 @@ public class SeedRequestSpecification : IRequestSpecification
     /// <param name="type">The target type.</param>
     public SeedRequestSpecification(Type type)
     {
-        this.TargetType = type ?? throw new ArgumentNullException(nameof(type));
+        TargetType = type ?? throw new ArgumentNullException(nameof(type));
     }
 
     /// <summary>
@@ -34,6 +34,6 @@ public class SeedRequestSpecification : IRequestSpecification
         if (request == null) throw new ArgumentNullException(nameof(request));
 
         return request is SeededRequest seededRequest &&
-               this.TargetType.Equals(seededRequest.Request);
+               TargetType.Equals(seededRequest.Request);
     }
 }

--- a/Src/AutoFixture/Kernel/SeededFactory.cs
+++ b/Src/AutoFixture/Kernel/SeededFactory.cs
@@ -14,7 +14,7 @@ public class SeededFactory<T> : ISpecimenBuilder
     /// <param name="factory">The function that will create the specimen from a seed.</param>
     public SeededFactory(Func<T, T> factory)
     {
-        this.Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
     /// <summary>
@@ -36,7 +36,7 @@ public class SeededFactory<T> : ISpecimenBuilder
     {
         if (request != null && request.Equals(typeof(T)))
         {
-            return this.Factory(default(T));
+            return Factory(default(T));
         }
 
         var seededRequest = request as SeededRequest;
@@ -57,6 +57,6 @@ public class SeededFactory<T> : ISpecimenBuilder
         }
         var seed = (T)seededRequest.Seed;
 
-        return this.Factory(seed);
+        return Factory(seed);
     }
 }

--- a/Src/AutoFixture/Kernel/SeededRequest.cs
+++ b/Src/AutoFixture/Kernel/SeededRequest.cs
@@ -14,8 +14,8 @@ public class SeededRequest : IEquatable<SeededRequest>
     /// <param name="seed">The seed.</param>
     public SeededRequest(object request, object seed)
     {
-        this.Request = request ?? throw new ArgumentNullException(nameof(request));
-        this.Seed = seed;
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        Seed = seed;
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public class SeededRequest : IEquatable<SeededRequest>
     {
         if (obj is SeededRequest other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
         return base.Equals(obj);
     }
@@ -51,7 +51,7 @@ public class SeededRequest : IEquatable<SeededRequest>
     /// <returns>The hash code for the instance.</returns>
     public override int GetHashCode()
     {
-        return this.Request.GetHashCode() ^ (this.Seed == null ? 0 : this.Seed.GetHashCode());
+        return Request.GetHashCode() ^ (Seed == null ? 0 : Seed.GetHashCode());
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public class SeededRequest : IEquatable<SeededRequest>
             return false;
         }
 
-        return this.Request == other.Request
-               && object.Equals(this.Seed, other.Seed);
+        return Request == other.Request
+               && object.Equals(Seed, other.Seed);
     }
 }

--- a/Src/AutoFixture/Kernel/SpecifiedNullCommand.cs
+++ b/Src/AutoFixture/Kernel/SpecifiedNullCommand.cs
@@ -29,7 +29,7 @@ public class SpecifiedNullCommand<T, TProperty> : ISpecifiedSpecimenCommand<T>
     {
         if (propertyPicker == null) throw new ArgumentNullException(nameof(propertyPicker));
 
-        this.Member = propertyPicker.GetWritableMember().Member;
+        Member = propertyPicker.GetWritableMember().Member;
     }
 
     /// <summary>
@@ -60,6 +60,6 @@ public class SpecifiedNullCommand<T, TProperty> : ISpecifiedSpecimenCommand<T>
         if (request == null) throw new ArgumentNullException(nameof(request));
 
         IEqualityComparer comparer = new MemberInfoEqualityComparer();
-        return comparer.Equals(this.Member, request);
+        return comparer.Equals(Member, request);
     }
 }

--- a/Src/AutoFixture/Kernel/SpecimenContext.cs
+++ b/Src/AutoFixture/Kernel/SpecimenContext.cs
@@ -14,7 +14,7 @@ public class SpecimenContext : ISpecimenContext
     /// <param name="builder">The builder that will handle requests.</param>
     public SpecimenContext(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -30,6 +30,6 @@ public class SpecimenContext : ISpecimenContext
     /// <returns>The result of a request to the contained <see cref="Builder"/>.</returns>
     public object Resolve(object request)
     {
-        return this.Builder.Create(request, this);
+        return Builder.Create(request, this);
     }
 }

--- a/Src/AutoFixture/Kernel/SpecimenCreatedEventArgs.cs
+++ b/Src/AutoFixture/Kernel/SpecimenCreatedEventArgs.cs
@@ -19,7 +19,7 @@ public class SpecimenCreatedEventArgs : RequestTraceEventArgs
     public SpecimenCreatedEventArgs(object request, object specimen, int depth)
         : base(request, depth)
     {
-        this.Specimen = specimen;
+        Specimen = specimen;
     }
 
     /// <summary>

--- a/Src/AutoFixture/Kernel/SpecimenFactory.cs
+++ b/Src/AutoFixture/Kernel/SpecimenFactory.cs
@@ -14,7 +14,7 @@ public class SpecimenFactory<T> : ISpecimenBuilder
     /// <param name="factory">The func that will create specimens.</param>
     public SpecimenFactory(Func<T> factory)
     {
-        this.Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public class SpecimenFactory<T> : ISpecimenBuilder
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Factory();
+        return Factory();
     }
 }
 
@@ -61,7 +61,7 @@ public class SpecimenFactory<TInput, T> : ISpecimenBuilder
     /// </remarks>
     public SpecimenFactory(Func<TInput, T> factory)
     {
-        this.Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
     /// <summary>
@@ -89,7 +89,7 @@ public class SpecimenFactory<TInput, T> : ISpecimenBuilder
         if (context == null) throw new ArgumentNullException(nameof(context));
 
         var p = (TInput)context.Resolve(typeof(TInput));
-        return this.Factory(p);
+        return Factory(p);
     }
 }
 
@@ -117,7 +117,7 @@ public class SpecimenFactory<TInput1, TInput2, T> : ISpecimenBuilder
     /// </remarks>
     public SpecimenFactory(Func<TInput1, TInput2, T> factory)
     {
-        this.Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
     /// <summary>
@@ -146,7 +146,7 @@ public class SpecimenFactory<TInput1, TInput2, T> : ISpecimenBuilder
 
         var p1 = (TInput1)context.Resolve(typeof(TInput1));
         var p2 = (TInput2)context.Resolve(typeof(TInput2));
-        return this.Factory(p1, p2);
+        return Factory(p1, p2);
     }
 }
 
@@ -175,7 +175,7 @@ public class SpecimenFactory<TInput1, TInput2, TInput3, T> : ISpecimenBuilder
     /// </remarks>
     public SpecimenFactory(Func<TInput1, TInput2, TInput3, T> factory)
     {
-        this.Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
     /// <summary>
@@ -205,7 +205,7 @@ public class SpecimenFactory<TInput1, TInput2, TInput3, T> : ISpecimenBuilder
         var p1 = (TInput1)context.Resolve(typeof(TInput1));
         var p2 = (TInput2)context.Resolve(typeof(TInput2));
         var p3 = (TInput3)context.Resolve(typeof(TInput3));
-        return this.Factory(p1, p2, p3);
+        return Factory(p1, p2, p3);
     }
 }
 
@@ -235,7 +235,7 @@ public class SpecimenFactory<TInput1, TInput2, TInput3, TInput4, T> : ISpecimenB
     /// </remarks>
     public SpecimenFactory(Func<TInput1, TInput2, TInput3, TInput4, T> factory)
     {
-        this.Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
     }
 
     /// <summary>
@@ -266,7 +266,7 @@ public class SpecimenFactory<TInput1, TInput2, TInput3, TInput4, T> : ISpecimenB
         var p2 = (TInput2)context.Resolve(typeof(TInput2));
         var p3 = (TInput3)context.Resolve(typeof(TInput3));
         var p4 = (TInput4)context.Resolve(typeof(TInput4));
-        return this.Factory(p1, p2, p3, p4);
+        return Factory(p1, p2, p3, p4);
     }
 }
 #pragma warning restore SA1402 // File may only contain a single type

--- a/Src/AutoFixture/Kernel/StaticMethod.cs
+++ b/Src/AutoFixture/Kernel/StaticMethod.cs
@@ -10,7 +10,7 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class StaticMethod : IMethod, IEquatable<StaticMethod>
 {
-    private readonly ParameterInfo[] paramInfos;
+    private readonly ParameterInfo[] _paramInfos;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StaticMethod"/> class.
@@ -28,8 +28,8 @@ public class StaticMethod : IMethod, IEquatable<StaticMethod>
     /// <param name="methodParameters">The method parameters.</param>
     public StaticMethod(MethodInfo methodInfo, ParameterInfo[] methodParameters)
     {
-        this.Method = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
-        this.paramInfos = methodParameters ?? throw new ArgumentNullException(nameof(methodParameters));
+        Method = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+        _paramInfos = methodParameters ?? throw new ArgumentNullException(nameof(methodParameters));
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public class StaticMethod : IMethod, IEquatable<StaticMethod>
     /// <summary>
     /// Gets information about the parameters of the method.
     /// </summary>
-    public IEnumerable<ParameterInfo> Parameters => this.paramInfos;
+    public IEnumerable<ParameterInfo> Parameters => _paramInfos;
 
     /// <summary>
     /// Determines whether the specified <see cref="object"/> is equal to this instance.
@@ -56,7 +56,7 @@ public class StaticMethod : IMethod, IEquatable<StaticMethod>
     {
         if (obj is StaticMethod other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
         return base.Equals(obj);
     }
@@ -70,8 +70,8 @@ public class StaticMethod : IMethod, IEquatable<StaticMethod>
     /// </returns>
     public override int GetHashCode()
     {
-        return this.Method.GetHashCode()
-               ^ this.Parameters.Aggregate(0, (current, parameter) => current + parameter.GetHashCode());
+        return Method.GetHashCode()
+               ^ Parameters.Aggregate(0, (current, parameter) => current + parameter.GetHashCode());
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public class StaticMethod : IMethod, IEquatable<StaticMethod>
     /// <returns>The result of the method call.</returns>
     public object Invoke(IEnumerable<object> parameters)
     {
-        return this.Method.Invoke(null, parameters.ToArray());
+        return Method.Invoke(null, parameters.ToArray());
     }
 
     /// <summary>
@@ -98,8 +98,8 @@ public class StaticMethod : IMethod, IEquatable<StaticMethod>
             return false;
         }
 
-        return this.Method.Equals(other.Method)
-               && this.Parameters.SequenceEqual(other.Parameters);
+        return Method.Equals(other.Method)
+               && Parameters.SequenceEqual(other.Parameters);
     }
 
     private static ParameterInfo[] GetMethodParameters(MethodInfo methodInfo)

--- a/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
+++ b/Src/AutoFixture/Kernel/TemplateMethodQuery.cs
@@ -27,7 +27,7 @@ public class TemplateMethodQuery : IMethodQuery
     /// <param name="template">The method info to compare.</param>
     public TemplateMethodQuery(MethodInfo template)
     {
-        this.Template = template ?? throw new ArgumentNullException(nameof(template));
+        Template = template ?? throw new ArgumentNullException(nameof(template));
     }
 
     /// <summary>
@@ -37,8 +37,8 @@ public class TemplateMethodQuery : IMethodQuery
     /// <param name="owner">The owner.</param>
     public TemplateMethodQuery(MethodInfo template, object owner)
     {
-        this.Owner = owner ?? throw new ArgumentNullException(nameof(owner));
-        this.Template = template ?? throw new ArgumentNullException(nameof(template));
+        Owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        Template = template ?? throw new ArgumentNullException(nameof(template));
     }
 
     /// <summary>
@@ -81,17 +81,17 @@ public class TemplateMethodQuery : IMethodQuery
         if (type == null) throw new ArgumentNullException(nameof(type));
 
         return from method in type.GetTypeInfo().GetMethods()
-            where string.Equals(method.Name, this.Template.Name, StringComparison.Ordinal) && (this.Owner != null || method.IsStatic)
+            where string.Equals(method.Name, Template.Name, StringComparison.Ordinal) && (Owner != null || method.IsStatic)
             let methodParameters = method.GetParameters()
-            let templateParameters = this.Template.GetParameters()
+            let templateParameters = Template.GetParameters()
             where methodParameters.Length >= templateParameters.Length
             let score = new LateBindingParameterScore(methodParameters, templateParameters)
             orderby score descending
             where methodParameters.All(p =>
                 p.Position >= templateParameters.Length ?
                     p.IsOptional || p.IsDefined(typeof(ParamArrayAttribute), true) :
-                    this.Compare(p.ParameterType, templateParameters[p.Position].ParameterType))
-            select new GenericMethod(method, this.GetMethodFactory(method));
+                    Compare(p.ParameterType, templateParameters[p.Position].ParameterType))
+            select new GenericMethod(method, GetMethodFactory(method));
     }
 
     private IMethodFactory GetMethodFactory(MethodInfo method)
@@ -99,7 +99,7 @@ public class TemplateMethodQuery : IMethodQuery
         if (method.IsStatic)
             return new MissingParametersSupplyingStaticMethodFactory();
 
-        return new MissingParametersSupplyingMethodFactory(this.Owner);
+        return new MissingParametersSupplyingMethodFactory(Owner);
     }
 
     private bool Compare(Type parameterType, Type templateParameterType)
@@ -119,7 +119,7 @@ public class TemplateMethodQuery : IMethodQuery
         if (genericArguments.Length == 0 || genericArguments.Length != templateGenericArguments.Length)
             return false;
 
-        return genericArguments.Zip(templateGenericArguments, this.Compare).All(x => x);
+        return genericArguments.Zip(templateGenericArguments, Compare).All(x => x);
     }
 
     private static Type[] GetTypeArguments(Type type)
@@ -131,7 +131,7 @@ public class TemplateMethodQuery : IMethodQuery
 
     private class LateBindingParameterScore : IComparable<LateBindingParameterScore>
     {
-        private readonly int score;
+        private readonly int _score;
 
         internal LateBindingParameterScore(IEnumerable<ParameterInfo> methodParameters,
             IEnumerable<ParameterInfo> templateParameters)
@@ -142,7 +142,7 @@ public class TemplateMethodQuery : IMethodQuery
             if (templateParameters == null)
                 throw new ArgumentNullException(nameof(templateParameters));
 
-            this.score = CalculateScore(methodParameters.Select(p => p.ParameterType),
+            _score = CalculateScore(methodParameters.Select(p => p.ParameterType),
                 templateParameters.Select(p => p.ParameterType));
         }
 
@@ -151,7 +151,7 @@ public class TemplateMethodQuery : IMethodQuery
             if (other == null)
                 return 1;
 
-            return this.score.CompareTo(other.score);
+            return _score.CompareTo(other._score);
         }
 
         private static int CalculateScore(IEnumerable<Type> methodParameters,

--- a/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
+++ b/Src/AutoFixture/Kernel/TerminatingWithPathSpecimenBuilder.cs
@@ -20,10 +20,10 @@ namespace AutoFixture.Kernel;
     Justification = "Fixture doesn't support disposal, so we cannot dispose current builder somehow.")]
 public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
 {
-    private readonly ThreadLocal<Stack<object>> requestsByThread
+    private readonly ThreadLocal<Stack<object>> _requestsByThread
         = new ThreadLocal<Stack<object>>(() => new Stack<object>());
 
-    private Stack<object> GetPathForCurrentThread() => this.requestsByThread.Value;
+    private Stack<object> GetPathForCurrentThread() => _requestsByThread.Value;
 
     /// <summary>
     /// Creates a new <see cref="TerminatingWithPathSpecimenBuilder"/> instance.
@@ -31,7 +31,7 @@ public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
     /// <param name="builder">The specimen builder which creation requests are redirected to.</param>
     public TerminatingWithPathSpecimenBuilder(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
     /// <summary>
     /// Gets the observed specimen requests, in the order they were requested.
     /// </summary>
-    public IEnumerable<object> SpecimenRequests => this.GetPathForCurrentThread().Reverse();
+    public IEnumerable<object> SpecimenRequests => GetPathForCurrentThread().Reverse();
 
     /// <summary>
     /// Creates a new specimen based on a request by delegating to its decorated builder.
@@ -54,10 +54,10 @@ public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
     /// </returns>
     public object Create(object request, ISpecimenContext context)
     {
-        this.GetPathForCurrentThread().Push(request);
+        GetPathForCurrentThread().Push(request);
         try
         {
-            var result = this.Builder.Create(request, context);
+            var result = Builder.Create(request, context);
             if (result is NoSpecimen)
             {
                 throw new ObjectCreationExceptionWithPath(
@@ -66,7 +66,7 @@ public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
                         BuildCoreMessageTemplate(request, null),
                         request,
                         Environment.NewLine),
-                    this.SpecimenRequests);
+                    SpecimenRequests);
             }
 
             return result;
@@ -84,12 +84,12 @@ public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
                     BuildCoreMessageTemplate(request, ex),
                     request,
                     Environment.NewLine),
-                this.SpecimenRequests,
+                SpecimenRequests,
                 ex);
         }
         finally
         {
-            this.GetPathForCurrentThread().Pop();
+            GetPathForCurrentThread().Pop();
         }
     }
 
@@ -183,8 +183,8 @@ public class TerminatingWithPathSpecimenBuilder : ISpecimenBuilderNode
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => this.GetEnumerator();
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
+++ b/Src/AutoFixture/Kernel/ThrowingRecursionGuard.cs
@@ -49,8 +49,8 @@ fixture.Behaviors.OfType<ThrowingRecursionBehavior>().ToList()
 fixture.Behaviors.Add(new OmitOnRecursionBehavior());
 
                 ",
-                this.RecordedRequests.Cast<object>().First().GetType()),
-            this.RecordedRequests.Cast<object>());
+                RecordedRequests.Cast<object>().First().GetType()),
+            RecordedRequests.Cast<object>());
     }
 
     /// <summary>Composes the supplied builders.</summary>
@@ -64,6 +64,6 @@ fixture.Behaviors.Add(new OmitOnRecursionBehavior());
         if (builders == null) throw new ArgumentNullException(nameof(builders));
 
         var builder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
-        return new ThrowingRecursionGuard(builder, this.Comparer);
+        return new ThrowingRecursionGuard(builder, Comparer);
     }
 }

--- a/Src/AutoFixture/Kernel/TraceWriter.cs
+++ b/Src/AutoFixture/Kernel/TraceWriter.cs
@@ -11,9 +11,9 @@ namespace AutoFixture.Kernel;
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "The main responsibility of this class isn't to be a 'collection' (which, by the way, it isn't - it's just an Iterator).")]
 public class TraceWriter : ISpecimenBuilderNode
 {
-    private readonly TextWriter writer;
-    private Action<TextWriter, object, int> writeRequest;
-    private Action<TextWriter, object, int> writeSpecimen;
+    private readonly TextWriter _writer;
+    private Action<TextWriter, object, int> _writeRequest;
+    private Action<TextWriter, object, int> _writeSpecimen;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TraceWriter"/> class.
@@ -25,13 +25,13 @@ public class TraceWriter : ISpecimenBuilderNode
         if (writer == null) throw new ArgumentNullException(nameof(writer));
         if (tracer == null) throw new ArgumentNullException(nameof(tracer));
 
-        this.Tracer = tracer;
-        this.Tracer.SpecimenRequested += (sender, e) => this.writeRequest(writer, e.Request, e.Depth);
-        this.Tracer.SpecimenCreated += (sender, e) => this.writeSpecimen(writer, e.Specimen, e.Depth);
+        Tracer = tracer;
+        Tracer.SpecimenRequested += (sender, e) => _writeRequest(writer, e.Request, e.Depth);
+        Tracer.SpecimenCreated += (sender, e) => _writeSpecimen(writer, e.Specimen, e.Depth);
 
-        this.writer = writer;
-        this.TraceRequestFormatter = (tw, r, i) => tw.WriteLine(new string(' ', i * 2) + "Requested: " + r);
-        this.TraceSpecimenFormatter = (tw, r, i) => tw.WriteLine(new string(' ', i * 2) + "Created: " + r);
+        _writer = writer;
+        TraceRequestFormatter = (tw, r, i) => tw.WriteLine(new string(' ', i * 2) + "Requested: " + r);
+        TraceSpecimenFormatter = (tw, r, i) => tw.WriteLine(new string(' ', i * 2) + "Created: " + r);
     }
 
     /// <summary>
@@ -45,8 +45,8 @@ public class TraceWriter : ISpecimenBuilderNode
     /// <value>The request trace formatter.</value>
     public Action<TextWriter, object, int> TraceRequestFormatter
     {
-        get => this.writeRequest;
-        set => this.writeRequest = value ?? throw new ArgumentNullException(nameof(value));
+        get => _writeRequest;
+        set => _writeRequest = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -55,8 +55,8 @@ public class TraceWriter : ISpecimenBuilderNode
     /// <value>The created specimen trace formatter.</value>
     public Action<TextWriter, object, int> TraceSpecimenFormatter
     {
-        get => this.writeSpecimen;
-        set => this.writeSpecimen = value ?? throw new ArgumentNullException(nameof(value));
+        get => _writeSpecimen;
+        set => _writeSpecimen = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public class TraceWriter : ISpecimenBuilderNode
     /// </returns>
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Tracer.Create(request, context);
+        return Tracer.Create(request, context);
     }
 
     /// <summary>Composes the supplied builders.</summary>
@@ -85,7 +85,7 @@ public class TraceWriter : ISpecimenBuilderNode
         var builder = CompositeSpecimenBuilder.ComposeIfMultiple(builders);
 
         return new TraceWriter(
-            this.writer,
+            _writer,
             new TracingBuilder(
                 builder));
     }
@@ -99,11 +99,11 @@ public class TraceWriter : ISpecimenBuilderNode
     /// </returns>
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Tracer.Builder;
+        yield return Tracer.Builder;
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixture/Kernel/TracingBuilder.cs
+++ b/Src/AutoFixture/Kernel/TracingBuilder.cs
@@ -8,8 +8,8 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class TracingBuilder : ISpecimenBuilder
 {
-    private IRequestSpecification filter;
-    private int depth;
+    private IRequestSpecification _filter;
+    private int _depth;
 
     /// <summary>
     /// Raised when a specimen is requested.
@@ -28,8 +28,8 @@ public class TracingBuilder : ISpecimenBuilder
     /// <param name="builder">The <see cref="ISpecimenBuilder"/> to decorate.</param>
     public TracingBuilder(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.filter = new TrueRequestSpecification();
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        _filter = new TrueRequestSpecification();
     }
 
     /// <summary>
@@ -52,8 +52,8 @@ public class TracingBuilder : ISpecimenBuilder
     /// </remarks>
     public IRequestSpecification Filter
     {
-        get => this.filter;
-        set => this.filter = value ?? throw new ArgumentNullException(nameof(value));
+        get => _filter;
+        set => _filter = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -72,17 +72,17 @@ public class TracingBuilder : ISpecimenBuilder
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        var isFilterSatisfied = this.filter.IsSatisfiedBy(request);
+        var isFilterSatisfied = _filter.IsSatisfiedBy(request);
         if (isFilterSatisfied)
         {
-            this.OnSpecimenRequested(new RequestTraceEventArgs(request, ++this.depth));
+            OnSpecimenRequested(new RequestTraceEventArgs(request, ++_depth));
         }
 
         bool specimenWasCreated = false;
         object specimen = null;
         try
         {
-            specimen = this.Builder.Create(request, context);
+            specimen = Builder.Create(request, context);
             specimenWasCreated = true;
             return specimen;
         }
@@ -92,9 +92,9 @@ public class TracingBuilder : ISpecimenBuilder
             {
                 if (specimenWasCreated)
                 {
-                    this.OnSpecimenCreated(new SpecimenCreatedEventArgs(request, specimen, this.depth));
+                    OnSpecimenCreated(new SpecimenCreatedEventArgs(request, specimen, _depth));
                 }
-                this.depth--;
+                _depth--;
             }
         }
     }
@@ -105,7 +105,7 @@ public class TracingBuilder : ISpecimenBuilder
     /// <param name="e">The event arguments for the event.</param>
     protected virtual void OnSpecimenCreated(SpecimenCreatedEventArgs e)
     {
-        this.SpecimenCreated?.Invoke(this, e);
+        SpecimenCreated?.Invoke(this, e);
     }
 
     /// <summary>
@@ -114,6 +114,6 @@ public class TracingBuilder : ISpecimenBuilder
     /// <param name="e">The event arguments for the event.</param>
     protected virtual void OnSpecimenRequested(RequestTraceEventArgs e)
     {
-        this.SpecimenRequested?.Invoke(this, e);
+        SpecimenRequested?.Invoke(this, e);
     }
 }

--- a/Src/AutoFixture/Kernel/TypeRelay.cs
+++ b/Src/AutoFixture/Kernel/TypeRelay.cs
@@ -8,7 +8,7 @@ namespace AutoFixture.Kernel;
 /// </summary>
 public class TypeRelay : ISpecimenBuilder
 {
-    private readonly IRequestSpecification fromSpecification;
+    private readonly IRequestSpecification _fromSpecification;
 
     /// <summary>
     /// Gets the type which is relayed from.
@@ -54,8 +54,8 @@ public class TypeRelay : ISpecimenBuilder
     /// </example>
     public TypeRelay(Type from, Type to)
     {
-        this.From = from ?? throw new ArgumentNullException(nameof(from));
-        this.To = to ?? throw new ArgumentNullException(nameof(to));
+        From = from ?? throw new ArgumentNullException(nameof(from));
+        To = to ?? throw new ArgumentNullException(nameof(to));
 
         if (from.GetTypeInfo().IsGenericTypeDefinition ^ to.GetTypeInfo().IsGenericTypeDefinition)
         {
@@ -63,7 +63,7 @@ public class TypeRelay : ISpecimenBuilder
                                         "or from closed type to closed type are supported only.");
         }
 
-        this.fromSpecification = new ExactTypeSpecification(from);
+        _fromSpecification = new ExactTypeSpecification(from);
     }
 
     /// <summary>
@@ -91,18 +91,18 @@ public class TypeRelay : ISpecimenBuilder
     {
         if (context == null) throw new ArgumentNullException(nameof(context));
 
-        if (request is Type t && this.fromSpecification.IsSatisfiedBy(request))
-            return context.Resolve(this.GetRedirectedTypeRequest(t));
+        if (request is Type t && _fromSpecification.IsSatisfiedBy(request))
+            return context.Resolve(GetRedirectedTypeRequest(t));
 
         return NoSpecimen.Instance;
     }
 
     private Type GetRedirectedTypeRequest(Type originalRequest)
     {
-        if (!this.From.GetTypeInfo().IsGenericTypeDefinition)
-            return this.To;
+        if (!From.GetTypeInfo().IsGenericTypeDefinition)
+            return To;
 
         var genericArguments = originalRequest.GetTypeInfo().GenericTypeArguments;
-        return this.To.GetTypeInfo().MakeGenericType(genericArguments);
+        return To.GetTypeInfo().MakeGenericType(genericArguments);
     }
 }

--- a/Src/AutoFixture/Kernel/UnspecifiedSpecimenCommand.cs
+++ b/Src/AutoFixture/Kernel/UnspecifiedSpecimenCommand.cs
@@ -16,7 +16,7 @@ public class UnspecifiedSpecimenCommand<T> : ISpecifiedSpecimenCommand<T>
     /// <param name="action">The action to perform on a specimen.</param>
     public UnspecifiedSpecimenCommand(Action<T> action)
     {
-        this.Action = action ?? throw new ArgumentNullException(nameof(action));
+        Action = action ?? throw new ArgumentNullException(nameof(action));
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public class UnspecifiedSpecimenCommand<T> : ISpecifiedSpecimenCommand<T>
     /// </param>
     public void Execute(T specimen, ISpecimenContext context)
     {
-        this.Action(specimen);
+        Action(specimen);
     }
 
     /// <summary>

--- a/Src/AutoFixture/MutableValueTypeGenerator.cs
+++ b/Src/AutoFixture/MutableValueTypeGenerator.cs
@@ -8,14 +8,14 @@ namespace AutoFixture;
 /// </summary>
 public class MutableValueTypeGenerator : ISpecimenBuilder
 {
-    private readonly IRequestSpecification valueTypeWithoutConstructorsSpecification;
+    private readonly IRequestSpecification _valueTypeWithoutConstructorsSpecification;
 
     /// <summary>
     /// Creates new instance.
     /// </summary>
     public MutableValueTypeGenerator()
     {
-        this.valueTypeWithoutConstructorsSpecification = new AndRequestSpecification(new ValueTypeSpecification(),
+        _valueTypeWithoutConstructorsSpecification = new AndRequestSpecification(new ValueTypeSpecification(),
             new NoConstructorsSpecification());
     }
 
@@ -30,7 +30,7 @@ public class MutableValueTypeGenerator : ISpecimenBuilder
     public object Create(object request, ISpecimenContext context)
     {
         Type type = request as Type;
-        if (type == null || !this.valueTypeWithoutConstructorsSpecification.IsSatisfiedBy(type))
+        if (type == null || !_valueTypeWithoutConstructorsSpecification.IsSatisfiedBy(type))
         {
             return NoSpecimen.Instance;
         }

--- a/Src/AutoFixture/NoAutoPropertiesCustomization.cs
+++ b/Src/AutoFixture/NoAutoPropertiesCustomization.cs
@@ -8,7 +8,7 @@ namespace AutoFixture;
 /// </summary>
 public class NoAutoPropertiesCustomization : ICustomization
 {
-    private readonly Type targetType;
+    private readonly Type _targetType;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NoAutoPropertiesCustomization"/> class.
@@ -21,11 +21,11 @@ public class NoAutoPropertiesCustomization : ICustomization
     {
         if (targetType == null) throw new ArgumentNullException(nameof(targetType));
 
-        this.targetType = targetType;
+        _targetType = targetType;
     }
 
     /// <summary>
-    /// Customizes the fixture by creating a <see cref="targetType"/> that has no auto populated properties.
+    /// Customizes the fixture by creating a <see cref="_targetType"/> that has no auto populated properties.
     /// </summary>
     /// <param name="fixture">The fixture to customize.</param>
     /// <exception cref="ArgumentNullException">
@@ -41,7 +41,7 @@ public class NoAutoPropertiesCustomization : ICustomization
         var constructor = new MethodInvoker(new ModestConstructorQuery());
 
         var builder = SpecimenBuilderNodeFactory.CreateTypedNode(
-            this.targetType, constructor);
+            _targetType, constructor);
 
         fixture.Customizations.Insert(0, builder);
     }

--- a/Src/AutoFixture/NullRecursionBehavior.cs
+++ b/Src/AutoFixture/NullRecursionBehavior.cs
@@ -9,7 +9,7 @@ namespace AutoFixture;
 public class NullRecursionBehavior : ISpecimenBuilderTransformation
 {
     private const int DefaultRecursionDepth = 1;
-    private readonly int recursionDepth;
+    private readonly int _recursionDepth;
 
     /// <summary>
     /// Initializes new instance of the <see cref="NullRecursionBehavior" /> class with default recursion depth.
@@ -26,7 +26,7 @@ public class NullRecursionBehavior : ISpecimenBuilderTransformation
     /// <param name="recursionDepth">The recursion depth at which the request will be assigned null.</param>
     public NullRecursionBehavior(int recursionDepth)
     {
-        this.recursionDepth = recursionDepth;
+        _recursionDepth = recursionDepth;
     }
 
     /// <summary>
@@ -41,6 +41,6 @@ public class NullRecursionBehavior : ISpecimenBuilderTransformation
     {
         if (builder == null) throw new ArgumentNullException(nameof(builder));
 
-        return new RecursionGuard(builder, new NullRecursionHandler(), this.recursionDepth);
+        return new RecursionGuard(builder, new NullRecursionHandler(), _recursionDepth);
     }
 }

--- a/Src/AutoFixture/NumericSequenceGenerator.cs
+++ b/Src/AutoFixture/NumericSequenceGenerator.cs
@@ -9,7 +9,7 @@ namespace AutoFixture;
 /// </summary>
 public class NumericSequenceGenerator : ISpecimenBuilder
 {
-    private long value;
+    private long _value;
 
     /// <summary>
     /// Creates an anonymous number.
@@ -26,7 +26,7 @@ public class NumericSequenceGenerator : ISpecimenBuilder
         if (type == null)
             return NoSpecimen.Instance;
 
-        return this.CreateNumericSpecimen(type);
+        return CreateNumericSpecimen(type);
     }
 
     private object CreateNumericSpecimen(Type request)
@@ -36,27 +36,27 @@ public class NumericSequenceGenerator : ISpecimenBuilder
         switch (typeCode)
         {
             case TypeCode.Byte:
-                return (byte)this.GetNextNumber();
+                return (byte)GetNextNumber();
             case TypeCode.Decimal:
-                return (decimal)this.GetNextNumber();
+                return (decimal)GetNextNumber();
             case TypeCode.Double:
-                return (double)this.GetNextNumber();
+                return (double)GetNextNumber();
             case TypeCode.Int16:
-                return (short)this.GetNextNumber();
+                return (short)GetNextNumber();
             case TypeCode.Int32:
-                return (int)this.GetNextNumber();
+                return (int)GetNextNumber();
             case TypeCode.Int64:
-                return this.GetNextNumber();
+                return GetNextNumber();
             case TypeCode.SByte:
-                return (sbyte)this.GetNextNumber();
+                return (sbyte)GetNextNumber();
             case TypeCode.Single:
-                return (float)this.GetNextNumber();
+                return (float)GetNextNumber();
             case TypeCode.UInt16:
-                return (ushort)this.GetNextNumber();
+                return (ushort)GetNextNumber();
             case TypeCode.UInt32:
-                return (uint)this.GetNextNumber();
+                return (uint)GetNextNumber();
             case TypeCode.UInt64:
-                return (ulong)this.GetNextNumber();
+                return (ulong)GetNextNumber();
             default:
                 return NoSpecimen.Instance;
         }
@@ -64,6 +64,6 @@ public class NumericSequenceGenerator : ISpecimenBuilder
 
     private long GetNextNumber()
     {
-        return Interlocked.Increment(ref this.value);
+        return Interlocked.Increment(ref _value);
     }
 }

--- a/Src/AutoFixture/OmitOnRecursionBehavior.cs
+++ b/Src/AutoFixture/OmitOnRecursionBehavior.cs
@@ -10,7 +10,7 @@ namespace AutoFixture;
 public class OmitOnRecursionBehavior : ISpecimenBuilderTransformation
 {
     private const int DefaultRecursionDepth = 1;
-    private readonly int recursionDepth;
+    private readonly int _recursionDepth;
 
     /// <summary>
     /// Initializes new instance of the <see cref="OmitOnRecursionBehavior" /> class with default recursion depth.
@@ -31,7 +31,7 @@ public class OmitOnRecursionBehavior : ISpecimenBuilderTransformation
         if (recursionDepth < 1)
             throw new ArgumentOutOfRangeException(nameof(recursionDepth), "Recursion depth must be greater than 0.");
 
-        this.recursionDepth = recursionDepth;
+        _recursionDepth = recursionDepth;
     }
 
     /// <summary>
@@ -47,6 +47,6 @@ public class OmitOnRecursionBehavior : ISpecimenBuilderTransformation
     {
         if (builder == null) throw new ArgumentNullException(nameof(builder));
 
-        return new RecursionGuard(builder, new OmitOnRecursionHandler(), this.recursionDepth);
+        return new RecursionGuard(builder, new OmitOnRecursionHandler(), _recursionDepth);
     }
 }

--- a/Src/AutoFixture/RandomBooleanSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomBooleanSequenceGenerator.cs
@@ -8,7 +8,7 @@ namespace AutoFixture;
 /// </summary>
 public class RandomBooleanSequenceGenerator : ISpecimenBuilder
 {
-    private readonly RandomNumericSequenceGenerator randomBooleanNumbers;
+    private readonly RandomNumericSequenceGenerator _randomBooleanNumbers;
 
     /// <summary>
     /// Initializes a new instance of the
@@ -16,7 +16,7 @@ public class RandomBooleanSequenceGenerator : ISpecimenBuilder
     /// </summary>
     public RandomBooleanSequenceGenerator()
     {
-        this.randomBooleanNumbers = new RandomNumericSequenceGenerator(0, 1);
+        _randomBooleanNumbers = new RandomNumericSequenceGenerator(0, 1);
     }
 
     /// <summary>
@@ -35,11 +35,11 @@ public class RandomBooleanSequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        return this.GenerateBoolean(context);
+        return GenerateBoolean(context);
     }
 
     private bool GenerateBoolean(ISpecimenContext context)
     {
-        return (int)this.randomBooleanNumbers.Create(typeof(int), context) == 0;
+        return (int)_randomBooleanNumbers.Create(typeof(int), context) == 0;
     }
 }

--- a/Src/AutoFixture/RandomCharSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomCharSequenceGenerator.cs
@@ -9,7 +9,7 @@ namespace AutoFixture;
 /// </summary>
 public class RandomCharSequenceGenerator : ISpecimenBuilder
 {
-    private readonly RandomNumericSequenceGenerator randomPrintableCharNumbers;
+    private readonly RandomNumericSequenceGenerator _randomPrintableCharNumbers;
 
     /// <summary>
     /// Initializes a new instance of the
@@ -17,7 +17,7 @@ public class RandomCharSequenceGenerator : ISpecimenBuilder
     /// </summary>
     public RandomCharSequenceGenerator()
     {
-        this.randomPrintableCharNumbers = new RandomNumericSequenceGenerator(33, 126);
+        _randomPrintableCharNumbers = new RandomNumericSequenceGenerator(33, 126);
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public class RandomCharSequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
 
         return Convert.ToChar(
-            this.randomPrintableCharNumbers.Create(typeof(int), context),
+            _randomPrintableCharNumbers.Create(typeof(int), context),
             CultureInfo.CurrentCulture);
     }
 }

--- a/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateOnlySequenceGenerator.cs
@@ -16,7 +16,7 @@ namespace AutoFixture;
 /// </remarks>
 public class RandomDateOnlySequenceGenerator : ISpecimenBuilder
 {
-    private readonly RandomNumericSequenceGenerator randomizer;
+    private readonly RandomNumericSequenceGenerator _randomizer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomDateOnlySequenceGenerator"/> class.
@@ -43,7 +43,7 @@ public class RandomDateOnlySequenceGenerator : ISpecimenBuilder
             throw new ArgumentException("The 'minDate' argument must be less than the 'maxDate'.");
         }
 
-        this.randomizer = new RandomNumericSequenceGenerator(minDate.DayNumber, maxDate.DayNumber);
+        _randomizer = new RandomNumericSequenceGenerator(minDate.DayNumber, maxDate.DayNumber);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public class RandomDateOnlySequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        var dayNumber = (int)this.randomizer.Create(typeof(int), context);
+        var dayNumber = (int)_randomizer.Create(typeof(int), context);
         return DateOnly.FromDayNumber(dayNumber);
     }
 }

--- a/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomDateTimeSequenceGenerator.cs
@@ -14,7 +14,7 @@ namespace AutoFixture;
 /// </remarks>
 public class RandomDateTimeSequenceGenerator : ISpecimenBuilder
 {
-    private readonly RandomNumericSequenceGenerator randomizer;
+    private readonly RandomNumericSequenceGenerator _randomizer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomDateTimeSequenceGenerator"/> class.
@@ -40,7 +40,7 @@ public class RandomDateTimeSequenceGenerator : ISpecimenBuilder
             throw new ArgumentException("The 'minDate' argument must be less than the 'maxDate'.");
         }
 
-        this.randomizer = new RandomNumericSequenceGenerator(minDate.Ticks, maxDate.Ticks);
+        _randomizer = new RandomNumericSequenceGenerator(minDate.Ticks, maxDate.Ticks);
     }
 
     /// <summary>
@@ -58,7 +58,7 @@ public class RandomDateTimeSequenceGenerator : ISpecimenBuilder
 
         return IsNotDateTimeRequest(request)
             ? NoSpecimen.Instance
-            : this.CreateRandomDate(context);
+            : CreateRandomDate(context);
     }
 
     private static bool IsNotDateTimeRequest(object request)
@@ -68,11 +68,11 @@ public class RandomDateTimeSequenceGenerator : ISpecimenBuilder
 
     private object CreateRandomDate(ISpecimenContext context)
     {
-        return new DateTime(this.GetRandomNumberOfTicks(context));
+        return new DateTime(GetRandomNumberOfTicks(context));
     }
 
     private long GetRandomNumberOfTicks(ISpecimenContext context)
     {
-        return (long)this.randomizer.Create(typeof(long), context);
+        return (long)_randomizer.Create(typeof(long), context);
     }
 }

--- a/Src/AutoFixture/RandomNumericSequenceGenerator.cs
+++ b/Src/AutoFixture/RandomNumericSequenceGenerator.cs
@@ -10,13 +10,13 @@ namespace AutoFixture;
 /// </summary>
 public class RandomNumericSequenceGenerator : ISpecimenBuilder
 {
-    private readonly long[] limits;
-    private readonly object syncRoot;
-    private readonly Random random;
-    private readonly HashSet<long> numbers;
-    private long lower;
-    private long upper;
-    private long count;
+    private readonly long[] _limits;
+    private readonly object _syncRoot;
+    private readonly Random _random;
+    private readonly HashSet<long> _numbers;
+    private long _lower;
+    private long _upper;
+    private long _count;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomNumericSequenceGenerator" /> class
@@ -50,11 +50,11 @@ public class RandomNumericSequenceGenerator : ISpecimenBuilder
 
         ValidateThatLimitsAreStrictlyAscending(limits);
 
-        this.limits = limits;
-        this.syncRoot = new object();
-        this.random = new Random();
-        this.numbers = new HashSet<long>();
-        this.CreateRange();
+        _limits = limits;
+        _syncRoot = new object();
+        _random = new Random();
+        _numbers = new HashSet<long>();
+        CreateRange();
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class RandomNumericSequenceGenerator : ISpecimenBuilder
     /// </value>
     public IEnumerable<long> Limits
     {
-        get { return this.limits; }
+        get { return _limits; }
     }
 
     /// <summary>
@@ -85,7 +85,7 @@ public class RandomNumericSequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        return this.CreateRandom(type);
+        return CreateRandom(type);
     }
 
     private static void ValidateThatLimitsAreStrictlyAscending(long[] limits)
@@ -101,38 +101,38 @@ public class RandomNumericSequenceGenerator : ISpecimenBuilder
         switch (Type.GetTypeCode(request))
         {
             case TypeCode.Byte:
-                return (byte)this.GetNextRandom();
+                return (byte)GetNextRandom();
 
             case TypeCode.Decimal:
-                return (decimal)this.GetNextRandom();
+                return (decimal)GetNextRandom();
 
             case TypeCode.Double:
-                return (double)this.GetNextRandom();
+                return (double)GetNextRandom();
 
             case TypeCode.Int16:
-                return (short)this.GetNextRandom();
+                return (short)GetNextRandom();
 
             case TypeCode.Int32:
-                return (int)this.GetNextRandom();
+                return (int)GetNextRandom();
 
             case TypeCode.Int64:
                 return
-                    this.GetNextRandom();
+                    GetNextRandom();
 
             case TypeCode.SByte:
-                return (sbyte)this.GetNextRandom();
+                return (sbyte)GetNextRandom();
 
             case TypeCode.Single:
-                return (float)this.GetNextRandom();
+                return (float)GetNextRandom();
 
             case TypeCode.UInt16:
-                return (ushort)this.GetNextRandom();
+                return (ushort)GetNextRandom();
 
             case TypeCode.UInt32:
-                return (uint)this.GetNextRandom();
+                return (uint)GetNextRandom();
 
             case TypeCode.UInt64:
-                return (ulong)this.GetNextRandom();
+                return (ulong)GetNextRandom();
 
             default:
                 return NoSpecimen.Instance;
@@ -141,56 +141,56 @@ public class RandomNumericSequenceGenerator : ISpecimenBuilder
 
     private long GetNextRandom()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            this.EvaluateRange();
+            EvaluateRange();
 
             long result;
             do
             {
-                if (this.lower >= int.MinValue &&
-                    this.upper <= int.MaxValue)
+                if (_lower >= int.MinValue &&
+                    _upper <= int.MaxValue)
                 {
-                    result = this.random.Next((int)this.lower, (int)this.upper);
+                    result = _random.Next((int)_lower, (int)_upper);
                 }
                 else
                 {
-                    result = this.GetNextInt64InRange();
+                    result = GetNextInt64InRange();
                 }
             }
-            while (this.numbers.Contains(result));
+            while (_numbers.Contains(result));
 
-            this.numbers.Add(result);
+            _numbers.Add(result);
             return result;
         }
     }
 
     private void EvaluateRange()
     {
-        if (this.count == (this.upper - this.lower))
+        if (_count == (_upper - _lower))
         {
-            this.count = 0;
-            this.CreateRange();
+            _count = 0;
+            CreateRange();
         }
 
-        this.count++;
+        _count++;
     }
 
     private void CreateRange()
     {
-        var remaining = this.limits.Where(x => x > this.upper - 1).ToArray();
-        if (remaining.Any() && this.numbers.Any())
+        var remaining = _limits.Where(x => x > _upper - 1).ToArray();
+        if (remaining.Any() && _numbers.Any())
         {
-            this.lower = this.upper;
-            this.upper = remaining.Min() + 1;
+            _lower = _upper;
+            _upper = remaining.Min() + 1;
         }
         else
         {
-            this.lower = this.limits[0];
-            this.upper = this.GetUpperRangeFromLimits();
+            _lower = _limits[0];
+            _upper = GetUpperRangeFromLimits();
         }
 
-        this.numbers.Clear();
+        _numbers.Clear();
     }
 
     /// <summary>
@@ -202,23 +202,23 @@ public class RandomNumericSequenceGenerator : ISpecimenBuilder
     /// <returns></returns>
     private long GetUpperRangeFromLimits()
     {
-        return this.limits[1] >= int.MaxValue
-            ? this.limits[1]
-            : this.limits[1] + 1;
+        return _limits[1] >= int.MaxValue
+            ? _limits[1]
+            : _limits[1] + 1;
     }
 
     private long GetNextInt64InRange()
     {
-        var range = (ulong)(this.upper - this.lower);
+        var range = (ulong)(_upper - _lower);
         ulong limit = ulong.MaxValue - (ulong.MaxValue % range);
         ulong number;
         do
         {
             var buffer = new byte[sizeof(ulong)];
-            this.random.NextBytes(buffer);
+            _random.NextBytes(buffer);
             number = BitConverter.ToUInt64(buffer, 0);
         }
         while (number > limit);
-        return (long)((number % range) + (ulong)this.lower);
+        return (long)((number % range) + (ulong)_lower);
     }
 }

--- a/Src/AutoFixture/RandomRangedNumberGenerator.cs
+++ b/Src/AutoFixture/RandomRangedNumberGenerator.cs
@@ -13,14 +13,14 @@ namespace AutoFixture;
 /// </summary>
 public class RandomRangedNumberGenerator : ISpecimenBuilder
 {
-    private readonly ConcurrentDictionary<RangedNumberRequest, ISpecimenBuilder> generatorMap;
+    private readonly ConcurrentDictionary<RangedNumberRequest, ISpecimenBuilder> _generatorMap;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomRangedNumberGenerator" /> class.
     /// </summary>
     public RandomRangedNumberGenerator()
     {
-        this.generatorMap = new ConcurrentDictionary<RangedNumberRequest, ISpecimenBuilder>();
+        _generatorMap = new ConcurrentDictionary<RangedNumberRequest, ISpecimenBuilder>();
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public class RandomRangedNumberGenerator : ISpecimenBuilder
 
         try
         {
-            return this.SelectGenerator(rangedNumberRequest).Create(rangedNumberRequest.OperandType, context);
+            return SelectGenerator(rangedNumberRequest).Create(rangedNumberRequest.OperandType, context);
         }
         catch (ArgumentException)
         {
@@ -60,7 +60,7 @@ public class RandomRangedNumberGenerator : ISpecimenBuilder
     /// <returns></returns>
     private ISpecimenBuilder SelectGenerator(RangedNumberRequest request)
     {
-        return this.generatorMap.GetOrAdd(request, CreateRandomGenerator);
+        return _generatorMap.GetOrAdd(request, CreateRandomGenerator);
     }
 
     private static ISpecimenBuilder CreateRandomGenerator(RangedNumberRequest request)
@@ -109,33 +109,33 @@ public class RandomRangedNumberGenerator : ISpecimenBuilder
     {
         private const long RandomValueRange = int.MaxValue;
 
-        private readonly double factor;
-        private readonly double minimum;
-        private readonly double maximum;
-        private readonly TypeCode resultTypeCode;
-        private readonly RandomNumericSequenceGenerator generator;
+        private readonly double _factor;
+        private readonly double _minimum;
+        private readonly double _maximum;
+        private readonly TypeCode _resultTypeCode;
+        private readonly RandomNumericSequenceGenerator _generator;
 
         public FloatingPointRangedGenerator(object minimum, object maximum, TypeCode resultTypeCode)
         {
-            this.minimum = Convert.ToDouble(minimum, CultureInfo.CurrentCulture);
-            this.maximum = Convert.ToDouble(maximum, CultureInfo.CurrentCulture);
-            this.resultTypeCode = resultTypeCode;
-            this.generator = new RandomNumericSequenceGenerator(0, RandomValueRange);
+            _minimum = Convert.ToDouble(minimum, CultureInfo.CurrentCulture);
+            _maximum = Convert.ToDouble(maximum, CultureInfo.CurrentCulture);
+            _resultTypeCode = resultTypeCode;
+            _generator = new RandomNumericSequenceGenerator(0, RandomValueRange);
 
             // (max - min) could lead to overflow, so we divide each part on range individually.
-            this.factor = Math.Abs((this.maximum / RandomValueRange) - (this.minimum / RandomValueRange));
+            _factor = Math.Abs((_maximum / RandomValueRange) - (_minimum / RandomValueRange));
         }
 
         public object Create(object request, ISpecimenContext context)
         {
-            var randomValue = this.generator.Create(typeof(double), context);
+            var randomValue = _generator.Create(typeof(double), context);
             if (randomValue is NoSpecimen) return NoSpecimen.Instance;
 
             // Half offset is needed to avoid overflow - full offset might be larger than double range.
-            double halfOffset = (this.factor / 2) * (double)randomValue;
-            double result = Math.Min(this.minimum + halfOffset + halfOffset, this.maximum);
+            double halfOffset = (_factor / 2) * (double)randomValue;
+            double result = Math.Min(_minimum + halfOffset + halfOffset, _maximum);
 
-            return Convert.ChangeType(result, this.resultTypeCode, CultureInfo.CurrentCulture);
+            return Convert.ChangeType(result, _resultTypeCode, CultureInfo.CurrentCulture);
         }
     }
 
@@ -143,33 +143,33 @@ public class RandomRangedNumberGenerator : ISpecimenBuilder
     {
         private const long RandomValueRange = int.MaxValue;
 
-        private readonly decimal factor;
-        private readonly decimal minimum;
-        private readonly decimal maximum;
-        private readonly TypeCode resultTypeCode;
-        private readonly RandomNumericSequenceGenerator generator;
+        private readonly decimal _factor;
+        private readonly decimal _minimum;
+        private readonly decimal _maximum;
+        private readonly TypeCode _resultTypeCode;
+        private readonly RandomNumericSequenceGenerator _generator;
 
         public HighPrecisionRangedGenerator(object minimum, object maximum, TypeCode resultTypeCode)
         {
-            this.minimum = Convert.ToDecimal(minimum, CultureInfo.CurrentCulture);
-            this.maximum = Convert.ToDecimal(maximum, CultureInfo.CurrentCulture);
-            this.resultTypeCode = resultTypeCode;
-            this.generator = new RandomNumericSequenceGenerator(0, RandomValueRange);
+            _minimum = Convert.ToDecimal(minimum, CultureInfo.CurrentCulture);
+            _maximum = Convert.ToDecimal(maximum, CultureInfo.CurrentCulture);
+            _resultTypeCode = resultTypeCode;
+            _generator = new RandomNumericSequenceGenerator(0, RandomValueRange);
 
             // (max - min) could lead to overflow, so we divide each part on range individually.
-            this.factor = Math.Abs((this.maximum / RandomValueRange) - (this.minimum / RandomValueRange));
+            _factor = Math.Abs((_maximum / RandomValueRange) - (_minimum / RandomValueRange));
         }
 
         public object Create(object request, ISpecimenContext context)
         {
-            var randomValue = this.generator.Create(typeof(decimal), context);
+            var randomValue = _generator.Create(typeof(decimal), context);
             if (randomValue is NoSpecimen) return NoSpecimen.Instance;
 
             // Half offset is needed to avoid overflow - full offset might be larger than decimal range.
-            var halfOffset = (this.factor / 2) * (decimal)randomValue;
+            var halfOffset = (_factor / 2) * (decimal)randomValue;
 
-            decimal result = Math.Min(this.minimum + halfOffset + halfOffset, this.maximum);
-            return Convert.ChangeType(result, this.resultTypeCode, CultureInfo.CurrentCulture);
+            decimal result = Math.Min(_minimum + halfOffset + halfOffset, _maximum);
+            return Convert.ChangeType(result, _resultTypeCode, CultureInfo.CurrentCulture);
         }
     }
 }

--- a/Src/AutoFixture/RandomTimeOnlySequenceGenerator.cs
+++ b/Src/AutoFixture/RandomTimeOnlySequenceGenerator.cs
@@ -16,14 +16,14 @@ namespace AutoFixture;
 /// </remarks>
 public class RandomTimeOnlySequenceGenerator : ISpecimenBuilder
 {
-    private static readonly TimeOnly Default = new(12, 0);
-    private readonly RandomNumericSequenceGenerator randomizer;
+    private static readonly TimeOnly s_default = new(12, 0);
+    private readonly RandomNumericSequenceGenerator _randomizer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RandomTimeOnlySequenceGenerator"/> class.
     /// </summary>
     public RandomTimeOnlySequenceGenerator()
-        : this(Default.AddHours(-6), Default.AddHours(6))
+        : this(s_default.AddHours(-6), s_default.AddHours(6))
     {
     }
 
@@ -43,7 +43,7 @@ public class RandomTimeOnlySequenceGenerator : ISpecimenBuilder
             throw new ArgumentException("The 'minTime' argument must be less than the 'maxTime'.");
         }
 
-        this.randomizer = new RandomNumericSequenceGenerator(minTime.Ticks, maxTime.Ticks);
+        _randomizer = new RandomNumericSequenceGenerator(minTime.Ticks, maxTime.Ticks);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public class RandomTimeOnlySequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        var ticks = (long)this.randomizer.Create(typeof(long), context);
+        var ticks = (long)_randomizer.Create(typeof(long), context);
         return new TimeOnly(ticks);
     }
 }

--- a/Src/AutoFixture/RangedNumberGenerator.cs
+++ b/Src/AutoFixture/RangedNumberGenerator.cs
@@ -10,16 +10,16 @@ namespace AutoFixture;
 /// </summary>
 public class RangedNumberGenerator : ISpecimenBuilder
 {
-    private readonly object syncRoot;
-    private object rangedValue;
+    private readonly object _syncRoot;
+    private object _rangedValue;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RangedNumberGenerator"/> class.
     /// </summary>
     public RangedNumberGenerator()
     {
-        this.syncRoot = new object();
-        this.rangedValue = null;
+        _syncRoot = new object();
+        _rangedValue = null;
     }
 
     /// <summary>
@@ -53,47 +53,47 @@ public class RangedNumberGenerator : ISpecimenBuilder
 
         try
         {
-            this.CreateAnonymous(range, value);
+            CreateAnonymous(range, value);
         }
         catch (InvalidOperationException)
         {
             return NoSpecimen.Instance;
         }
 
-        return this.rangedValue;
+        return _rangedValue;
     }
 
     private void CreateAnonymous(RangedNumberRequest range, IComparable value)
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
             var minimum = (IComparable)range.Minimum;
             var maximum = (IComparable)range.Maximum;
 
-            if (this.rangedValue != null)
+            if (_rangedValue != null)
             {
                 object target;
                 if ((range.OperandType == typeof(byte) &&
                      Convert.ToInt32(
-                         this.rangedValue,
+                         _rangedValue,
                          CultureInfo.CurrentCulture) > byte.MaxValue) ||
                     (range.OperandType == typeof(short) &&
                      Convert.ToInt32(
-                         this.rangedValue,
+                         _rangedValue,
                          CultureInfo.CurrentCulture) > short.MaxValue))
                     target = minimum;
                 else
-                    target = this.rangedValue;
+                    target = _rangedValue;
 
-                this.rangedValue = Convert.ChangeType(target, range.OperandType, CultureInfo.CurrentCulture);
+                _rangedValue = Convert.ChangeType(target, range.OperandType, CultureInfo.CurrentCulture);
             }
 
-            if (this.rangedValue != null && (minimum.CompareTo(this.rangedValue) <= 0 && maximum.CompareTo(this.rangedValue) > 0))
+            if (_rangedValue != null && (minimum.CompareTo(_rangedValue) <= 0 && maximum.CompareTo(_rangedValue) > 0))
             {
-                this.rangedValue =
+                _rangedValue =
                     Convert.ChangeType(
                         RangedNumberGenerator.Add(
-                            this.rangedValue,
+                            _rangedValue,
                             Convert.ChangeType(
                                 1,
                                 range.OperandType,
@@ -101,9 +101,9 @@ public class RangedNumberGenerator : ISpecimenBuilder
                         range.OperandType,
                         CultureInfo.CurrentCulture);
 
-                if (maximum.CompareTo(this.rangedValue) < 0)
+                if (maximum.CompareTo(_rangedValue) < 0)
                 {
-                    this.rangedValue = Convert.ChangeType(
+                    _rangedValue = Convert.ChangeType(
                         maximum,
                         range.OperandType,
                         CultureInfo.CurrentCulture);
@@ -111,36 +111,36 @@ public class RangedNumberGenerator : ISpecimenBuilder
             }
             else if (minimum.CompareTo(value) == 0)
             {
-                this.rangedValue = minimum;
+                _rangedValue = minimum;
             }
             else if (maximum.CompareTo(value) == 0)
             {
-                this.rangedValue = maximum;
+                _rangedValue = maximum;
             }
             else if (minimum.CompareTo(value) <= 0 && maximum.CompareTo(value) <= 0)
             {
-                this.rangedValue = minimum;
+                _rangedValue = minimum;
             }
-            else if (minimum.CompareTo(this.rangedValue) <= 0 && maximum.CompareTo(this.rangedValue) <= 0)
+            else if (minimum.CompareTo(_rangedValue) <= 0 && maximum.CompareTo(_rangedValue) <= 0)
             {
-                this.rangedValue = minimum;
+                _rangedValue = minimum;
             }
             else if (minimum.CompareTo(value) < 0)
             {
-                this.rangedValue = value;
+                _rangedValue = value;
             }
             else
             {
-                this.rangedValue = RangedNumberGenerator.Add(minimum, value);
+                _rangedValue = RangedNumberGenerator.Add(minimum, value);
 
-                if (minimum.CompareTo(this.rangedValue) > 0 ||
-                    maximum.CompareTo(this.rangedValue) < 0)
+                if (minimum.CompareTo(_rangedValue) > 0 ||
+                    maximum.CompareTo(_rangedValue) < 0)
                 {
-                    this.rangedValue = minimum;
+                    _rangedValue = minimum;
                 }
             }
 
-            this.rangedValue = Convert.ChangeType(this.rangedValue, range.OperandType, CultureInfo.CurrentCulture);
+            _rangedValue = Convert.ChangeType(_rangedValue, range.OperandType, CultureInfo.CurrentCulture);
         }
     }
 

--- a/Src/AutoFixture/ReadonlyCollectionPropertiesBehavior.cs
+++ b/Src/AutoFixture/ReadonlyCollectionPropertiesBehavior.cs
@@ -30,7 +30,7 @@ public class ReadonlyCollectionPropertiesBehavior : ISpecimenBuilderTransformati
     /// <param name="propertyQuery">The query that will be applied to select readonly collection properties.</param>
     public ReadonlyCollectionPropertiesBehavior(IPropertyQuery propertyQuery)
     {
-        this.PropertyQuery = propertyQuery;
+        PropertyQuery = propertyQuery;
     }
 
     /// <summary>
@@ -58,9 +58,9 @@ public class ReadonlyCollectionPropertiesBehavior : ISpecimenBuilderTransformati
 
         return new Postprocessor(
             builder,
-            new ReadonlyCollectionPropertiesCommand(this.PropertyQuery),
+            new ReadonlyCollectionPropertiesCommand(PropertyQuery),
             new AndRequestSpecification(
-                new ReadonlyCollectionPropertiesSpecification(this.PropertyQuery),
+                new ReadonlyCollectionPropertiesSpecification(PropertyQuery),
                 new OmitFixtureSpecification()));
     }
 }

--- a/Src/AutoFixture/RegularExpressionGenerator.cs
+++ b/Src/AutoFixture/RegularExpressionGenerator.cs
@@ -10,16 +10,16 @@ namespace AutoFixture;
 /// </summary>
 public class RegularExpressionGenerator : ISpecimenBuilder
 {
-    private readonly Random random;
-    private readonly object syncRoot;
+    private readonly Random _random;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RegularExpressionGenerator"/> class.
     /// </summary>
     public RegularExpressionGenerator()
     {
-        this.random = new Random();
-        this.syncRoot = new object();
+        _random = new Random();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public class RegularExpressionGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        return this.GenerateRegularExpression(regularExpressionRequest);
+        return GenerateRegularExpression(regularExpressionRequest);
     }
 
     private object GenerateRegularExpression(RegularExpressionRequest request)
@@ -51,7 +51,7 @@ public class RegularExpressionGenerator : ISpecimenBuilder
         {
             // Use the Xeger constructor overload that that takes an instance of Random.
             // Otherwise identically strings can be generated, if regex are generated within short time.
-            string regex = new Xeger(pattern, new Random(this.GenerateSeed())).Generate();
+            string regex = new Xeger(pattern, new Random(GenerateSeed())).Generate();
             if (Regex.IsMatch(regex, pattern))
             {
                 return regex;
@@ -71,9 +71,9 @@ public class RegularExpressionGenerator : ISpecimenBuilder
 
     private int GenerateSeed()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return this.random.Next();
+            return _random.Next();
         }
     }
 }

--- a/Src/AutoFixture/ResidueCollectorNode.cs
+++ b/Src/AutoFixture/ResidueCollectorNode.cs
@@ -33,7 +33,7 @@ public class ResidueCollectorNode : ISpecimenBuilderNode
     /// <seealso cref="Builder" />
     public ResidueCollectorNode(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>Composes the supplied builders.</summary>
@@ -70,7 +70,7 @@ public class ResidueCollectorNode : ISpecimenBuilderNode
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        return this.Builder.Create(request, context);
+        return Builder.Create(request, context);
     }
 
     /// <summary>Returns the decorated builder as a sequence.</summary>
@@ -78,7 +78,7 @@ public class ResidueCollectorNode : ISpecimenBuilderNode
     /// <seealso cref="Builder" />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.Builder;
+        yield return Builder;
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public class ResidueCollectorNode : ISpecimenBuilderNode
     /// <seealso cref="GetEnumerator()" />
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     /// <summary>Gets the builder decorated by this instance.</summary>

--- a/Src/AutoFixture/SByteSequenceGenerator.cs
+++ b/Src/AutoFixture/SByteSequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class SByteSequenceGenerator : ISpecimenBuilder
 {
-    private sbyte s;
-    private readonly object syncRoot;
+    private sbyte _s;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SByteSequenceGenerator"/> class.
     /// </summary>
     public SByteSequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -27,9 +27,9 @@ public class SByteSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public sbyte Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.s;
+            return ++_s;
         }
     }
 
@@ -42,7 +42,7 @@ public class SByteSequenceGenerator : ISpecimenBuilder
     [CLSCompliant(false)]
     public sbyte CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <summary>
@@ -62,7 +62,7 @@ public class SByteSequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/SingleSequenceGenerator.cs
+++ b/Src/AutoFixture/SingleSequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class SingleSequenceGenerator : ISpecimenBuilder
 {
-    private float f;
-    private readonly object syncRoot;
+    private float _f;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SingleSequenceGenerator"/> class.
     /// </summary>
     public SingleSequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -26,9 +26,9 @@ public class SingleSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please use the Create(request, context) method as this overload will be removed to make API uniform.")]
     public float Create()
     {
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.f;
+            return ++_f;
         }
     }
 
@@ -40,7 +40,7 @@ public class SingleSequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public float CreateAnonymous()
     {
-        return this.Create();
+        return Create();
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public class SingleSequenceGenerator : ISpecimenBuilder
         }
 
 #pragma warning disable 618
-        return this.Create();
+        return Create();
 #pragma warning restore 618
     }
 }

--- a/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
+++ b/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
@@ -35,7 +35,7 @@ namespace AutoFixture;
 /// </remarks>
 public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISpecimenBuilderTransformation>
 {
-    private readonly Func<ISpecimenBuilderNode, bool> isWrappedGraph;
+    private readonly Func<ISpecimenBuilderNode, bool> _isWrappedGraph;
 
     /// <summary>
     /// Initializes a new instance of the
@@ -67,11 +67,11 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISp
     {
         if (transformations == null) throw new ArgumentNullException(nameof(transformations));
 
-        this.Graph = graph ?? throw new ArgumentNullException(nameof(graph));
-        this.isWrappedGraph = wrappedGraphPredicate ?? throw new ArgumentNullException(nameof(wrappedGraphPredicate));
+        Graph = graph ?? throw new ArgumentNullException(nameof(graph));
+        _isWrappedGraph = wrappedGraphPredicate ?? throw new ArgumentNullException(nameof(wrappedGraphPredicate));
 
         foreach (var t in transformations)
-            this.Add(t);
+            Add(t);
     }
 
     /// <summary>
@@ -106,10 +106,10 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISp
     /// </remarks>
     protected override void ClearItems()
     {
-        var wasNotEmpty = this.Count > 0;
+        var wasNotEmpty = Count > 0;
         base.ClearItems();
         if (wasNotEmpty)
-            this.UpdateGraph();
+            UpdateGraph();
     }
 
     /// <summary>
@@ -129,7 +129,7 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISp
     protected override void InsertItem(int index, ISpecimenBuilderTransformation item)
     {
         base.InsertItem(index, item);
-        this.UpdateGraph();
+        UpdateGraph();
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISp
     protected override void RemoveItem(int index)
     {
         base.RemoveItem(index);
-        this.UpdateGraph();
+        UpdateGraph();
     }
 
     /// <summary>Replaces the element at the specified index.</summary>
@@ -166,7 +166,7 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISp
     protected override void SetItem(int index, ISpecimenBuilderTransformation item)
     {
         base.SetItem(index, item);
-        this.UpdateGraph();
+        UpdateGraph();
     }
 
     /// <summary>Raises the <see cref="GraphChanged" /> event.</summary>
@@ -176,18 +176,18 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISp
     /// </param>
     protected virtual void OnGraphChanged(SpecimenBuilderNodeEventArgs e)
     {
-        var handler = this.GraphChanged;
+        var handler = GraphChanged;
         if (handler != null)
             handler(this, e);
     }
 
     private void UpdateGraph()
     {
-        ISpecimenBuilderNode g = this.Graph.FindFirstNode(this.isWrappedGraph);
-        ISpecimenBuilderNode builder = this.Aggregate(g, (b, t) => t.Transform(b));
+        ISpecimenBuilderNode g = Graph.FindFirstNode(_isWrappedGraph);
+        ISpecimenBuilderNode builder = Aggregate(g, (b, t) => t.Transform(b));
 
-        this.Graph = builder;
+        Graph = builder;
 
-        this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(this.Graph));
+        OnGraphChanged(new SpecimenBuilderNodeEventArgs(Graph));
     }
 }

--- a/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
+++ b/Src/AutoFixture/SingletonSpecimenBuilderNodeStackAdapterCollection.cs
@@ -184,7 +184,7 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollection : Collection<ISp
     private void UpdateGraph()
     {
         ISpecimenBuilderNode g = Graph.FindFirstNode(_isWrappedGraph);
-        ISpecimenBuilderNode builder = Aggregate(g, (b, t) => t.Transform(b));
+        ISpecimenBuilderNode builder = this.Aggregate(g, (b, t) => t.Transform(b));
 
         Graph = builder;
 

--- a/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeAdapterCollection.cs
@@ -20,9 +20,9 @@ namespace AutoFixture;
 /// </remarks>
 public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
 {
-    private readonly Func<ISpecimenBuilderNode, bool> isAdaptedBuilder;
-    private ISpecimenBuilderNode adaptedBuilderNode;
-    private ISpecimenBuilderNode graph;
+    private readonly Func<ISpecimenBuilderNode, bool> _isAdaptedBuilder;
+    private ISpecimenBuilderNode _adaptedBuilderNode;
+    private ISpecimenBuilderNode _graph;
 
     private ISpecimenBuilderNode AdaptedBuilderNode
     {
@@ -33,20 +33,20 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
             // Some of the collections are not even touched after the construction and are immediately
             // recreated again after a subsequent customization.
             // To cover such scenarios we evaluate value on demand only saving the initialization time.
-            if (this.adaptedBuilderNode != null)
-                return this.adaptedBuilderNode;
+            if (_adaptedBuilderNode != null)
+                return _adaptedBuilderNode;
 
             // The intermediate "result" variable is needed to ensure that null value can be never returned
             // in case of concurrency (we can set field to null). While current collection implementation doesn't
             // seem to support concurrency, the additional guard adds more safety.
-            var result = this.adaptedBuilderNode = this.FindAdaptedSpecimenBuilderNode();
+            var result = _adaptedBuilderNode = FindAdaptedSpecimenBuilderNode();
             return result;
         }
     }
 
-    private void InvalidateCachedAdaptedBuilderNode() => this.adaptedBuilderNode = null;
+    private void InvalidateCachedAdaptedBuilderNode() => _adaptedBuilderNode = null;
 
-    private IEnumerable<ISpecimenBuilder> AdaptedBuilders => this.AdaptedBuilderNode;
+    private IEnumerable<ISpecimenBuilder> AdaptedBuilders => AdaptedBuilderNode;
 
     /// <summary>
     /// Initializes a new instance of the
@@ -74,8 +74,8 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
         ISpecimenBuilderNode graph,
         Func<ISpecimenBuilderNode, bool> adaptedBuilderPredicate)
     {
-        this.graph = graph ?? throw new ArgumentNullException(nameof(graph));
-        this.isAdaptedBuilder = adaptedBuilderPredicate ?? throw new ArgumentNullException(nameof(adaptedBuilderPredicate));
+        _graph = graph ?? throw new ArgumentNullException(nameof(graph));
+        _isAdaptedBuilder = adaptedBuilderPredicate ?? throw new ArgumentNullException(nameof(adaptedBuilderPredicate));
     }
 
     /// <summary>
@@ -115,7 +115,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
 
-        return this.AdaptedBuilders.IndexOf(item);
+        return AdaptedBuilders.IndexOf(item);
     }
 
     /// <summary>
@@ -146,7 +146,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
 
-        this.Mutate(this.AdaptedBuilders.Insert(index, item));
+        Mutate(AdaptedBuilders.Insert(index, item));
     }
 
     /// <summary>
@@ -171,7 +171,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
     public void RemoveAt(int index)
     {
-        this.Mutate(this.AdaptedBuilders.RemoveAt(index));
+        Mutate(AdaptedBuilders.RemoveAt(index));
     }
 
     /// <summary>
@@ -193,8 +193,8 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// </returns>
     public ISpecimenBuilder this[int index]
     {
-        get => this.AdaptedBuilders.ElementAt(index);
-        set => this.Mutate(this.AdaptedBuilders.SetItem(index, value));
+        get => AdaptedBuilders.ElementAt(index);
+        set => Mutate(AdaptedBuilders.SetItem(index, value));
     }
 
     /// <summary>
@@ -219,7 +219,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
 
-        this.Mutate(this.AdaptedBuilders.Concat(new[] { item }));
+        Mutate(AdaptedBuilders.Concat(new[] { item }));
     }
 
     /// <summary>
@@ -241,7 +241,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
     public void Clear()
     {
-        this.Mutate(Enumerable.Empty<ISpecimenBuilder>());
+        Mutate(Enumerable.Empty<ISpecimenBuilder>());
     }
 
     /// <summary>
@@ -266,7 +266,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
 
-        return this.AdaptedBuilders.Contains(item);
+        return AdaptedBuilders.Contains(item);
     }
 
     /// <summary>Copies the elements of the collection to an
@@ -292,7 +292,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
     public void CopyTo(ISpecimenBuilder[] array, int arrayIndex)
     {
-        this.AdaptedBuilders.ToArray().CopyTo(array, arrayIndex);
+        AdaptedBuilders.ToArray().CopyTo(array, arrayIndex);
     }
 
     /// <summary>
@@ -311,7 +311,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
     public int Count
     {
-        get { return this.AdaptedBuilders.Count(); }
+        get { return AdaptedBuilders.Count(); }
     }
 
     /// <summary>
@@ -358,10 +358,10 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
 
-        var contained = this.Contains(item);
+        var contained = Contains(item);
 
-        var index = this.IndexOf(item);
-        this.RemoveAt(index);
+        var index = IndexOf(item);
+        RemoveAt(index);
 
         return contained;
     }
@@ -385,7 +385,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        return this.AdaptedBuilders.GetEnumerator();
+        return AdaptedBuilders.GetEnumerator();
     }
 
     /// <summary>
@@ -407,7 +407,7 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     /// <summary>
@@ -428,12 +428,12 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// <seealso cref="SpecimenBuilderNodeAdapterCollection(ISpecimenBuilderNode, Func{ISpecimenBuilderNode, bool})" />
     public ISpecimenBuilderNode Graph
     {
-        get => this.graph;
+        get => _graph;
         private set
         {
-            this.graph = value;
-            this.InvalidateCachedAdaptedBuilderNode();
-            this.OnGraphChanged(new SpecimenBuilderNodeEventArgs(value));
+            _graph = value;
+            InvalidateCachedAdaptedBuilderNode();
+            OnGraphChanged(new SpecimenBuilderNodeEventArgs(value));
         }
     }
 
@@ -444,21 +444,21 @@ public class SpecimenBuilderNodeAdapterCollection : IList<ISpecimenBuilder>
     /// </param>
     protected virtual void OnGraphChanged(SpecimenBuilderNodeEventArgs e)
     {
-        this.GraphChanged?.Invoke(this, e);
+        GraphChanged?.Invoke(this, e);
     }
 
     private void Mutate(IEnumerable<ISpecimenBuilder> builders)
     {
-        var adaptedNode = this.AdaptedBuilderNode;
+        var adaptedNode = AdaptedBuilderNode;
 
-        this.Graph = this.Graph.ReplaceNodes(
+        Graph = Graph.ReplaceNodes(
             with: builders,
             when: adaptedNode.Equals);
     }
 
     private ISpecimenBuilderNode FindAdaptedSpecimenBuilderNode()
     {
-        var markerNode = this.Graph.FindFirstNode(this.isAdaptedBuilder);
+        var markerNode = Graph.FindFirstNode(_isAdaptedBuilder);
         return (ISpecimenBuilderNode)markerNode.First();
     }
 }

--- a/Src/AutoFixture/SpecimenBuilderNodeEventArgs.cs
+++ b/Src/AutoFixture/SpecimenBuilderNodeEventArgs.cs
@@ -17,7 +17,7 @@ public class SpecimenBuilderNodeEventArgs : EventArgs
     /// <exception cref="System.ArgumentNullException">graph.</exception>
     public SpecimenBuilderNodeEventArgs(ISpecimenBuilderNode graph)
     {
-        this.Graph = graph ?? throw new ArgumentNullException(nameof(graph));
+        Graph = graph ?? throw new ArgumentNullException(nameof(graph));
     }
 
     /// <summary>

--- a/Src/AutoFixture/StrictlyMonotonicallyIncreasingDateTimeGenerator.cs
+++ b/Src/AutoFixture/StrictlyMonotonicallyIncreasingDateTimeGenerator.cs
@@ -9,8 +9,8 @@ namespace AutoFixture;
 /// </summary>
 public class StrictlyMonotonicallyIncreasingDateTimeGenerator : ISpecimenBuilder
 {
-    private readonly DateTime seed;
-    private int baseValue;
+    private readonly DateTime _seed;
+    private int _baseValue;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StrictlyMonotonicallyIncreasingDateTimeGenerator"/> class.
@@ -18,7 +18,7 @@ public class StrictlyMonotonicallyIncreasingDateTimeGenerator : ISpecimenBuilder
     /// <param name="seed">The base <see cref="DateTime"/> value used to generate <see cref="DateTime"/> specimens.</param>
     public StrictlyMonotonicallyIncreasingDateTimeGenerator(DateTime seed)
     {
-        this.seed = seed;
+        _seed = seed;
     }
 
     /// <summary>
@@ -37,11 +37,11 @@ public class StrictlyMonotonicallyIncreasingDateTimeGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        return this.seed.AddDays(this.GetNextNumberInSequence());
+        return _seed.AddDays(GetNextNumberInSequence());
     }
 
     private int GetNextNumberInSequence()
     {
-        return Interlocked.Increment(ref this.baseValue);
+        return Interlocked.Increment(ref _baseValue);
     }
 }

--- a/Src/AutoFixture/StringGenerator.cs
+++ b/Src/AutoFixture/StringGenerator.cs
@@ -19,7 +19,7 @@ public class StringGenerator : ISpecimenBuilder
     /// </param>
     public StringGenerator(Func<object> specimenFactory)
     {
-        this.Factory = specimenFactory ?? throw new ArgumentNullException(nameof(specimenFactory));
+        Factory = specimenFactory ?? throw new ArgumentNullException(nameof(specimenFactory));
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public class StringGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        var specimen = this.Factory();
+        var specimen = Factory();
         if (specimen == null)
         {
             return NoSpecimen.Instance;

--- a/Src/AutoFixture/TracingBehavior.cs
+++ b/Src/AutoFixture/TracingBehavior.cs
@@ -26,7 +26,7 @@ public class TracingBehavior : ISpecimenBuilderTransformation
     /// <param name="writer">The writer to which diagnostics is written.</param>
     public TracingBehavior(TextWriter writer)
     {
-        this.Writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        Writer = writer ?? throw new ArgumentNullException(nameof(writer));
     }
 
     /// <summary>
@@ -46,6 +46,6 @@ public class TracingBehavior : ISpecimenBuilderTransformation
     {
         if (builder == null) throw new ArgumentNullException(nameof(builder));
 
-        return new TraceWriter(this.Writer, new TracingBuilder(builder));
+        return new TraceWriter(Writer, new TracingBuilder(builder));
     }
 }

--- a/Src/AutoFixture/UInt16SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt16SequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class UInt16SequenceGenerator : ISpecimenBuilder
 {
-    private ushort u;
-    private readonly object syncRoot;
+    private ushort _u;
+    private readonly object _syncRoot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UInt16SequenceGenerator"/> class.
     /// </summary>
     public UInt16SequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class UInt16SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public ushort CreateAnonymous()
     {
-        return (ushort)this.Create(typeof(ushort), null);
+        return (ushort)Create(typeof(ushort), null);
     }
 
     /// <summary>
@@ -46,9 +46,9 @@ public class UInt16SequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.u;
+            return ++_u;
         }
     }
 }

--- a/Src/AutoFixture/UInt32SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt32SequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class UInt32SequenceGenerator : ISpecimenBuilder
 {
-    private readonly object syncRoot;
-    private uint u;
+    private readonly object _syncRoot;
+    private uint _u;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UInt32SequenceGenerator"/> class.
     /// </summary>
     public UInt32SequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class UInt32SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public uint CreateAnonymous()
     {
-        return (uint)this.Create(typeof(uint), null);
+        return (uint)Create(typeof(uint), null);
     }
 
     /// <summary>
@@ -46,9 +46,9 @@ public class UInt32SequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.u;
+            return ++_u;
         }
     }
 }

--- a/Src/AutoFixture/UInt64SequenceGenerator.cs
+++ b/Src/AutoFixture/UInt64SequenceGenerator.cs
@@ -8,15 +8,15 @@ namespace AutoFixture;
 /// </summary>
 public class UInt64SequenceGenerator : ISpecimenBuilder
 {
-    private readonly object syncRoot;
-    private ulong u;
+    private readonly object _syncRoot;
+    private ulong _u;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UInt64SequenceGenerator"/> class.
     /// </summary>
     public UInt64SequenceGenerator()
     {
-        this.syncRoot = new object();
+        _syncRoot = new object();
     }
 
     /// <summary>
@@ -27,7 +27,7 @@ public class UInt64SequenceGenerator : ISpecimenBuilder
     [Obsolete("Please move over to using Create() as this method will be removed in the next release", true)]
     public ulong CreateAnonymous()
     {
-        return (ulong)this.Create(typeof(ulong), null);
+        return (ulong)Create(typeof(ulong), null);
     }
 
     /// <summary>
@@ -46,9 +46,9 @@ public class UInt64SequenceGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        lock (this.syncRoot)
+        lock (_syncRoot)
         {
-            return ++this.u;
+            return ++_u;
         }
     }
 }

--- a/Src/AutoFixture/UnwrapMemberRequest.cs
+++ b/Src/AutoFixture/UnwrapMemberRequest.cs
@@ -9,15 +9,15 @@ namespace AutoFixture;
 /// </summary>
 public class UnwrapMemberRequest : ISpecimenBuilder
 {
-    private IRequestMemberTypeResolver requestMemberTypeResolver = new RequestMemberTypeResolver();
+    private IRequestMemberTypeResolver _requestMemberTypeResolver = new RequestMemberTypeResolver();
 
     /// <summary>
     /// Gets or sets resolver used to extract member type.
     /// </summary>
     public IRequestMemberTypeResolver MemberTypeResolver
     {
-        get => this.requestMemberTypeResolver;
-        set => this.requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
+        get => _requestMemberTypeResolver;
+        set => _requestMemberTypeResolver = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -30,7 +30,7 @@ public class UnwrapMemberRequest : ISpecimenBuilder
     /// </summary>
     public UnwrapMemberRequest(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <inheritdoc />
@@ -38,9 +38,9 @@ public class UnwrapMemberRequest : ISpecimenBuilder
     {
         if (context == null) throw new ArgumentNullException(nameof(context));
 
-        if (this.MemberTypeResolver.TryGetMemberType(request, out Type memberType))
+        if (MemberTypeResolver.TryGetMemberType(request, out Type memberType))
         {
-            return this.Builder.Create(memberType, context);
+            return Builder.Create(memberType, context);
         }
 
         return NoSpecimen.Instance;

--- a/Src/AutoFixture/UriScheme.cs
+++ b/Src/AutoFixture/UriScheme.cs
@@ -34,7 +34,7 @@ public class UriScheme : IEquatable<UriScheme>
                 "a letter and followed by any combination of letters, digits, plus ('+'), period ('.'), or hyphen ('-').");
         }
 
-        this.Scheme = scheme;
+        Scheme = scheme;
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public class UriScheme : IEquatable<UriScheme>
     /// </returns>
     public override string ToString()
     {
-        return this.Scheme;
+        return Scheme;
     }
 
     /// <summary>
@@ -65,7 +65,7 @@ public class UriScheme : IEquatable<UriScheme>
     {
         if (obj is UriScheme other)
         {
-            return this.Equals(other);
+            return Equals(other);
         }
 
         return base.Equals(obj);
@@ -80,7 +80,7 @@ public class UriScheme : IEquatable<UriScheme>
     /// </returns>
     public override int GetHashCode()
     {
-        return HashCode.Combine(this.Scheme);
+        return HashCode.Combine(Scheme);
     }
 
     /// <summary>
@@ -102,7 +102,7 @@ public class UriScheme : IEquatable<UriScheme>
             return false;
         }
 
-        return this.Scheme.Equals(other.Scheme, StringComparison.Ordinal);
+        return Scheme.Equals(other.Scheme, StringComparison.Ordinal);
     }
 
     private static bool IsValid(string scheme)

--- a/Src/AutoFixture/Utf8EncodingGenerator.cs
+++ b/Src/AutoFixture/Utf8EncodingGenerator.cs
@@ -11,7 +11,7 @@ namespace AutoFixture;
 [Obsolete("Please use a 'AutoFixture.Kernel.FilteringSpecimenBuilder' instead.", true)]
 public class Utf8EncodingGenerator : ISpecimenBuilder
 {
-    private readonly ExactTypeSpecification encodingTypeSpecification = new ExactTypeSpecification(typeof(Encoding));
+    private readonly ExactTypeSpecification _encodingTypeSpecification = new ExactTypeSpecification(typeof(Encoding));
 
     /// <summary>
     /// Generates a Encoding specimen based on a <see cref="Encoding"/> type request.
@@ -31,7 +31,7 @@ public class Utf8EncodingGenerator : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        if (!this.encodingTypeSpecification.IsSatisfiedBy(request))
+        if (!_encodingTypeSpecification.IsSatisfiedBy(request))
         {
             return NoSpecimen.Instance;
         }

--- a/Src/AutoFixtureDocumentationTest/Commerce/Order.cs
+++ b/Src/AutoFixtureDocumentationTest/Commerce/Order.cs
@@ -6,8 +6,8 @@ public class Order
 {
     public Order(uint id)
     {
-        this.Id = id;
-        this.OrderLines = new List<OrderLine>();
+        Id = id;
+        OrderLines = new List<OrderLine>();
     }
 
     public Address BillingAddress { get; set; }

--- a/Src/AutoFixtureDocumentationTest/Commerce/OrderLine.cs
+++ b/Src/AutoFixtureDocumentationTest/Commerce/OrderLine.cs
@@ -4,8 +4,8 @@ public class OrderLine
 {
     public OrderLine(Product product)
     {
-        this.Product = product;
-        this.Quantity = 1;
+        Product = product;
+        Quantity = 1;
     }
 
     public Product Product { get; private set; }

--- a/Src/AutoFixtureDocumentationTest/Commerce/Product.cs
+++ b/Src/AutoFixtureDocumentationTest/Commerce/Product.cs
@@ -4,7 +4,7 @@ public class Product
 {
     public Product(uint id)
     {
-        this.Id = id;
+        Id = id;
     }
 
     public uint Id { get; private set; }

--- a/Src/AutoFixtureDocumentationTest/Contact/Parsing/Contact.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/Parsing/Contact.cs
@@ -4,8 +4,8 @@ public class Contact
 {
     public Contact(string name, string phoneNumber)
     {
-        this.Name = name;
-        this.PhoneNumber =
+        Name = name;
+        PhoneNumber =
             Contact.ParsePhoneNumber(phoneNumber);
     }
 

--- a/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/Contact.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/Contact.cs
@@ -4,8 +4,8 @@ public class Contact
 {
     public Contact(string name, DanishPhoneNumber phoneNumber)
     {
-        this.Name = name;
-        this.PhoneNumber = phoneNumber;
+        Name = name;
+        PhoneNumber = phoneNumber;
     }
 
     public string Name { get; set; }

--- a/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/DanishPhoneNumber.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/ValidatingValueObject/DanishPhoneNumber.cs
@@ -12,7 +12,7 @@ public class DanishPhoneNumber
         {
             throw new ArgumentOutOfRangeException(nameof(number));
         }
-        this.RawNumber = number;
+        RawNumber = number;
     }
 
     public static bool IsValid(int number)

--- a/Src/AutoFixtureDocumentationTest/Contact/ValueObject/Contact.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/ValueObject/Contact.cs
@@ -4,8 +4,8 @@ public class Contact
 {
     public Contact(string name, DanishPhoneNumber phoneNumber)
     {
-        this.Name = name;
-        this.PhoneNumber = phoneNumber;
+        Name = name;
+        PhoneNumber = phoneNumber;
     }
 
     public string Name { get; set; }

--- a/Src/AutoFixtureDocumentationTest/Contact/ValueObject/DanishPhoneNumber.cs
+++ b/Src/AutoFixtureDocumentationTest/Contact/ValueObject/DanishPhoneNumber.cs
@@ -4,7 +4,7 @@ public class DanishPhoneNumber
 {
     public DanishPhoneNumber(int number)
     {
-        this.RawNumber = number;
+        RawNumber = number;
     }
 
     public int RawNumber { get; }

--- a/Src/AutoFixtureDocumentationTest/DependencyConstraints.cs
+++ b/Src/AutoFixtureDocumentationTest/DependencyConstraints.cs
@@ -11,7 +11,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+        var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.DoesNotContain(references, an => an.Name == assemblyName);
     }

--- a/Src/AutoFixtureDocumentationTest/Extension/Constraints/ConstrainedStringGenerator.cs
+++ b/Src/AutoFixtureDocumentationTest/Extension/Constraints/ConstrainedStringGenerator.cs
@@ -4,8 +4,8 @@ namespace AutoFixtureDocumentationTest.Extension.Constraints;
 
 public class ConstrainedStringGenerator
 {
-    private readonly int minimumLength;
-    private readonly int maximumLength;
+    private readonly int _minimumLength;
+    private readonly int _maximumLength;
 
     public ConstrainedStringGenerator(int minimumLength,
         int maximumLength)
@@ -19,20 +19,20 @@ public class ConstrainedStringGenerator
             throw new ArgumentOutOfRangeException("...");
         }
 
-        this.minimumLength = minimumLength;
-        this.maximumLength = maximumLength;
+        _minimumLength = minimumLength;
+        _maximumLength = maximumLength;
     }
 
     public string CreateaAnonymous(string seed)
     {
         var s = string.Empty;
-        while (s.Length < this.minimumLength)
+        while (s.Length < _minimumLength)
         {
             s += ConstrainedStringGenerator.CreateAnonymous(seed);
         }
-        if (s.Length > this.maximumLength)
+        if (s.Length > _maximumLength)
         {
-            s = s.Substring(0, this.maximumLength);
+            s = s.Substring(0, _maximumLength);
         }
         return s;
     }

--- a/Src/AutoFixtureDocumentationTest/Greedy/Bastard.cs
+++ b/Src/AutoFixtureDocumentationTest/Greedy/Bastard.cs
@@ -16,7 +16,7 @@ public class Bastard
             throw new ArgumentNullException(nameof(foo));
         }
 
-        this.Foo = foo;
+        Foo = foo;
     }
 
     public IFoo Foo { get; }

--- a/Src/AutoFixtureDocumentationTest/Intermediate/FakeMyInterface.cs
+++ b/Src/AutoFixtureDocumentationTest/Intermediate/FakeMyInterface.cs
@@ -5,17 +5,17 @@ namespace AutoFixtureDocumentationTest.Intermediate;
 
 public class FakeMyInterface : IMyInterface
 {
-    private readonly IList<Thing> things;
+    private readonly IList<Thing> _things;
 
     public FakeMyInterface()
     {
-        this.things = new List<Thing>();
+        _things = new List<Thing>();
     }
 
     public FakeMyInterface(int number, string text)
     {
-        this.Number = number;
-        this.Text = text;
+        Number = number;
+        Text = text;
     }
 
     public int Number { get; private set; }
@@ -24,11 +24,11 @@ public class FakeMyInterface : IMyInterface
 
     public IEnumerable<int> ThingNumbers
     {
-        get { return this.things.Select(t => t.Number); }
+        get { return _things.Select(t => t.Number); }
     }
 
     public void AddThing(Thing thing)
     {
-        this.things.Add(thing);
+        _things.Add(thing);
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Intermediate/MyClass.cs
+++ b/Src/AutoFixtureDocumentationTest/Intermediate/MyClass.cs
@@ -4,15 +4,15 @@ namespace AutoFixtureDocumentationTest.Intermediate;
 
 public class MyClass
 {
-    private readonly IMyInterface d;
+    private readonly IMyInterface _d;
 
     public MyClass(IMyInterface mi)
     {
-        this.d = mi;
+        _d = mi;
     }
 
     public int CalculateSumOfThings()
     {
-        return this.d.ThingNumbers.Sum();
+        return _d.ThingNumbers.Sum();
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Intermediate/MyClassFixture.cs
+++ b/Src/AutoFixtureDocumentationTest/Intermediate/MyClassFixture.cs
@@ -9,7 +9,7 @@ internal class MyClassFixture : Fixture
     internal MyClassFixture()
     {
         Things = new List<Thing>();
-        Register<IMyInterface>(() =>
+        this.Register<IMyInterface>(() =>
         {
             var fake = new FakeMyInterface();
             Things.ToList().ForEach(t =>

--- a/Src/AutoFixtureDocumentationTest/Intermediate/MyClassFixture.cs
+++ b/Src/AutoFixtureDocumentationTest/Intermediate/MyClassFixture.cs
@@ -8,11 +8,11 @@ internal class MyClassFixture : Fixture
 {
     internal MyClassFixture()
     {
-        this.Things = new List<Thing>();
-        this.Register<IMyInterface>(() =>
+        Things = new List<Thing>();
+        Register<IMyInterface>(() =>
         {
             var fake = new FakeMyInterface();
-            this.Things.ToList().ForEach(t =>
+            Things.ToList().ForEach(t =>
                 fake.AddThing(t));
             return fake;
         });

--- a/Src/AutoFixtureDocumentationTest/Intermediate/Person.cs
+++ b/Src/AutoFixtureDocumentationTest/Intermediate/Person.cs
@@ -4,7 +4,7 @@ namespace AutoFixtureDocumentationTest.Intermediate;
 
 public class Person
 {
-    private Person spouse;
+    private Person _spouse;
 
     public DateTime BirthDay { get; set; }
 
@@ -12,13 +12,13 @@ public class Person
 
     public Person Spouse
     {
-        get => this.spouse;
+        get => _spouse;
         set
         {
-            this.spouse = value;
+            _spouse = value;
             if (value != null)
             {
-                value.spouse = this;
+                value._spouse = this;
             }
         }
     }

--- a/Src/AutoFixtureDocumentationTest/Intermediate/Thing.cs
+++ b/Src/AutoFixtureDocumentationTest/Intermediate/Thing.cs
@@ -6,7 +6,7 @@ public class Thing
 {
     public Thing()
     {
-        this.Id = Guid.NewGuid();
+        Id = Guid.NewGuid();
     }
 
     public Guid Id { get; private set; }

--- a/Src/AutoFixtureDocumentationTest/Simple/ComplexChild.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/ComplexChild.cs
@@ -4,13 +4,13 @@ public class ComplexChild
 {
     public ComplexChild(string name)
     {
-        this.Name = name;
+        Name = name;
     }
 
     public ComplexChild(string name, int number)
     {
-        this.Name = name;
-        this.Number = number;
+        Name = name;
+        Number = number;
     }
 
     public string Name { get; }

--- a/Src/AutoFixtureDocumentationTest/Simple/ComplexParent.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/ComplexParent.cs
@@ -4,7 +4,7 @@ public class ComplexParent
 {
     public ComplexParent(ComplexChild child)
     {
-        this.Child = child;
+        Child = child;
     }
 
     public ComplexChild Child { get; }

--- a/Src/AutoFixtureDocumentationTest/Simple/Filter.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/Filter.cs
@@ -4,32 +4,32 @@ namespace AutoFixtureDocumentationTest.Simple;
 
 public class Filter
 {
-    private int max;
-    private int min;
+    private int _max;
+    private int _min;
 
     public int Max
     {
-        get => this.max;
+        get => _max;
         set
         {
-            if (value < this.Min)
+            if (value < Min)
             {
                 throw new ArgumentOutOfRangeException(nameof(value));
             }
-            this.max = value;
+            _max = value;
         }
     }
 
     public int Min
     {
-        get => this.min;
+        get => _min;
         set
         {
-            if (value > this.Max)
+            if (value > Max)
             {
                 throw new ArgumentOutOfRangeException(nameof(value));
             }
-            this.min = value;
+            _min = value;
         }
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Simple/MyViewModel.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/MyViewModel.cs
@@ -5,29 +5,29 @@ namespace AutoFixtureDocumentationTest.Simple;
 
 public class MyViewModel
 {
-    private readonly List<MyClass> availableItems;
-    private MyClass selectedItem;
+    private readonly List<MyClass> _availableItems;
+    private MyClass _selectedItem;
 
     public MyViewModel()
     {
-        this.availableItems = new List<MyClass>();
+        _availableItems = new List<MyClass>();
     }
 
     public ICollection<MyClass> AvailableItems
     {
-        get { return this.availableItems; }
+        get { return _availableItems; }
     }
 
     public MyClass SelectedItem
     {
-        get => this.selectedItem;
+        get => _selectedItem;
         set
         {
-            if (!this.availableItems.Contains(value))
+            if (!_availableItems.Contains(value))
             {
                 throw new ArgumentException("...");
             }
-            this.selectedItem = value;
+            _selectedItem = value;
         }
     }
 }

--- a/Src/AutoFixtureDocumentationTest/Simple/SomeImp.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/SomeImp.cs
@@ -4,27 +4,27 @@ namespace AutoFixtureDocumentationTest.Simple;
 
 public class SomeImp : IBadDesign
 {
-    private MyClass mc;
-    private string message;
+    private MyClass _mc;
+    private string _message;
 
     public string Message
     {
-        get => this.message;
+        get => _message;
         set
         {
-            if (this.mc == null)
+            if (_mc == null)
             {
                 throw new InvalidOperationException("...");
             }
 
-            this.message = value;
-            this.TransformedMessage = this.mc.DoStuff(value);
+            _message = value;
+            TransformedMessage = _mc.DoStuff(value);
         }
     }
 
     public void Initialize(MyClass mc)
     {
-        this.mc = mc;
+        _mc = mc;
     }
 
     public string TransformedMessage { get; private set; }

--- a/Src/AutoFixtureDocumentationTest/Simple/Vehicle.cs
+++ b/Src/AutoFixtureDocumentationTest/Simple/Vehicle.cs
@@ -4,7 +4,7 @@ public class Vehicle
 {
     public Vehicle()
     {
-        this.Wheels = 4;
+        Wheels = 4;
     }
 
     public int Wheels { get; set; }

--- a/Src/AutoFixtureUnitTest/CommandMock.cs
+++ b/Src/AutoFixtureUnitTest/CommandMock.cs
@@ -6,14 +6,14 @@ public class CommandMock<T>
 {
     public CommandMock()
     {
-        this.OnCommand = x => { };
+        OnCommand = x => { };
     }
 
     public Action<T> OnCommand { get; set; }
 
     public void Command(T x)
     {
-        this.OnCommand(x);
+        OnCommand(x);
     }
 }
 
@@ -21,14 +21,14 @@ public class CommandMock<T1, T2>
 {
     public CommandMock()
     {
-        this.OnCommand = (x1, x2) => { };
+        OnCommand = (x1, x2) => { };
     }
 
     public Action<T1, T2> OnCommand { get; set; }
 
     public void Command(T1 x1, T2 x2)
     {
-        this.OnCommand(x1, x2);
+        OnCommand(x1, x2);
     }
 }
 
@@ -36,14 +36,14 @@ public class CommandMock<T1, T2, T3>
 {
     public CommandMock()
     {
-        this.OnCommand = (x1, x2, x3) => { };
+        OnCommand = (x1, x2, x3) => { };
     }
 
     public Action<T1, T2, T3> OnCommand { get; set; }
 
     public void Command(T1 x1, T2 x2, T3 x3)
     {
-        this.OnCommand(x1, x2, x3);
+        OnCommand(x1, x2, x3);
     }
 }
 
@@ -51,13 +51,13 @@ public class CommandMock<T1, T2, T3, T4>
 {
     public CommandMock()
     {
-        this.OnCommand = (x1, x2, x3, x4) => { };
+        OnCommand = (x1, x2, x3, x4) => { };
     }
 
     public Action<T1, T2, T3, T4> OnCommand { get; set; }
 
     public void Command(T1 x1, T2 x2, T3 x3, T4 x4)
     {
-        this.OnCommand(x1, x2, x3, x4);
+        OnCommand(x1, x2, x3, x4);
     }
 }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthArgumentSupportTests.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthArgumentSupportTests.cs
@@ -45,7 +45,7 @@ public class StringLengthArgumentSupportTests
         public ClassWithShortStringLengthConstrainedConstructorArgument(
             [StringLength(ShortTextMaximumLength)] string shortText)
         {
-            this.ShortText = shortText;
+            ShortText = shortText;
         }
     }
 
@@ -57,7 +57,7 @@ public class StringLengthArgumentSupportTests
         public ClassWithLongStringLengthConstrainedConstructorArgument(
             [StringLength(LongTextLength, MinimumLength = LongTextLength)] string longText)
         {
-            this.LongText = longText;
+            LongText = longText;
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedConstructorHost.cs
+++ b/Src/AutoFixtureUnitTest/DataAnnotations/StringLengthValidatedConstructorHost.cs
@@ -9,7 +9,7 @@ public class StringLengthValidatedConstructorHost<T>
 {
     public StringLengthValidatedConstructorHost([StringLength(5)] T value)
     {
-        this.Value = value;
+        Value = value;
     }
 
     public T Value { get; private set; }

--- a/Src/AutoFixtureUnitTest/DelegatingCustomization.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingCustomization.cs
@@ -7,12 +7,12 @@ internal class DelegatingCustomization : ICustomization
 {
     public DelegatingCustomization()
     {
-        this.OnCustomize = f => { };
+        OnCustomize = f => { };
     }
 
     public void Customize(IFixture fixture)
     {
-        this.OnCustomize(fixture);
+        OnCustomize(fixture);
     }
 
     internal Action<IFixture> OnCustomize { get; set; }

--- a/Src/AutoFixtureUnitTest/DelegatingEqualityComparer.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingEqualityComparer.cs
@@ -8,12 +8,12 @@ public class DelegatingEqualityComparer : IEqualityComparer
 {
     public DelegatingEqualityComparer()
     {
-        this.OnEquals = (x, y) => false;
+        OnEquals = (x, y) => false;
     }
 
     bool IEqualityComparer.Equals(object x, object y)
     {
-        return this.OnEquals(x, y);
+        return OnEquals(x, y);
     }
 
     int IEqualityComparer.GetHashCode(object obj)
@@ -31,12 +31,12 @@ internal class DelegatingEqualityComparer<T> : IEqualityComparer<T>
 {
     public DelegatingEqualityComparer()
     {
-        this.OnEquals = (x, y) => false;
+        OnEquals = (x, y) => false;
     }
 
     bool IEqualityComparer<T>.Equals(T x, T y)
     {
-        return this.OnEquals(x, y);
+        return OnEquals(x, y);
     }
 
     int IEqualityComparer<T>.GetHashCode(T obj)

--- a/Src/AutoFixtureUnitTest/DelegatingRecursionGuard.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingRecursionGuard.cs
@@ -31,7 +31,7 @@ public class DelegatingRecursionGuard : RecursionGuard
     [Obsolete]
     public override object HandleRecursiveRequest(object request)
     {
-        return this.OnHandleRecursiveRequest(request);
+        return OnHandleRecursiveRequest(request);
     }
 
     public override ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
@@ -41,7 +41,7 @@ public class DelegatingRecursionGuard : RecursionGuard
 
     internal IEnumerable<object> UnprotectedRecordedRequests
     {
-        get { return this.RecordedRequests.Cast<object>(); }
+        get { return RecordedRequests.Cast<object>(); }
     }
 
     internal Func<object, object> OnHandleRecursiveRequest { get; set; }

--- a/Src/AutoFixtureUnitTest/DelegatingRecursionHandler.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingRecursionHandler.cs
@@ -8,14 +8,14 @@ public class DelegatingRecursionHandler : IRecursionHandler
 {
     public DelegatingRecursionHandler()
     {
-        this.OnHandleRecursiveRequest = (r, rs) => new object();
+        OnHandleRecursiveRequest = (r, rs) => new object();
     }
 
     public object HandleRecursiveRequest(
         object request,
         IEnumerable<object> recordedRequests)
     {
-        return this.OnHandleRecursiveRequest(request, recordedRequests);
+        return OnHandleRecursiveRequest(request, recordedRequests);
     }
 
     internal Func<object, IEnumerable<object>, object> OnHandleRecursiveRequest { get; set; }

--- a/Src/AutoFixtureUnitTest/DelegatingRequestMemberTypeResolver.cs
+++ b/Src/AutoFixtureUnitTest/DelegatingRequestMemberTypeResolver.cs
@@ -7,12 +7,12 @@ internal class DelegatingRequestMemberTypeResolver : IRequestMemberTypeResolver
 {
     public DelegatingRequestMemberTypeResolver()
     {
-        this.OnTryGetMemberType = r => null;
+        OnTryGetMemberType = r => null;
     }
 
     public bool TryGetMemberType(object request, out Type memberType)
     {
-        memberType = this.OnTryGetMemberType(request);
+        memberType = OnTryGetMemberType(request);
         return memberType != null;
     }
 

--- a/Src/AutoFixtureUnitTest/DependencyConstraints.cs
+++ b/Src/AutoFixtureUnitTest/DependencyConstraints.cs
@@ -27,7 +27,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+        var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.DoesNotContain(references, an => an.Name == assemblyName);
     }

--- a/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
+++ b/Src/AutoFixtureUnitTest/Dsl/DelegatingComposer.cs
@@ -13,63 +13,63 @@ public class DelegatingComposer<T> : ICustomizationComposer<T>
 {
     public DelegatingComposer()
     {
-        this.OnFromSeed = f => new DelegatingComposer<T>();
-        this.OnFromBuilder = f => new DelegatingComposer<T>();
-        this.OnFromFactory = f => new DelegatingComposer<T>();
-        this.OnFromOverloadFactory = f => new DelegatingComposer<T>();
-        this.OnDo = f => new DelegatingComposer<T>();
-        this.OnOmitAutoProperties = () => new DelegatingComposer<T>();
-        this.OnAnonymousWith = f => new DelegatingComposer<T>();
-        this.OnWithOverloadValue = (f, v) => new DelegatingComposer<T>();
-        this.OnWithOverloadFactory = (f, vf) => new DelegatingComposer<T>();
-        this.OnWithAutoProperties = () => new DelegatingComposer<T>();
-        this.OnWithout = f => new DelegatingComposer<T>();
-        this.OnCreate = (r, c) => new object();
+        OnFromSeed = f => new DelegatingComposer<T>();
+        OnFromBuilder = f => new DelegatingComposer<T>();
+        OnFromFactory = f => new DelegatingComposer<T>();
+        OnFromOverloadFactory = f => new DelegatingComposer<T>();
+        OnDo = f => new DelegatingComposer<T>();
+        OnOmitAutoProperties = () => new DelegatingComposer<T>();
+        OnAnonymousWith = f => new DelegatingComposer<T>();
+        OnWithOverloadValue = (f, v) => new DelegatingComposer<T>();
+        OnWithOverloadFactory = (f, vf) => new DelegatingComposer<T>();
+        OnWithAutoProperties = () => new DelegatingComposer<T>();
+        OnWithout = f => new DelegatingComposer<T>();
+        OnCreate = (r, c) => new object();
     }
 
-    public IPostprocessComposer<T> FromSeed(Func<T, T> factory) => this.OnFromSeed(factory);
+    public IPostprocessComposer<T> FromSeed(Func<T, T> factory) => OnFromSeed(factory);
 
-    public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory) => this.OnFromBuilder(factory);
+    public IPostprocessComposer<T> FromFactory(ISpecimenBuilder factory) => OnFromBuilder(factory);
 
-    public IPostprocessComposer<T> FromFactory(Func<T> factory) => this.OnFromFactory(factory);
+    public IPostprocessComposer<T> FromFactory(Func<T> factory) => OnFromFactory(factory);
 
     public IPostprocessComposer<T> FromFactory<TInput>(Func<TInput, T> factory) =>
-        this.OnFromOverloadFactory(factory);
+        OnFromOverloadFactory(factory);
 
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2>(Func<TInput1, TInput2, T> factory) =>
-        this.OnFromOverloadFactory(factory);
+        OnFromOverloadFactory(factory);
 
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3>(Func<TInput1, TInput2, TInput3, T> factory) =>
-        this.OnFromOverloadFactory(factory);
+        OnFromOverloadFactory(factory);
 
     public IPostprocessComposer<T> FromFactory<TInput1, TInput2, TInput3, TInput4>(Func<TInput1, TInput2, TInput3, TInput4, T> factory) =>
-        this.OnFromOverloadFactory(factory);
+        OnFromOverloadFactory(factory);
 
-    public IPostprocessComposer<T> Do(Action<T> action) => this.OnDo(action);
+    public IPostprocessComposer<T> Do(Action<T> action) => OnDo(action);
 
-    public IPostprocessComposer<T> OmitAutoProperties() => this.OnOmitAutoProperties();
+    public IPostprocessComposer<T> OmitAutoProperties() => OnOmitAutoProperties();
 
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker) =>
-        this.OnAnonymousWith(propertyPicker);
+        OnAnonymousWith(propertyPicker);
 
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, TProperty value) =>
-        this.OnWithOverloadValue(propertyPicker, value);
+        OnWithOverloadValue(propertyPicker, value);
 
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, Func<TProperty> valueFactory) =>
-        this.OnWithOverloadFactory(propertyPicker, valueFactory);
+        OnWithOverloadFactory(propertyPicker, valueFactory);
 
     public IPostprocessComposer<T> With<TProperty, TInput>(Expression<Func<T, TProperty>> propertyPicker, Func<TInput, TProperty> valueFactory) =>
-        this.OnWithOverloadFactory(propertyPicker, valueFactory);
+        OnWithOverloadFactory(propertyPicker, valueFactory);
 
     public IPostprocessComposer<T> With<TProperty>(Expression<Func<T, TProperty>> propertyPicker, ISpecimenBuilder builder) =>
-        this.OnWithOverloadFactory(propertyPicker, builder);
+        OnWithOverloadFactory(propertyPicker, builder);
 
-    public IPostprocessComposer<T> WithAutoProperties() => this.OnWithAutoProperties();
+    public IPostprocessComposer<T> WithAutoProperties() => OnWithAutoProperties();
 
     public IPostprocessComposer<T> Without<TProperty>(Expression<Func<T, TProperty>> propertyPicker) =>
-        this.OnWithout(propertyPicker);
+        OnWithout(propertyPicker);
 
-    public object Create(object request, ISpecimenContext context) => this.OnCreate(request, context);
+    public object Create(object request, ISpecimenContext context) => OnCreate(request, context);
 
     internal Func<Func<T, T>, IPostprocessComposer<T>> OnFromSeed { get; set; }
     internal Func<ISpecimenBuilder, IPostprocessComposer<T>> OnFromBuilder { get; set; }

--- a/Src/AutoFixtureUnitTest/FakeMemberInfo.cs
+++ b/Src/AutoFixtureUnitTest/FakeMemberInfo.cs
@@ -7,30 +7,30 @@ namespace AutoFixtureUnitTest;
 
 internal class FakeMemberInfo : ICustomAttributeProvider
 {
-    private readonly IEnumerable<ProvidedAttribute> providedAttributes;
+    private readonly IEnumerable<ProvidedAttribute> _providedAttributes;
 
     public FakeMemberInfo(params ProvidedAttribute[] providedAttributes)
     {
-        this.providedAttributes = providedAttributes;
+        _providedAttributes = providedAttributes;
     }
 
     public object[] GetCustomAttributes(bool inherit)
     {
-        return (from p in this.providedAttributes
+        return (from p in _providedAttributes
             where MatchesInheritance(p, inherit)
             select p.Attribute).ToArray();
     }
 
     public object[] GetCustomAttributes(Type attributeType, bool inherit)
     {
-        return (from p in this.providedAttributes
+        return (from p in _providedAttributes
             where p.Attribute.GetType() == attributeType && MatchesInheritance(p, inherit)
             select p.Attribute).ToArray();
     }
 
     public bool IsDefined(Type attributeType, bool inherit)
     {
-        return (from p in this.providedAttributes
+        return (from p in _providedAttributes
             where p.Attribute.GetType() == attributeType && MatchesInheritance(p, inherit)
             select p.Attribute).Any();
     }

--- a/Src/AutoFixtureUnitTest/FixtureTest.cs
+++ b/Src/AutoFixtureUnitTest/FixtureTest.cs
@@ -5329,21 +5329,21 @@ public class FixtureTest
 
     private class RecursiveSequenceNode : IEnumerable<RecursiveSequenceNode>
     {
-        private readonly IEnumerable<RecursiveSequenceNode> nodes;
+        private readonly IEnumerable<RecursiveSequenceNode> _nodes;
 
         public RecursiveSequenceNode(IEnumerable<RecursiveSequenceNode> nodes)
         {
-            this.nodes = nodes;
+            _nodes = nodes;
         }
 
         public IEnumerator<RecursiveSequenceNode> GetEnumerator()
         {
-            return this.nodes.GetEnumerator();
+            return _nodes.GetEnumerator();
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
     }
 
@@ -5423,21 +5423,21 @@ public class FixtureTest
 
     private class RecursiveArrayNode : IEnumerable<RecursiveArrayNode>
     {
-        private readonly RecursiveArrayNode[] nodes;
+        private readonly RecursiveArrayNode[] _nodes;
 
         public RecursiveArrayNode(RecursiveArrayNode[] nodes)
         {
-            this.nodes = nodes;
+            _nodes = nodes;
         }
 
         public IEnumerator<RecursiveArrayNode> GetEnumerator()
         {
-            return this.nodes.AsEnumerable().GetEnumerator();
+            return _nodes.AsEnumerable().GetEnumerator();
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
     }
 
@@ -5572,7 +5572,7 @@ public class FixtureTest
 
         public RecursionTestObjectWithConstructorReferenceOutA(RecursionTestObjectWithConstructorReferenceOutB b)
         {
-            this.ReferenceToB = b;
+            ReferenceToB = b;
         }
     }
 
@@ -5586,7 +5586,7 @@ public class FixtureTest
 
         public RecursionTestObjectWithConstructorReferenceOutB(RecursionTestObjectWithConstructorReferenceOutA a)
         {
-            this.ReferenceToA = a;
+            ReferenceToA = a;
         }
     }
 

--- a/Src/AutoFixtureUnitTest/GeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/GeneratorTest.cs
@@ -132,7 +132,7 @@ internal class CountTestCases : IEnumerable<object[]>
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }
 

--- a/Src/AutoFixtureUnitTest/Kernel/ActionSpecimenCommandTests.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/ActionSpecimenCommandTests.cs
@@ -17,7 +17,7 @@ public abstract class ActionSpecimenCommandTests<T>
     public void ExecuteCorrectlyInvokesSingleAction()
     {
         // Arrange
-        var specimen = this.CreateSpecimen();
+        var specimen = CreateSpecimen();
 
         var verified = false;
         Action<T> mock = x => verified = specimen.Equals(x);
@@ -34,7 +34,7 @@ public abstract class ActionSpecimenCommandTests<T>
     public void ExecuteCorrectlyInvokeDoubleAction()
     {
         // Arrange
-        var specimen = this.CreateSpecimen();
+        var specimen = CreateSpecimen();
         var context = new DelegatingSpecimenContext();
 
         var verified = false;

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingCriterion.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingCriterion.cs
@@ -6,12 +6,12 @@ public class DelegatingCriterion<T> : IEquatable<T>
 {
     public DelegatingCriterion()
     {
-        this.OnEquals = _ => false;
+        OnEquals = _ => false;
     }
 
     public bool Equals(T other)
     {
-        return this.OnEquals(other);
+        return OnEquals(other);
     }
 
     public Func<T, bool> OnEquals { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingMethod.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingMethod.cs
@@ -10,18 +10,18 @@ public class DelegatingMethod : IMethod
 {
     public DelegatingMethod()
     {
-        this.OnParameters = Enumerable.Empty<ParameterInfo>;
-        this.OnInvoke = p => null;
+        OnParameters = Enumerable.Empty<ParameterInfo>;
+        OnInvoke = p => null;
     }
 
     public IEnumerable<ParameterInfo> Parameters
     {
-        get { return this.OnParameters(); }
+        get { return OnParameters(); }
     }
 
     public object Invoke(IEnumerable<object> parameters)
     {
-        return this.OnInvoke(parameters);
+        return OnInvoke(parameters);
     }
 
     internal Func<IEnumerable<ParameterInfo>> OnParameters { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingMethodFactory.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingMethodFactory.cs
@@ -8,12 +8,12 @@ public class DelegatingMethodFactory : IMethodFactory
 {
     public DelegatingMethodFactory()
     {
-        this.OnCreate = m => null;
+        OnCreate = m => null;
     }
 
     public IMethod Create(MethodInfo methodInfo)
     {
-        return this.OnCreate(methodInfo);
+        return OnCreate(methodInfo);
     }
 
     internal Func<MethodInfo, IMethod> OnCreate { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingMethodQuery.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingMethodQuery.cs
@@ -9,12 +9,12 @@ public class DelegatingMethodQuery : IMethodQuery
 {
     public DelegatingMethodQuery()
     {
-        this.OnSelectMethods = t => Enumerable.Empty<IMethod>();
+        OnSelectMethods = t => Enumerable.Empty<IMethod>();
     }
 
     public IEnumerable<IMethod> SelectMethods(Type type)
     {
-        return this.OnSelectMethods(type);
+        return OnSelectMethods(type);
     }
 
     internal Func<Type, IEnumerable<IMethod>> OnSelectMethods { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingPropertyQuery.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingPropertyQuery.cs
@@ -9,11 +9,11 @@ public class DelegatingPropertyQuery : IPropertyQuery
 {
     public DelegatingPropertyQuery()
     {
-        this.OnSelectProperties = t => t.GetTypeInfo().GetProperties();
+        OnSelectProperties = t => t.GetTypeInfo().GetProperties();
     }
 
     public IEnumerable<PropertyInfo> SelectProperties(Type type)
-        => this.OnSelectProperties?.Invoke(type);
+        => OnSelectProperties?.Invoke(type);
 
     internal Func<Type, IEnumerable<PropertyInfo>> OnSelectProperties { get; set; }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingRequestSpecification.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingRequestSpecification.cs
@@ -7,12 +7,12 @@ internal class DelegatingRequestSpecification : IRequestSpecification
 {
     public DelegatingRequestSpecification()
     {
-        this.OnIsSatisfiedBy = r => false;
+        OnIsSatisfiedBy = r => false;
     }
 
     public bool IsSatisfiedBy(object request)
     {
-        return this.OnIsSatisfiedBy(request);
+        return OnIsSatisfiedBy(request);
     }
 
     internal Predicate<object> OnIsSatisfiedBy { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenBuilder.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenBuilder.cs
@@ -7,12 +7,12 @@ internal class DelegatingSpecimenBuilder : ISpecimenBuilder
 {
     public DelegatingSpecimenBuilder()
     {
-        this.OnCreate = (r, c) => null;
+        OnCreate = (r, c) => null;
     }
 
     public object Create(object request, ISpecimenContext container)
     {
-        return this.OnCreate(request, container);
+        return OnCreate(request, container);
     }
 
     internal Func<object, ISpecimenContext, object> OnCreate { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenBuilderTransformation.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenBuilderTransformation.cs
@@ -7,12 +7,12 @@ public class DelegatingSpecimenBuilderTransformation : ISpecimenBuilderTransform
 {
     public DelegatingSpecimenBuilderTransformation()
     {
-        this.OnTransform = b => (ISpecimenBuilderNode)b;
+        OnTransform = b => (ISpecimenBuilderNode)b;
     }
 
     public ISpecimenBuilderNode Transform(ISpecimenBuilder builder)
     {
-        return this.OnTransform(builder);
+        return OnTransform(builder);
     }
 
     internal Func<ISpecimenBuilder, ISpecimenBuilderNode> OnTransform { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenCommand.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenCommand.cs
@@ -7,12 +7,12 @@ public class DelegatingSpecimenCommand : ISpecimenCommand
 {
     public DelegatingSpecimenCommand()
     {
-        this.OnExecute = (s, c) => { };
+        OnExecute = (s, c) => { };
     }
 
     public void Execute(object specimen, ISpecimenContext context)
     {
-        this.OnExecute(specimen, context);
+        OnExecute(specimen, context);
     }
 
     internal Action<object, ISpecimenContext> OnExecute { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenContext.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingSpecimenContext.cs
@@ -7,12 +7,12 @@ internal class DelegatingSpecimenContext : ISpecimenContext
 {
     public DelegatingSpecimenContext()
     {
-        this.OnResolve = r => null;
+        OnResolve = r => null;
     }
 
     public object Resolve(object request)
     {
-        return this.OnResolve(request);
+        return OnResolve(request);
     }
 
     internal Func<object, object> OnResolve { get; set; }

--- a/Src/AutoFixtureUnitTest/Kernel/DelegatingTracingBuilder.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DelegatingTracingBuilder.cs
@@ -16,11 +16,11 @@ internal class DelegatingTracingBuilder : TracingBuilder
 
     internal void RaiseSpecimenCreated(SpecimenCreatedEventArgs e)
     {
-        this.OnSpecimenCreated(e);
+        OnSpecimenCreated(e);
     }
 
     internal void RaiseSpecimenRequested(RequestTraceEventArgs e)
     {
-        this.OnSpecimenRequested(e);
+        OnSpecimenRequested(e);
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/DisposableSpy.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/DisposableSpy.cs
@@ -8,7 +8,7 @@ public class DisposableSpy : IDisposable
 
     public void Dispose()
     {
-        this.Dispose(true);
+        Dispose(true);
         GC.SuppressFinalize(this);
     }
 
@@ -16,7 +16,7 @@ public class DisposableSpy : IDisposable
     {
         if (disposing)
         {
-            this.Disposed = true;
+            Disposed = true;
         }
     }
 }

--- a/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/Kernel/NodeComparer.cs
@@ -10,22 +10,22 @@ namespace AutoFixtureUnitTest.Kernel;
 
 internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 {
-    private readonly IEqualityComparer<IRequestSpecification> specificationComparer;
-    private readonly IEqualityComparer<IMethodQuery> queryComparer;
-    private readonly IEqualityComparer<ISpecimenCommand> commandComparer;
+    private readonly IEqualityComparer<IRequestSpecification> _specificationComparer;
+    private readonly IEqualityComparer<IMethodQuery> _queryComparer;
+    private readonly IEqualityComparer<ISpecimenCommand> _commandComparer;
 
     public NodeComparer()
     {
-        this.specificationComparer = new SpecificationComparer();
-        this.queryComparer = new QueryComparer();
-        this.commandComparer = new CommandComparer(this.specificationComparer);
+        _specificationComparer = new SpecificationComparer();
+        _queryComparer = new QueryComparer();
+        _commandComparer = new CommandComparer(_specificationComparer);
     }
 
     public bool Equals(ISpecimenBuilder x, ISpecimenBuilder y)
     {
         if (x is FilteringSpecimenBuilder fx &&
             y is FilteringSpecimenBuilder fy &&
-            this.specificationComparer.Equals(fx.Specification, fy.Specification))
+            _specificationComparer.Equals(fx.Specification, fy.Specification))
             return true;
 
         if (x is CompositeSpecimenBuilder && y is CompositeSpecimenBuilder)
@@ -33,7 +33,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         if (x is NoSpecimenOutputGuard gx &&
             y is NoSpecimenOutputGuard gy &&
-            this.specificationComparer.Equals(gx.Specification, gy.Specification))
+            _specificationComparer.Equals(gx.Specification, gy.Specification))
             return true;
 
         if (x is SeedIgnoringRelay && y is SeedIgnoringRelay)
@@ -43,12 +43,12 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         if (x is MethodInvoker mix &&
             y is MethodInvoker miy &&
-            this.queryComparer.Equals(mix.Query, miy.Query))
+            _queryComparer.Equals(mix.Query, miy.Query))
             return true;
 
         if (x is Omitter omx &&
             y is Omitter omy &&
-            this.specificationComparer.Equals(omx.Specification, omy.Specification))
+            _specificationComparer.Equals(omx.Specification, omy.Specification))
             return true;
 
         if (x is DelegatingSpecimenBuilder dx &&
@@ -58,8 +58,8 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         if (x is Postprocessor px &&
             y is Postprocessor py &&
-            this.commandComparer.Equals(px.Command, py.Command) &&
-            this.specificationComparer.Equals(px.Specification, py.Specification))
+            _commandComparer.Equals(px.Command, py.Command) &&
+            _specificationComparer.Equals(px.Specification, py.Specification))
             return true;
 
         if (GenericComparer.CreateFromTemplate(x).Equals(y))
@@ -75,18 +75,18 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
     private class SpecificationComparer : IEqualityComparer<IRequestSpecification>
     {
-        private readonly IEqualityComparer<IEqualityComparer> comparerComparer;
+        private readonly IEqualityComparer<IEqualityComparer> _comparerComparer;
 
         public SpecificationComparer()
         {
-            this.comparerComparer = new ComparerComparer();
+            _comparerComparer = new ComparerComparer();
         }
 
         public bool Equals(IRequestSpecification x, IRequestSpecification y)
         {
             if (x is InverseRequestSpecification invx &&
                 y is InverseRequestSpecification invy &&
-                this.Equals(invx.Specification, invy.Specification))
+                Equals(invx.Specification, invy.Specification))
                 return true;
 
             if (x is OrRequestSpecification ox &&
@@ -118,7 +118,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
             if (x is EqualRequestSpecification eqx &&
                 y is EqualRequestSpecification eqy &&
                 object.Equals(eqx.Target, eqy.Target) &&
-                this.comparerComparer.Equals(eqx.Comparer, eqy.Comparer))
+                _comparerComparer.Equals(eqx.Comparer, eqy.Comparer))
                 return true;
 
             return EqualityComparer<IRequestSpecification>.Default.Equals(x, y);
@@ -166,11 +166,11 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
     private class CommandComparer : IEqualityComparer<ISpecimenCommand>
     {
-        private readonly IEqualityComparer<IRequestSpecification> specificationComparer;
+        private readonly IEqualityComparer<IRequestSpecification> _specificationComparer;
 
         public CommandComparer(IEqualityComparer<IRequestSpecification> specificationComparer)
         {
-            this.specificationComparer = specificationComparer;
+            _specificationComparer = specificationComparer;
         }
 
         public bool Equals(ISpecimenCommand x, ISpecimenCommand y)
@@ -179,7 +179,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
                 y is AutoPropertiesCommand apy)
             {
                 return
-                    this.specificationComparer.Equals(apx.Specification, apy.Specification) &&
+                    _specificationComparer.Equals(apx.Specification, apy.Specification) &&
                     apx.ExplicitSpecimenType == apy.ExplicitSpecimenType;
             }
 
@@ -194,7 +194,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
     private static class GenericComparer
     {
-        private static readonly Dictionary<Type, Type> Equatables =
+        private static readonly Dictionary<Type, Type> s_equatables =
             new Dictionary<Type, Type>
             {
                 { typeof(SeededFactory<>), typeof(SeededFactoryEquatable<>) },
@@ -214,7 +214,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
             if (!t.GetTypeInfo().IsGenericType)
                 return new object();
 
-            if (Equatables.TryGetValue(t.GetGenericTypeDefinition(), out Type equatableType))
+            if (s_equatables.TryGetValue(t.GetGenericTypeDefinition(), out Type equatableType))
             {
                 var typeArguments = t.GetGenericArguments();
                 return equatableType.MakeGenericType(typeArguments)
@@ -235,7 +235,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         protected override bool EqualsInstance(SeededFactory<T> other)
         {
-            return this.Item.Factory.Equals(other.Factory);
+            return Item.Factory.Equals(other.Factory);
         }
     }
 
@@ -248,7 +248,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         protected override bool EqualsInstance(SpecimenFactory<T> other)
         {
-            return this.Item.Factory.Equals(other.Factory);
+            return Item.Factory.Equals(other.Factory);
         }
     }
 
@@ -261,7 +261,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         protected override bool EqualsInstance(SpecimenFactory<TInput, T> other)
         {
-            return this.Item.Factory.Equals(other.Factory);
+            return Item.Factory.Equals(other.Factory);
         }
     }
 
@@ -274,7 +274,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         protected override bool EqualsInstance(SpecimenFactory<TInput1, TInput2, T> other)
         {
-            return this.Item.Factory.Equals(other.Factory);
+            return Item.Factory.Equals(other.Factory);
         }
     }
 
@@ -287,7 +287,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         protected override bool EqualsInstance(SpecimenFactory<TInput1, TInput2, TInput3, T> other)
         {
-            return this.Item.Factory.Equals(other.Factory);
+            return Item.Factory.Equals(other.Factory);
         }
     }
 
@@ -300,7 +300,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         protected override bool EqualsInstance(SpecimenFactory<TInput1, TInput2, TInput3, TInput4, T> other)
         {
-            return this.Item.Factory.Equals(other.Factory);
+            return Item.Factory.Equals(other.Factory);
         }
     }
 
@@ -339,7 +339,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
 
         protected override bool EqualsInstance(BindingCommand<T, TProperty> other)
         {
-            return this.Item.Member == other.Member;
+            return Item.Member == other.Member;
         }
     }
 
@@ -348,7 +348,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
     {
         public GenericEquatable(T item)
         {
-            this.Item = item;
+            Item = item;
         }
 
         public T Item { get; }
@@ -356,13 +356,13 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
         public override bool Equals(object obj)
         {
             if (obj is T other)
-                return this.Equals(other);
+                return Equals(other);
             return base.Equals(obj);
         }
 
         public override int GetHashCode()
         {
-            return this.Item.GetHashCode();
+            return Item.GetHashCode();
         }
 
         public bool Equals(T other)
@@ -370,7 +370,7 @@ internal class NodeComparer : IEqualityComparer<ISpecimenBuilder>
             if (other == null)
                 return false;
 
-            return this.EqualsInstance(other);
+            return EqualsInstance(other);
         }
 
         protected abstract bool EqualsInstance(T other);

--- a/Src/AutoFixtureUnitTest/LoopTest.cs
+++ b/Src/AutoFixtureUnitTest/LoopTest.cs
@@ -6,16 +6,16 @@ namespace AutoFixtureUnitTest;
 internal class LoopTest<TSut, TResult>
     where TSut : new()
 {
-    private readonly Func<TSut, TResult> create;
+    private readonly Func<TSut, TResult> _create;
 
     internal LoopTest(Func<TSut, TResult> func)
     {
-        this.create = func;
+        _create = func;
     }
 
     public void Execute(int loopCount)
     {
-        this.Execute(loopCount, (TResult)Convert.ChangeType(loopCount, typeof(TResult)));
+        Execute(loopCount, (TResult)Convert.ChangeType(loopCount, typeof(TResult)));
     }
 
     public void Execute(int loopCount, TResult expectedResult)
@@ -26,7 +26,7 @@ internal class LoopTest<TSut, TResult>
         TResult result = default(TResult);
         for (int i = 0; i < loopCount; i++)
         {
-            result = this.create(sut);
+            result = _create(sut);
         }
         // Assert
         Assert.Equal<TResult>(expectedResult, result);

--- a/Src/AutoFixtureUnitTest/MarkerNode.cs
+++ b/Src/AutoFixtureUnitTest/MarkerNode.cs
@@ -6,11 +6,11 @@ namespace AutoFixtureUnitTest;
 
 public class MarkerNode : ISpecimenBuilderNode
 {
-    private readonly ISpecimenBuilder builder;
+    private readonly ISpecimenBuilder _builder;
 
     public MarkerNode(ISpecimenBuilder builder)
     {
-        this.builder = builder;
+        _builder = builder;
     }
 
     public ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
@@ -23,16 +23,16 @@ public class MarkerNode : ISpecimenBuilderNode
 
     public object Create(object request, ISpecimenContext context)
     {
-        return this.builder.Create(request, context);
+        return _builder.Create(request, context);
     }
 
     public IEnumerator<ISpecimenBuilder> GetEnumerator()
     {
-        yield return this.builder;
+        yield return _builder;
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoFixtureUnitTest/MarkerNodeTests.cs
+++ b/Src/AutoFixtureUnitTest/MarkerNodeTests.cs
@@ -16,9 +16,9 @@ public abstract class MarkerNodeTests<T>
     {
         // Arrange
         var expected = new DelegatingSpecimenBuilder();
-        var sut = this.CreateSut(expected);
+        var sut = CreateSut(expected);
         // Act
-        ISpecimenBuilder actual = this.GetBuilder(sut);
+        ISpecimenBuilder actual = GetBuilder(sut);
         // Assert
         Assert.Equal(expected, actual);
     }
@@ -28,7 +28,7 @@ public abstract class MarkerNodeTests<T>
     {
         // Arrange
         var dummy = new DelegatingSpecimenBuilder();
-        var sut = this.CreateSut(dummy);
+        var sut = CreateSut(dummy);
         // Act
         var expected = new[]
         {
@@ -41,7 +41,7 @@ public abstract class MarkerNodeTests<T>
         var mn = Assert.IsAssignableFrom<T>(actual);
         var builders =
             Assert.IsAssignableFrom<IEnumerable<ISpecimenBuilder>>(
-                this.GetBuilder(mn));
+                GetBuilder(mn));
         Assert.True(expected.SequenceEqual(builders));
     }
 
@@ -50,13 +50,13 @@ public abstract class MarkerNodeTests<T>
     {
         // Arrange
         var dummy = new DelegatingSpecimenBuilder();
-        var sut = this.CreateSut(dummy);
+        var sut = CreateSut(dummy);
         var expected = new DelegatingSpecimenBuilder();
         // Act
         var actual = sut.Compose(new[] { expected });
         // Assert
         var mn = Assert.IsAssignableFrom<T>(actual);
-        Assert.Equal(expected, this.GetBuilder(mn));
+        Assert.Equal(expected, GetBuilder(mn));
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public abstract class MarkerNodeTests<T>
                 return expected;
             }
         };
-        var sut = this.CreateSut(stub);
+        var sut = CreateSut(stub);
         // Act
         var actual = sut.Create(request, context);
         // Assert
@@ -88,7 +88,7 @@ public abstract class MarkerNodeTests<T>
         // Arrange
         var expected = new DelegatingSpecimenBuilder();
         // Act
-        var sut = this.CreateSut(expected);
+        var sut = CreateSut(expected);
         // Assert
         Assert.True(new[] { expected }.SequenceEqual(sut));
         Assert.True(new object[] { expected }.SequenceEqual(
@@ -99,7 +99,7 @@ public abstract class MarkerNodeTests<T>
     public void ConstructWithNullBuilderThrows()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            this.CreateSut(null));
+            CreateSut(null));
     }
 
     public abstract T CreateSut(ISpecimenBuilder builder);

--- a/Src/AutoFixtureUnitTest/ProvidedAttribute.cs
+++ b/Src/AutoFixtureUnitTest/ProvidedAttribute.cs
@@ -6,8 +6,8 @@ internal class ProvidedAttribute
 {
     public ProvidedAttribute(Attribute attribute, bool inherited)
     {
-        this.Attribute = attribute;
-        this.Inherited = inherited;
+        Attribute = attribute;
+        Inherited = inherited;
     }
 
     public Attribute Attribute { get; }

--- a/Src/AutoFixtureUnitTest/QueryMock.cs
+++ b/Src/AutoFixtureUnitTest/QueryMock.cs
@@ -6,14 +6,14 @@ public class QueryMock<T, TResult>
 {
     public QueryMock()
     {
-        this.OnQuery = x => default(TResult);
+        OnQuery = x => default(TResult);
     }
 
     public Func<T, TResult> OnQuery { get; set; }
 
     public TResult Query(T x)
     {
-        return this.OnQuery(x);
+        return OnQuery(x);
     }
 }
 
@@ -21,14 +21,14 @@ public class QueryMock<T1, T2, TResult>
 {
     public QueryMock()
     {
-        this.OnQuery = (x1, x2) => default(TResult);
+        OnQuery = (x1, x2) => default(TResult);
     }
 
     public Func<T1, T2, TResult> OnQuery { get; set; }
 
     public TResult Query(T1 x1, T2 x2)
     {
-        return this.OnQuery(x1, x2);
+        return OnQuery(x1, x2);
     }
 }
 
@@ -36,14 +36,14 @@ public class QueryMock<T1, T2, T3, TResult>
 {
     public QueryMock()
     {
-        this.OnQuery = (x1, x2, x3) => default(TResult);
+        OnQuery = (x1, x2, x3) => default(TResult);
     }
 
     public Func<T1, T2, T3, TResult> OnQuery { get; set; }
 
     public TResult Query(T1 x1, T2 x2, T3 x3)
     {
-        return this.OnQuery(x1, x2, x3);
+        return OnQuery(x1, x2, x3);
     }
 }
 
@@ -51,13 +51,13 @@ public class QueryMock<T1, T2, T3, T4, TResult>
 {
     public QueryMock()
     {
-        this.OnQuery = (x1, x2, x3, x4) => default(TResult);
+        OnQuery = (x1, x2, x3, x4) => default(TResult);
     }
 
     public Func<T1, T2, T3, T4, TResult> OnQuery { get; set; }
 
     public TResult Query(T1 x1, T2 x2, T3 x3, T4 x4)
     {
-        return this.OnQuery(x1, x2, x3, x4);
+        return OnQuery(x1, x2, x3, x4);
     }
 }

--- a/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
+++ b/Src/AutoFixtureUnitTest/RangedNumberGeneratorTest.cs
@@ -511,7 +511,7 @@ public class RangedNumberGeneratorTest
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
 
         private static object[] CreateTestCase(Type operandType, object minimum, object maximum, object contextValue, object expectedResult)

--- a/Src/AutoFixtureUnitTest/SingletonSpecimenBuilderNodeStackAdapterCollectionTest.cs
+++ b/Src/AutoFixtureUnitTest/SingletonSpecimenBuilderNodeStackAdapterCollectionTest.cs
@@ -11,12 +11,12 @@ namespace AutoFixtureUnitTest;
 
 public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
 {
-    private readonly ISpecimenBuilderNode graph;
-    private readonly SingletonSpecimenBuilderNodeStackAdapterCollection sut;
+    private readonly ISpecimenBuilderNode _graph;
+    private readonly SingletonSpecimenBuilderNodeStackAdapterCollection _sut;
 
     public SingletonSpecimenBuilderNodeStackAdapterCollectionTest()
     {
-        this.graph = new MarkerNode(
+        _graph = new MarkerNode(
             new CompositeSpecimenBuilder(
                 new CompositeSpecimenBuilder(
                     new DelegatingSpecimenBuilder(),
@@ -28,19 +28,19 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
                 new CompositeSpecimenBuilder(new DelegatingSpecimenBuilder(),
                     new DelegatingSpecimenBuilder(),
                     new DelegatingSpecimenBuilder())));
-        this.sut = new SingletonSpecimenBuilderNodeStackAdapterCollection(this.graph, n => n is MarkerNode);
+        _sut = new SingletonSpecimenBuilderNodeStackAdapterCollection(_graph, n => n is MarkerNode);
     }
 
     [Fact]
     public void SutIsSpecimenBuilderTransformationList()
     {
-        Assert.IsAssignableFrom<IList<ISpecimenBuilderTransformation>>(this.sut);
+        Assert.IsAssignableFrom<IList<ISpecimenBuilderTransformation>>(_sut);
     }
 
     [Fact]
     public void SutIsCollection()
     {
-        Assert.IsAssignableFrom<Collection<ISpecimenBuilderTransformation>>(this.sut);
+        Assert.IsAssignableFrom<Collection<ISpecimenBuilderTransformation>>(_sut);
     }
 
     [Fact]
@@ -48,9 +48,9 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     {
         // Arrange
         // Act
-        ISpecimenBuilderNode actual = this.sut.Graph;
+        ISpecimenBuilderNode actual = _sut.Graph;
         // Assert
-        Assert.Equal(this.graph, actual);
+        Assert.Equal(_graph, actual);
     }
 
     [Fact]
@@ -58,11 +58,11 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == this.sut.Graph;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == _sut.Graph;
         // Act
         var dummyIndex = 0;
         var dummyItem = new DelegatingSpecimenBuilderTransformation();
-        this.sut.Insert(dummyIndex, dummyItem);
+        _sut.Insert(dummyIndex, dummyItem);
         // Assert
         Assert.True(verified);
     }
@@ -71,12 +71,12 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void RemoveAtRaisesGraphChanged()
     {
         // Arrange
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation());
+        _sut.Add(new DelegatingSpecimenBuilderTransformation());
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == this.sut.Graph;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == _sut.Graph;
         // Act
         var dummyIndex = 0;
-        this.sut.RemoveAt(dummyIndex);
+        _sut.RemoveAt(dummyIndex);
         // Assert
         Assert.True(verified);
     }
@@ -85,13 +85,13 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void SetItemRaisesGraphChanged()
     {
         // Arrange
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation());
+        _sut.Add(new DelegatingSpecimenBuilderTransformation());
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == this.sut.Graph;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == _sut.Graph;
         // Act
         var dummyIndex = 0;
         var dummyItem = new DelegatingSpecimenBuilderTransformation();
-        this.sut[dummyIndex] = dummyItem;
+        _sut[dummyIndex] = dummyItem;
         // Assert
         Assert.True(verified);
     }
@@ -101,10 +101,10 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == this.sut.Graph;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == _sut.Graph;
         // Act
         var dummyItem = new DelegatingSpecimenBuilderTransformation();
-        this.sut.Add(dummyItem);
+        _sut.Add(dummyItem);
         // Assert
         Assert.True(verified);
     }
@@ -113,11 +113,11 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void ClearNonEmptyCollectionRaisesGraphChanged()
     {
         // Arrange
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation());
+        _sut.Add(new DelegatingSpecimenBuilderTransformation());
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == this.sut.Graph;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == _sut.Graph;
         // Act
-        this.sut.Clear();
+        _sut.Clear();
         // Assert
         Assert.True(verified);
     }
@@ -126,11 +126,11 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void ClearEmptyCollectionDoesNotRaiseGraphChanged()
     {
         // Arrange
-        this.sut.Clear();
+        _sut.Clear();
         var invoked = false;
-        this.sut.GraphChanged += (s, e) => invoked = true;
+        _sut.GraphChanged += (s, e) => invoked = true;
         // Act
-        this.sut.Clear();
+        _sut.Clear();
         // Assert
         Assert.False(invoked);
     }
@@ -140,12 +140,12 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     {
         // Arrange
         var item = new DelegatingSpecimenBuilderTransformation();
-        this.sut.Add(item);
+        _sut.Add(item);
 
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == this.sut.Graph;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null && e.Graph == _sut.Graph;
         // Act
-        this.sut.Remove(item);
+        _sut.Remove(item);
         // Assert
         Assert.True(verified);
     }
@@ -156,9 +156,9 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
         // Arrange
         var item = new DelegatingSpecimenBuilderTransformation();
         var invoked = false;
-        this.sut.GraphChanged += (s, e) => invoked = true;
+        _sut.GraphChanged += (s, e) => invoked = true;
         // Act
-        this.sut.Remove(item);
+        _sut.Remove(item);
         // Assert
         Assert.False(invoked);
     }
@@ -170,18 +170,18 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void InsertItemCorrectlyChangesGraph(int index)
     {
         // Arrange
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
         // Act
         var item = new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode(index, b) };
-        this.sut.Insert(index, item);
+        _sut.Insert(index, item);
         // Assert
-        var expected = this.sut.Aggregate(
-            this.graph,
+        var expected = _sut.Aggregate(
+            _graph,
             (b, t) => (ISpecimenBuilderNode)t.Transform(b));
 
-        Assert.True(expected.GraphEquals(this.sut.Graph,
+        Assert.True(expected.GraphEquals(_sut.Graph,
             new TaggedNodeComparer(new TrueComparer<ISpecimenBuilder>())));
     }
 
@@ -189,13 +189,13 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void ClearCorrectlyChangesGraph()
     {
         // Arrange
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
         // Act
-        this.sut.Clear();
+        _sut.Clear();
         // Assert
-        Assert.True(this.graph.GraphEquals(this.sut.Graph,
+        Assert.True(_graph.GraphEquals(_sut.Graph,
             new TrueComparer<ISpecimenBuilder>()));
     }
 
@@ -206,17 +206,17 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void RemoveAtCorrectlyChangesGraph(int index)
     {
         // Arrange
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
         // Act
-        this.sut.RemoveAt(index);
+        _sut.RemoveAt(index);
         // Assert
-        var expected = this.sut.Aggregate(
-            this.graph,
+        var expected = _sut.Aggregate(
+            _graph,
             (b, t) => (ISpecimenBuilderNode)t.Transform(b));
 
-        Assert.True(expected.GraphEquals(this.sut.Graph,
+        Assert.True(expected.GraphEquals(_sut.Graph,
             new TaggedNodeComparer(new TrueComparer<ISpecimenBuilder>())));
     }
 
@@ -227,18 +227,18 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
     public void SetItemCorrectlyChangesGraph(int index)
     {
         // Arrange
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
-        this.sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("A", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("B", b) });
+        _sut.Add(new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode("C", b) });
         // Act
         var item = new DelegatingSpecimenBuilderTransformation { OnTransform = b => new TaggedNode(index, b) };
-        this.sut[index] = item;
+        _sut[index] = item;
         // Assert
-        var expected = this.sut.Aggregate(
-            this.graph,
+        var expected = _sut.Aggregate(
+            _graph,
             (b, t) => (ISpecimenBuilderNode)t.Transform(b));
 
-        Assert.True(expected.GraphEquals(this.sut.Graph,
+        Assert.True(expected.GraphEquals(_sut.Graph,
             new TaggedNodeComparer(new TrueComparer<ISpecimenBuilder>())));
     }
 
@@ -251,7 +251,7 @@ public class SingletonSpecimenBuilderNodeStackAdapterCollectionTest
         var z = new DelegatingSpecimenBuilderTransformation();
         // Act
         var s = new SingletonSpecimenBuilderNodeStackAdapterCollection(
-            this.graph, n => n is MarkerNode, x, y, z);
+            _graph, n => n is MarkerNode, x, y, z);
         // Assert
         Assert.True(new[] { x, y, z }.SequenceEqual(s));
     }

--- a/Src/AutoFixtureUnitTest/SpecimenBuilderNodeAdapterCollectionTest.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenBuilderNodeAdapterCollectionTest.cs
@@ -10,12 +10,12 @@ namespace AutoFixtureUnitTest;
 
 public class SpecimenBuilderNodeAdapterCollectionTest
 {
-    private readonly ISpecimenBuilderNode graph;
-    private readonly SpecimenBuilderNodeAdapterCollection sut;
+    private readonly ISpecimenBuilderNode _graph;
+    private readonly SpecimenBuilderNodeAdapterCollection _sut;
 
     public SpecimenBuilderNodeAdapterCollectionTest()
     {
-        this.graph = new CompositeSpecimenBuilder(
+        _graph = new CompositeSpecimenBuilder(
             new CompositeSpecimenBuilder(
                 new DelegatingSpecimenBuilder(),
                 new DelegatingSpecimenBuilder(),
@@ -29,7 +29,7 @@ public class SpecimenBuilderNodeAdapterCollectionTest
                 new DelegatingSpecimenBuilder(),
                 new DelegatingSpecimenBuilder(),
                 new DelegatingSpecimenBuilder()));
-        this.sut = new SpecimenBuilderNodeAdapterCollection(this.graph, s => s is MarkerNode);
+        _sut = new SpecimenBuilderNodeAdapterCollection(_graph, s => s is MarkerNode);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class SpecimenBuilderNodeAdapterCollectionTest
         // Arrange
         // Act
         // Assert
-        Assert.IsAssignableFrom<IList<ISpecimenBuilder>>(this.sut);
+        Assert.IsAssignableFrom<IList<ISpecimenBuilder>>(_sut);
     }
 
     [Theory]
@@ -48,9 +48,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void IndexOfReturnsCorrectResult(int expected)
     {
         // Arrange
-        var item = this.FindMarkedNode().ElementAt(expected);
+        var item = FindMarkedNode().ElementAt(expected);
         // Act
-        var actual = this.sut.IndexOf(item);
+        var actual = _sut.IndexOf(item);
         // Assert
         Assert.Equal(expected, actual);
     }
@@ -61,7 +61,7 @@ public class SpecimenBuilderNodeAdapterCollectionTest
         // Arrange
         var item = new DelegatingSpecimenBuilder();
         // Act
-        var actual = this.sut.IndexOf(item);
+        var actual = _sut.IndexOf(item);
         // Assert
         Assert.Equal(-1, actual);
     }
@@ -75,9 +75,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
         // Arrange
         var item = new DelegatingSpecimenBuilder();
         // Act
-        this.sut.Insert(expected, item);
+        _sut.Insert(expected, item);
         // Assert
-        var actual = this.sut.IndexOf(item);
+        var actual = _sut.IndexOf(item);
         Assert.Equal(expected, actual);
     }
 
@@ -88,9 +88,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void ContainsReturnsTrueForContainedItem(int index)
     {
         // Arrange
-        var item = this.FindMarkedNode().ElementAt(index);
+        var item = FindMarkedNode().ElementAt(index);
         // Act
-        var actual = this.sut.Contains(item);
+        var actual = _sut.Contains(item);
         // Assert
         Assert.True(actual);
     }
@@ -101,7 +101,7 @@ public class SpecimenBuilderNodeAdapterCollectionTest
         // Arrange
         var uncontainedItem = new DelegatingSpecimenBuilder();
         // Act
-        var actual = this.sut.Contains(uncontainedItem);
+        var actual = _sut.Contains(uncontainedItem);
         // Assert
         Assert.False(actual);
     }
@@ -113,11 +113,11 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void RemoveAtCorrectlyRemovesItem(int index)
     {
         // Arrange
-        var itemToBeRemoved = this.FindMarkedNode().ElementAt(index);
+        var itemToBeRemoved = FindMarkedNode().ElementAt(index);
         // Act
-        this.sut.RemoveAt(index);
+        _sut.RemoveAt(index);
         // Assert
-        Assert.DoesNotContain(itemToBeRemoved, this.sut);
+        Assert.DoesNotContain(itemToBeRemoved, _sut);
     }
 
     [Theory]
@@ -127,9 +127,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void GetItemReturnsCorrectResult(int index)
     {
         // Arrange
-        var expected = this.FindMarkedNode().ElementAt(index);
+        var expected = FindMarkedNode().ElementAt(index);
         // Act
-        var actual = this.sut[index];
+        var actual = _sut[index];
         // Assert
         Assert.Equal(expected, actual);
     }
@@ -138,7 +138,7 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void GetItemForIncorrectIndexThrows()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            this.sut[1337]);
+            _sut[1337]);
     }
 
     [Theory]
@@ -150,9 +150,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
         // Arrange
         var item = new DelegatingSpecimenBuilder();
         // Act
-        this.sut[expected] = item;
+        _sut[expected] = item;
         // Assert
-        Assert.Equal(expected, this.sut.IndexOf(item));
+        Assert.Equal(expected, _sut.IndexOf(item));
     }
 
     [Theory]
@@ -162,11 +162,11 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void SetItemCorrectlyRemovesExistingItem(int index)
     {
         // Arrange
-        var itemToReplace = this.FindMarkedNode().ElementAt(index);
+        var itemToReplace = FindMarkedNode().ElementAt(index);
         // Act
-        this.sut[index] = new DelegatingSpecimenBuilder();
+        _sut[index] = new DelegatingSpecimenBuilder();
         // Assert
-        Assert.DoesNotContain(itemToReplace, this.sut);
+        Assert.DoesNotContain(itemToReplace, _sut);
     }
 
     [Theory]
@@ -176,16 +176,16 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void SetItemForIncorrectIndexThrows(int invalidIndex)
     {
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            this.sut[invalidIndex] = new DelegatingSpecimenBuilder());
+            _sut[invalidIndex] = new DelegatingSpecimenBuilder());
     }
 
     [Fact]
     public void SutYieldsCorrectItems()
     {
-        var expected = (ISpecimenBuilderNode)this.graph
+        var expected = (ISpecimenBuilderNode)_graph
             .OfType<MarkerNode>().Single().Single();
-        Assert.True(expected.SequenceEqual(this.sut));
-        Assert.True(expected.Cast<object>().SequenceEqual(((System.Collections.IEnumerable)this.sut).Cast<object>()));
+        Assert.True(expected.SequenceEqual(_sut));
+        Assert.True(expected.Cast<object>().SequenceEqual(((System.Collections.IEnumerable)_sut).Cast<object>()));
     }
 
     [Fact]
@@ -193,9 +193,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         // Act
-        var actual = this.sut.Count;
+        var actual = _sut.Count;
         // Assert
-        var expected = this.FindMarkedNode().Count();
+        var expected = FindMarkedNode().Count();
         Assert.Equal(expected, actual);
     }
 
@@ -204,9 +204,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         // Act
-        this.sut.Clear();
+        _sut.Clear();
         // Assert
-        Assert.Empty(this.sut);
+        Assert.Empty(_sut);
     }
 
     [Fact]
@@ -214,11 +214,11 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         var item = new DelegatingSpecimenBuilder();
-        var expected = this.FindMarkedNode().Concat(new[] { item });
+        var expected = FindMarkedNode().Concat(new[] { item });
         // Act
-        this.sut.Add(item);
+        _sut.Add(item);
         // Assert
-        Assert.True(expected.SequenceEqual(this.sut));
+        Assert.True(expected.SequenceEqual(_sut));
     }
 
     [Theory]
@@ -228,10 +228,10 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void CopyToCorrectlyCopiesItems(int index)
     {
         // Arrange
-        var expected = this.FindMarkedNode().ToArray();
+        var expected = FindMarkedNode().ToArray();
         var a = new ISpecimenBuilder[expected.Length + index];
         // Act
-        this.sut.CopyTo(a, index);
+        _sut.CopyTo(a, index);
         // Assert
         Assert.True(expected.SequenceEqual(a.Skip(index)));
     }
@@ -239,7 +239,7 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     [Fact]
     public void IsReadOnlyReturnsCorrectResult()
     {
-        Assert.False(this.sut.IsReadOnly);
+        Assert.False(_sut.IsReadOnly);
     }
 
     [Theory]
@@ -249,11 +249,11 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void RemoveCorrectlyRemovesItem(int index)
     {
         // Arrange
-        var item = this.FindMarkedNode().ElementAt(index);
+        var item = FindMarkedNode().ElementAt(index);
         // Act
-        this.sut.Remove(item);
+        _sut.Remove(item);
         // Assert
-        Assert.DoesNotContain(item, this.sut);
+        Assert.DoesNotContain(item, _sut);
     }
 
     [Theory]
@@ -263,9 +263,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     public void RemoveReturnsTrueForContainedItem(int index)
     {
         // Arrange
-        var item = this.FindMarkedNode().ElementAt(index);
+        var item = FindMarkedNode().ElementAt(index);
         // Act
-        var actual = this.sut.Remove(item);
+        var actual = _sut.Remove(item);
         // Assert
         Assert.True(actual);
     }
@@ -276,7 +276,7 @@ public class SpecimenBuilderNodeAdapterCollectionTest
         // Arrange
         var uncontainedItem = new DelegatingSpecimenBuilder();
         // Act
-        var actual = this.sut.Remove(uncontainedItem);
+        var actual = _sut.Remove(uncontainedItem);
         // Assert
         Assert.False(actual);
     }
@@ -286,9 +286,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         // Act
-        ISpecimenBuilderNode actual = this.sut.Graph;
+        ISpecimenBuilderNode actual = _sut.Graph;
         // Assert
-        Assert.Equal(this.graph, actual);
+        Assert.Equal(_graph, actual);
     }
 
     [Fact]
@@ -296,11 +296,11 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null;
         // Act
         var dummyIndex = 1;
         var dummyItem = new DelegatingSpecimenBuilder();
-        this.sut.Insert(dummyIndex, dummyItem);
+        _sut.Insert(dummyIndex, dummyItem);
         // Assert
         Assert.True(verified);
     }
@@ -310,10 +310,10 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null;
         // Act
         var dummyIndex = 1;
-        this.sut.RemoveAt(dummyIndex);
+        _sut.RemoveAt(dummyIndex);
         // Assert
         Assert.True(verified);
     }
@@ -323,11 +323,11 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null;
         // Act
         var dummyIndex = 1;
         var dummyItem = new DelegatingSpecimenBuilder();
-        this.sut[dummyIndex] = dummyItem;
+        _sut[dummyIndex] = dummyItem;
         // Assert
         Assert.True(verified);
     }
@@ -337,10 +337,10 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null;
         // Act
         var dummyItem = new DelegatingSpecimenBuilder();
-        this.sut.Add(dummyItem);
+        _sut.Add(dummyItem);
         // Assert
         Assert.True(verified);
     }
@@ -350,9 +350,9 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null;
         // Act
-        this.sut.Clear();
+        _sut.Clear();
         // Assert
         Assert.True(verified);
     }
@@ -365,18 +365,18 @@ public class SpecimenBuilderNodeAdapterCollectionTest
     {
         // Arrange
         var verified = false;
-        this.sut.GraphChanged += (s, e) => verified = s != null && e != null;
+        _sut.GraphChanged += (s, e) => verified = s != null && e != null;
 
-        var item = this.FindMarkedNode().ElementAt(index);
+        var item = FindMarkedNode().ElementAt(index);
         // Act
-        this.sut.Remove(item);
+        _sut.Remove(item);
         // Assert
         Assert.True(verified);
     }
 
     private ISpecimenBuilderNode FindMarkedNode()
     {
-        return (ISpecimenBuilderNode)this.graph
+        return (ISpecimenBuilderNode)_graph
             .OfType<MarkerNode>()
             .Single()
             .Single();

--- a/Src/AutoFixtureUnitTest/SpecimenWithEverything.cs
+++ b/Src/AutoFixtureUnitTest/SpecimenWithEverything.cs
@@ -34,9 +34,9 @@ internal class SpecimenWithEverything
         string stringReadOnlyAssignedByCtorOnly,
         List<ConcreteType> listOfConcreteTypesAssignedByCtorOnly)
     {
-        this.StringReadOnlyFieldAssignedByCtorOnly = stringReadOnlyFieldAssignedByCtorOnly;
-        this.StringReadOnlyAssignedByCtorOnly = stringReadOnlyAssignedByCtorOnly;
-        this.ListOfConcreteTypesAssignedByCtorOnly = listOfConcreteTypesAssignedByCtorOnly;
+        StringReadOnlyFieldAssignedByCtorOnly = stringReadOnlyFieldAssignedByCtorOnly;
+        StringReadOnlyAssignedByCtorOnly = stringReadOnlyAssignedByCtorOnly;
+        ListOfConcreteTypesAssignedByCtorOnly = listOfConcreteTypesAssignedByCtorOnly;
     }
 
     // public fields

--- a/Src/AutoFixtureUnitTest/TaggedNode.cs
+++ b/Src/AutoFixtureUnitTest/TaggedNode.cs
@@ -9,12 +9,12 @@ public class TaggedNode : CompositeSpecimenBuilder
     public TaggedNode(object tag, params ISpecimenBuilder[] builders)
         : base(builders)
     {
-        this.Tag = tag;
+        Tag = tag;
     }
 
     public override ISpecimenBuilderNode Compose(IEnumerable<ISpecimenBuilder> builders)
     {
-        return new TaggedNode(this.Tag, builders.ToArray());
+        return new TaggedNode(Tag, builders.ToArray());
     }
 
     public object Tag { get; }

--- a/Src/AutoFixtureUnitTest/TaggedNodeComparer.cs
+++ b/Src/AutoFixtureUnitTest/TaggedNodeComparer.cs
@@ -5,7 +5,7 @@ namespace AutoFixtureUnitTest;
 
 public class TaggedNodeComparer : IEqualityComparer<ISpecimenBuilder>
 {
-    private readonly IEqualityComparer<ISpecimenBuilder> nonTaggedComparer;
+    private readonly IEqualityComparer<ISpecimenBuilder> _nonTaggedComparer;
 
     public TaggedNodeComparer()
         : this(EqualityComparer<ISpecimenBuilder>.Default)
@@ -14,7 +14,7 @@ public class TaggedNodeComparer : IEqualityComparer<ISpecimenBuilder>
 
     public TaggedNodeComparer(IEqualityComparer<ISpecimenBuilder> nonTaggedComparer)
     {
-        this.nonTaggedComparer = nonTaggedComparer;
+        _nonTaggedComparer = nonTaggedComparer;
     }
 
     public bool Equals(ISpecimenBuilder x, ISpecimenBuilder y)
@@ -23,7 +23,7 @@ public class TaggedNodeComparer : IEqualityComparer<ISpecimenBuilder>
         var n2 = y as TaggedNode;
         if (n1 != null && n2 != null)
             return n1.Tag.Equals(n2.Tag);
-        return this.nonTaggedComparer.Equals(x, y);
+        return _nonTaggedComparer.Equals(x, y);
     }
 
     public int GetHashCode(ISpecimenBuilder obj)
@@ -31,6 +31,6 @@ public class TaggedNodeComparer : IEqualityComparer<ISpecimenBuilder>
         var tn = obj as TaggedNode;
         if (tn != null)
             return tn.Tag.GetHashCode();
-        return this.nonTaggedComparer.GetHashCode(obj);
+        return _nonTaggedComparer.GetHashCode(obj);
     }
 }

--- a/Src/AutoFixtureUnitTest/TextGuidRegex.cs
+++ b/Src/AutoFixtureUnitTest/TextGuidRegex.cs
@@ -11,11 +11,11 @@ internal class TextGuidRegex : Regex
 
     internal string GetGuid(string s)
     {
-        return this.Match(s).Groups["guid"].Value;
+        return Match(s).Groups["guid"].Value;
     }
 
     internal string GetText(string s)
     {
-        return this.Match(s).Groups["text"].Value;
+        return Match(s).Groups["text"].Value;
     }
 }

--- a/Src/AutoFixtureUnitTest/UseCultureAttribute.cs
+++ b/Src/AutoFixtureUnitTest/UseCultureAttribute.cs
@@ -9,9 +9,10 @@ namespace AutoFixtureUnitTest;
 public class UseCultureAttribute : BeforeAfterTestAttribute
 {
     [ThreadStatic]
-    private static CultureInfo t_originalCulture;
+    private static CultureInfo s_originalCulture_t;
+
     [ThreadStatic]
-    private static CultureInfo t_originalUiCulture;
+    private static CultureInfo s_originalUiCulture_t;
 
     private readonly CultureInfo _culture;
     private readonly CultureInfo _uiCulture;
@@ -29,15 +30,15 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
 
     public override void Before(MethodInfo methodUnderTest)
     {
-        t_originalCulture = CultureInfo.CurrentCulture;
-        t_originalUiCulture = CultureInfo.CurrentCulture;
+        s_originalCulture_t = CultureInfo.CurrentCulture;
+        s_originalUiCulture_t = CultureInfo.CurrentCulture;
 
         SetCurrentCulture(_culture, _uiCulture);
     }
 
     public override void After(MethodInfo methodUnderTest)
     {
-        SetCurrentCulture(t_originalCulture, t_originalUiCulture);
+        SetCurrentCulture(s_originalCulture_t, s_originalUiCulture_t);
     }
 
     private static void SetCurrentCulture(CultureInfo culture, CultureInfo uiCulture)

--- a/Src/AutoFixtureUnitTest/UseCultureAttribute.cs
+++ b/Src/AutoFixtureUnitTest/UseCultureAttribute.cs
@@ -9,12 +9,12 @@ namespace AutoFixtureUnitTest;
 public class UseCultureAttribute : BeforeAfterTestAttribute
 {
     [ThreadStatic]
-    private static CultureInfo originalCulture;
+    private static CultureInfo t_originalCulture;
     [ThreadStatic]
-    private static CultureInfo originalUiCulture;
+    private static CultureInfo t_originalUiCulture;
 
-    private readonly CultureInfo culture;
-    private readonly CultureInfo uiCulture;
+    private readonly CultureInfo _culture;
+    private readonly CultureInfo _uiCulture;
 
     public UseCultureAttribute(string culture)
         : this(culture, culture)
@@ -23,21 +23,21 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
 
     public UseCultureAttribute(string culture, string uiCulture)
     {
-        this.culture = new CultureInfo(culture);
-        this.uiCulture = new CultureInfo(uiCulture);
+        _culture = new CultureInfo(culture);
+        _uiCulture = new CultureInfo(uiCulture);
     }
 
     public override void Before(MethodInfo methodUnderTest)
     {
-        originalCulture = CultureInfo.CurrentCulture;
-        originalUiCulture = CultureInfo.CurrentCulture;
+        t_originalCulture = CultureInfo.CurrentCulture;
+        t_originalUiCulture = CultureInfo.CurrentCulture;
 
-        SetCurrentCulture(this.culture, this.uiCulture);
+        SetCurrentCulture(_culture, _uiCulture);
     }
 
     public override void After(MethodInfo methodUnderTest)
     {
-        SetCurrentCulture(originalCulture, originalUiCulture);
+        SetCurrentCulture(t_originalCulture, t_originalUiCulture);
     }
 
     private static void SetCurrentCulture(CultureInfo culture, CultureInfo uiCulture)

--- a/Src/AutoMoq/AutoConfiguredMoqCustomization.cs
+++ b/Src/AutoMoq/AutoConfiguredMoqCustomization.cs
@@ -16,7 +16,7 @@ public class AutoConfiguredMoqCustomization : AutoMoqCustomization
     /// </summary>
     public AutoConfiguredMoqCustomization()
     {
-        this.ConfigureMembers = true;
+        ConfigureMembers = true;
     }
 
     /// <summary>
@@ -25,6 +25,6 @@ public class AutoConfiguredMoqCustomization : AutoMoqCustomization
     public AutoConfiguredMoqCustomization(ISpecimenBuilder relay)
         : base(relay)
     {
-        this.ConfigureMembers = true;
+        ConfigureMembers = true;
     }
 }

--- a/Src/AutoMoq/AutoMockPropertiesCommand.cs
+++ b/Src/AutoMoq/AutoMockPropertiesCommand.cs
@@ -10,7 +10,7 @@ namespace AutoFixture.AutoMoq;
 /// </summary>
 public class AutoMockPropertiesCommand : ISpecimenCommand
 {
-    private readonly ISpecimenCommand autoPropertiesCommand =
+    private readonly ISpecimenCommand _autoPropertiesCommand =
         new AutoPropertiesCommand(new IgnoreProxyMembersSpecification());
 
     /// <summary>
@@ -26,7 +26,7 @@ public class AutoMockPropertiesCommand : ISpecimenCommand
         if (mock == null)
             return;
 
-        this.autoPropertiesCommand.Execute(mock.Object, context);
+        _autoPropertiesCommand.Execute(mock.Object, context);
     }
 
     /// <summary>

--- a/Src/AutoMoq/AutoMoqCustomization.cs
+++ b/Src/AutoMoq/AutoMoqCustomization.cs
@@ -13,7 +13,7 @@ namespace AutoFixture.AutoMoq;
 /// </remarks>
 public class AutoMoqCustomization : ICustomization
 {
-    private ISpecimenBuilder relay;
+    private ISpecimenBuilder _relay;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AutoMoqCustomization"/> class.
@@ -39,7 +39,7 @@ public class AutoMoqCustomization : ICustomization
               "Please use the AutoMoqCustomization() overload (without arguments) instead and set the Relay property.")]
     public AutoMoqCustomization(ISpecimenBuilder relay)
     {
-        this.relay = relay ?? throw new ArgumentNullException(nameof(relay));
+        _relay = relay ?? throw new ArgumentNullException(nameof(relay));
     }
 
     /// <summary>
@@ -59,8 +59,8 @@ public class AutoMoqCustomization : ICustomization
     /// </summary>
     public ISpecimenBuilder Relay
     {
-        get => this.relay;
-        set => this.relay = value ?? throw new ArgumentNullException(nameof(value));
+        get => _relay;
+        set => _relay = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class AutoMoqCustomization : ICustomization
                 new MockConstructorQuery()));
 
         // If members should be automatically configured, wrap the builder with members setup postprocessor.
-        if (this.ConfigureMembers)
+        if (ConfigureMembers)
         {
             mockBuilder = new Postprocessor(
                 builder: mockBuilder,
@@ -87,9 +87,9 @@ public class AutoMoqCustomization : ICustomization
         }
 
         fixture.Customizations.Add(mockBuilder);
-        fixture.ResidueCollectors.Add(this.Relay);
+        fixture.ResidueCollectors.Add(Relay);
 
-        if (this.GenerateDelegates)
+        if (GenerateDelegates)
         {
             fixture.Customizations.Add(new MockRelay(new DelegateSpecification()));
         }

--- a/Src/AutoMoq/MockConstructorMethod.cs
+++ b/Src/AutoMoq/MockConstructorMethod.cs
@@ -7,12 +7,12 @@ namespace AutoFixture.AutoMoq;
 
 internal class MockConstructorMethod : IMethod
 {
-    private readonly ConstructorInfo ctor;
+    private readonly ConstructorInfo _ctor;
 
     internal MockConstructorMethod(ConstructorInfo ctor, ParameterInfo[] paramInfos)
     {
-        this.ctor = ctor ?? throw new ArgumentNullException(nameof(ctor));
-        this.Parameters = paramInfos ?? throw new ArgumentNullException(nameof(paramInfos));
+        _ctor = ctor ?? throw new ArgumentNullException(nameof(ctor));
+        Parameters = paramInfos ?? throw new ArgumentNullException(nameof(paramInfos));
     }
 
     public IEnumerable<ParameterInfo> Parameters { get; }
@@ -20,6 +20,6 @@ internal class MockConstructorMethod : IMethod
     public object Invoke(IEnumerable<object> parameters)
     {
         var paramsArray = new object[] { parameters };
-        return this.ctor.Invoke(paramsArray);
+        return _ctor.Invoke(paramsArray);
     }
 }

--- a/Src/AutoMoq/MockConstructorQuery.cs
+++ b/Src/AutoMoq/MockConstructorQuery.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.AutoMoq;
 /// </summary>
 public class MockConstructorQuery : IMethodQuery
 {
-    private static readonly DelegateSpecification DelegateSpecification = new DelegateSpecification();
+    private static readonly DelegateSpecification s_delegateSpecification = new DelegateSpecification();
 
     /// <summary>
     /// Selects constructors for the supplied <see cref="Moq.Mock{T}"/> type.
@@ -46,7 +46,7 @@ public class MockConstructorQuery : IMethodQuery
         }
 
         var mockType = type.GetMockedType();
-        if (mockType.GetTypeInfo().IsInterface || DelegateSpecification.IsSatisfiedBy(mockType))
+        if (mockType.GetTypeInfo().IsInterface || s_delegateSpecification.IsSatisfiedBy(mockType))
         {
             return new[] { new ConstructorMethod(type.GetDefaultConstructor()) };
         }

--- a/Src/AutoMoq/MockPostprocessor.cs
+++ b/Src/AutoMoq/MockPostprocessor.cs
@@ -21,7 +21,7 @@ public class MockPostprocessor : ISpecimenBuilder
     /// </param>
     public MockPostprocessor(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public class MockPostprocessor : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        var specimen = this.Builder.Create(request, context);
+        var specimen = Builder.Create(request, context);
         if (specimen is NoSpecimen || specimen is OmitSpecimen || specimen == null)
             return specimen;
 

--- a/Src/AutoMoq/MockRelay.cs
+++ b/Src/AutoMoq/MockRelay.cs
@@ -28,7 +28,7 @@ public class MockRelay : ISpecimenBuilder
     /// </param>
     public MockRelay(IRequestSpecification mockableSpecification)
     {
-        this.MockableSpecification = mockableSpecification ?? throw new ArgumentNullException(nameof(mockableSpecification));
+        MockableSpecification = mockableSpecification ?? throw new ArgumentNullException(nameof(mockableSpecification));
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class MockRelay : ISpecimenBuilder
     {
         if (context == null) throw new ArgumentNullException(nameof(context));
 
-        if (!this.MockableSpecification.IsSatisfiedBy(request))
+        if (!MockableSpecification.IsSatisfiedBy(request))
             return NoSpecimen.Instance;
 
         var t = request as Type;

--- a/Src/AutoMoq/MockSealedPropertiesCommand.cs
+++ b/Src/AutoMoq/MockSealedPropertiesCommand.cs
@@ -13,7 +13,7 @@ namespace AutoFixture.AutoMoq;
 [Obsolete("This class will be removed in a future version of AutoFixture. Use AutoMockPropertiesCommand instead, which will populate both sealed and overridable properties.", true)]
 public class MockSealedPropertiesCommand : ISpecimenCommand
 {
-    private readonly ISpecimenCommand autoPropertiesCommand =
+    private readonly ISpecimenCommand _autoPropertiesCommand =
         new AutoPropertiesCommand(new MockSealedPropertySpecification());
 
     /// <summary>
@@ -31,7 +31,7 @@ public class MockSealedPropertiesCommand : ISpecimenCommand
         if (mock == null)
             return;
 
-        this.autoPropertiesCommand.Execute(mock.Object, context);
+        _autoPropertiesCommand.Execute(mock.Object, context);
     }
 
     private class MockSealedPropertySpecification : IRequestSpecification

--- a/Src/AutoMoq/MockVirtualMethodsCommand.cs
+++ b/Src/AutoMoq/MockVirtualMethodsCommand.cs
@@ -29,7 +29,7 @@ namespace AutoFixture.AutoMoq;
 /// </remarks>
 public class MockVirtualMethodsCommand : ISpecimenCommand
 {
-    private static readonly DelegateSpecification DelegateSpecification = new DelegateSpecification();
+    private static readonly DelegateSpecification s_delegateSpecification = new DelegateSpecification();
 
     /// <summary>
     /// Sets up a mocked object's methods so that the return values will be retrieved from a fixture,
@@ -58,14 +58,14 @@ public class MockVirtualMethodsCommand : ISpecimenCommand
             {
                 if (method.IsVoid())
                 {
-                    this.GetType()
+                    GetType()
                         .GetMethod(nameof(SetupVoidMethod), BindingFlags.NonPublic | BindingFlags.Static)
                         .MakeGenericMethod(mockedType)
                         .Invoke(this, new object[] { mock, methodInvocationLambda });
                 }
                 else
                 {
-                    this.GetType()
+                    GetType()
                         .GetMethod(nameof(SetupMethod), BindingFlags.NonPublic | BindingFlags.Static)
                         .MakeGenericMethod(mockedType, returnType)
                         .Invoke(this, new object[] { mock, methodInvocationLambda, context });
@@ -113,7 +113,7 @@ public class MockVirtualMethodsCommand : ISpecimenCommand
     private static IEnumerable<MethodInfo> GetConfigurableMethods(Type type)
     {
         // If "type" is a delegate, return "Invoke" method only and skip the rest of the methods.
-        var methods = DelegateSpecification.IsSatisfiedBy(type)
+        var methods = s_delegateSpecification.IsSatisfiedBy(type)
             ? new[] { type.GetTypeInfo().GetMethod("Invoke") }
             : type.GetAllMethods();
 
@@ -164,7 +164,7 @@ public class MockVirtualMethodsCommand : ISpecimenCommand
             return null;
 
         Expression methodCall;
-        if (DelegateSpecification.IsSatisfiedBy(mockedType))
+        if (s_delegateSpecification.IsSatisfiedBy(mockedType))
         {
             // e.g. "x(It.IsAny<string>(), out parameter)"
             methodCall = Expression.Invoke(lambdaParam, methodCallParams);

--- a/Src/AutoMoqUnitTest/DependencyConstraints.cs
+++ b/Src/AutoMoqUnitTest/DependencyConstraints.cs
@@ -26,7 +26,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
+        var references = GetType().GetTypeInfo().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.DoesNotContain(references, an => an.Name == assemblyName);
     }

--- a/Src/AutoMoqUnitTest/TestTypes/TypeWithIndexer.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/TypeWithIndexer.cs
@@ -2,11 +2,11 @@
 
 public class TypeWithIndexer
 {
-    private readonly int[] array = new[] { -99, -99, -99 };
+    private readonly int[] _array = new[] { -99, -99, -99 };
 
     public int this[int index]
     {
-        get { return this.array[index]; }
-        set { this.array[index] = value; }
+        get { return _array[index]; }
+        set { _array[index] = value; }
     }
 }

--- a/Src/AutoMoqUnitTest/TestTypes/TypeWithPrivateField.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/TypeWithPrivateField.cs
@@ -2,10 +2,10 @@
 
 public class TypeWithPrivateField
 {
-    private string field = string.Empty;
+    private string _field = string.Empty;
 
     public string GetPrivateField()
     {
-        return this.field;
+        return _field;
     }
 }

--- a/Src/AutoMoqUnitTest/TestTypes/TypeWithPrivateProperty.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/TypeWithPrivateProperty.cs
@@ -4,7 +4,7 @@ public class TypeWithPrivateProperty
 {
     public TypeWithPrivateProperty()
     {
-        this.PrivateProperty = "Awesome string";
+        PrivateProperty = "Awesome string";
     }
 
     // ReSharper disable UnusedAutoPropertyAccessor.Local

--- a/Src/AutoMoqUnitTest/TestTypes/TypeWithPropertyWithPrivateSetter.cs
+++ b/Src/AutoMoqUnitTest/TestTypes/TypeWithPropertyWithPrivateSetter.cs
@@ -4,7 +4,7 @@ public class TypeWithPropertyWithPrivateSetter
 {
     public TypeWithPropertyWithPrivateSetter()
     {
-        this.PropertyWithPrivateSetter = "Awesome string";
+        PropertyWithPrivateSetter = "Awesome string";
     }
 
     public string PropertyWithPrivateSetter { get; private set; }

--- a/Src/AutoMoqUnitTest/ValidNonMockSpecimens.cs
+++ b/Src/AutoMoqUnitTest/ValidNonMockSpecimens.cs
@@ -15,6 +15,6 @@ internal class ValidNonMockSpecimens : IEnumerable<object[]>
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoConfiguredNSubstituteCustomization.cs
@@ -17,7 +17,7 @@ public class AutoConfiguredNSubstituteCustomization : AutoNSubstituteCustomizati
     /// <remarks>Uses a new instance of <see cref="NSubstituteBuilder"/> as the builder.</remarks>
     public AutoConfiguredNSubstituteCustomization()
     {
-        this.ConfigureMembers = true;
+        ConfigureMembers = true;
     }
 
     /// <summary>
@@ -27,6 +27,6 @@ public class AutoConfiguredNSubstituteCustomization : AutoNSubstituteCustomizati
     public AutoConfiguredNSubstituteCustomization(ISpecimenBuilder relay)
         : base(relay)
     {
-        this.ConfigureMembers = true;
+        ConfigureMembers = true;
     }
 }

--- a/Src/AutoNSubstitute/AutoNSubstituteCustomization.cs
+++ b/Src/AutoNSubstitute/AutoNSubstituteCustomization.cs
@@ -12,7 +12,7 @@ namespace AutoFixture.AutoNSubstitute;
 /// </remarks>
 public class AutoNSubstituteCustomization : ICustomization
 {
-    private ISpecimenBuilder relay;
+    private ISpecimenBuilder _relay;
 
     /// <summary>Initializes a new instance of the <see cref="AutoNSubstituteCustomization"/> class.
     /// <para>
@@ -33,18 +33,18 @@ public class AutoNSubstituteCustomization : ICustomization
               "Please use the AutoNSubstituteCustomization() overload (without arguments) instead and set the Relay property.")]
     public AutoNSubstituteCustomization(ISpecimenBuilder relay)
     {
-        this.relay = relay ?? throw new ArgumentNullException(nameof(relay));
+        _relay = relay ?? throw new ArgumentNullException(nameof(relay));
     }
 
     /// <summary>Gets the builder that will be added to <see cref="IFixture.ResidueCollectors"/> when <see cref="Customize"/> is invoked.</summary>
     [Obsolete("This property is obsolete - use the Relay property instead.")]
-    public ISpecimenBuilder Builder => this.relay;
+    public ISpecimenBuilder Builder => _relay;
 
     /// <summary>Gets or sets the relay that will be added to <see cref="IFixture.ResidueCollectors"/> when <see cref="Customize"/> is invoked.</summary>
     public ISpecimenBuilder Relay
     {
-        get => this.relay;
-        set => this.relay = value ?? throw new ArgumentNullException(nameof(value));
+        get => _relay;
+        set => _relay = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ public class AutoNSubstituteCustomization : ICustomization
             new MethodInvoker(
                 new NSubstituteMethodQuery()));
 
-        if (this.ConfigureMembers)
+        if (ConfigureMembers)
         {
             substituteBuilder = new Postprocessor(
                 substituteBuilder,
@@ -78,9 +78,9 @@ public class AutoNSubstituteCustomization : ICustomization
 
         fixture.Customizations.Insert(0, substituteBuilder);
         fixture.Customizations.Insert(0, new SubstituteAttributeRelay());
-        fixture.ResidueCollectors.Add(this.Relay);
+        fixture.ResidueCollectors.Add(Relay);
 
-        if (this.GenerateDelegates)
+        if (GenerateDelegates)
         {
             fixture.Customizations.Add(new SubstituteRelay(new DelegateSpecification()));
         }

--- a/Src/AutoNSubstitute/CompatShim.cs
+++ b/Src/AutoNSubstitute/CompatShim.cs
@@ -12,20 +12,20 @@ namespace AutoFixture.AutoNSubstitute;
 /// </summary>
 internal static class CompatShim
 {
-    private static readonly Func<ISubstituteState, ISubstitutionContext, ICallSpecificationFactory> CallSpecificationFactoryResolver = GetCallSpecificationFactoryResolver();
+    private static readonly Func<ISubstituteState, ISubstitutionContext, ICallSpecificationFactory> s_callSpecificationFactoryResolver = GetCallSpecificationFactoryResolver();
 
-    private static readonly Func<ICallResults, ICall, bool> HasCallResultForResolver = GetHasCallResultForResolver();
+    private static readonly Func<ICallResults, ICall, bool> s_hasCallResultForResolver = GetHasCallResultForResolver();
 
-    private static readonly Func<ICallHandler[], Route> RouteFactory = GetRouteFactory();
+    private static readonly Func<ICallHandler[], Route> s_routeFactory = GetRouteFactory();
 
     public static ICallSpecificationFactory GetCallSpecificationFactory(ISubstituteState substituteState, ISubstitutionContext substitutionContext) =>
-        CallSpecificationFactoryResolver.Invoke(substituteState, substitutionContext);
+        s_callSpecificationFactoryResolver.Invoke(substituteState, substitutionContext);
 
     public static bool CallResults_HasCallResultFor(ICallResults callResults, ICall call) =>
-        HasCallResultForResolver.Invoke(callResults, call);
+        s_hasCallResultForResolver.Invoke(callResults, call);
 
     public static Route Route_CreateNew(ICallHandler[] handlers) =>
-        RouteFactory.Invoke(handlers);
+        s_routeFactory.Invoke(handlers);
 
     private static Func<ISubstituteState, ISubstitutionContext, ICallSpecificationFactory> GetCallSpecificationFactoryResolver()
     {

--- a/Src/AutoNSubstitute/CustomCallHandler/AutoFixtureValuesHandler.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/AutoFixtureValuesHandler.cs
@@ -36,9 +36,9 @@ public class AutoFixtureValuesHandler : ICallHandler
         if (resultCache == null) throw new ArgumentNullException(nameof(resultCache));
         if (callSpecificationFactory == null) throw new ArgumentNullException(nameof(callSpecificationFactory));
 
-        this.ResultResolver = resultResolver;
-        this.ResultCache = resultCache;
-        this.CallSpecificationFactory = callSpecificationFactory;
+        ResultResolver = resultResolver;
+        ResultCache = resultCache;
+        CallSpecificationFactory = callSpecificationFactory;
     }
 
     /// <summary>
@@ -50,12 +50,12 @@ public class AutoFixtureValuesHandler : ICallHandler
 
         // Don't care about concurrency. If race condition happens - simply use the latest result.
         CallResultData result;
-        if (!this.ResultCache.TryGetResult(call, out result))
+        if (!ResultCache.TryGetResult(call, out result))
         {
-            result = this.ResultResolver.ResolveResult(call);
-            var callSpec = this.CallSpecificationFactory.CreateFrom(call, MatchArgs.AsSpecifiedInCall);
+            result = ResultResolver.ResolveResult(call);
+            var callSpec = CallSpecificationFactory.CreateFrom(call, MatchArgs.AsSpecifiedInCall);
 
-            this.ResultCache.AddResult(callSpec, result);
+            ResultCache.AddResult(callSpec, result);
         }
 
         var callArguments = call.GetArguments();

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultCache.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultCache.cs
@@ -16,7 +16,7 @@ public class CallResultCache : ICallResultCache
         if (callSpecification == null) throw new ArgumentNullException(nameof(callSpecification));
         if (result == null) throw new ArgumentNullException(nameof(result));
 
-        this.CallResults.Push(new ResultForCallSpec(callSpecification, result));
+        CallResults.Push(new ResultForCallSpec(callSpecification, result));
     }
 
     /// <inheritdoc />
@@ -24,7 +24,7 @@ public class CallResultCache : ICallResultCache
     {
         if (callInfo == null) throw new ArgumentNullException(nameof(callInfo));
 
-        var result = this.CallResults.FirstOrDefault(c => c.IsResultFor(callInfo));
+        var result = CallResults.FirstOrDefault(c => c.IsResultFor(callInfo));
 
         callResult = result?.Result;
         return result != null;
@@ -32,16 +32,16 @@ public class CallResultCache : ICallResultCache
 
     private class ResultForCallSpec
     {
-        private readonly ICallSpecification callSpecification;
+        private readonly ICallSpecification _callSpecification;
 
         public CallResultData Result { get; }
 
         public ResultForCallSpec(ICallSpecification callSpecification, CallResultData result)
         {
-            this.callSpecification = callSpecification;
-            this.Result = result;
+            _callSpecification = callSpecification;
+            Result = result;
         }
 
-        public bool IsResultFor(ICall call) => this.callSpecification.IsSatisfiedBy(call);
+        public bool IsResultFor(ICall call) => _callSpecification.IsSatisfiedBy(call);
     }
 }

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultData.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultData.cs
@@ -23,8 +23,8 @@ public class CallResultData
     /// </summary>
     public CallResultData(Maybe<object> returnValue, IEnumerable<ArgumentValue> argumentValues)
     {
-        this.ReturnValue = returnValue;
-        this.ArgumentValues = argumentValues;
+        ReturnValue = returnValue;
+        ArgumentValues = argumentValues;
     }
 
     /// <summary>
@@ -47,8 +47,8 @@ public class CallResultData
         /// </summary>
         public ArgumentValue(int index, object value)
         {
-            this.Index = index;
-            this.Value = value;
+            Index = index;
+            Value = value;
         }
     }
 }

--- a/Src/AutoNSubstitute/CustomCallHandler/CallResultResolver.cs
+++ b/Src/AutoNSubstitute/CustomCallHandler/CallResultResolver.cs
@@ -11,17 +11,17 @@ namespace AutoFixture.AutoNSubstitute.CustomCallHandler;
 /// <inheritdoc />
 public class CallResultResolver : ICallResultResolver
 {
-    private static readonly Type DelegateCallType;
-    private static readonly FieldInfo DelegateTypeFieldInfo;
+    private static readonly Type s_delegateCallType;
+    private static readonly FieldInfo s_delegateTypeFieldInfo;
 
     [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline",
         Justification = "One field initialization depends on other one - order should be guaranteed.")]
     static CallResultResolver()
     {
         const string delegateCallTypeName = "NSubstitute.Proxies.DelegateProxy.DelegateCall";
-        DelegateCallType = typeof(Substitute).GetTypeInfo().Assembly.GetType(delegateCallTypeName, throwOnError: false);
-        DelegateTypeFieldInfo =
-            DelegateCallType?.GetField("_delegateType", BindingFlags.Instance | BindingFlags.NonPublic);
+        s_delegateCallType = typeof(Substitute).GetTypeInfo().Assembly.GetType(delegateCallTypeName, throwOnError: false);
+        s_delegateTypeFieldInfo =
+            s_delegateCallType?.GetField("_delegateType", BindingFlags.Instance | BindingFlags.NonPublic);
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public class CallResultResolver : ICallResultResolver
     /// </summary>
     public CallResultResolver(ISpecimenContext specimenContext)
     {
-        this.SpecimenContext = specimenContext ?? throw new ArgumentNullException(nameof(specimenContext));
+        SpecimenContext = specimenContext ?? throw new ArgumentNullException(nameof(specimenContext));
     }
 
     /// <inheritdoc />
@@ -42,7 +42,7 @@ public class CallResultResolver : ICallResultResolver
     {
         if (callInfo == null) throw new ArgumentNullException(nameof(callInfo));
 
-        var returnValue = this.ResolveReturnValue(callInfo);
+        var returnValue = ResolveReturnValue(callInfo);
         var returnMaybe = returnValue is OmitSpecimen ? Maybe.Nothing<object>() : Maybe.Just(returnValue);
 
         // Resolve ref/out parameter values.
@@ -55,7 +55,7 @@ public class CallResultResolver : ICallResultResolver
             if (!parameterInfo.ParameterType.IsByRef) continue;
 
             // Unwrap parameter type, because it is Type& for ref/out methods.
-            var value = this.SpecimenContext.Resolve(parameterInfo.ParameterType.GetElementType());
+            var value = SpecimenContext.Resolve(parameterInfo.ParameterType.GetElementType());
             if (value is OmitSpecimen) continue;
 
             argumentValues.Add(new CallResultData.ArgumentValue(i, value));
@@ -72,10 +72,10 @@ public class CallResultResolver : ICallResultResolver
         var propertyInfo = call.GetMethodInfo().GetPropertyFromGetterCallOrNull();
         if (propertyInfo != null)
         {
-            return this.SpecimenContext.Resolve(propertyInfo);
+            return SpecimenContext.Resolve(propertyInfo);
         }
 
-        return this.SpecimenContext.Resolve(call.GetReturnType());
+        return SpecimenContext.Resolve(call.GetReturnType());
     }
 
     private static ParameterInfo[] GetMethodParameters(ICall call)
@@ -83,9 +83,9 @@ public class CallResultResolver : ICallResultResolver
         // A workaround for the older versions of NSubstitute to retrieve the original delegate signature.
         // The related issue has been fixed in v4, so no tweaks are required there.
         // The workaround will be self disabled in v4+ due to the internal NSubstitute refactoring.
-        if (call.Target().GetType() == DelegateCallType && DelegateTypeFieldInfo != null)
+        if (call.Target().GetType() == s_delegateCallType && s_delegateTypeFieldInfo != null)
         {
-            var delegateType = (Type)DelegateTypeFieldInfo.GetValue(call.Target());
+            var delegateType = (Type)s_delegateTypeFieldInfo.GetValue(call.Target());
             return delegateType.GetMethod("Invoke").GetParameters();
         }
 

--- a/Src/AutoNSubstitute/NSubstituteBuilder.cs
+++ b/Src/AutoNSubstitute/NSubstituteBuilder.cs
@@ -31,8 +31,8 @@ public class NSubstituteBuilder : ISpecimenBuilder
     /// <seealso cref="SubstitutionSpecification"/>
     public NSubstituteBuilder(ISpecimenBuilder builder, IRequestSpecification substitutionSpecification)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.SubstitutionSpecification = substitutionSpecification ?? throw new ArgumentNullException(nameof(substitutionSpecification));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        SubstitutionSpecification = substitutionSpecification ?? throw new ArgumentNullException(nameof(substitutionSpecification));
     }
 
     /// <summary>Gets the decorated builder supplied through the constructor.</summary>
@@ -60,10 +60,10 @@ public class NSubstituteBuilder : ISpecimenBuilder
     /// </remarks>
     public object Create(object request, ISpecimenContext context)
     {
-        if (!this.SubstitutionSpecification.IsSatisfiedBy(request))
+        if (!SubstitutionSpecification.IsSatisfiedBy(request))
             return NoSpecimen.Instance;
 
-        var substitute = this.Builder.Create(request, context);
+        var substitute = Builder.Create(request, context);
         if (substitute == null)
             return NoSpecimen.Instance;
 

--- a/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
+++ b/Src/AutoNSubstitute/NSubstituteMethodQuery.cs
@@ -11,7 +11,7 @@ namespace AutoFixture.AutoNSubstitute;
 /// <summary>Selects appropriate methods to create substitutes.</summary>
 public class NSubstituteMethodQuery : IMethodQuery
 {
-    private static readonly IRequestSpecification DelegateSpecification = new DelegateSpecification();
+    private static readonly IRequestSpecification s_delegateSpecification = new DelegateSpecification();
 
     /// <summary>Selects the methods for the supplied type.</summary>
     /// <param name="type">The type.</param>
@@ -20,7 +20,7 @@ public class NSubstituteMethodQuery : IMethodQuery
     {
         if (type == null) throw new ArgumentNullException(nameof(type));
 
-        if (type.GetTypeInfo().IsInterface || DelegateSpecification.IsSatisfiedBy(type))
+        if (type.GetTypeInfo().IsInterface || s_delegateSpecification.IsSatisfiedBy(type))
             return new[] { SubstituteMethod.Create(type) };
 
         return from ci in type.GetPublicAndProtectedConstructors()
@@ -54,7 +54,7 @@ public class NSubstituteMethodQuery : IMethodQuery
     {
         public SubstituteMethod(IEnumerable<ParameterInfo> parameterInfos)
         {
-            this.Parameters = parameterInfos;
+            Parameters = parameterInfos;
         }
 
         public IEnumerable<ParameterInfo> Parameters { get; }

--- a/Src/AutoNSubstitute/NSubstituteRegisterCallHandlerCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteRegisterCallHandlerCommand.cs
@@ -58,9 +58,9 @@ public class NSubstituteRegisterCallHandlerCommand : ISpecimenCommand
         ICallResultCacheFactory callResultCacheFactory,
         ICallResultResolverFactory callResultResolverFactory)
     {
-        this.SubstitutionContext = substitutionContext ?? throw new ArgumentNullException(nameof(substitutionContext));
-        this.CallResultCacheFactory = callResultCacheFactory ?? throw new ArgumentNullException(nameof(callResultCacheFactory));
-        this.CallResultResolverFactory = callResultResolverFactory ?? throw new ArgumentNullException(nameof(callResultResolverFactory));
+        SubstitutionContext = substitutionContext ?? throw new ArgumentNullException(nameof(substitutionContext));
+        CallResultCacheFactory = callResultCacheFactory ?? throw new ArgumentNullException(nameof(callResultCacheFactory));
+        CallResultResolverFactory = callResultResolverFactory ?? throw new ArgumentNullException(nameof(callResultResolverFactory));
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class NSubstituteRegisterCallHandlerCommand : ISpecimenCommand
 
         try
         {
-            router = this.SubstitutionContext.GetCallRouterFor(specimen);
+            router = SubstitutionContext.GetCallRouterFor(specimen);
         }
         catch (NotASubstituteException)
         {
@@ -86,14 +86,14 @@ public class NSubstituteRegisterCallHandlerCommand : ISpecimenCommand
         // Add extensibility point for users to allow to use different cache implementation.
         // For instance users might want to disable results caching, as was proposed here:
         // https://github.com/AutoFixture/AutoFixture/issues/625
-        var resultsCacheForSubstitution = this.CallResultCacheFactory.CreateCache();
-        var callResultsResolver = this.CallResultResolverFactory.Create(context);
+        var resultsCacheForSubstitution = CallResultCacheFactory.CreateCache();
+        var callResultsResolver = CallResultResolverFactory.Create(context);
 
         router.RegisterCustomCallHandlerFactory(
             substituteState =>
                 new AutoFixtureValuesHandler(
                     callResultsResolver,
                     resultsCacheForSubstitution,
-                    CompatShim.GetCallSpecificationFactory(substituteState, this.SubstitutionContext)));
+                    CompatShim.GetCallSpecificationFactory(substituteState, SubstitutionContext)));
     }
 }

--- a/Src/AutoNSubstitute/NSubstituteSealedPropertiesCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteSealedPropertiesCommand.cs
@@ -13,7 +13,7 @@ namespace AutoFixture.AutoNSubstitute;
 /// </summary>
 public class NSubstituteSealedPropertiesCommand : ISpecimenCommand
 {
-    private static readonly AutoPropertiesCommand AutoPropertiesCommand =
+    private static readonly AutoPropertiesCommand s_autoPropertiesCommand =
         new AutoPropertiesCommand(new NSubstituteSealedPropertySpecification());
 
     /// <summary>
@@ -36,7 +36,7 @@ public class NSubstituteSealedPropertiesCommand : ISpecimenCommand
             return;
         }
 
-        AutoPropertiesCommand.Execute(specimen, context);
+        s_autoPropertiesCommand.Execute(specimen, context);
     }
 
     private class NSubstituteSealedPropertySpecification : IRequestSpecification

--- a/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
+++ b/Src/AutoNSubstitute/NSubstituteVirtualMethodsCommand.cs
@@ -39,7 +39,7 @@ namespace AutoFixture.AutoNSubstitute;
           "Use the NSubstituteRegisterCallHandlerCommand class and its dependencies instead.")]
 public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
 {
-    private static readonly MethodInfo[] ObjectMethods = typeof(object).GetMethods();
+    private static readonly MethodInfo[] s_objectMethods = typeof(object).GetMethods();
 
     /// <summary>
     /// Sets up a substitute object's methods so that the return values will be retrieved from a fixture,
@@ -79,12 +79,12 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
             .Where(method => method.IsOverridable() &&
                              !method.IsGenericMethod &&
                              !method.IsVoid() &&
-                             !ObjectMethods.Contains(method.GetBaseDefinition()));
+                             !s_objectMethods.Contains(method.GetBaseDefinition()));
     }
 
     private class SubstituteValueFactory
     {
-        private static readonly IMethod ReturnsMethodInfo =
+        private static readonly IMethod s_returnsMethodInfo =
             GetNSubstituteMethod("Returns");
 
         private static IMethod GetNSubstituteMethod(string methodName)
@@ -136,28 +136,28 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
             return type.Name;
         }
 
-        private readonly object substitute;
-        private readonly ISpecimenContext context;
+        private readonly object _substitute;
+        private readonly ISpecimenContext _context;
 
         public SubstituteValueFactory(object substitute, ISpecimenContext context)
         {
-            this.substitute = substitute ?? throw new ArgumentNullException(nameof(substitute));
-            this.context = context ?? throw new ArgumentNullException(nameof(context));
+            _substitute = substitute ?? throw new ArgumentNullException(nameof(substitute));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
         public object Substitute
         {
-            get { return this.substitute; }
+            get { return _substitute; }
         }
 
         public ISpecimenContext Context
         {
-            get { return this.context; }
+            get { return _context; }
         }
 
         public static void Returns<T>(T value, Func<CallInfo, T> returnThis)
         {
-            ReturnsMethodInfo.Invoke(new object[] { value, returnThis });
+            s_returnsMethodInfo.Invoke(new object[] { value, returnThis });
         }
 
         public void ReturnsUsingContext(MethodInfo methodInfo)
@@ -187,31 +187,31 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
             //    That is because Do() {} callback is executed before known return values are returned.
             //    After our substitute is configured in When-Do, NSubstitute checks whether there is return value for current call.
             //    Return value is, of course, present and it returns that value to the consumer.
-            this.Substitute
-                .WhenForAnyArgs(_ => this.InvokeMethod(methodInfo))
+            Substitute
+                .WhenForAnyArgs(_ => InvokeMethod(methodInfo))
                 .Do(callInfo =>
                 {
                     var arguments = callInfo.Args();
 
                     var callRouter =
-                        SubstitutionContext.Current.GetCallRouterFor(this.Substitute);
+                        SubstitutionContext.Current.GetCallRouterFor(Substitute);
 
                     callRouter.SetRoute(state => CompatShim.Route_CreateNew(
                         new ICallHandler[]
                         {
                             new NoSetupCallbackHandler(state, () =>
                             {
-                                var value = this.Resolve(methodInfo.ReturnType);
+                                var value = Resolve(methodInfo.ReturnType);
                                 if (value is OmitSpecimen)
                                     return;
 
-                                this.ReturnsFixedValue(methodInfo, value);
-                                this.InvokeMethod(methodInfo, arguments);
+                                ReturnsFixedValue(methodInfo, value);
+                                InvokeMethod(methodInfo, arguments);
                             }),
                             new ReturnDefaultForReturnTypeHandler(
                                 new DefaultForType())
                         }));
-                    this.InvokeMethod(methodInfo, arguments);
+                    InvokeMethod(methodInfo, arguments);
                 });
         }
 
@@ -232,7 +232,7 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
                 // Run task on default scheduler to prevent attach to the context scheduler.
                 // User could execute this code in context of its own scheduler that performs aggressive inling
                 // and our task will be inlined by that scheduler.
-                var task = Task.Factory.StartNew(() => this.Context.Resolve(type), cancelableToken,
+                var task = Task.Factory.StartNew(() => Context.Resolve(type), cancelableToken,
                     TaskCreationOptions.None, TaskScheduler.Default);
 
                 // It could happen that task above is inlined on the current thread.
@@ -247,7 +247,7 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
 
         private void ReturnsFixedValue(MethodInfo methodInfo, object value)
         {
-            var refValues = this.GetFixedRefValues(methodInfo);
+            var refValues = GetFixedRefValues(methodInfo);
             Returns(null, x =>
             {
                 SetRefValues(x, refValues);
@@ -259,7 +259,7 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
         {
             return GetRefParameters(methodInfo)
                 .Select(t => Tuple.Create(t.Item1,
-                    new Lazy<object>(() => this.Context.Resolve(t.Item2.ParameterType.GetElementType()))))
+                    new Lazy<object>(() => Context.Resolve(t.Item2.ParameterType.GetElementType()))))
                 .ToList();
         }
 
@@ -268,7 +268,7 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
             if (methodInfo.IsVoid())
                 return;
 
-            this.ReturnsUsingContext(methodInfo);
+            ReturnsUsingContext(methodInfo);
         }
 
         private static void SetRefValues(CallInfo callInfo, IEnumerable<Tuple<int, Lazy<object>>> values)
@@ -289,7 +289,7 @@ public class NSubstituteVirtualMethodsCommand : ISpecimenCommand
 
         private void InvokeMethod(MethodInfo methodInfo, object[] parameters = null)
         {
-            methodInfo.Invoke(this.Substitute, parameters ?? GetDefaultParameters(methodInfo));
+            methodInfo.Invoke(Substitute, parameters ?? GetDefaultParameters(methodInfo));
         }
 
         private static object[] GetDefaultParameters(MethodInfo methodInfo)

--- a/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
+++ b/Src/AutoNSubstitute/NoSetupCallbackHandler.cs
@@ -7,24 +7,24 @@ namespace AutoFixture.AutoNSubstitute;
           "Use the NSubstituteRegisterCallHandlerCommand class and its dependencies instead.")]
 internal class NoSetupCallbackHandler : ICallHandler
 {
-    private readonly ISubstituteState state;
-    private readonly Action action;
+    private readonly ISubstituteState _state;
+    private readonly Action _action;
 
     public NoSetupCallbackHandler(ISubstituteState state, Action action)
     {
-        this.state = state ?? throw new ArgumentNullException(nameof(state));
-        this.action = action ?? throw new ArgumentNullException(nameof(action));
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+        _action = action ?? throw new ArgumentNullException(nameof(action));
     }
 
     public bool HasResultFor(ICall call)
     {
-        return CompatShim.CallResults_HasCallResultFor(this.state.CallResults, call);
+        return CompatShim.CallResults_HasCallResultFor(_state.CallResults, call);
     }
 
     RouteAction ICallHandler.Handle(ICall call)
     {
-        if (!this.HasResultFor(call))
-            this.action();
+        if (!HasResultFor(call))
+            _action();
 
         return RouteAction.Continue();
     }

--- a/Src/AutoNSubstitute/SubstituteRelay.cs
+++ b/Src/AutoNSubstitute/SubstituteRelay.cs
@@ -27,7 +27,7 @@ public class SubstituteRelay : ISpecimenBuilder
     /// <param name="specification">Specification to test whether request should be relayed.</param>
     public SubstituteRelay(IRequestSpecification specification)
     {
-        this.Specification = specification ?? throw new ArgumentNullException(nameof(specification));
+        Specification = specification ?? throw new ArgumentNullException(nameof(specification));
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class SubstituteRelay : ISpecimenBuilder
     {
         if (context == null) throw new ArgumentNullException(nameof(context));
 
-        if (!this.Specification.IsSatisfiedBy(request))
+        if (!Specification.IsSatisfiedBy(request))
             return NoSpecimen.Instance;
 
         var requestedType = request as Type;

--- a/Src/AutoNSubstitute/SubstituteRequest.cs
+++ b/Src/AutoNSubstitute/SubstituteRequest.cs
@@ -21,7 +21,7 @@ public class SubstituteRequest
     /// </param>
     public SubstituteRequest(Type targetType)
     {
-        this.TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+        TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
     }
 
     /// <summary>
@@ -32,5 +32,5 @@ public class SubstituteRequest
     /// <summary>
     /// Add user friendly request message.
     /// </summary>
-    public override string ToString() => "NSubstituteRequest: " + this.TargetType;
+    public override string ToString() => "NSubstituteRequest: " + TargetType;
 }

--- a/Src/AutoNSubstitute/SubstituteRequestHandler.cs
+++ b/Src/AutoNSubstitute/SubstituteRequestHandler.cs
@@ -24,7 +24,7 @@ public class SubstituteRequestHandler : ISpecimenBuilder
     /// </param>
     public SubstituteRequestHandler(ISpecimenBuilder substituteFactory)
     {
-        this.SubstituteFactory = substituteFactory ?? throw new ArgumentNullException(nameof(substituteFactory));
+        SubstituteFactory = substituteFactory ?? throw new ArgumentNullException(nameof(substituteFactory));
     }
 
     /// <summary>
@@ -48,6 +48,6 @@ public class SubstituteRequestHandler : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        return this.SubstituteFactory.Create(substituteRequest.TargetType, context);
+        return SubstituteFactory.Create(substituteRequest.TargetType, context);
     }
 }

--- a/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/AutoConfiguredFixtureIntegrationTest.cs
@@ -758,14 +758,14 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
         private class Issue630_TryingAlwaysSatisfyInlineTaskScheduler : TaskScheduler
         {
             private const int DelayMSec = 100;
-            private readonly object syncRoot = new object();
+            private readonly object _syncRoot = new object();
             private HashSet<Task> Tasks { get; } = new HashSet<Task>();
 
             protected override void QueueTask(Task task)
             {
-                lock (this.syncRoot)
+                lock (_syncRoot)
                 {
-                    this.Tasks.Add(task);
+                    Tasks.Add(task);
                 }
 
                 ThreadPool.QueueUserWorkItem(_ =>
@@ -773,39 +773,39 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
                     Thread.Sleep(DelayMSec);
 
                     // If task cannot be dequeued - it was already executed.
-                    if (this.TryDequeue(task))
+                    if (TryDequeue(task))
                     {
-                        this.TryExecuteTask(task);
+                        TryExecuteTask(task);
                     }
                 });
             }
 
             protected override bool TryDequeue(Task task)
             {
-                lock (this.syncRoot)
+                lock (_syncRoot)
                 {
-                    return this.Tasks.Remove(task);
+                    return Tasks.Remove(task);
                 }
             }
 
             protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
             {
                 // If was queued, try to remove from queue before inlining. Ignore otherwise - it's already executed.
-                if (taskWasPreviouslyQueued && !this.TryDequeue(task))
+                if (taskWasPreviouslyQueued && !TryDequeue(task))
                 {
                     return false;
                 }
 
-                this.TryExecuteTask(task);
+                TryExecuteTask(task);
                 return true;
             }
 
             protected override IEnumerable<Task> GetScheduledTasks()
             {
-                lock (this.syncRoot)
+                lock (_syncRoot)
                 {
                     // Create copy to ensure that it's not modified during enumeration
-                    return this.Tasks.ToArray();
+                    return Tasks.ToArray();
                 }
             }
         }
@@ -840,7 +840,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
         {
             protected override void QueueTask(Task task)
             {
-                this.TryExecuteTask(task);
+                TryExecuteTask(task);
             }
 
             protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)

--- a/Src/AutoNSubstituteUnitTest/FixtureIntegrationTest.cs
+++ b/Src/AutoNSubstituteUnitTest/FixtureIntegrationTest.cs
@@ -948,14 +948,14 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
         private class Issue630_TryingAlwaysSatisfyInlineTaskScheduler : TaskScheduler
         {
             private const int DelayMSec = 100;
-            private readonly object syncRoot = new object();
+            private readonly object _syncRoot = new object();
             private HashSet<Task> Tasks { get; } = new HashSet<Task>();
 
             protected override void QueueTask(Task task)
             {
-                lock (this.syncRoot)
+                lock (_syncRoot)
                 {
-                    this.Tasks.Add(task);
+                    Tasks.Add(task);
                 }
 
                 ThreadPool.QueueUserWorkItem(_ =>
@@ -963,39 +963,39 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
                     Thread.Sleep(DelayMSec);
 
                     // If task cannot be dequeued - it was already executed.
-                    if (this.TryDequeue(task))
+                    if (TryDequeue(task))
                     {
-                        this.TryExecuteTask(task);
+                        TryExecuteTask(task);
                     }
                 });
             }
 
             protected override bool TryDequeue(Task task)
             {
-                lock (this.syncRoot)
+                lock (_syncRoot)
                 {
-                    return this.Tasks.Remove(task);
+                    return Tasks.Remove(task);
                 }
             }
 
             protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
             {
                 // If was queued, try to remove from queue before inlining. Ignore otherwise - it's already executed.
-                if (taskWasPreviouslyQueued && !this.TryDequeue(task))
+                if (taskWasPreviouslyQueued && !TryDequeue(task))
                 {
                     return false;
                 }
 
-                this.TryExecuteTask(task);
+                TryExecuteTask(task);
                 return true;
             }
 
             protected override IEnumerable<Task> GetScheduledTasks()
             {
-                lock (this.syncRoot)
+                lock (_syncRoot)
                 {
                     // Create copy to ensure that it's not modified during enumeration
-                    return this.Tasks.ToArray();
+                    return Tasks.ToArray();
                 }
             }
         }
@@ -1029,7 +1029,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
         {
             protected override void QueueTask(Task task)
             {
-                this.TryExecuteTask(task);
+                TryExecuteTask(task);
             }
 
             protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)

--- a/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.cs
+++ b/Src/AutoNSubstituteUnitTest/NSubstituteRegisterCallHandlerCommandTest.cs
@@ -200,7 +200,7 @@ namespace AutoFixture.AutoNSubstitute.UnitTest
 
             public void RegisterCustomCallHandlerFactory(CallHandlerFactory factory)
             {
-                this.RegisteredFactory = factory;
+                RegisteredFactory = factory;
             }
 
             public void Clear(ClearOptions clear) => throw new NotImplementedException();

--- a/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithIndexer.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithIndexer.cs
@@ -2,12 +2,12 @@
 {
     public abstract class TypeWithIndexer
     {
-        private readonly int[] array = new[] { -99, -99, -99 };
+        private readonly int[] _array = new[] { -99, -99, -99 };
 
         public int this[int index]
         {
-            get { return this.array[index]; }
-            set { this.array[index] = value; }
+            get { return _array[index]; }
+            set { _array[index] = value; }
         }
     }
 }

--- a/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithPrivateField.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithPrivateField.cs
@@ -2,11 +2,11 @@
 {
     public abstract class TypeWithPrivateField
     {
-        private string field = string.Empty;
+        private string _field = string.Empty;
 
         public string GetPrivateField()
         {
-            return this.field;
+            return _field;
         }
     }
 }

--- a/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithPrivateProperty.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithPrivateProperty.cs
@@ -4,7 +4,7 @@
     {
         protected TypeWithPrivateProperty()
         {
-            this.PrivateProperty = "Awesome string";
+            PrivateProperty = "Awesome string";
         }
 
         // ReSharper disable UnusedAutoPropertyAccessor.Local

--- a/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithPropertyWithPrivateSetter.cs
+++ b/Src/AutoNSubstituteUnitTest/TestTypes/TypeWithPropertyWithPrivateSetter.cs
@@ -4,7 +4,7 @@
     {
         protected TypeWithPropertyWithPrivateSetter()
         {
-            this.PropertyWithPrivateSetter = "Awesome string";
+            PropertyWithPrivateSetter = "Awesome string";
         }
 
         public string PropertyWithPrivateSetter { get; private set; }

--- a/Src/AutoRhinoMock/RhinoMockAroundAdvice.cs
+++ b/Src/AutoRhinoMock/RhinoMockAroundAdvice.cs
@@ -24,7 +24,7 @@ public class RhinoMockAroundAdvice : ISpecimenBuilder
     /// <seealso cref="Builder" />
     public RhinoMockAroundAdvice(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class RhinoMockAroundAdvice : ISpecimenBuilder
             return NoSpecimen.Instance;
         }
 
-        var built = this.Builder.Create(request, context);
+        var built = Builder.Create(request, context);
         var m = built as IMockedObject;
         if (m == null)
         {

--- a/Src/AutoRhinoMock/RhinoMockConstructorMethod.cs
+++ b/Src/AutoRhinoMock/RhinoMockConstructorMethod.cs
@@ -33,8 +33,8 @@ public class RhinoMockConstructorMethod : IMethod
     /// </param>
     public RhinoMockConstructorMethod(Type mockTargetType, ParameterInfo[] parameterInfos)
     {
-        this.MockTargetType = mockTargetType ?? throw new ArgumentNullException(nameof(mockTargetType));
-        this.Parameters = parameterInfos ?? throw new ArgumentNullException(nameof(parameterInfos));
+        MockTargetType = mockTargetType ?? throw new ArgumentNullException(nameof(mockTargetType));
+        Parameters = parameterInfos ?? throw new ArgumentNullException(nameof(parameterInfos));
     }
 
     /// <summary>
@@ -58,6 +58,6 @@ public class RhinoMockConstructorMethod : IMethod
     /// <returns>A mock instance created with Rhino Mocks.</returns>
     public object Invoke(IEnumerable<object> parameters)
     {
-        return MockRepository.GenerateMock(this.MockTargetType, new Type[0], parameters.ToArray());
+        return MockRepository.GenerateMock(MockTargetType, new Type[0], parameters.ToArray());
     }
 }

--- a/Src/AutoRhinoMockUnitTest/DependencyConstraints.cs
+++ b/Src/AutoRhinoMockUnitTest/DependencyConstraints.cs
@@ -25,7 +25,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().Assembly.GetReferencedAssemblies();
+        var references = GetType().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.DoesNotContain(references, an => an.Name == assemblyName);
     }

--- a/Src/AutoRhinoMockUnitTest/RhinoMockTestTypes.cs
+++ b/Src/AutoRhinoMockUnitTest/RhinoMockTestTypes.cs
@@ -4,11 +4,11 @@ public class RhinoMockTestTypes
 {
     public abstract class AnotherAbstractTypeWithNonDefaultConstructor<T>
     {
-        private readonly T value;
+        private readonly T _value;
 
         protected AnotherAbstractTypeWithNonDefaultConstructor(T value)
         {
-            this.value = value;
+            _value = value;
         }
     }
 
@@ -16,7 +16,7 @@ public class RhinoMockTestTypes
     {
         public ConcreteGenericType(T value)
         {
-            this.Value = value;
+            Value = value;
         }
 
         public T Value { get; }
@@ -26,8 +26,8 @@ public class RhinoMockTestTypes
     {
         public ConcreteDoublyGenericType(T1 value1, T2 value2)
         {
-            this.Value1 = value1;
-            this.Value2 = value2;
+            Value1 = value1;
+            Value2 = value2;
         }
 
         public T1 Value1 { get; }

--- a/Src/Idioms/CompositeBehaviorExpectation.cs
+++ b/Src/Idioms/CompositeBehaviorExpectation.cs
@@ -17,7 +17,7 @@ public class CompositeBehaviorExpectation : IBehaviorExpectation
     /// <seealso cref="BehaviorExpectations" />
     public CompositeBehaviorExpectation(params IBehaviorExpectation[] behaviorExpectations)
     {
-        this.BehaviorExpectations = behaviorExpectations;
+        BehaviorExpectations = behaviorExpectations;
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public class CompositeBehaviorExpectation : IBehaviorExpectation
     /// <param name="command">The command whose behavior must be examined.</param>
     public void Verify(IGuardClauseCommand command)
     {
-        foreach (var be in this.BehaviorExpectations)
+        foreach (var be in BehaviorExpectations)
         {
             be.Verify(command);
         }

--- a/Src/Idioms/CompositeIdiomaticAssertion.cs
+++ b/Src/Idioms/CompositeIdiomaticAssertion.cs
@@ -17,7 +17,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="assertions">The encapsulated assertions.</param>
     public CompositeIdiomaticAssertion(params IIdiomaticAssertion[] assertions)
     {
-        this.Assertions = assertions;
+        Assertions = assertions;
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="constructorInfo">The constructor whose behavior must be verified.</param>
     public void Verify(ConstructorInfo constructorInfo)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(constructorInfo);
         }
@@ -55,7 +55,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="constructorInfos">The constructors whose behavior must be verified.</param>
     public void Verify(IEnumerable<ConstructorInfo> constructorInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(constructorInfos);
         }
@@ -68,7 +68,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="assemblies">The assemblies whose behaviour must be verified.</param>
     public void Verify(params Assembly[] assemblies)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(assemblies);
         }
@@ -81,7 +81,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="assemblies">The assemblies whose behaviour must be verified.</param>
     public void Verify(IEnumerable<Assembly> assemblies)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(assemblies);
         }
@@ -94,7 +94,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="assembly">The assembly whose behaviour must be verified.</param>
     public void Verify(Assembly assembly)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(assembly);
         }
@@ -107,7 +107,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="types">The types whose behaviour must be verified.</param>
     public void Verify(params Type[] types)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(types);
         }
@@ -120,7 +120,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="types">The types whose behaviour must be verified.</param>
     public void Verify(IEnumerable<Type> types)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(types);
         }
@@ -133,7 +133,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="type">The type whose behaviour must be verified.</param>
     public void Verify(Type type)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(type);
         }
@@ -146,7 +146,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="memberInfos">The members whose behaviour must be verified.</param>
     public void Verify(params MemberInfo[] memberInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(memberInfos);
         }
@@ -159,7 +159,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="memberInfos">The members whose behaviour must be verified.</param>
     public void Verify(IEnumerable<MemberInfo> memberInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(memberInfos);
         }
@@ -172,7 +172,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="memberInfo">The member whose behaviour must be verified.</param>
     public void Verify(MemberInfo memberInfo)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(memberInfo);
         }
@@ -185,7 +185,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="constructorInfos">The constructors whose behavior must be verified.</param>
     public void Verify(params ConstructorInfo[] constructorInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(constructorInfos);
         }
@@ -198,7 +198,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="methodInfo">The method whose behavior must be verified.</param>
     public void Verify(MethodInfo methodInfo)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(methodInfo);
         }
@@ -211,7 +211,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="methodInfos">The methods whose behavior must be verified.</param>
     public void Verify(IEnumerable<MethodInfo> methodInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(methodInfos);
         }
@@ -224,7 +224,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="methodInfos">The methods whose behavior must be verified.</param>
     public void Verify(params MethodInfo[] methodInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(methodInfos);
         }
@@ -237,7 +237,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="propertyInfo">The property whose behavior must be verified.</param>
     public void Verify(PropertyInfo propertyInfo)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(propertyInfo);
         }
@@ -250,7 +250,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="propertyInfos">The properties whose behavior must be verified.</param>
     public void Verify(IEnumerable<PropertyInfo> propertyInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(propertyInfos);
         }
@@ -263,7 +263,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="propertyInfos">The properties whose behavior must be verified.</param>
     public void Verify(params PropertyInfo[] propertyInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(propertyInfos);
         }
@@ -276,7 +276,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="fieldInfo">The field whose behavior must be verified.</param>
     public void Verify(FieldInfo fieldInfo)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(fieldInfo);
         }
@@ -289,7 +289,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="fieldInfos">The fields whose behavior must be verified.</param>
     public void Verify(IEnumerable<FieldInfo> fieldInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(fieldInfos);
         }
@@ -302,7 +302,7 @@ public class CompositeIdiomaticAssertion : IIdiomaticAssertion
     /// <param name="fieldInfos">The fields whose behavior must be verified.</param>
     public void Verify(params FieldInfo[] fieldInfos)
     {
-        foreach (var assertion in this.Assertions)
+        foreach (var assertion in Assertions)
         {
             assertion.Verify(fieldInfos);
         }

--- a/Src/Idioms/ConstructorInitializedMemberAssertion.cs
+++ b/Src/Idioms/ConstructorInitializedMemberAssertion.cs
@@ -43,9 +43,9 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
         IEqualityComparer comparer,
         IEqualityComparer<IReflectionElement> parameterMemberMatcher)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-        this.ParameterMemberMatcher = parameterMemberMatcher ??
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        ParameterMemberMatcher = parameterMemberMatcher ??
                                       throw new ArgumentNullException(nameof(parameterMemberMatcher));
     }
 
@@ -114,10 +114,10 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
         // matcher with one that behaves the similar to the previous
         // behaviour
         IEqualityComparer<IReflectionElement> matcher =
-            this.ParameterMemberMatcher is DefaultParameterMemberMatcher
+            ParameterMemberMatcher is DefaultParameterMemberMatcher
                 ? new DefaultParameterMemberMatcher(
                     new DefaultParameterMemberMatcher.NameIgnoreCaseAndTypeEqualComparer())
-                : this.ParameterMemberMatcher;
+                : ParameterMemberMatcher;
 
         var firstParameterNotExposed = parameters.FirstOrDefault(
             p => !publicPropertiesAndFields.Any(m =>
@@ -150,7 +150,7 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
     {
         if (propertyInfo == null) throw new ArgumentNullException(nameof(propertyInfo));
 
-        var matchingConstructors = this.GetConstructorsWithInitializerForMember(propertyInfo).ToArray();
+        var matchingConstructors = GetConstructorsWithInitializerForMember(propertyInfo).ToArray();
 
         if (!matchingConstructors.Any())
         {
@@ -173,10 +173,10 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
         }
 
         var expectedAndActual = matchingConstructors
-            .Select(ctor => this.BuildSpecimenFromConstructor(ctor, propertyInfo));
+            .Select(ctor => BuildSpecimenFromConstructor(ctor, propertyInfo));
 
         // Compare the value passed into the constructor with the value returned from the property
-        if (expectedAndActual.Any(s => !this.Comparer.Equals(s.Expected, s.Actual)))
+        if (expectedAndActual.Any(s => !Comparer.Equals(s.Expected, s.Actual)))
         {
             throw new ConstructorInitializedMemberException(propertyInfo);
         }
@@ -203,7 +203,7 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
     {
         if (fieldInfo == null) throw new ArgumentNullException(nameof(fieldInfo));
 
-        var matchingConstructors = this.GetConstructorsWithInitializerForMember(fieldInfo).ToArray();
+        var matchingConstructors = GetConstructorsWithInitializerForMember(fieldInfo).ToArray();
         if (!matchingConstructors.Any())
         {
             if (RequiresConstructorInitialization(fieldInfo))
@@ -224,10 +224,10 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
         }
 
         var expectedAndActual = matchingConstructors
-            .Select(ctor => this.BuildSpecimenFromConstructor(ctor, fieldInfo));
+            .Select(ctor => BuildSpecimenFromConstructor(ctor, fieldInfo));
 
         // Compare the value passed into the constructor with the value returned from the property
-        if (expectedAndActual.Any(s => !this.Comparer.Equals(s.Expected, s.Actual)))
+        if (expectedAndActual.Any(s => !Comparer.Equals(s.Expected, s.Actual)))
         {
             throw new ConstructorInitializedMemberException(fieldInfo);
         }
@@ -269,13 +269,13 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
             .Select(pi => new
             {
                 Parameter = pi,
-                Value = this.GetParameterValue(pi)
+                Value = GetParameterValue(pi)
             })
             .ToArray();
 
         // Get the value expected to be assigned to the matching member
         var expectedValueForMember = parametersAndValues
-            .Single(p => this.IsMatchingParameterAndMember(p.Parameter, propertyOrField))
+            .Single(p => IsMatchingParameterAndMember(p.Parameter, propertyOrField))
             .Value;
 
         // Construct an instance of the specimen class
@@ -296,13 +296,13 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
         => parameterInfo.ParameterType switch
         {
             { } t when t == typeof(bool) => true,
-            { IsEnum: true } => this.GetEnumParameterValue(parameterInfo),
-            _ => this.Builder.CreateAnonymous(parameterInfo)
+            { IsEnum: true } => GetEnumParameterValue(parameterInfo),
+            _ => Builder.CreateAnonymous(parameterInfo)
         };
 
     private object GetEnumParameterValue(ParameterInfo parameterInfo)
     {
-        var value = this.Builder.CreateAnonymous(parameterInfo);
+        var value = Builder.CreateAnonymous(parameterInfo);
 
         // Ensure enum isn't getting the default value, otherwise
         // we won't be able to determine whether initialization
@@ -312,15 +312,15 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
 
         // If the second consecutive attempt does not yield a non-default result,
         // then the value must have been frozen, so no point trying again.
-        return this.Builder.CreateAnonymous(parameterInfo);
+        return Builder.CreateAnonymous(parameterInfo);
     }
 
     private class ExpectedAndActual
     {
         public ExpectedAndActual(object expected, object actual)
         {
-            this.Expected = expected;
-            this.Actual = actual;
+            Expected = expected;
+            Actual = actual;
         }
 
         public object Expected { get; }
@@ -331,19 +331,19 @@ public class ConstructorInitializedMemberAssertion : IdiomaticAssertion
     private IEnumerable<ConstructorInfo> GetConstructorsWithInitializerForMember(MemberInfo member)
     {
         return member.ReflectedType?.GetConstructors()
-            .Where(ci => this.IsConstructorWithMatchingArgument(ci, member));
+            .Where(ci => IsConstructorWithMatchingArgument(ci, member));
     }
 
     private bool IsMatchingParameterAndMember(ParameterInfo parameter, MemberInfo fieldOrProperty)
     {
-        return this.ParameterMemberMatcher.Equals(
+        return ParameterMemberMatcher.Equals(
             fieldOrProperty.ToReflectionElement(), parameter.ToReflectionElement());
     }
 
     private bool IsConstructorWithMatchingArgument(ConstructorInfo ci, MemberInfo memberInfo)
     {
         return ci.GetParameters().Any(parameterElement =>
-            this.IsMatchingParameterAndMember(parameterElement, memberInfo));
+            IsMatchingParameterAndMember(parameterElement, memberInfo));
     }
 
     private static IEnumerable<MemberInfo> GetPublicPropertiesAndFields(Type t)

--- a/Src/Idioms/ConstructorInitializedMemberException.cs
+++ b/Src/Idioms/ConstructorInitializedMemberException.cs
@@ -15,10 +15,10 @@ namespace AutoFixture.Idioms;
 public class ConstructorInitializedMemberException : Exception
 {
     [NonSerialized]
-    private readonly MemberInfo memberInfo;
+    private readonly MemberInfo _memberInfo;
 
     [NonSerialized]
-    private readonly ParameterInfo missingParameter;
+    private readonly ParameterInfo _missingParameter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConstructorInitializedMemberException"/> class.
@@ -41,8 +41,8 @@ public class ConstructorInitializedMemberException : Exception
     public ConstructorInitializedMemberException(ConstructorInfo constructorInfo, ParameterInfo missingParameter, string message)
         : base(message)
     {
-        this.memberInfo = constructorInfo;
-        this.missingParameter = missingParameter;
+        _memberInfo = constructorInfo;
+        _missingParameter = missingParameter;
     }
 
     /// <summary>
@@ -60,8 +60,8 @@ public class ConstructorInitializedMemberException : Exception
         ConstructorInfo constructorInfo, ParameterInfo missingParameter, string message, Exception innerException)
         : base(message, innerException)
     {
-        this.memberInfo = constructorInfo;
-        this.missingParameter = missingParameter;
+        _memberInfo = constructorInfo;
+        _missingParameter = missingParameter;
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public class ConstructorInitializedMemberException : Exception
     public ConstructorInitializedMemberException(FieldInfo fieldInfo, string message)
         : base(message)
     {
-        this.memberInfo = fieldInfo;
+        _memberInfo = fieldInfo;
     }
 
     /// <summary>
@@ -99,7 +99,7 @@ public class ConstructorInitializedMemberException : Exception
     public ConstructorInitializedMemberException(FieldInfo fieldInfo, string message, Exception innerException)
         : base(message, innerException)
     {
-        this.memberInfo = fieldInfo;
+        _memberInfo = fieldInfo;
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public class ConstructorInitializedMemberException : Exception
     public ConstructorInitializedMemberException(PropertyInfo propertyInfo, string message)
         : base(message)
     {
-        this.memberInfo = propertyInfo;
+        _memberInfo = propertyInfo;
     }
 
     /// <summary>
@@ -137,7 +137,7 @@ public class ConstructorInitializedMemberException : Exception
     public ConstructorInitializedMemberException(PropertyInfo propertyInfo, string message, Exception innerException)
         : base(message, innerException)
     {
-        this.memberInfo = propertyInfo;
+        _memberInfo = propertyInfo;
     }
 
     /// <summary>
@@ -155,33 +155,33 @@ public class ConstructorInitializedMemberException : Exception
     protected ConstructorInitializedMemberException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {
-        this.memberInfo = (PropertyInfo)info.GetValue("memberInfo", typeof(MemberInfo));
+        _memberInfo = (PropertyInfo)info.GetValue("memberInfo", typeof(MemberInfo));
     }
 
     /// <summary>
     /// Gets the property or field supplied via the constructor.
     /// </summary>
-    public MemberInfo MemberInfo => this.memberInfo;
+    public MemberInfo MemberInfo => _memberInfo;
 
     /// <summary>
     /// Gets the property supplied via the constructor.
     /// </summary>
-    public PropertyInfo PropertyInfo => this.memberInfo as PropertyInfo;
+    public PropertyInfo PropertyInfo => _memberInfo as PropertyInfo;
 
     /// <summary>
     /// Gets the property supplied via the constructor.
     /// </summary>
-    public FieldInfo FieldInfo => this.memberInfo as FieldInfo;
+    public FieldInfo FieldInfo => _memberInfo as FieldInfo;
 
     /// <summary>
     /// Gets the constructor which has a <see cref="MissingParameter"/>.
     /// </summary>
-    public ConstructorInfo ConstructorInfo => this.memberInfo as ConstructorInfo;
+    public ConstructorInfo ConstructorInfo => _memberInfo as ConstructorInfo;
 
     /// <summary>
     /// Gets the parameter that was not exposed as a field or property.
     /// </summary>
-    public ParameterInfo MissingParameter => this.missingParameter;
+    public ParameterInfo MissingParameter => _missingParameter;
 
     /// <summary>
     /// Adds <see cref="PropertyInfo" /> to a
@@ -200,7 +200,7 @@ public class ConstructorInitializedMemberException : Exception
     {
         base.GetObjectData(info, context);
 
-        info.AddValue("memberInfo", this.memberInfo);
+        info.AddValue("memberInfo", _memberInfo);
     }
 
     private static string FormatDefaultMessage(ConstructorInfo constructorInfo, ParameterInfo missingParameter)

--- a/Src/Idioms/CopyAndUpdateAssertion.cs
+++ b/Src/Idioms/CopyAndUpdateAssertion.cs
@@ -54,9 +54,9 @@ public class CopyAndUpdateAssertion : IdiomaticAssertion
         IEqualityComparer comparer,
         IEqualityComparer<IReflectionElement> parameterMemberMatcher)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
-        this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-        this.ParameterMemberMatcher = parameterMemberMatcher ?? throw new ArgumentNullException(nameof(parameterMemberMatcher));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        ParameterMemberMatcher = parameterMemberMatcher ?? throw new ArgumentNullException(nameof(parameterMemberMatcher));
     }
 
     /// <summary>
@@ -134,8 +134,8 @@ public class CopyAndUpdateAssertion : IdiomaticAssertion
                 select new
                 {
                     Parameter = parameter,
-                    Member = publicMembers.FirstOrDefault(m => this.IsMatchingParameterAndMember(parameter, m)),
-                    Value = this.Builder.CreateAnonymous(parameter)
+                    Member = publicMembers.FirstOrDefault(m => IsMatchingParameterAndMember(parameter, m)),
+                    Value = Builder.CreateAnonymous(parameter)
                 })
             .ToArray();
 
@@ -148,7 +148,7 @@ public class CopyAndUpdateAssertion : IdiomaticAssertion
         }
 
         // Build a specimen and invoke the 'Copy and update' method
-        var specimen = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var specimen = Builder.CreateAnonymous(methodInfo.ReflectedType);
         var copiedAndUpdatedSpecimen = methodInfo.Invoke(specimen, parameters.Select(p => p.Value).ToArray());
         VerifyCopiedAndUpdatedSpecimenType(methodInfo, copiedAndUpdatedSpecimen, specimen);
 
@@ -164,7 +164,7 @@ public class CopyAndUpdateAssertion : IdiomaticAssertion
                     .Value
                     .Single()
             })
-            .FirstOrDefault(p => !this.Comparer.Equals(p.Expected, p.Actual));
+            .FirstOrDefault(p => !Comparer.Equals(p.Expected, p.Actual));
 
         if (firstUpdatedParameterWithUnexpectedValue != null)
         {
@@ -174,7 +174,7 @@ public class CopyAndUpdateAssertion : IdiomaticAssertion
         // Verify each member without a matching update parameter, remained unchanged
         var firstNonEqualMemberExpectedToBeEqual = publicMembers
             .Except(parameters.Select(p => p.Member))
-            .FirstOrDefault(m => !this.AreMemberValuesEqual(specimen, copiedAndUpdatedSpecimen, m));
+            .FirstOrDefault(m => !AreMemberValuesEqual(specimen, copiedAndUpdatedSpecimen, m));
 
         if (firstNonEqualMemberExpectedToBeEqual != null)
         {
@@ -237,7 +237,7 @@ public class CopyAndUpdateAssertion : IdiomaticAssertion
             copiedAndUpdatedMemberValue = fieldInfo.GetValue(copiedAndUpdatedSpecimen);
         }
 
-        return this.Comparer.Equals(specimenMemberValue, copiedAndUpdatedMemberValue);
+        return Comparer.Equals(specimenMemberValue, copiedAndUpdatedMemberValue);
     }
 
     private static IEnumerable<MemberInfo> GetPublicPropertiesAndFields(Type t)
@@ -249,7 +249,7 @@ public class CopyAndUpdateAssertion : IdiomaticAssertion
 
     private bool IsMatchingParameterAndMember(ParameterInfo parameter, MemberInfo fieldOrProperty)
     {
-        return this.ParameterMemberMatcher.Equals(
+        return ParameterMemberMatcher.Equals(
             parameter.ToReflectionElement(), fieldOrProperty.ToReflectionElement());
     }
 

--- a/Src/Idioms/CopyAndUpdateException.cs
+++ b/Src/Idioms/CopyAndUpdateException.cs
@@ -14,13 +14,13 @@ namespace AutoFixture.Idioms;
 public class CopyAndUpdateException : Exception
 {
     [NonSerialized]
-    private readonly MethodInfo methodInfo;
+    private readonly MethodInfo _methodInfo;
 
     [NonSerialized]
-    private readonly MemberInfo memberWithInvalidValue;
+    private readonly MemberInfo _memberWithInvalidValue;
 
     [NonSerialized]
-    private ParameterInfo argumentWithNoMatchingPublicMember;
+    private ParameterInfo _argumentWithNoMatchingPublicMember;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CopyAndUpdateException"/> class.
@@ -38,7 +38,7 @@ public class CopyAndUpdateException : Exception
     public CopyAndUpdateException(string message, MethodInfo methodInfo)
         : this(message)
     {
-        this.methodInfo = methodInfo;
+        _methodInfo = methodInfo;
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public class CopyAndUpdateException : Exception
     public CopyAndUpdateException(MethodInfo methodInfo, MemberInfo memberWithInvalidValue)
         : this(FormatMessageForMethodAndMember(methodInfo, memberWithInvalidValue), methodInfo)
     {
-        this.memberWithInvalidValue = memberWithInvalidValue;
+        _memberWithInvalidValue = memberWithInvalidValue;
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public class CopyAndUpdateException : Exception
     public CopyAndUpdateException(MethodInfo methodInfo, ParameterInfo argumentWithNoMatchingPublicMember)
         : this(FormatMessageForMethodAndArgument(methodInfo, argumentWithNoMatchingPublicMember), methodInfo)
     {
-        this.ArgumentWithNoMatchingPublicMember = argumentWithNoMatchingPublicMember;
+        ArgumentWithNoMatchingPublicMember = argumentWithNoMatchingPublicMember;
     }
 
     /// <summary>
@@ -107,12 +107,12 @@ public class CopyAndUpdateException : Exception
     /// <summary>
     /// Gets the 'copy and update' method which is ill-behaved.
     /// </summary>
-    public MethodInfo MethodInfo => this.methodInfo;
+    public MethodInfo MethodInfo => _methodInfo;
 
     /// <summary>
     /// Gets the member which was found to have an incorrect value.
     /// </summary>
-    public MemberInfo MemberWithInvalidValue => this.memberWithInvalidValue;
+    public MemberInfo MemberWithInvalidValue => _memberWithInvalidValue;
 
     /// <summary>
     /// Gets the argument of the 'copy and update' method for which no matching public
@@ -120,8 +120,8 @@ public class CopyAndUpdateException : Exception
     /// </summary>
     public ParameterInfo ArgumentWithNoMatchingPublicMember
     {
-        get => this.argumentWithNoMatchingPublicMember;
-        set => this.argumentWithNoMatchingPublicMember = value;
+        get => _argumentWithNoMatchingPublicMember;
+        set => _argumentWithNoMatchingPublicMember = value;
     }
 
     /// <summary>
@@ -140,9 +140,9 @@ public class CopyAndUpdateException : Exception
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         base.GetObjectData(info, context);
-        info.AddValue("methodInfo", this.MethodInfo);
-        info.AddValue("memberWithInvalidValue", this.MemberWithInvalidValue);
-        info.AddValue("argumentWithNoMatchingPublicMember", this.ArgumentWithNoMatchingPublicMember);
+        info.AddValue("methodInfo", MethodInfo);
+        info.AddValue("memberWithInvalidValue", MemberWithInvalidValue);
+        info.AddValue("argumentWithNoMatchingPublicMember", ArgumentWithNoMatchingPublicMember);
     }
 
     private static string FormatMessageForMethodAndArgument(MethodInfo methodInfo, ParameterInfo argumentWithNoMatchingPublicMember)

--- a/Src/Idioms/EqualityComparerEqualsAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsAssertion.cs
@@ -31,7 +31,7 @@ public abstract class EqualityComparerEqualsAssertion : IdiomaticAssertion
     /// </remarks>
     protected EqualityComparerEqualsAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public abstract class EqualityComparerEqualsAssertion : IdiomaticAssertion
         if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
         if (!IsEqualityComparerEqualsMethod(methodInfo)) return;
 
-        this.VerifyEquals(methodInfo, methodInfo.GetParameters()[0].ParameterType);
+        VerifyEquals(methodInfo, methodInfo.GetParameters()[0].ParameterType);
     }
 
     /// <summary>

--- a/Src/Idioms/EqualityComparerEqualsNullAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsNullAssertion.cs
@@ -42,8 +42,8 @@ public class EqualityComparerEqualsNullAssertion : EqualityComparerEqualsAsserti
         if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
         if (methodInfo.ReflectedType!.IsValueType) return;
 
-        var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-        var testSubject = this.Builder.CreateAnonymous(argumentType);
+        var comparer = Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var testSubject = Builder.CreateAnonymous(argumentType);
 
         var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, null });
 

--- a/Src/Idioms/EqualityComparerEqualsNullNullAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsNullNullAssertion.cs
@@ -42,7 +42,7 @@ public class EqualityComparerEqualsNullNullAssertion : EqualityComparerEqualsAss
         if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
         if (methodInfo.ReflectedType!.IsValueType) return;
 
-        var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var comparer = Builder.CreateAnonymous(methodInfo.ReflectedType);
 
         var result = (bool)methodInfo.Invoke(comparer, new object[] { null, null });
 

--- a/Src/Idioms/EqualityComparerEqualsSelfAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsSelfAssertion.cs
@@ -41,8 +41,8 @@ public class EqualityComparerEqualsSelfAssertion : EqualityComparerEqualsAsserti
         if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
         if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
 
-        var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-        var testSubject = this.Builder.CreateAnonymous(argumentType);
+        var comparer = Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var testSubject = Builder.CreateAnonymous(argumentType);
 
         var result = (bool)methodInfo.Invoke(comparer, new[] { testSubject, testSubject });
 

--- a/Src/Idioms/EqualityComparerEqualsSymmetricAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsSymmetricAssertion.cs
@@ -41,9 +41,9 @@ public class EqualityComparerEqualsSymmetricAssertion : EqualityComparerEqualsAs
         if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
         if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
 
-        var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-        var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
-        var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
+        var comparer = Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var firstTestSubject = Builder.CreateAnonymous(argumentType);
+        var secondTestSubject = Builder.CreateAnonymous(argumentType);
 
         var directResult = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
         var invertedResult = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, firstTestSubject });

--- a/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
+++ b/Src/Idioms/EqualityComparerEqualsTransitiveAssertion.cs
@@ -41,10 +41,10 @@ public class EqualityComparerEqualsTransitiveAssertion : EqualityComparerEqualsA
         if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
         if (argumentType == null) throw new ArgumentNullException(nameof(argumentType));
 
-        var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-        var firstTestSubject = this.Builder.CreateAnonymous(argumentType);
-        var secondTestSubject = this.Builder.CreateAnonymous(argumentType);
-        var thirdTestSubject = this.Builder.CreateAnonymous(argumentType);
+        var comparer = Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var firstTestSubject = Builder.CreateAnonymous(argumentType);
+        var secondTestSubject = Builder.CreateAnonymous(argumentType);
+        var thirdTestSubject = Builder.CreateAnonymous(argumentType);
 
         var firstToSecond = (bool)methodInfo.Invoke(comparer, new[] { firstTestSubject, secondTestSubject });
         var secondToThird = (bool)methodInfo.Invoke(comparer, new[] { secondTestSubject, thirdTestSubject });

--- a/Src/Idioms/EqualityComparerGetHashCodeAssertion.cs
+++ b/Src/Idioms/EqualityComparerGetHashCodeAssertion.cs
@@ -33,7 +33,7 @@ public class EqualityComparerGetHashCodeAssertion : IdiomaticAssertion
     /// </remarks>
     public EqualityComparerGetHashCodeAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -46,8 +46,8 @@ public class EqualityComparerGetHashCodeAssertion : IdiomaticAssertion
         if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
         if (!IsEqualityComparerGetHashCode(methodInfo)) return;
 
-        var comparer = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-        var testSubject = this.Builder.CreateAnonymous(methodInfo.GetParameters()[0].ParameterType);
+        var comparer = Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var testSubject = Builder.CreateAnonymous(methodInfo.GetParameters()[0].ParameterType);
 
         var firstHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });
         var secondHashCode = (int)methodInfo.Invoke(comparer, new[] { testSubject });

--- a/Src/Idioms/EqualsNewObjectAssertion.cs
+++ b/Src/Idioms/EqualsNewObjectAssertion.cs
@@ -27,7 +27,7 @@ public class EqualsNewObjectAssertion : IdiomaticAssertion
     /// </remarks>
     public EqualsNewObjectAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class EqualsNewObjectAssertion : IdiomaticAssertion
             return;
         }
 
-        var instance = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var instance = Builder.CreateAnonymous(methodInfo.ReflectedType);
         var equalsResult = instance.Equals(new object());
         if (equalsResult)
         {

--- a/Src/Idioms/EqualsNullAssertion.cs
+++ b/Src/Idioms/EqualsNullAssertion.cs
@@ -28,7 +28,7 @@ public class EqualsNullAssertion : IdiomaticAssertion
     /// </remarks>
     public EqualsNullAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class EqualsNullAssertion : IdiomaticAssertion
             return;
         }
 
-        var instance = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var instance = Builder.CreateAnonymous(methodInfo.ReflectedType);
         var equalsResult = instance.Equals(null);
         if (equalsResult)
         {

--- a/Src/Idioms/EqualsSelfAssertion.cs
+++ b/Src/Idioms/EqualsSelfAssertion.cs
@@ -27,7 +27,7 @@ public class EqualsSelfAssertion : IdiomaticAssertion
     /// </remarks>
     public EqualsSelfAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -51,7 +51,7 @@ public class EqualsSelfAssertion : IdiomaticAssertion
             return;
         }
 
-        var instance = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var instance = Builder.CreateAnonymous(methodInfo.ReflectedType);
         var equalsResult = instance.Equals(instance);
         if (!equalsResult)
         {

--- a/Src/Idioms/EqualsSuccessiveAssertion.cs
+++ b/Src/Idioms/EqualsSuccessiveAssertion.cs
@@ -28,7 +28,7 @@ public class EqualsSuccessiveAssertion : IdiomaticAssertion
     /// </remarks>
     public EqualsSuccessiveAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -53,8 +53,8 @@ public class EqualsSuccessiveAssertion : IdiomaticAssertion
             return;
         }
 
-        var instance = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
-        var other = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var instance = Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var other = Builder.CreateAnonymous(methodInfo.ReflectedType);
 
         var results = Enumerable.Range(1, 3)
             .Select(i => instance.Equals(other))

--- a/Src/Idioms/GetHashCodeSuccessiveAssertion.cs
+++ b/Src/Idioms/GetHashCodeSuccessiveAssertion.cs
@@ -29,7 +29,7 @@ public class GetHashCodeSuccessiveAssertion : IdiomaticAssertion
     /// </remarks>
     public GetHashCodeSuccessiveAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public class GetHashCodeSuccessiveAssertion : IdiomaticAssertion
             return;
         }
 
-        var instance = this.Builder.CreateAnonymous(methodInfo.ReflectedType);
+        var instance = Builder.CreateAnonymous(methodInfo.ReflectedType);
 
         var results = Enumerable.Range(1, 3)
             .Select(i => instance.GetHashCode())

--- a/Src/Idioms/GuardClauseAssertion.cs
+++ b/Src/Idioms/GuardClauseAssertion.cs
@@ -15,7 +15,7 @@ namespace AutoFixture.Idioms;
 /// </summary>
 public class GuardClauseAssertion : IdiomaticAssertion
 {
-    private readonly OpenGenericTypeClosingUtil openGenericTypeClosingUtil;
+    private readonly OpenGenericTypeClosingUtil _openGenericTypeClosingUtil;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GuardClauseAssertion" /> class.
@@ -51,10 +51,10 @@ public class GuardClauseAssertion : IdiomaticAssertion
     /// </remarks>
     public GuardClauseAssertion(ISpecimenBuilder builder, IBehaviorExpectation behaviorExpectation)
     {
-        this.Builder = builder;
-        this.BehaviorExpectation = behaviorExpectation;
+        Builder = builder;
+        BehaviorExpectation = behaviorExpectation;
 
-        this.openGenericTypeClosingUtil = new OpenGenericTypeClosingUtil(builder);
+        _openGenericTypeClosingUtil = new OpenGenericTypeClosingUtil(builder);
     }
 
     /// <summary>
@@ -91,10 +91,10 @@ public class GuardClauseAssertion : IdiomaticAssertion
         if (constructorInfo == null)
             throw new ArgumentNullException(nameof(constructorInfo));
 
-        constructorInfo = this.openGenericTypeClosingUtil.CloseGenericType(constructorInfo);
+        constructorInfo = _openGenericTypeClosingUtil.CloseGenericType(constructorInfo);
 
         var method = new ConstructorMethod(constructorInfo);
-        this.DoVerify(method, isReturnValueDeferable: false, isReturnValueTask: false);
+        DoVerify(method, isReturnValueDeferable: false, isReturnValueTask: false);
     }
 
     /// <summary>
@@ -119,10 +119,10 @@ public class GuardClauseAssertion : IdiomaticAssertion
             methodInfo.IsAbstract)
             return;
 
-        methodInfo = this.openGenericTypeClosingUtil.CloseGenericType(methodInfo);
-        methodInfo = this.openGenericTypeClosingUtil.CloseGenericMethod(methodInfo);
+        methodInfo = _openGenericTypeClosingUtil.CloseGenericType(methodInfo);
+        methodInfo = _openGenericTypeClosingUtil.CloseGenericMethod(methodInfo);
 
-        var method = this.CreateMethod(methodInfo);
+        var method = CreateMethod(methodInfo);
         var returnType = methodInfo.ReturnType;
 
         // According to MSDN method with yield could have only 4 possible types:
@@ -139,7 +139,7 @@ public class GuardClauseAssertion : IdiomaticAssertion
         var isReturnValueTask =
             typeof(System.Threading.Tasks.Task).IsAssignableFrom(returnType);
 
-        this.DoVerify(method, isReturnValueDeferable, isReturnValueTask);
+        DoVerify(method, isReturnValueDeferable, isReturnValueTask);
     }
 
     /// <summary>
@@ -161,17 +161,17 @@ public class GuardClauseAssertion : IdiomaticAssertion
         if (propertyInfo.GetSetMethod() == null)
             return;
 
-        propertyInfo = this.openGenericTypeClosingUtil.CloseGenericType(propertyInfo);
+        propertyInfo = _openGenericTypeClosingUtil.CloseGenericType(propertyInfo);
 
-        var owner = this.CreateOwner(propertyInfo);
+        var owner = CreateOwner(propertyInfo);
         var command = new PropertySetCommand(propertyInfo, owner);
         var unwrapper = new ReflectionExceptionUnwrappingCommand(command);
-        this.BehaviorExpectation.Verify(unwrapper);
+        BehaviorExpectation.Verify(unwrapper);
     }
 
     private IMethod CreateMethod(MethodInfo methodInfo)
     {
-        var owner = this.CreateOwner(methodInfo);
+        var owner = CreateOwner(methodInfo);
         return owner != null
             ? (IMethod)new InstanceMethod(methodInfo, owner)
             : new StaticMethod(methodInfo);
@@ -179,19 +179,19 @@ public class GuardClauseAssertion : IdiomaticAssertion
 
     private object CreateOwner(PropertyInfo property)
     {
-        return this.CreateOwner(property.GetSetMethod());
+        return CreateOwner(property.GetSetMethod());
     }
 
     private object CreateOwner(MethodBase method)
     {
-        return method.IsStatic ? null : this.CreateOwner(method.ReflectedType);
+        return method.IsStatic ? null : CreateOwner(method.ReflectedType);
     }
 
     private object CreateOwner(Type type)
     {
         try
         {
-            return this.Builder.CreateAnonymous(type);
+            return Builder.CreateAnonymous(type);
         }
         catch (ObjectCreationException e)
         {
@@ -207,40 +207,40 @@ public class GuardClauseAssertion : IdiomaticAssertion
     private void DoVerify(IMethod method, bool isReturnValueDeferable, bool isReturnValueTask)
     {
         if (isReturnValueDeferable)
-            this.VerifyDeferrableIterator(method);
+            VerifyDeferrableIterator(method);
         else if (isReturnValueTask)
-            this.VerifyDeferrableTask(method);
+            VerifyDeferrableTask(method);
         else
-            this.VerifyNormal(method);
+            VerifyNormal(method);
     }
 
     private void VerifyDeferrableIterator(IMethod method)
     {
-        foreach (var command in this.GetParameterGuardCommands(method))
+        foreach (var command in GetParameterGuardCommands(method))
         {
-            this.BehaviorExpectation.Verify(new IteratorMethodInvokeCommand(command));
+            BehaviorExpectation.Verify(new IteratorMethodInvokeCommand(command));
         }
     }
 
     private void VerifyDeferrableTask(IMethod method)
     {
-        foreach (var command in this.GetParameterGuardCommands(method))
+        foreach (var command in GetParameterGuardCommands(method))
         {
-            this.BehaviorExpectation.Verify(new TaskReturnMethodInvokeCommand(command));
+            BehaviorExpectation.Verify(new TaskReturnMethodInvokeCommand(command));
         }
     }
 
     private void VerifyNormal(IMethod method)
     {
-        foreach (var command in this.GetParameterGuardCommands(method))
+        foreach (var command in GetParameterGuardCommands(method))
         {
-            this.BehaviorExpectation.Verify(command);
+            BehaviorExpectation.Verify(command);
         }
     }
 
     private IEnumerable<ReflectionExceptionUnwrappingCommand> GetParameterGuardCommands(IMethod method)
     {
-        var arguments = this.GetParameters(method);
+        var arguments = GetParameters(method);
         return from pi in method.Parameters
             where !pi.IsOut
             let expansion = new IndexedReplacement<object>(pi.Position, arguments)
@@ -256,7 +256,7 @@ public class GuardClauseAssertion : IdiomaticAssertion
         {
             try
             {
-                result.Add(this.Builder.CreateAnonymous(GetParameterType(pi)));
+                result.Add(Builder.CreateAnonymous(GetParameterType(pi)));
             }
             catch (ObjectCreationException e)
             {
@@ -288,34 +288,34 @@ public class GuardClauseAssertion : IdiomaticAssertion
         private const string Message = @"A Guard Clause test was performed on a method that returns a Task, Task<T> (possibly in an 'async' method), but the test failed. See the inner exception for more details. However, because of the async nature of the task, this test failure may look like a false positive. Perhaps you already have a Guard Clause in place, but inside the Task or inside a method marked with the 'async' keyword (if you're using C#); if this is the case, the Guard Clause is dormant, and will first be triggered when a client accesses the Result of the Task. This doesn't adhere to the Fail Fast principle, so should be addressed.
 See https://github.com/AutoFixture/AutoFixture/issues/268 for more details.";
 
-        private readonly IGuardClauseCommand command;
+        private readonly IGuardClauseCommand _command;
 
         public TaskReturnMethodInvokeCommand(IGuardClauseCommand command)
         {
-            this.command = command;
+            _command = command;
         }
 
-        public Type RequestedType => this.command.RequestedType;
+        public Type RequestedType => _command.RequestedType;
 
-        public string RequestedParameterName => this.command.RequestedParameterName;
+        public string RequestedParameterName => _command.RequestedParameterName;
 
-        public void Execute(object value) => this.command.Execute(value);
+        public void Execute(object value) => _command.Execute(value);
 
         public Exception CreateException(string value)
         {
-            var e = this.command.CreateException(value);
+            var e = _command.CreateException(value);
             return new GuardClauseException(Message, e);
         }
 
         public Exception CreateException(string value, Exception innerException)
         {
-            var e = this.command.CreateException(value, innerException);
+            var e = _command.CreateException(value, innerException);
             return new GuardClauseException(Message, e);
         }
 
         public Exception CreateException(string value, string customError, Exception innerException)
         {
-            var e = this.command.CreateException(value, customError, innerException);
+            var e = _command.CreateException(value, customError, innerException);
             return new GuardClauseException(Message, e);
         }
     }
@@ -325,34 +325,34 @@ See https://github.com/AutoFixture/AutoFixture/issues/268 for more details.";
         private const string Message = @"A Guard Clause test was performed on a method that may contain a deferred iterator block, but the test failed. See the inner exception for more details. However, because of the deferred nature of the iterator block, this test failure may look like a false positive. Perhaps you already have a Guard Clause in place, but in conjunction with the 'yield' keyword (if you're using C#); if this is the case, the Guard Clause is dormant, and will first be triggered when a client starts looping over the iterator. This doesn't adhere to the Fail Fast principle, so should be addressed.
 See e.g. http://codeblog.jonskeet.uk/2008/03/02/c-4-idea-iterator-blocks-and-parameter-checking/ for more details.";
 
-        private readonly IGuardClauseCommand command;
+        private readonly IGuardClauseCommand _command;
 
         public IteratorMethodInvokeCommand(IGuardClauseCommand command)
         {
-            this.command = command;
+            _command = command;
         }
 
-        public Type RequestedType => this.command.RequestedType;
+        public Type RequestedType => _command.RequestedType;
 
-        public string RequestedParameterName => this.command.RequestedParameterName;
+        public string RequestedParameterName => _command.RequestedParameterName;
 
-        public void Execute(object value) => this.command.Execute(value);
+        public void Execute(object value) => _command.Execute(value);
 
         public Exception CreateException(string value)
         {
-            var e = this.command.CreateException(value);
+            var e = _command.CreateException(value);
             return new GuardClauseException(Message, e);
         }
 
         public Exception CreateException(string value, Exception innerException)
         {
-            var e = this.command.CreateException(value, innerException);
+            var e = _command.CreateException(value, innerException);
             return new GuardClauseException(Message, e);
         }
 
         public Exception CreateException(string value, string customError, Exception innerException)
         {
-            var e = this.command.CreateException(value, customError, innerException);
+            var e = _command.CreateException(value, customError, innerException);
             return new GuardClauseException(Message, e);
         }
     }

--- a/Src/Idioms/IdiomaticAssertion.cs
+++ b/Src/Idioms/IdiomaticAssertion.cs
@@ -33,7 +33,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
 
         foreach (var a in assemblies)
         {
-            this.Verify(a);
+            Verify(a);
         }
     }
 
@@ -44,7 +44,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     /// <param name="assemblies">The assemblies.</param>
     public virtual void Verify(IEnumerable<Assembly> assemblies)
     {
-        this.Verify(assemblies.ToArray());
+        Verify(assemblies.ToArray());
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     {
         if (assembly == null) throw new ArgumentNullException(nameof(assembly));
 
-        this.Verify(assembly.GetExportedTypes());
+        Verify(assembly.GetExportedTypes());
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
 
         foreach (var t in types)
         {
-            this.Verify(t);
+            Verify(t);
         }
     }
 
@@ -79,7 +79,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     /// <param name="types">The types.</param>
     public virtual void Verify(IEnumerable<Type> types)
     {
-        this.Verify(types.ToArray());
+        Verify(types.ToArray());
     }
 
     /// <summary>
@@ -92,10 +92,10 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     {
         if (type == null) throw new ArgumentNullException(nameof(type));
 
-        this.Verify(type.GetConstructors());
-        this.Verify(GetMethodsForAssertion(type));
-        this.Verify(type.GetProperties());
-        this.Verify(type.GetFields());
+        Verify(type.GetConstructors());
+        Verify(GetMethodsForAssertion(type));
+        Verify(type.GetProperties());
+        Verify(type.GetFields());
     }
 
     /// <summary>
@@ -109,7 +109,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
 
         foreach (var m in memberInfos)
         {
-            this.Verify(m);
+            Verify(m);
         }
     }
 
@@ -120,7 +120,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     /// <param name="memberInfos">The members.</param>
     public virtual void Verify(IEnumerable<MemberInfo> memberInfos)
     {
-        this.Verify(memberInfos.ToArray());
+        Verify(memberInfos.ToArray());
     }
 
     /// <summary>
@@ -134,19 +134,19 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
         switch (memberInfo)
         {
             case ConstructorInfo c:
-                this.Verify(c);
+                Verify(c);
                 break;
 
             case MethodInfo m:
-                this.Verify(m);
+                Verify(m);
                 break;
 
             case PropertyInfo p:
-                this.Verify(p);
+                Verify(p);
                 break;
 
             case FieldInfo f:
-                this.Verify(f);
+                Verify(f);
                 break;
         }
     }
@@ -162,7 +162,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
 
         foreach (var c in constructorInfos)
         {
-            this.Verify(c);
+            Verify(c);
         }
     }
 
@@ -173,7 +173,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     /// <param name="constructorInfos">The constructors.</param>
     public virtual void Verify(IEnumerable<ConstructorInfo> constructorInfos)
     {
-        this.Verify(constructorInfos.ToArray());
+        Verify(constructorInfos.ToArray());
     }
 
     /// <summary>
@@ -195,7 +195,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
 
         foreach (var f in fieldInfos)
         {
-            this.Verify(f);
+            Verify(f);
         }
     }
 
@@ -206,7 +206,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     /// <param name="fieldInfos">The Fields.</param>
     public virtual void Verify(IEnumerable<FieldInfo> fieldInfos)
     {
-        this.Verify(fieldInfos.ToArray());
+        Verify(fieldInfos.ToArray());
     }
 
     /// <summary>
@@ -228,7 +228,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
 
         foreach (var m in methodInfos)
         {
-            this.Verify(m);
+            Verify(m);
         }
     }
 
@@ -239,7 +239,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     /// <param name="methodInfos">The methods.</param>
     public virtual void Verify(IEnumerable<MethodInfo> methodInfos)
     {
-        this.Verify(methodInfos.ToArray());
+        Verify(methodInfos.ToArray());
     }
 
     /// <summary>
@@ -261,7 +261,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
 
         foreach (var p in propertyInfos)
         {
-            this.Verify(p);
+            Verify(p);
         }
     }
 
@@ -272,7 +272,7 @@ public abstract class IdiomaticAssertion : IIdiomaticAssertion
     /// <param name="propertyInfos">The properties.</param>
     public virtual void Verify(IEnumerable<PropertyInfo> propertyInfos)
     {
-        this.Verify(propertyInfos.ToArray());
+        Verify(propertyInfos.ToArray());
     }
 
     /// <summary>

--- a/Src/Idioms/IndexedReplacement.cs
+++ b/Src/Idioms/IndexedReplacement.cs
@@ -28,8 +28,8 @@ public class IndexedReplacement<T> : IExpansion<T>
     /// <seealso cref="Expand" />
     public IndexedReplacement(int replacementIndex, params T[] source)
     {
-        this.ReplacementIndex = replacementIndex;
-        this.Source = source;
+        ReplacementIndex = replacementIndex;
+        Source = source;
     }
 
     /// <summary>
@@ -70,8 +70,8 @@ public class IndexedReplacement<T> : IExpansion<T>
     /// </remarks>
     public IEnumerable<T> Expand(T value)
     {
-        var list = this.Source.ToList();
-        list[this.ReplacementIndex] = value;
+        var list = Source.ToList();
+        list[ReplacementIndex] = value;
         return list;
     }
 

--- a/Src/Idioms/MethodInvokeCommand.cs
+++ b/Src/Idioms/MethodInvokeCommand.cs
@@ -21,9 +21,9 @@ public class MethodInvokeCommand : IGuardClauseCommand
     /// <param name="parameterInfo">The parameter.</param>
     public MethodInvokeCommand(IMethod method, IExpansion<object> expansion, ParameterInfo parameterInfo)
     {
-        this.Method = method;
-        this.Expansion = expansion;
-        this.ParameterInfo = parameterInfo;
+        Method = method;
+        Expansion = expansion;
+        ParameterInfo = parameterInfo;
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class MethodInvokeCommand : IGuardClauseCommand
     /// the <see cref="Execute"/> method - in this case the type of the
     /// <see cref="ParameterInfo" />.
     /// </remarks>
-    public Type RequestedType => this.ParameterInfo.ParameterType;
+    public Type RequestedType => ParameterInfo.ParameterType;
 
     /// <summary>
     /// Gets the parameter name of the requested value.
@@ -60,7 +60,7 @@ public class MethodInvokeCommand : IGuardClauseCommand
     /// the <see cref="Execute"/> method - in this case the name of the
     /// <see cref="ParameterInfo" />.
     /// </remarks>
-    public string RequestedParameterName => this.ParameterInfo.Name;
+    public string RequestedParameterName => ParameterInfo.Name;
 
     /// <summary>
     /// Invokes the method with the specified value.
@@ -74,25 +74,25 @@ public class MethodInvokeCommand : IGuardClauseCommand
     /// </remarks>
     public void Execute(object value)
     {
-        this.Method.Invoke(this.Expansion.Expand(value));
+        Method.Invoke(Expansion.Expand(value));
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value)
     {
-        return new GuardClauseException(this.CreateExceptionMessage(value));
+        return new GuardClauseException(CreateExceptionMessage(value));
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value, Exception innerException)
     {
-        return new GuardClauseException(this.CreateExceptionMessage(value), innerException);
+        return new GuardClauseException(CreateExceptionMessage(value), innerException);
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value, string customError, Exception innerException)
     {
-        return new GuardClauseException(this.CreateExceptionMessage(value, customError), innerException);
+        return new GuardClauseException(CreateExceptionMessage(value, customError), innerException);
     }
 
     private string CreateExceptionMessage(string value,
@@ -104,11 +104,11 @@ public class MethodInvokeCommand : IGuardClauseCommand
             Environment.NewLine,
             value,
             failureReason,
-            this.ParameterInfo.Name,
-            this.ParameterInfo.Member.Name,
-            this.ParameterInfo.Member,
-            this.ParameterInfo.ParameterType.AssemblyQualifiedName,
-            this.ParameterInfo.Member.DeclaringType.AssemblyQualifiedName,
-            this.ParameterInfo.Member.ReflectedType.AssemblyQualifiedName);
+            ParameterInfo.Name,
+            ParameterInfo.Member.Name,
+            ParameterInfo.Member,
+            ParameterInfo.ParameterType.AssemblyQualifiedName,
+            ParameterInfo.Member.DeclaringType.AssemblyQualifiedName,
+            ParameterInfo.Member.ReflectedType.AssemblyQualifiedName);
     }
 }

--- a/Src/Idioms/NameAndType.cs
+++ b/Src/Idioms/NameAndType.cs
@@ -16,8 +16,8 @@ internal class NameAndType
 
     public NameAndType(string name, Type type)
     {
-        this.Name = name;
-        this.Type = type;
+        Name = name;
+        Type = type;
     }
 
     public override bool Equals(object obj)
@@ -27,16 +27,16 @@ internal class NameAndType
         if (other == null)
             return base.Equals(obj);
 
-        return object.Equals(this.Type, other.Type)
-               && string.Equals(this.Name, other.Name,
+        return object.Equals(Type, other.Type)
+               && string.Equals(Name, other.Name,
                    StringComparison.OrdinalIgnoreCase);
     }
 
     public override int GetHashCode()
     {
         HashCode hashCode = default;
-        hashCode.Add(this.Type);
-        hashCode.Add(this.Name.ToUpperInvariant());
+        hashCode.Add(Type);
+        hashCode.Add(Name.ToUpperInvariant());
         return hashCode.ToHashCode();
     }
 }

--- a/Src/Idioms/NameAndTypeCollectingVisitor.cs
+++ b/Src/Idioms/NameAndTypeCollectingVisitor.cs
@@ -11,15 +11,15 @@ namespace AutoFixture.Idioms;
 /// </summary>
 internal class NameAndTypeCollectingVisitor : ReflectionVisitor<IEnumerable<NameAndType>>
 {
-    private readonly NameAndType[] values;
+    private readonly NameAndType[] _values;
 
     public NameAndTypeCollectingVisitor(
         params NameAndType[] values)
     {
-        this.values = values;
+        _values = values;
     }
 
-    public override IEnumerable<NameAndType> Value => this.values;
+    public override IEnumerable<NameAndType> Value => _values;
 
     public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
         FieldInfoElement fieldInfoElement)
@@ -29,7 +29,7 @@ internal class NameAndTypeCollectingVisitor : ReflectionVisitor<IEnumerable<Name
             fieldInfoElement.FieldInfo.Name,
             fieldInfoElement.FieldInfo.FieldType);
         return new NameAndTypeCollectingVisitor(
-            this.values.Concat(new[] { v }).ToArray());
+            _values.Concat(new[] { v }).ToArray());
     }
 
     public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
@@ -40,7 +40,7 @@ internal class NameAndTypeCollectingVisitor : ReflectionVisitor<IEnumerable<Name
             parameterInfoElement.ParameterInfo.Name,
             parameterInfoElement.ParameterInfo.ParameterType);
         return new NameAndTypeCollectingVisitor(
-            this.values.Concat(new[] { v }).ToArray());
+            _values.Concat(new[] { v }).ToArray());
     }
 
     public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
@@ -51,6 +51,6 @@ internal class NameAndTypeCollectingVisitor : ReflectionVisitor<IEnumerable<Name
             propertyInfoElement.PropertyInfo.Name,
             propertyInfoElement.PropertyInfo.PropertyType);
         return new NameAndTypeCollectingVisitor(
-            this.values.Concat(new[] { v }).ToArray());
+            _values.Concat(new[] { v }).ToArray());
     }
 }

--- a/Src/Idioms/OpenGenericTypeClosingUtil.cs
+++ b/Src/Idioms/OpenGenericTypeClosingUtil.cs
@@ -18,18 +18,18 @@ internal class OpenGenericTypeClosingUtil
 
     public OpenGenericTypeClosingUtil(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     public ConstructorInfo CloseGenericType(ConstructorInfo constructorInfo)
     {
-        return (ConstructorInfo)this.ResolveUnclosedGenericType(constructorInfo, t => t.GetConstructors());
+        return (ConstructorInfo)ResolveUnclosedGenericType(constructorInfo, t => t.GetConstructors());
     }
 
     public PropertyInfo CloseGenericType(PropertyInfo propertyInfo)
     {
         return propertyInfo.ReflectedType.ContainsGenericParameters
-            ? new AutoGenericType(this.Builder, propertyInfo.ReflectedType)
+            ? new AutoGenericType(Builder, propertyInfo.ReflectedType)
                 .Value
                 .GetProperties()
                 .Single(pi => string.Equals(pi.Name, propertyInfo.Name, StringComparison.Ordinal))
@@ -39,14 +39,14 @@ internal class OpenGenericTypeClosingUtil
     public MethodInfo CloseGenericMethod(MethodInfo methodInfo)
     {
         return methodInfo.ContainsGenericParameters
-            ? new AutoGenericMethod(this.Builder, methodInfo)
+            ? new AutoGenericMethod(Builder, methodInfo)
                 .Value
             : methodInfo;
     }
 
     public MethodInfo CloseGenericType(MethodInfo methodInfo)
     {
-        return (MethodInfo)this.ResolveUnclosedGenericType(methodInfo, t => t.GetMethods());
+        return (MethodInfo)ResolveUnclosedGenericType(methodInfo, t => t.GetMethods());
     }
 
     private MethodBase ResolveUnclosedGenericType(MethodBase method,
@@ -57,7 +57,7 @@ internal class OpenGenericTypeClosingUtil
             return method;
         }
 
-        var autoGenericType = new AutoGenericType(this.Builder, method.ReflectedType);
+        var autoGenericType = new AutoGenericType(Builder, method.ReflectedType);
         return methodSetToMatch(autoGenericType.Value).Single(c => IsMatched(c, method, autoGenericType));
     }
 
@@ -71,24 +71,24 @@ internal class OpenGenericTypeClosingUtil
 
     private class AutoGenericType
     {
-        private readonly ISpecimenBuilder specimenBuilder;
-        private readonly Type unclosedGenericType;
-        private readonly AutoGenericArgumentCollection autoGenericArguments;
+        private readonly ISpecimenBuilder _specimenBuilder;
+        private readonly Type _unclosedGenericType;
+        private readonly AutoGenericArgumentCollection _autoGenericArguments;
 
         public AutoGenericType(ISpecimenBuilder specimenBuilder, Type unclosedGenericType)
         {
-            this.specimenBuilder = specimenBuilder;
-            this.unclosedGenericType = unclosedGenericType;
-            this.autoGenericArguments = new AutoGenericArgumentCollection();
+            _specimenBuilder = specimenBuilder;
+            _unclosedGenericType = unclosedGenericType;
+            _autoGenericArguments = new AutoGenericArgumentCollection();
         }
 
         public Type Value
         {
             get
             {
-                return this.unclosedGenericType
+                return _unclosedGenericType
                     .GetGenericTypeDefinition()
-                    .MakeGenericType(this.GetTypedArguments());
+                    .MakeGenericType(GetTypedArguments());
             }
         }
 
@@ -96,24 +96,24 @@ internal class OpenGenericTypeClosingUtil
         {
             return parameterInfos.Select(
                 pi => pi.ParameterType.IsByRef
-                    ? this.ResolveUnclosedParameterType(pi.ParameterType.GetElementType()).MakeByRefType()
-                    : this.ResolveUnclosedParameterType(pi.ParameterType));
+                    ? ResolveUnclosedParameterType(pi.ParameterType.GetElementType()).MakeByRefType()
+                    : ResolveUnclosedParameterType(pi.ParameterType));
         }
 
         private Type ResolveUnclosedParameterType(Type parameterType)
         {
             if (parameterType.IsArray)
-                return this.ResolveNestedArrayParameterType(parameterType);
+                return ResolveNestedArrayParameterType(parameterType);
 
             if (parameterType.IsGenericType)
-                return this.ReosolveNestedGenericParameterType(parameterType);
+                return ReosolveNestedGenericParameterType(parameterType);
 
-            return this.ResolveGenericParameter(parameterType);
+            return ResolveGenericParameter(parameterType);
         }
 
         private Type ResolveNestedArrayParameterType(Type parameterType)
         {
-            var elementType = this.ResolveUnclosedParameterType(parameterType.GetElementType());
+            var elementType = ResolveUnclosedParameterType(parameterType.GetElementType());
             var rank = parameterType.GetArrayRank();
             return rank == 1 ? elementType.MakeArrayType() : elementType.MakeArrayType(rank);
         }
@@ -121,26 +121,26 @@ internal class OpenGenericTypeClosingUtil
         private Type ReosolveNestedGenericParameterType(Type parameterType)
         {
             var genericArguments = parameterType.GetGenericArguments();
-            var typeArguments = genericArguments.Select(this.ResolveUnclosedParameterType).ToArray();
+            var typeArguments = genericArguments.Select(ResolveUnclosedParameterType).ToArray();
             return parameterType.GetGenericTypeDefinition().MakeGenericType(typeArguments);
         }
 
         private Type ResolveGenericParameter(Type parameterType)
         {
-            return this.IsGenericTypeParameter(parameterType)
-                ? this.autoGenericArguments[parameterType.Name].Value
+            return IsGenericTypeParameter(parameterType)
+                ? _autoGenericArguments[parameterType.Name].Value
                 : parameterType;
         }
 
         private bool IsGenericTypeParameter(Type parameterType)
         {
             return parameterType.IsGenericParameter
-                   && this.autoGenericArguments.Contains(parameterType.Name);
+                   && _autoGenericArguments.Contains(parameterType.Name);
         }
 
         private Type[] GetTypedArguments()
         {
-            return this.unclosedGenericType
+            return _unclosedGenericType
                 .GetGenericArguments()
                 .Select(t =>
                 {
@@ -149,8 +149,8 @@ internal class OpenGenericTypeClosingUtil
                         return t;
                     }
 
-                    var autoGenericArgument = new AutoGenericArgument(this.specimenBuilder, t);
-                    this.autoGenericArguments.Add(autoGenericArgument);
+                    var autoGenericArgument = new AutoGenericArgument(_specimenBuilder, t);
+                    _autoGenericArguments.Add(autoGenericArgument);
                     return autoGenericArgument.Value;
                 })
                 .ToArray();
@@ -159,30 +159,30 @@ internal class OpenGenericTypeClosingUtil
 
     private class AutoGenericMethod
     {
-        private readonly ISpecimenBuilder specimenBuilder;
-        private readonly MethodInfo unclosedGenericMethod;
+        private readonly ISpecimenBuilder _specimenBuilder;
+        private readonly MethodInfo _unclosedGenericMethod;
 
         public AutoGenericMethod(ISpecimenBuilder specimenBuilder, MethodInfo unclosedGenericMethod)
         {
-            this.specimenBuilder = specimenBuilder;
-            this.unclosedGenericMethod = unclosedGenericMethod;
+            _specimenBuilder = specimenBuilder;
+            _unclosedGenericMethod = unclosedGenericMethod;
         }
 
         public MethodInfo Value
         {
             get
             {
-                return this.unclosedGenericMethod
-                    .MakeGenericMethod(this.GetTypedArguments());
+                return _unclosedGenericMethod
+                    .MakeGenericMethod(GetTypedArguments());
             }
         }
 
         private Type[] GetTypedArguments()
         {
-            return this.unclosedGenericMethod
+            return _unclosedGenericMethod
                 .GetGenericArguments()
                 .Select(t => t.IsGenericParameter
-                    ? new AutoGenericArgument(this.specimenBuilder, t).Value
+                    ? new AutoGenericArgument(_specimenBuilder, t).Value
                     : t)
                 .ToArray();
         }
@@ -200,13 +200,13 @@ internal class OpenGenericTypeClosingUtil
 
     private class AutoGenericArgument
     {
-        private readonly ISpecimenBuilder specimenBuilder;
-        private Type value;
+        private readonly ISpecimenBuilder _specimenBuilder;
+        private Type _value;
 
         public AutoGenericArgument(ISpecimenBuilder specimenBuilder, Type genericArgument)
         {
-            this.specimenBuilder = specimenBuilder;
-            this.GenericArgument = genericArgument;
+            _specimenBuilder = specimenBuilder;
+            GenericArgument = genericArgument;
         }
 
         public Type GenericArgument { get; }
@@ -215,44 +215,44 @@ internal class OpenGenericTypeClosingUtil
         {
             get
             {
-                if (this.value == null)
+                if (_value == null)
                 {
-                    this.value = new DynamicDummyType(
-                            this.specimenBuilder, this.GetBaseType(), this.GetInterfaces())
+                    _value = new DynamicDummyType(
+                            _specimenBuilder, GetBaseType(), GetInterfaces())
                         .Value;
                 }
 
-                return this.value;
+                return _value;
             }
         }
 
         private Type GetBaseType()
         {
-            if (this.HasClassConstraint())
+            if (HasClassConstraint())
             {
                 return typeof(object);
             }
 
-            return this.GetConstraintType() ?? typeof(ValueType);
+            return GetConstraintType() ?? typeof(ValueType);
         }
 
         private Type GetConstraintType()
         {
-            return this.GenericArgument
+            return GenericArgument
                 .GetGenericParameterConstraints()
                 .SingleOrDefault(t => !t.IsInterface);
         }
 
         private bool HasClassConstraint()
         {
-            return (this.GenericArgument.GenericParameterAttributes
+            return (GenericArgument.GenericParameterAttributes
                     & GenericParameterAttributes.ReferenceTypeConstraint)
                    == GenericParameterAttributes.ReferenceTypeConstraint;
         }
 
         private Type[] GetInterfaces()
         {
-            return this.GenericArgument
+            return GenericArgument
                 .GetGenericParameterConstraints()
                 .Where(t => t.IsInterface)
                 .ToArray();
@@ -263,97 +263,97 @@ internal class OpenGenericTypeClosingUtil
     {
         private const string SpecimenBuilderFieldName = "specimenBuilder";
 
-        private static readonly AssemblyBuilder AssemblyBuilder =
+        private static readonly AssemblyBuilder s_assemblyBuilder =
             AssemblyBuilder.DefineDynamicAssembly(
                 new AssemblyName("AutoFixture.DynamicProxyAssembly"),
                 AssemblyBuilderAccess.Run);
 
-        private static readonly ModuleBuilder ModuleBuilder =
-            AssemblyBuilder.DefineDynamicModule("DynamicProxyModule");
+        private static readonly ModuleBuilder s_moduleBuilder =
+            s_assemblyBuilder.DefineDynamicModule("DynamicProxyModule");
 
-        private static readonly MethodInfo FixtureCreateGenericMethod =
+        private static readonly MethodInfo s_fixtureCreateGenericMethod =
             typeof(SpecimenFactory).GetMethod("Create", new[] { typeof(ISpecimenBuilder) });
 
-        private readonly ISpecimenBuilder specimenBuilder;
-        private readonly Type baseType;
-        private readonly Type[] interfaces;
-        private ConstructorBuilder constructorBuilder;
-        private TypeBuilder typeBuilder;
-        private MethodBuilder methodBuilder;
-        private MethodInfo methodInfo;
-        private FieldBuilder specimenBuilderFieldBuilder;
-        private ConstructorInfo baseTypeConstructor;
+        private readonly ISpecimenBuilder _specimenBuilder;
+        private readonly Type _baseType;
+        private readonly Type[] _interfaces;
+        private ConstructorBuilder _constructorBuilder;
+        private TypeBuilder _typeBuilder;
+        private MethodBuilder _methodBuilder;
+        private MethodInfo _methodInfo;
+        private FieldBuilder _specimenBuilderFieldBuilder;
+        private ConstructorInfo _baseTypeConstructor;
 
         public DynamicDummyType(ISpecimenBuilder specimenBuilder, Type baseType, Type[] interfaces)
         {
-            this.specimenBuilder = specimenBuilder;
-            this.baseType = baseType;
-            this.interfaces = interfaces;
+            _specimenBuilder = specimenBuilder;
+            _baseType = baseType;
+            _interfaces = interfaces;
         }
 
         public Type Value
         {
             get
             {
-                this.DefineTypeBuilder();
-                this.ImplementDefaultConstructor();
-                this.ImplementAbstractMethods();
-                this.ImplementInterfaceMethods();
-                var dummyType = this.typeBuilder.CreateTypeInfo();
-                this.SetStaticSpecimenBuilderField(dummyType);
+                DefineTypeBuilder();
+                ImplementDefaultConstructor();
+                ImplementAbstractMethods();
+                ImplementInterfaceMethods();
+                var dummyType = _typeBuilder.CreateTypeInfo();
+                SetStaticSpecimenBuilderField(dummyType);
                 return dummyType;
             }
         }
 
         private void DefineTypeBuilder()
         {
-            lock (ModuleBuilder)
+            lock (s_moduleBuilder)
             {
-                this.typeBuilder = ModuleBuilder.DefineType(
-                    this.GetBaseTypeName(),
+                _typeBuilder = s_moduleBuilder.DefineType(
+                    GetBaseTypeName(),
                     TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed,
-                    this.baseType,
-                    this.interfaces);
+                    _baseType,
+                    _interfaces);
             }
         }
 
         private string GetBaseTypeName()
         {
 #if NET5_0_OR_GREATER
-                return this.baseType.Name + Guid.NewGuid().ToString().Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase);
+                return _baseType.Name + Guid.NewGuid().ToString().Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase);
 #else
-            return this.baseType.Name + Guid.NewGuid().ToString().Replace("-", string.Empty);
+            return _baseType.Name + Guid.NewGuid().ToString().Replace("-", string.Empty);
 #endif
         }
 
         private void ImplementDefaultConstructor()
         {
-            this.DefineConstructorBuilder();
-            this.SetBaseTypeConstructor();
-            this.EmitDefaultConstructor();
+            DefineConstructorBuilder();
+            SetBaseTypeConstructor();
+            EmitDefaultConstructor();
         }
 
         private void DefineConstructorBuilder()
         {
-            this.constructorBuilder = this.typeBuilder.DefineConstructor(
+            _constructorBuilder = _typeBuilder.DefineConstructor(
                 MethodAttributes.Public, CallingConventions.Standard, new Type[0]);
         }
 
         private void SetBaseTypeConstructor()
         {
-            this.baseTypeConstructor =
-                this.baseType
+            _baseTypeConstructor =
+                _baseType
                     .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                     .Where(c => c.IsPublic || c.IsFamilyOrAssembly || c.IsFamily)
                     .OrderBy(c => c.GetParameters().Length)
                     .FirstOrDefault();
 
-            this.EnsureBaseTypeConstructorIsAccessible();
+            EnsureBaseTypeConstructorIsAccessible();
         }
 
         private void EnsureBaseTypeConstructorIsAccessible()
         {
-            if (this.baseTypeConstructor != null)
+            if (_baseTypeConstructor != null)
             {
                 return;
             }
@@ -364,16 +364,16 @@ internal class OpenGenericTypeClosingUtil
             throw new ArgumentException(string.Format(
                 CultureInfo.CurrentCulture,
                 message,
-                this.typeBuilder.BaseType));
+                _typeBuilder.BaseType));
         }
 
         private void EmitDefaultConstructor()
         {
-            var generator = this.constructorBuilder.GetILGenerator();
-            if (this.baseTypeConstructor.GetParameters().Any())
+            var generator = _constructorBuilder.GetILGenerator();
+            if (_baseTypeConstructor.GetParameters().Any())
             {
-                this.DefineStaticSpecimenBuilderFieldBuilder();
-                this.EmitCallBaseTypeConstructor(generator);
+                DefineStaticSpecimenBuilderFieldBuilder();
+                EmitCallBaseTypeConstructor(generator);
             }
 
             generator.Emit(OpCodes.Ret);
@@ -381,12 +381,12 @@ internal class OpenGenericTypeClosingUtil
 
         private void DefineStaticSpecimenBuilderFieldBuilder()
         {
-            if (this.specimenBuilderFieldBuilder != null)
+            if (_specimenBuilderFieldBuilder != null)
             {
                 return;
             }
 
-            this.specimenBuilderFieldBuilder = this.typeBuilder.DefineField(
+            _specimenBuilderFieldBuilder = _typeBuilder.DefineField(
                 SpecimenBuilderFieldName,
                 typeof(IFixture),
                 FieldAttributes.Private | FieldAttributes.Static);
@@ -395,34 +395,34 @@ internal class OpenGenericTypeClosingUtil
         private void EmitCallBaseTypeConstructor(ILGenerator generator)
         {
             generator.Emit(OpCodes.Ldarg_0);
-            foreach (var parameterInfo in this.baseTypeConstructor.GetParameters())
+            foreach (var parameterInfo in _baseTypeConstructor.GetParameters())
             {
-                this.EmitCallFixtureCreate(generator, parameterInfo.ParameterType);
+                EmitCallFixtureCreate(generator, parameterInfo.ParameterType);
             }
 
-            generator.Emit(OpCodes.Call, this.baseTypeConstructor);
+            generator.Emit(OpCodes.Call, _baseTypeConstructor);
         }
 
         private void EmitCallFixtureCreate(ILGenerator generator, Type returnType)
         {
-            generator.Emit(OpCodes.Ldsfld, this.specimenBuilderFieldBuilder);
-            generator.Emit(OpCodes.Call, FixtureCreateGenericMethod.MakeGenericMethod(returnType));
+            generator.Emit(OpCodes.Ldsfld, _specimenBuilderFieldBuilder);
+            generator.Emit(OpCodes.Call, s_fixtureCreateGenericMethod.MakeGenericMethod(returnType));
         }
 
         private void ImplementAbstractMethods()
         {
-            foreach (MethodInfo method in this.GetAbstractMethods())
+            foreach (MethodInfo method in GetAbstractMethods())
             {
-                this.methodInfo = method;
-                this.ImplementMethod();
+                _methodInfo = method;
+                ImplementMethod();
             }
         }
 
         private void ImplementInterfaceMethods()
         {
-            foreach (var @interface in this.interfaces)
+            foreach (var @interface in _interfaces)
             {
-                this.ImplementInterfaceMethods(@interface);
+                ImplementInterfaceMethods(@interface);
             }
         }
 
@@ -430,48 +430,48 @@ internal class OpenGenericTypeClosingUtil
         {
             foreach (var method in @interface.GetMethods())
             {
-                this.methodInfo = method;
-                this.ImplementMethod();
+                _methodInfo = method;
+                ImplementMethod();
             }
 
             foreach (Type parentType in @interface.GetInterfaces())
             {
-                this.ImplementInterfaceMethods(parentType);
+                ImplementInterfaceMethods(parentType);
             }
         }
 
         private IEnumerable<MethodInfo> GetAbstractMethods()
         {
-            return this.typeBuilder.BaseType
+            return _typeBuilder.BaseType
                 .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .Where(m => m.IsAbstract);
         }
 
         private void ImplementMethod()
         {
-            this.DefineMethodBuilder();
-            this.DefineMethodGenericParameters();
-            this.DefineStaticSpecimenBuilderFieldBuilder();
-            this.EmitReturningDefaultValue();
+            DefineMethodBuilder();
+            DefineMethodGenericParameters();
+            DefineStaticSpecimenBuilderFieldBuilder();
+            EmitReturningDefaultValue();
         }
 
         private void DefineMethodBuilder()
         {
-            this.methodBuilder = this.typeBuilder.DefineMethod(
-                this.methodInfo.Name,
+            _methodBuilder = _typeBuilder.DefineMethod(
+                _methodInfo.Name,
                 MethodAttributes.Public | MethodAttributes.Virtual,
                 CallingConventions.Standard,
-                this.methodInfo.ReturnType,
-                this.methodInfo.GetParameters().Select(p => p.ParameterType).ToArray());
+                _methodInfo.ReturnType,
+                _methodInfo.GetParameters().Select(p => p.ParameterType).ToArray());
         }
 
         private void DefineMethodGenericParameters()
         {
-            var genericArguments = this.methodInfo.GetGenericArguments();
+            var genericArguments = _methodInfo.GetGenericArguments();
             if (genericArguments.Any())
             {
                 var typeParameters =
-                    this.methodBuilder.DefineGenericParameters(genericArguments.Select(a => a.Name).ToArray());
+                    _methodBuilder.DefineGenericParameters(genericArguments.Select(a => a.Name).ToArray());
                 for (int i = 0; i < genericArguments.Length; i++)
                 {
                     DefineMethodGenericConstraints(genericArguments[i], typeParameters[i]);
@@ -489,10 +489,10 @@ internal class OpenGenericTypeClosingUtil
 
         private void EmitReturningDefaultValue()
         {
-            var generator = this.methodBuilder.GetILGenerator();
-            if (this.methodBuilder.ReturnType != typeof(void))
+            var generator = _methodBuilder.GetILGenerator();
+            if (_methodBuilder.ReturnType != typeof(void))
             {
-                this.EmitCallFixtureCreate(generator, this.methodInfo.ReturnType);
+                EmitCallFixtureCreate(generator, _methodInfo.ReturnType);
             }
 
             generator.Emit(OpCodes.Ret);
@@ -500,13 +500,13 @@ internal class OpenGenericTypeClosingUtil
 
         private void SetStaticSpecimenBuilderField(Type dummyType)
         {
-            if (this.specimenBuilderFieldBuilder == null)
+            if (_specimenBuilderFieldBuilder == null)
             {
                 return;
             }
 
             dummyType.GetField(SpecimenBuilderFieldName, BindingFlags.Static | BindingFlags.NonPublic)
-                .SetValue(null, this.specimenBuilder);
+                .SetValue(null, _specimenBuilder);
         }
     }
 }

--- a/Src/Idioms/PropertySetCommand.cs
+++ b/Src/Idioms/PropertySetCommand.cs
@@ -23,8 +23,8 @@ public class PropertySetCommand : IGuardClauseCommand
     /// </remarks>
     public PropertySetCommand(PropertyInfo propertyInfo, object owner)
     {
-        this.PropertyInfo = propertyInfo;
-        this.Owner = owner;
+        PropertyInfo = propertyInfo;
+        Owner = owner;
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public class PropertySetCommand : IGuardClauseCommand
     /// the <see cref="Execute"/> method - in this case the type of the
     /// <see cref="PropertyInfo" />.
     /// </remarks>
-    public Type RequestedType => this.PropertyInfo.PropertyType;
+    public Type RequestedType => PropertyInfo.PropertyType;
 
     /// <summary>
     /// Gets the parameter name of the requested value.
@@ -65,25 +65,25 @@ public class PropertySetCommand : IGuardClauseCommand
     /// </remarks>
     public void Execute(object value)
     {
-        this.PropertyInfo.SetValue(this.Owner, value, null);
+        PropertyInfo.SetValue(Owner, value, null);
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value)
     {
-        return new GuardClauseException(this.CreateExceptionMessage(value));
+        return new GuardClauseException(CreateExceptionMessage(value));
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value, Exception innerException)
     {
-        return new GuardClauseException(this.CreateExceptionMessage(value), innerException);
+        return new GuardClauseException(CreateExceptionMessage(value), innerException);
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value, string customError, Exception innerException)
     {
-        return new GuardClauseException(this.CreateExceptionMessage(value, customError), innerException);
+        return new GuardClauseException(CreateExceptionMessage(value, customError), innerException);
     }
 
     private string CreateExceptionMessage(string value,
@@ -95,9 +95,9 @@ public class PropertySetCommand : IGuardClauseCommand
             Environment.NewLine,
             value,
             failureReason,
-            this.PropertyInfo.Name,
-            this.PropertyInfo.PropertyType.AssemblyQualifiedName,
-            this.PropertyInfo.DeclaringType.AssemblyQualifiedName,
-            this.PropertyInfo.ReflectedType.AssemblyQualifiedName);
+            PropertyInfo.Name,
+            PropertyInfo.PropertyType.AssemblyQualifiedName,
+            PropertyInfo.DeclaringType.AssemblyQualifiedName,
+            PropertyInfo.ReflectedType.AssemblyQualifiedName);
     }
 }

--- a/Src/Idioms/ReflectionExceptionUnwrappingCommand.cs
+++ b/Src/Idioms/ReflectionExceptionUnwrappingCommand.cs
@@ -16,7 +16,7 @@ public class ReflectionExceptionUnwrappingCommand : IGuardClauseCommand
     /// <param name="command">The decorated command.</param>
     public ReflectionExceptionUnwrappingCommand(IGuardClauseCommand command)
     {
-        this.Command = command;
+        Command = command;
     }
 
     /// <summary>
@@ -25,10 +25,10 @@ public class ReflectionExceptionUnwrappingCommand : IGuardClauseCommand
     public IGuardClauseCommand Command { get; }
 
     /// <inheritdoc />
-    public Type RequestedType => this.Command.RequestedType;
+    public Type RequestedType => Command.RequestedType;
 
     /// <inheritdoc />
-    public string RequestedParameterName => this.Command.RequestedParameterName;
+    public string RequestedParameterName => Command.RequestedParameterName;
 
     /// <summary>
     /// Executes the action on the decorated <see cref="Command" />. If a
@@ -40,7 +40,7 @@ public class ReflectionExceptionUnwrappingCommand : IGuardClauseCommand
     {
         try
         {
-            this.Command.Execute(value);
+            Command.Execute(value);
         }
         catch (TargetInvocationException e)
         {
@@ -51,18 +51,18 @@ public class ReflectionExceptionUnwrappingCommand : IGuardClauseCommand
     /// <inheritdoc />
     public Exception CreateException(string value)
     {
-        return this.Command.CreateException(value);
+        return Command.CreateException(value);
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value, Exception innerException)
     {
-        return this.Command.CreateException(value, innerException);
+        return Command.CreateException(value, innerException);
     }
 
     /// <inheritdoc />
     public Exception CreateException(string value, string customError, Exception innerException)
     {
-        return this.Command.CreateException(value, customError, innerException);
+        return Command.CreateException(value, customError, innerException);
     }
 }

--- a/Src/Idioms/ReflectionVisitorElementComparer.cs
+++ b/Src/Idioms/ReflectionVisitorElementComparer.cs
@@ -13,25 +13,25 @@ namespace AutoFixture.Idioms;
 /// <typeparam name="T"></typeparam>
 internal abstract class ReflectionVisitorElementComparer<T> : IEqualityComparer<IReflectionElement>
 {
-    private readonly IReflectionVisitor<IEnumerable<T>> visitor;
-    private readonly IEqualityComparer<T> comparer;
+    private readonly IReflectionVisitor<IEnumerable<T>> _visitor;
+    private readonly IEqualityComparer<T> _comparer;
 
     internal ReflectionVisitorElementComparer(
         IReflectionVisitor<IEnumerable<T>> visitor,
         IEqualityComparer<T> comparer = null)
     {
-        this.visitor = visitor;
-        this.comparer = comparer ?? EqualityComparer<T>.Default;
+        _visitor = visitor;
+        _comparer = comparer ?? EqualityComparer<T>.Default;
     }
 
     bool IEqualityComparer<IReflectionElement>.Equals(IReflectionElement x, IReflectionElement y)
     {
         var values = new CompositeReflectionElement(x, y)
-            .Accept(this.visitor)
+            .Accept(_visitor)
             .Value
             .ToArray();
 
-        var distinctValues = values.Distinct(this.comparer);
+        var distinctValues = values.Distinct(_comparer);
 
         return values.Length == 2
                && distinctValues.Count() == 1;
@@ -41,7 +41,7 @@ internal abstract class ReflectionVisitorElementComparer<T> : IEqualityComparer<
     {
         if (obj == null) throw new ArgumentNullException(nameof(obj));
         return obj
-            .Accept(this.visitor)
+            .Accept(_visitor)
             .Value
             .Single()
             .GetHashCode();

--- a/Src/Idioms/WritablePropertyAssertion.cs
+++ b/Src/Idioms/WritablePropertyAssertion.cs
@@ -37,7 +37,7 @@ public class WritablePropertyAssertion : IdiomaticAssertion
     /// </remarks>
     public WritablePropertyAssertion(ISpecimenBuilder builder)
     {
-        this.Builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        Builder = builder ?? throw new ArgumentNullException(nameof(builder));
     }
 
     /// <summary>
@@ -70,8 +70,8 @@ public class WritablePropertyAssertion : IdiomaticAssertion
         if (propertyInfo.GetSetMethod() == null)
             return;
 
-        var specimen = this.Builder.CreateAnonymous(propertyInfo.ReflectedType);
-        var propertyValue = this.Builder.CreateAnonymous(propertyInfo.PropertyType);
+        var specimen = Builder.CreateAnonymous(propertyInfo.ReflectedType);
+        var propertyValue = Builder.CreateAnonymous(propertyInfo.PropertyType);
 
         propertyInfo.SetValue(specimen, propertyValue, null);
         var result = propertyInfo.GetValue(specimen, null);

--- a/Src/Idioms/WritablePropertyException.cs
+++ b/Src/Idioms/WritablePropertyException.cs
@@ -15,7 +15,7 @@ namespace AutoFixture.Idioms;
 public class WritablePropertyException : Exception
 {
     [NonSerialized]
-    private readonly PropertyInfo propertyInfo;
+    private readonly PropertyInfo _propertyInfo;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WritablePropertyException"/> class.
@@ -36,7 +36,7 @@ public class WritablePropertyException : Exception
     public WritablePropertyException(PropertyInfo propertyInfo, string message)
         : base(message)
     {
-        this.propertyInfo = propertyInfo;
+        _propertyInfo = propertyInfo;
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class WritablePropertyException : Exception
     public WritablePropertyException(PropertyInfo propertyInfo, string message, Exception innerException)
         : base(message, innerException)
     {
-        this.propertyInfo = propertyInfo;
+        _propertyInfo = propertyInfo;
     }
 
     /// <summary>
@@ -71,7 +71,7 @@ public class WritablePropertyException : Exception
         : base(info, context)
     {
 #if SERIALIZABLE_MEMBERINFO
-            this.propertyInfo = (PropertyInfo)info.GetValue("PropertyInfo", typeof(PropertyInfo));
+            _propertyInfo = (PropertyInfo)info.GetValue("PropertyInfo", typeof(PropertyInfo));
 #endif
     }
 
@@ -81,7 +81,7 @@ public class WritablePropertyException : Exception
     /// Notice, value might null after deserialization on platforms that don't support <see cref="PropertyInfo"/> serialization.
     /// </remarks>
     /// </summary>
-    public PropertyInfo PropertyInfo => this.propertyInfo;
+    public PropertyInfo PropertyInfo => _propertyInfo;
 
     /// <summary>
     /// Adds <see cref="PropertyInfo" /> to a
@@ -101,7 +101,7 @@ public class WritablePropertyException : Exception
         base.GetObjectData(info, context);
 
 #if SERIALIZABLE_MEMBERINFO
-        info.AddValue("PropertyInfo", this.propertyInfo);
+        info.AddValue("PropertyInfo", _propertyInfo);
 #endif
     }
 

--- a/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
+++ b/Src/IdiomsUnitTest/ConstructorInitializedMemberAssertionTest.cs
@@ -601,7 +601,7 @@ public class ConstructorInitializedMemberAssertionTest
     {
         public IllBehavedPropertyMatchedByEvenPositionConstructorParameter(T1 member1, T2 member2)
         {
-            this.Member1 = member1;
+            Member1 = member1;
         }
 
         public T1 Member1 { get; }
@@ -613,7 +613,7 @@ public class ConstructorInitializedMemberAssertionTest
     {
         public IllBehavedFieldMatchedByEvenPositionConstructorParameter(T1 member1, T2 member2)
         {
-            this.Member1 = member1;
+            Member1 = member1;
         }
 
         public readonly T1 Member1;
@@ -646,23 +646,23 @@ public class ConstructorInitializedMemberAssertionTest
 
     private class WriteOnlyPropertyHolder<T>
     {
-        private T writeOnlyPropertyBackingField;
+        private T _writeOnlyPropertyBackingField;
 
         public WriteOnlyPropertyHolder(T writeOnlyProperty)
         {
-            this.writeOnlyPropertyBackingField = writeOnlyProperty;
+            _writeOnlyPropertyBackingField = writeOnlyProperty;
         }
 
         public T GetWriteOnlyProperty()
         {
-            return this.writeOnlyPropertyBackingField;
+            return _writeOnlyPropertyBackingField;
         }
 
         public T WriteOnlyProperty
         {
             set
             {
-                this.writeOnlyPropertyBackingField = value;
+                _writeOnlyPropertyBackingField = value;
             }
         }
     }
@@ -671,7 +671,7 @@ public class ConstructorInitializedMemberAssertionTest
     {
         public ComplexType()
         {
-            this.Children = new Collection<ComplexTypeChild>();
+            Children = new Collection<ComplexTypeChild>();
         }
 
         public ICollection<ComplexTypeChild> Children { get; set; }
@@ -684,16 +684,16 @@ public class ConstructorInitializedMemberAssertionTest
 
     private class PropertyIsAssignableFromConstructorArgumentType
     {
-        private readonly IEnumerable<string> bribbets;
+        private readonly IEnumerable<string> _bribbets;
 
         public PropertyIsAssignableFromConstructorArgumentType(params string[] bribbets)
         {
-            this.bribbets = bribbets;
+            _bribbets = bribbets;
         }
 
         public IEnumerable<string> Bribbets
         {
-            get { return this.bribbets; }
+            get { return _bribbets; }
         }
     }
 
@@ -703,7 +703,7 @@ public class ConstructorInitializedMemberAssertionTest
 
         public ReadOnlyFieldInitializedViaConstructorWithDifferentType(int value)
         {
-            this.Field = value.ToString(CultureInfo.CurrentCulture);
+            Field = value.ToString(CultureInfo.CurrentCulture);
         }
     }
 
@@ -713,7 +713,7 @@ public class ConstructorInitializedMemberAssertionTest
 
         public ReadOnlyFieldInitializedViaConstructor(T field)
         {
-            this.Field = field;
+            Field = field;
         }
     }
 
@@ -732,24 +732,24 @@ public class ConstructorInitializedMemberAssertionTest
     {
         public ReadOnlyPropertiesInitializedViaConstructor(T1 property1)
         {
-            this.Property1 = property1;
+            Property1 = property1;
         }
 
         public ReadOnlyPropertiesInitializedViaConstructor(T2 property2)
         {
-            this.Property2 = property2;
+            Property2 = property2;
         }
 
         public ReadOnlyPropertiesInitializedViaConstructor(T1 property1, T2 property2)
         {
-            this.Property1 = property1;
-            this.Property2 = property2;
+            Property1 = property1;
+            Property2 = property2;
         }
 
         public ReadOnlyPropertiesInitializedViaConstructor(T1 property1, T2 property2, TriState noMatchingProperty)
         {
-            this.Property1 = property1;
-            this.Property2 = property2;
+            Property1 = property1;
+            Property2 = property2;
         }
 
         public T1 Property1 { get; private set; }
@@ -778,24 +778,24 @@ public class ConstructorInitializedMemberAssertionTest
     {
         public FieldsInitializedViaConstructor(T1 field1)
         {
-            this.Field1 = field1;
+            Field1 = field1;
         }
 
         public FieldsInitializedViaConstructor(T2 field2)
         {
-            this.Field2 = field2;
+            Field2 = field2;
         }
 
         public FieldsInitializedViaConstructor(T1 field1, T2 field2)
         {
-            this.Field1 = field1;
-            this.Field2 = field2;
+            Field1 = field1;
+            Field2 = field2;
         }
 
         public FieldsInitializedViaConstructor(T1 field1, T2 field2, TriState noMatchingField)
         {
-            this.Field1 = field1;
-            this.Field2 = field2;
+            Field1 = field1;
+            Field2 = field2;
         }
 
         public T1 Field1;
@@ -806,7 +806,7 @@ public class ConstructorInitializedMemberAssertionTest
     {
         public ReadOnlyPropertyInitializedViaConstructor(T property)
         {
-            this.Property = property;
+            Property = property;
         }
 
         public T Property { get; private set; }

--- a/Src/IdiomsUnitTest/CopyAndUpdateAssertionTest.cs
+++ b/Src/IdiomsUnitTest/CopyAndUpdateAssertionTest.cs
@@ -177,24 +177,24 @@ public class CopyAndUpdateAssertionTest
 
         public ImmutableWellBehavedCopyMethods(int first, string second, ComplexMutable<int, int, int> third)
         {
-            this.First = first;
-            this.Second = second;
-            this.Third = third;
+            First = first;
+            Second = second;
+            Third = third;
         }
 
         public ImmutableWellBehavedCopyMethods WithFirst(int first)
         {
-            return new ImmutableWellBehavedCopyMethods(first, this.Second, this.Third);
+            return new ImmutableWellBehavedCopyMethods(first, Second, Third);
         }
 
         public ImmutableWellBehavedCopyMethods WithSecond(string second)
         {
-            return new ImmutableWellBehavedCopyMethods(this.First, second, this.Third);
+            return new ImmutableWellBehavedCopyMethods(First, second, Third);
         }
 
         public ImmutableWellBehavedCopyMethods WithThird(ComplexMutable<int, int, int> third)
         {
-            return new ImmutableWellBehavedCopyMethods(this.First, this.Second, third);
+            return new ImmutableWellBehavedCopyMethods(First, Second, third);
         }
     }
 
@@ -206,24 +206,24 @@ public class CopyAndUpdateAssertionTest
 
         public MutableWellBehavedCopyMethods(int first, string second, ComplexMutable<int, int, int> third)
         {
-            this.First = first;
-            this.Second = second;
-            this.Third = third;
+            First = first;
+            Second = second;
+            Third = third;
         }
 
         public MutableWellBehavedCopyMethods WithFirst(int first)
         {
-            return new MutableWellBehavedCopyMethods(first, this.Second, this.Third);
+            return new MutableWellBehavedCopyMethods(first, Second, Third);
         }
 
         public MutableWellBehavedCopyMethods WithSecond(string second)
         {
-            return new MutableWellBehavedCopyMethods(this.First, second, this.Third);
+            return new MutableWellBehavedCopyMethods(First, second, Third);
         }
 
         public MutableWellBehavedCopyMethods WithThird(ComplexMutable<int, int, int> third)
         {
-            return new MutableWellBehavedCopyMethods(this.First, this.Second, third);
+            return new MutableWellBehavedCopyMethods(First, Second, third);
         }
     }
 
@@ -235,24 +235,24 @@ public class CopyAndUpdateAssertionTest
 
         public ImmutableIllBehavedCopyMethods(int first, string second, ComplexMutable<int, int, int> third)
         {
-            this.First = first;
-            this.Second = second;
-            this.Third = third;
+            First = first;
+            Second = second;
+            Third = third;
         }
 
         public ImmutableIllBehavedCopyMethods WithFirstButSecondDefault(int first)
         {
-            return new ImmutableIllBehavedCopyMethods(first, default(string), this.Third);
+            return new ImmutableIllBehavedCopyMethods(first, default(string), Third);
         }
 
         public ImmutableIllBehavedCopyMethods WithSecondButThirdDefault(string second)
         {
-            return new ImmutableIllBehavedCopyMethods(this.First, second, default(ComplexMutable<int, int, int>));
+            return new ImmutableIllBehavedCopyMethods(First, second, default(ComplexMutable<int, int, int>));
         }
 
         public ImmutableIllBehavedCopyMethods WithThirdButFirstDefault(ComplexMutable<int, int, int> third)
         {
-            return new ImmutableIllBehavedCopyMethods(default(int), this.Second, third);
+            return new ImmutableIllBehavedCopyMethods(default(int), Second, third);
         }
     }
 
@@ -264,19 +264,19 @@ public class CopyAndUpdateAssertionTest
 
         public MutableIllBehavedCopyMethods(int first, string second, ComplexMutable<int, int, int> third)
         {
-            this.First = first;
-            this.Second = second;
-            this.Third = third;
+            First = first;
+            Second = second;
+            Third = third;
         }
 
         public MutableIllBehavedCopyMethods WithFirstButFirstDifferent(int first)
         {
-            return new MutableIllBehavedCopyMethods(first + 1, this.Second, this.Third);
+            return new MutableIllBehavedCopyMethods(first + 1, Second, Third);
         }
 
         public MutableIllBehavedCopyMethods WithSecondButSecondDifferent(string second)
         {
-            return new MutableIllBehavedCopyMethods(this.First, second + "extra unexpected", this.Third);
+            return new MutableIllBehavedCopyMethods(First, second + "extra unexpected", Third);
         }
 
         public MutableIllBehavedCopyMethods WithThirdButThirdDifferent(ComplexMutable<int, int, int> third)
@@ -287,22 +287,22 @@ public class CopyAndUpdateAssertionTest
                 Second = third.Second,
                 Third = third.Third,
             };
-            return new MutableIllBehavedCopyMethods(this.First, this.Second, differentThird);
+            return new MutableIllBehavedCopyMethods(First, Second, differentThird);
         }
 
         public MutableIllBehavedCopyMethods WithFirstButSecondDefault(int first)
         {
-            return new MutableIllBehavedCopyMethods(first, default(string), this.Third);
+            return new MutableIllBehavedCopyMethods(first, default(string), Third);
         }
 
         public MutableIllBehavedCopyMethods WithSecondButThirdDefault(string second)
         {
-            return new MutableIllBehavedCopyMethods(this.First, second, default(ComplexMutable<int, int, int>));
+            return new MutableIllBehavedCopyMethods(First, second, default(ComplexMutable<int, int, int>));
         }
 
         public MutableIllBehavedCopyMethods WithThirdButFirstDefault(ComplexMutable<int, int, int> third)
         {
-            return new MutableIllBehavedCopyMethods(default(int), this.Second, third);
+            return new MutableIllBehavedCopyMethods(default(int), Second, third);
         }
     }
 
@@ -313,13 +313,13 @@ public class CopyAndUpdateAssertionTest
 
         public ImmutableWithDifferentName(int sameName, int differentName)
         {
-            this.SameName = sameName;
-            this.DifferentNameX = differentName;
+            SameName = sameName;
+            DifferentNameX = differentName;
         }
 
         public ImmutableWithDifferentName With(int differentName)
         {
-            return new ImmutableWithDifferentName(this.SameName, differentName);
+            return new ImmutableWithDifferentName(SameName, differentName);
         }
     }
 
@@ -330,13 +330,13 @@ public class CopyAndUpdateAssertionTest
 
         public ImmutableWithDifferentType(int sameType, int differentType)
         {
-            this.SameType = sameType;
-            this.DifferentType = differentType.ToString(CultureInfo.InvariantCulture);
+            SameType = sameType;
+            DifferentType = differentType.ToString(CultureInfo.InvariantCulture);
         }
 
         public ImmutableWithDifferentType With(int differentType)
         {
-            return new ImmutableWithDifferentType(this.SameType, differentType);
+            return new ImmutableWithDifferentType(SameType, differentType);
         }
     }
 
@@ -347,8 +347,8 @@ public class CopyAndUpdateAssertionTest
 
         public ImmutableWithDifferentBoth(int sameBoth, int differentBoth)
         {
-            this.SameBoth = sameBoth;
-            this.DifferentBothX = differentBoth.ToString(CultureInfo.InvariantCulture);
+            SameBoth = sameBoth;
+            DifferentBothX = differentBoth.ToString(CultureInfo.InvariantCulture);
         }
 
         public ImmutableWithDifferentBoth With(int sameBoth, int differentBoth)

--- a/Src/IdiomsUnitTest/DelegatingBehaviorExpectation.cs
+++ b/Src/IdiomsUnitTest/DelegatingBehaviorExpectation.cs
@@ -7,13 +7,13 @@ public class DelegatingBehaviorExpectation : IBehaviorExpectation
 {
     public DelegatingBehaviorExpectation()
     {
-        this.OnVerify = c => { };
+        OnVerify = c => { };
     }
 
     public Action<IGuardClauseCommand> OnVerify { get; set; }
 
     public void Verify(IGuardClauseCommand command)
     {
-        this.OnVerify(command);
+        OnVerify(command);
     }
 }

--- a/Src/IdiomsUnitTest/DelegatingExpansion.cs
+++ b/Src/IdiomsUnitTest/DelegatingExpansion.cs
@@ -8,13 +8,13 @@ public class DelegatingExpansion<T> : IExpansion<T>
 {
     public DelegatingExpansion()
     {
-        this.OnExpand = v => new[] { v };
+        OnExpand = v => new[] { v };
     }
 
     public Func<T, IEnumerable<T>> OnExpand { get; set; }
 
     public IEnumerable<T> Expand(T value)
     {
-        return this.OnExpand(value);
+        return OnExpand(value);
     }
 }

--- a/Src/IdiomsUnitTest/DelegatingGuardClauseCommand.cs
+++ b/Src/IdiomsUnitTest/DelegatingGuardClauseCommand.cs
@@ -7,11 +7,11 @@ public class DelegatingGuardClauseCommand : IGuardClauseCommand
 {
     public DelegatingGuardClauseCommand()
     {
-        this.RequestedType = typeof(object);
-        this.OnExecute = v => { };
-        this.OnCreateException = v => new Exception();
-        this.OnCreateExceptionWithInner = (v, e) => new Exception();
-        this.OnCreateExceptionWithFailureReason = (v, r, e) => new Exception();
+        RequestedType = typeof(object);
+        OnExecute = v => { };
+        OnCreateException = v => new Exception();
+        OnCreateExceptionWithInner = (v, e) => new Exception();
+        OnCreateExceptionWithFailureReason = (v, r, e) => new Exception();
     }
 
     public Action<object> OnExecute { get; set; }
@@ -28,21 +28,21 @@ public class DelegatingGuardClauseCommand : IGuardClauseCommand
 
     public void Execute(object value)
     {
-        this.OnExecute(value);
+        OnExecute(value);
     }
 
     public Exception CreateException(string value)
     {
-        return this.OnCreateException(value);
+        return OnCreateException(value);
     }
 
     public Exception CreateException(string value, Exception innerException)
     {
-        return this.OnCreateExceptionWithInner(value, innerException);
+        return OnCreateExceptionWithInner(value, innerException);
     }
 
     public Exception CreateException(string value, string customError, Exception innerException)
     {
-        return this.OnCreateExceptionWithFailureReason(value, customError, innerException);
+        return OnCreateExceptionWithFailureReason(value, customError, innerException);
     }
 }

--- a/Src/IdiomsUnitTest/DelegatingIdiomaticAssertion.cs
+++ b/Src/IdiomsUnitTest/DelegatingIdiomaticAssertion.cs
@@ -9,27 +9,27 @@ public class DelegatingIdiomaticAssertion : IdiomaticAssertion
 {
     public DelegatingIdiomaticAssertion()
     {
-        this.OnAssemblyArrayVerify = a => { };
-        this.OnAssembliesVerify = a => { };
-        this.OnAssemblyVerify = a => { };
-        this.OnTypeArrayVerify = t => { };
-        this.OnTypesVerify = t => { };
-        this.OnTypeVerify = t => { };
-        this.OnMemberInfoArrayVerify = m => { };
-        this.OnMemberInfosVerify = m => { };
-        this.OnMemberInfoVerify = m => { };
-        this.OnConstructorInfoArrayVerify = c => { };
-        this.OnConstructorInfosVerify = c => { };
-        this.OnConstructorInfoVerify = c => { };
-        this.OnMethodInfoArrayVerify = m => { };
-        this.OnMethodInfosVerify = m => { };
-        this.OnMethodInfoVerify = m => { };
-        this.OnPropertyInfoArrayVerify = p => { };
-        this.OnPropertyInfosVerify = p => { };
-        this.OnPropertyInfoVerify = p => { };
-        this.OnFieldInfoArrayVerify = p => { };
-        this.OnFieldInfosVerify = p => { };
-        this.OnFieldInfoVerify = p => { };
+        OnAssemblyArrayVerify = a => { };
+        OnAssembliesVerify = a => { };
+        OnAssemblyVerify = a => { };
+        OnTypeArrayVerify = t => { };
+        OnTypesVerify = t => { };
+        OnTypeVerify = t => { };
+        OnMemberInfoArrayVerify = m => { };
+        OnMemberInfosVerify = m => { };
+        OnMemberInfoVerify = m => { };
+        OnConstructorInfoArrayVerify = c => { };
+        OnConstructorInfosVerify = c => { };
+        OnConstructorInfoVerify = c => { };
+        OnMethodInfoArrayVerify = m => { };
+        OnMethodInfosVerify = m => { };
+        OnMethodInfoVerify = m => { };
+        OnPropertyInfoArrayVerify = p => { };
+        OnPropertyInfosVerify = p => { };
+        OnPropertyInfoVerify = p => { };
+        OnFieldInfoArrayVerify = p => { };
+        OnFieldInfosVerify = p => { };
+        OnFieldInfoVerify = p => { };
     }
 
     public Action<Assembly[]> OnAssemblyArrayVerify { get; set; }
@@ -76,127 +76,127 @@ public class DelegatingIdiomaticAssertion : IdiomaticAssertion
 
     public override void Verify(params Assembly[] assemblies)
     {
-        this.OnAssemblyArrayVerify(assemblies);
+        OnAssemblyArrayVerify(assemblies);
         base.Verify(assemblies);
     }
 
     public override void Verify(IEnumerable<Assembly> assemblies)
     {
-        this.OnAssembliesVerify(assemblies);
+        OnAssembliesVerify(assemblies);
         base.Verify(assemblies);
     }
 
     public override void Verify(Assembly assembly)
     {
-        this.OnAssemblyVerify(assembly);
+        OnAssemblyVerify(assembly);
         base.Verify(assembly);
     }
 
     public override void Verify(params Type[] types)
     {
-        this.OnTypeArrayVerify(types);
+        OnTypeArrayVerify(types);
         base.Verify(types);
     }
 
     public override void Verify(IEnumerable<Type> types)
     {
-        this.OnTypesVerify(types);
+        OnTypesVerify(types);
         base.Verify(types);
     }
 
     public override void Verify(Type type)
     {
-        this.OnTypeVerify(type);
+        OnTypeVerify(type);
         base.Verify(type);
     }
 
     public override void Verify(params MemberInfo[] memberInfos)
     {
-        this.OnMemberInfoArrayVerify(memberInfos);
+        OnMemberInfoArrayVerify(memberInfos);
         base.Verify(memberInfos);
     }
 
     public override void Verify(IEnumerable<MemberInfo> memberInfos)
     {
-        this.OnMemberInfosVerify(memberInfos);
+        OnMemberInfosVerify(memberInfos);
         base.Verify(memberInfos);
     }
 
     public override void Verify(MemberInfo memberInfo)
     {
-        this.OnMemberInfoVerify(memberInfo);
+        OnMemberInfoVerify(memberInfo);
         base.Verify(memberInfo);
     }
 
     public override void Verify(params ConstructorInfo[] constructorInfos)
     {
-        this.OnConstructorInfoArrayVerify(constructorInfos);
+        OnConstructorInfoArrayVerify(constructorInfos);
         base.Verify(constructorInfos);
     }
 
     public override void Verify(IEnumerable<ConstructorInfo> constructorInfos)
     {
-        this.OnConstructorInfosVerify(constructorInfos);
+        OnConstructorInfosVerify(constructorInfos);
         base.Verify(constructorInfos);
     }
 
     public override void Verify(ConstructorInfo constructorInfo)
     {
-        this.OnConstructorInfoVerify(constructorInfo);
+        OnConstructorInfoVerify(constructorInfo);
         base.Verify(constructorInfo);
     }
 
     public override void Verify(params MethodInfo[] methodInfos)
     {
-        this.OnMethodInfoArrayVerify(methodInfos);
+        OnMethodInfoArrayVerify(methodInfos);
         base.Verify(methodInfos);
     }
 
     public override void Verify(IEnumerable<MethodInfo> methodInfos)
     {
-        this.OnMethodInfosVerify(methodInfos);
+        OnMethodInfosVerify(methodInfos);
         base.Verify(methodInfos);
     }
 
     public override void Verify(MethodInfo methodInfo)
     {
-        this.OnMethodInfoVerify(methodInfo);
+        OnMethodInfoVerify(methodInfo);
         base.Verify(methodInfo);
     }
 
     public override void Verify(params PropertyInfo[] propertyInfos)
     {
-        this.OnPropertyInfoArrayVerify(propertyInfos);
+        OnPropertyInfoArrayVerify(propertyInfos);
         base.Verify(propertyInfos);
     }
 
     public override void Verify(IEnumerable<PropertyInfo> propertyInfos)
     {
-        this.OnPropertyInfosVerify(propertyInfos);
+        OnPropertyInfosVerify(propertyInfos);
         base.Verify(propertyInfos);
     }
 
     public override void Verify(PropertyInfo propertyInfo)
     {
-        this.OnPropertyInfoVerify(propertyInfo);
+        OnPropertyInfoVerify(propertyInfo);
         base.Verify(propertyInfo);
     }
 
     public override void Verify(params FieldInfo[] fieldInfos)
     {
-        this.OnFieldInfoArrayVerify(fieldInfos);
+        OnFieldInfoArrayVerify(fieldInfos);
         base.Verify(fieldInfos);
     }
 
     public override void Verify(IEnumerable<FieldInfo> fieldInfos)
     {
-        this.OnFieldInfosVerify(fieldInfos);
+        OnFieldInfosVerify(fieldInfos);
         base.Verify(fieldInfos);
     }
 
     public override void Verify(FieldInfo fieldInfo)
     {
-        this.OnFieldInfoVerify(fieldInfo);
+        OnFieldInfoVerify(fieldInfo);
         base.Verify(fieldInfo);
     }
 }

--- a/Src/IdiomsUnitTest/DelegatingMethod.cs
+++ b/Src/IdiomsUnitTest/DelegatingMethod.cs
@@ -10,8 +10,8 @@ public class DelegatingMethod : IMethod
 {
     public DelegatingMethod()
     {
-        this.Parameters = Enumerable.Empty<ParameterInfo>();
-        this.OnInvoke = p => new object();
+        Parameters = Enumerable.Empty<ParameterInfo>();
+        OnInvoke = p => new object();
     }
 
     public Func<IEnumerable<object>, object> OnInvoke { get; set; }
@@ -20,6 +20,6 @@ public class DelegatingMethod : IMethod
 
     public object Invoke(IEnumerable<object> parameters)
     {
-        return this.OnInvoke(parameters);
+        return OnInvoke(parameters);
     }
 }

--- a/Src/IdiomsUnitTest/DependencyConstraints.cs
+++ b/Src/IdiomsUnitTest/DependencyConstraints.cs
@@ -26,7 +26,7 @@ public class DependencyConstraints
     {
         // Arrange
         // Act
-        var references = this.GetType().Assembly.GetReferencedAssemblies();
+        var references = GetType().Assembly.GetReferencedAssemblies();
         // Assert
         Assert.DoesNotContain(references, an => an.Name == assemblyName);
     }

--- a/Src/IdiomsUnitTest/EqualityComparerEqualsSymmetricAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerEqualsSymmetricAssertionTest.cs
@@ -115,14 +115,14 @@ public class EqualityComparerEqualsSymmetricAssertionTest
     private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
     {
 #pragma warning disable CA1805 // This explicitly demonstrates the field is initialized with a default value
-        private static bool flag = false;
+        private static bool s_flag = false;
 #pragma warning restore CA1805
 
         public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
         {
-            flag = !flag;
+            s_flag = !s_flag;
 
-            return flag;
+            return s_flag;
         }
 
         public int GetHashCode(PropertyHolder<int> obj)

--- a/Src/IdiomsUnitTest/EqualityComparerEqualsTransitiveAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerEqualsTransitiveAssertionTest.cs
@@ -115,14 +115,14 @@ public class EqualityComparerEqualsTransitiveAssertionTest
     private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
     {
 #pragma warning disable CA1805 // This explicitly initializes the flag to false.
-        private static bool flag = false;
+        private static bool s_flag = false;
 #pragma warning restore CA1805
 
         public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
         {
-            flag = !flag;
+            s_flag = !s_flag;
 
-            return flag;
+            return s_flag;
         }
 
         public int GetHashCode(PropertyHolder<int> obj)

--- a/Src/IdiomsUnitTest/EqualityComparerGetHashCodeAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualityComparerGetHashCodeAssertionTest.cs
@@ -102,7 +102,7 @@ public class EqualityComparerGetHashCodeAssertionTest
 
     private class IllBehavedEqualityComparer : IEqualityComparer<PropertyHolder<int>>
     {
-        private static readonly Random HashCodeGenerator = new Random();
+        private static readonly Random s_hashCodeGenerator = new Random();
 
         public bool Equals(PropertyHolder<int> x, PropertyHolder<int> y)
         {
@@ -111,7 +111,7 @@ public class EqualityComparerGetHashCodeAssertionTest
 
         public int GetHashCode(PropertyHolder<int> obj)
         {
-            return HashCodeGenerator.Next();
+            return s_hashCodeGenerator.Next();
         }
     }
 #pragma warning restore 659

--- a/Src/IdiomsUnitTest/EqualsSuccessiveAssertionTest.cs
+++ b/Src/IdiomsUnitTest/EqualsSuccessiveAssertionTest.cs
@@ -99,7 +99,7 @@ public class EqualsSuccessiveAssertionTest
 
         public override bool Equals(object obj)
         {
-            return ++this.EqualsCallCount % 2 == 0;
+            return ++EqualsCallCount % 2 == 0;
         }
     }
 #pragma warning restore 659

--- a/Src/IdiomsUnitTest/GetHashCodeSuccessiveAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GetHashCodeSuccessiveAssertionTest.cs
@@ -95,11 +95,11 @@ public class GetHashCodeSuccessiveAssertionTest
 
     private class IllBehavedEqualsSelfObjectOverride
     {
-        private static readonly Random HashCodeGenerator = new Random();
+        private static readonly Random s_hashCodeGenerator = new Random();
 
         public override int GetHashCode()
         {
-            return HashCodeGenerator.Next();
+            return s_hashCodeGenerator.Next();
         }
     }
 #pragma warning restore 659

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.Generics.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.Generics.cs
@@ -449,8 +449,8 @@ public partial class GuardClauseAssertionTest
 
         public ParameterizedConstructorTestType(object argument1, string argument2)
         {
-            this.Argument1 = argument1;
-            this.Argument2 = argument2;
+            Argument1 = argument1;
+            Argument2 = argument2;
         }
 
         public object Argument1 { get; }

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.Utils.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.Utils.cs
@@ -26,7 +26,7 @@ public partial class GuardClauseAssertionTest
     {
         public MemberRef(T member)
         {
-            this.Member = member;
+            Member = member;
         }
 
         public T Member { get; }
@@ -34,12 +34,12 @@ public partial class GuardClauseAssertionTest
         public override string ToString()
         {
             var str = new StringBuilder();
-            str.Append(GetNonMangledTypeName(this.Member.DeclaringType));
+            str.Append(GetNonMangledTypeName(Member.DeclaringType));
             str.Append('.');
 
-            str.Append(this.Member.Name);
+            str.Append(Member.Name);
 
-            var methodBase = this.Member as MethodBase;
+            var methodBase = Member as MethodBase;
             if (methodBase != null)
             {
                 str.Append('(');

--- a/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
+++ b/Src/IdiomsUnitTest/GuardClauseAssertionTest.cs
@@ -530,7 +530,7 @@ public partial class GuardClauseAssertionTest
         {
             public ReadOnlyCollection(params object[] items)
             {
-                this.InnerList.AddRange(items);
+                InnerList.AddRange(items);
             }
         }
 
@@ -748,12 +748,12 @@ public partial class GuardClauseAssertionTest
 
     private class TypeWithPropertyOfTypeWithoutImplementers
     {
-        private IHaveNoImplementers propertyOfTypeWithoutImplementers;
+        private IHaveNoImplementers _propertyOfTypeWithoutImplementers;
 
         public IHaveNoImplementers PropertyOfTypeWithoutImplementers
         {
-            get => this.propertyOfTypeWithoutImplementers;
-            set => this.propertyOfTypeWithoutImplementers = value ?? throw new ArgumentNullException(nameof(value));
+            get => _propertyOfTypeWithoutImplementers;
+            set => _propertyOfTypeWithoutImplementers = value ?? throw new ArgumentNullException(nameof(value));
         }
     }
 

--- a/Src/IdiomsUnitTest/IdiomaticAssertionTest.cs
+++ b/Src/IdiomsUnitTest/IdiomaticAssertionTest.cs
@@ -43,7 +43,7 @@ public class IdiomaticAssertionTest
     public void VerifyAssemblyArrayCorrectlyInvokesNextVerify()
     {
         // Arrange
-        var assemblies = new[] { this.GetType().Assembly, typeof(IdiomaticAssertion).GetType().Assembly, typeof(Fixture).GetType().Assembly };
+        var assemblies = new[] { GetType().Assembly, typeof(IdiomaticAssertion).GetType().Assembly, typeof(Fixture).GetType().Assembly };
 
         var observedAssemblies = new List<Assembly>();
         var sut = new DelegatingIdiomaticAssertion { OnAssemblyVerify = observedAssemblies.Add };
@@ -57,7 +57,7 @@ public class IdiomaticAssertionTest
     public void VerifyAssembliesCorrectlyInvokesNextVerify()
     {
         // Arrange
-        var assemblies = new[] { typeof(IdiomaticAssertion).GetType().Assembly, this.GetType().Assembly, typeof(Fixture).GetType().Assembly }.AsEnumerable();
+        var assemblies = new[] { typeof(IdiomaticAssertion).GetType().Assembly, GetType().Assembly, typeof(Fixture).GetType().Assembly }.AsEnumerable();
 
         var observedAssemblies = new List<Assembly>();
         var sut = new DelegatingIdiomaticAssertion { OnAssemblyVerify = observedAssemblies.Add };
@@ -81,7 +81,7 @@ public class IdiomaticAssertionTest
     public void VerifyAssemblyCorrectlyInvokesNextVerify()
     {
         // Arrange
-        var assembly = this.GetType().Assembly;
+        var assembly = GetType().Assembly;
         var expectedTypes = assembly.GetExportedTypes();
 
         var mockVerified = false;

--- a/Src/IdiomsUnitTest/IndexedReplacementTest.cs
+++ b/Src/IdiomsUnitTest/IndexedReplacementTest.cs
@@ -24,7 +24,7 @@ public abstract class IndexedReplacementTest<T>
     {
         // Arrange
         var dummyIndex = 0;
-        var source = Enumerable.Range(1, 3).Select(i => this.CreateItem()).ToList().AsEnumerable();
+        var source = Enumerable.Range(1, 3).Select(i => CreateItem()).ToList().AsEnumerable();
         var sut = new IndexedReplacement<T>(dummyIndex, source);
         // Act
         IEnumerable<T> result = sut.Source;
@@ -37,7 +37,7 @@ public abstract class IndexedReplacementTest<T>
     {
         // Arrange
         var dummyIndex = 0;
-        var source = Enumerable.Range(1, 3).Select(i => this.CreateItem()).ToArray();
+        var source = Enumerable.Range(1, 3).Select(i => CreateItem()).ToArray();
         var sut = new IndexedReplacement<T>(dummyIndex, source);
         // Act
         IEnumerable<T> result = sut.Source;
@@ -82,10 +82,10 @@ public abstract class IndexedReplacementTest<T>
     public void ExpandReturnsCorrectResult(int replacementIndex)
     {
         // Arrange
-        var source = Enumerable.Range(1, 3).Select(i => this.CreateItem()).ToList();
+        var source = Enumerable.Range(1, 3).Select(i => CreateItem()).ToList();
         var sut = new IndexedReplacement<T>(replacementIndex, source);
         // Act
-        var replacementValue = this.CreateItem();
+        var replacementValue = CreateItem();
         var result = sut.Expand(replacementValue);
         // Assert
         var expected = source.ToList();
@@ -106,11 +106,11 @@ public class IndexedReplacementTestOfObject : IndexedReplacementTest<object>
 
 public class IndexedReplacementTestOfInt : IndexedReplacementTest<int>
 {
-    private int i;
+    private int _i;
 
     protected override int CreateItem()
     {
-        return this.i++;
+        return _i++;
     }
 }
 

--- a/Src/IdiomsUnitTest/Scenario.cs
+++ b/Src/IdiomsUnitTest/Scenario.cs
@@ -141,8 +141,8 @@ public class Scenario
         public PublicPropertiesAreAssignableFromConstructorParameterTypes(
             string[] bribbets, int[] numbers)
         {
-            this.Bribbets = bribbets;
-            this.Numbers = numbers;
+            Bribbets = bribbets;
+            Numbers = numbers;
         }
 
         public IEnumerable<string> Bribbets { get; private set; }
@@ -157,7 +157,7 @@ public class Scenario
         public PublicPropertiesAreAssignableFromConstructorParameterTypes WithNumbers(int[] numbers)
         {
             return new PublicPropertiesAreAssignableFromConstructorParameterTypes(
-                (string[])this.Bribbets, numbers);
+                (string[])Bribbets, numbers);
         }
     }
 
@@ -165,8 +165,8 @@ public class Scenario
     {
         public NameAndType(string name, Type type)
         {
-            this.Name = name;
-            this.Type = type;
+            Name = name;
+            Type = type;
         }
 
         public string Name { get; private set; }
@@ -190,17 +190,17 @@ public class Scenario
     private class NameAndTypeCollectingVisitor
         : ReflectionVisitor<IEnumerable<NameAndType>>
     {
-        private readonly NameAndType[] values;
+        private readonly NameAndType[] _values;
 
         public NameAndTypeCollectingVisitor(
             params NameAndType[] values)
         {
-            this.values = values;
+            _values = values;
         }
 
         public override IEnumerable<NameAndType> Value
         {
-            get { return this.values; }
+            get { return _values; }
         }
 
         public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
@@ -211,7 +211,7 @@ public class Scenario
                 fieldInfoElement.FieldInfo.Name,
                 fieldInfoElement.FieldInfo.FieldType);
             return new NameAndTypeCollectingVisitor(
-                this.values.Concat(new[] { v }).ToArray());
+                _values.Concat(new[] { v }).ToArray());
         }
 
         public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
@@ -222,7 +222,7 @@ public class Scenario
                 parameterInfoElement.ParameterInfo.Name,
                 parameterInfoElement.ParameterInfo.ParameterType);
             return new NameAndTypeCollectingVisitor(
-                this.values.Concat(new[] { v }).ToArray());
+                _values.Concat(new[] { v }).ToArray());
         }
 
         public override IReflectionVisitor<IEnumerable<NameAndType>> Visit(
@@ -233,31 +233,31 @@ public class Scenario
                 propertyInfoElement.PropertyInfo.Name,
                 propertyInfoElement.PropertyInfo.PropertyType);
             return new NameAndTypeCollectingVisitor(
-                this.values.Concat(new[] { v }).ToArray());
+                _values.Concat(new[] { v }).ToArray());
         }
     }
 
     private class VisitorEqualityComparer<T> : IEqualityComparer<IReflectionElement>
     {
-        private readonly IReflectionVisitor<IEnumerable<T>> visitor;
-        private readonly IEqualityComparer<T> comparer;
+        private readonly IReflectionVisitor<IEnumerable<T>> _visitor;
+        private readonly IEqualityComparer<T> _comparer;
 
         internal VisitorEqualityComparer(
             IReflectionVisitor<IEnumerable<T>> visitor,
             IEqualityComparer<T> comparer)
         {
-            this.visitor = visitor;
-            this.comparer = comparer;
+            _visitor = visitor;
+            _comparer = comparer;
         }
 
         bool IEqualityComparer<IReflectionElement>.Equals(IReflectionElement x, IReflectionElement y)
         {
             var values = new CompositeReflectionElement(x, y)
-                .Accept(this.visitor)
+                .Accept(_visitor)
                 .Value
                 .ToArray();
 
-            var distinctValues = values.Distinct(this.comparer);
+            var distinctValues = values.Distinct(_comparer);
             return values.Length == 2
                    && distinctValues.Count() == 1;
         }
@@ -266,7 +266,7 @@ public class Scenario
         {
             if (obj == null) throw new ArgumentNullException(nameof(obj));
             return obj
-                .Accept(this.visitor)
+                .Accept(_visitor)
                 .Value
                 .Single()
                 .GetHashCode();

--- a/Src/TestTypeFoundation/AbstractGenericType.cs
+++ b/Src/TestTypeFoundation/AbstractGenericType.cs
@@ -4,7 +4,7 @@ public abstract class AbstractGenericType<T>
 {
     protected AbstractGenericType(T t)
     {
-        this.Value = t;
+        Value = t;
     }
 
     public T Value { get; }

--- a/Src/TestTypeFoundation/AbstractTypeWithConstructorWithMultipleParameters.cs
+++ b/Src/TestTypeFoundation/AbstractTypeWithConstructorWithMultipleParameters.cs
@@ -6,8 +6,8 @@ public abstract class AbstractTypeWithConstructorWithMultipleParameters<T1, T2>
         T1 parameter1,
         T2 parameter2)
     {
-        this.Property1 = parameter1;
-        this.Property2 = parameter2;
+        Property1 = parameter1;
+        Property2 = parameter2;
     }
 
     public T1 Property1 { get; }

--- a/Src/TestTypeFoundation/AbstractTypeWithNonDefaultConstructor.cs
+++ b/Src/TestTypeFoundation/AbstractTypeWithNonDefaultConstructor.cs
@@ -11,7 +11,7 @@ public abstract class AbstractTypeWithNonDefaultConstructor<T>
             throw new ArgumentNullException(nameof(value));
         }
 
-        this.Property = value;
+        Property = value;
     }
 
     public T Property { get; }

--- a/Src/TestTypeFoundation/CollectionHolder.cs
+++ b/Src/TestTypeFoundation/CollectionHolder.cs
@@ -6,7 +6,7 @@ public class CollectionHolder<T>
 {
     public CollectionHolder()
     {
-        this.Collection = new List<T>();
+        Collection = new List<T>();
     }
 
     public ICollection<T> Collection { get; private set; }

--- a/Src/TestTypeFoundation/CompositeType.cs
+++ b/Src/TestTypeFoundation/CompositeType.cs
@@ -18,7 +18,7 @@ public class CompositeType : AbstractType
             throw new ArgumentNullException(nameof(types));
         }
 
-        this.Types = types;
+        Types = types;
     }
 
     public IEnumerable<AbstractType> Types { get; }

--- a/Src/TestTypeFoundation/ConcreteType.cs
+++ b/Src/TestTypeFoundation/ConcreteType.cs
@@ -8,28 +8,28 @@ public class ConcreteType : AbstractType
 
     public ConcreteType(object obj)
     {
-        this.Property1 = obj;
+        Property1 = obj;
     }
 
     public ConcreteType(object obj1, object obj2)
     {
-        this.Property1 = obj1;
-        this.Property2 = obj2;
+        Property1 = obj1;
+        Property2 = obj2;
     }
 
     public ConcreteType(object obj1, object obj2, object obj3)
     {
-        this.Property1 = obj1;
-        this.Property2 = obj2;
-        this.Property3 = obj3;
+        Property1 = obj1;
+        Property2 = obj2;
+        Property3 = obj3;
     }
 
     public ConcreteType(object obj1, object obj2, object obj3, object obj4)
     {
-        this.Property1 = obj1;
-        this.Property2 = obj2;
-        this.Property3 = obj3;
-        this.Property4 = obj4;
+        Property1 = obj1;
+        Property2 = obj2;
+        Property3 = obj3;
+        Property4 = obj4;
     }
 
     public override object Property4 { get; set; }

--- a/Src/TestTypeFoundation/DoubleParameterType.cs
+++ b/Src/TestTypeFoundation/DoubleParameterType.cs
@@ -4,8 +4,8 @@ public class DoubleParameterType<T1, T2>
 {
     public DoubleParameterType(T1 parameter1, T2 parameter2)
     {
-        this.Parameter1 = parameter1;
-        this.Parameter2 = parameter2;
+        Parameter1 = parameter1;
+        Parameter2 = parameter2;
     }
 
     public T1 Parameter1 { get; private set; }

--- a/Src/TestTypeFoundation/EqualityResponder.cs
+++ b/Src/TestTypeFoundation/EqualityResponder.cs
@@ -2,20 +2,20 @@
 
 public class EqualityResponder
 {
-    private readonly bool equals;
+    private readonly bool _equals;
 
     public EqualityResponder(bool equals)
     {
-        this.equals = equals;
+        _equals = equals;
     }
 
     public override bool Equals(object obj)
     {
-        return this.equals;
+        return _equals;
     }
 
     public override int GetHashCode()
     {
-        return this.equals.GetHashCode();
+        return _equals.GetHashCode();
     }
 }

--- a/Src/TestTypeFoundation/GenericType.cs
+++ b/Src/TestTypeFoundation/GenericType.cs
@@ -12,7 +12,7 @@ public class GenericType<T>
             throw new ArgumentNullException(nameof(t));
         }
 
-        this.Value = t;
+        Value = t;
     }
 
     private T Value { get; }

--- a/Src/TestTypeFoundation/GuardedConstructorHost.cs
+++ b/Src/TestTypeFoundation/GuardedConstructorHost.cs
@@ -12,7 +12,7 @@ public class GuardedConstructorHost<T>
             throw new ArgumentNullException(nameof(item));
         }
 
-        this.Item = item;
+        Item = item;
     }
 
     public T Item { get; }

--- a/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyField.cs
+++ b/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyField.cs
@@ -14,7 +14,7 @@ public class GuardedConstructorHostHoldingStaticReadOnlyField<TItem, TStaticFiel
             throw new ArgumentNullException(nameof(item));
         }
 
-        this.Item = item;
+        Item = item;
     }
 
     public TItem Item { get; private set; }

--- a/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyProperty.cs
+++ b/Src/TestTypeFoundation/GuardedConstructorHostHoldingStaticReadOnlyProperty.cs
@@ -17,7 +17,7 @@ public class GuardedConstructorHostHoldingStaticReadOnlyProperty<TItem, TStaticP
             throw new ArgumentNullException(nameof(item));
         }
 
-        this.Item = item;
+        Item = item;
     }
 
     public static TStaticProperty Property { get; private set; }

--- a/Src/TestTypeFoundation/GuardedPropertyHolder.cs
+++ b/Src/TestTypeFoundation/GuardedPropertyHolder.cs
@@ -5,13 +5,13 @@ namespace TestTypeFoundation;
 public class GuardedPropertyHolder<T>
     where T : class
 {
-    private T property;
+    private T _property;
 
     public T Property
     {
         get
         {
-            return this.property;
+            return _property;
         }
 
         set
@@ -21,7 +21,7 @@ public class GuardedPropertyHolder<T>
                 throw new ArgumentNullException(nameof(value));
             }
 
-            this.property = value;
+            _property = value;
         }
     }
 }

--- a/Src/TestTypeFoundation/IllBehavedPropertyHolder.cs
+++ b/Src/TestTypeFoundation/IllBehavedPropertyHolder.cs
@@ -2,7 +2,7 @@ namespace TestTypeFoundation;
 
 public class IllBehavedPropertyHolder<T>
 {
-    private T propertyIllBehavedSet;
+    private T _propertyIllBehavedSet;
 
     public T PropertyIllBehavedGet
     {
@@ -20,12 +20,12 @@ public class IllBehavedPropertyHolder<T>
     {
         get
         {
-            return this.propertyIllBehavedSet;
+            return _propertyIllBehavedSet;
         }
 
         set
         {
-            this.propertyIllBehavedSet = default(T);
+            _propertyIllBehavedSet = default(T);
         }
     }
 }

--- a/Src/TestTypeFoundation/IndexedPropertyHolder.cs
+++ b/Src/TestTypeFoundation/IndexedPropertyHolder.cs
@@ -4,16 +4,16 @@ namespace TestTypeFoundation;
 
 public class IndexedPropertyHolder<T>
 {
-    private readonly List<T> items;
+    private readonly List<T> _items;
 
     public IndexedPropertyHolder()
     {
-        this.items = new List<T>();
+        _items = new List<T>();
     }
 
     public T this[int index]
     {
-        get { return this.items[index]; }
-        set { this.items[index] = value; }
+        get { return _items[index]; }
+        set { _items[index] = value; }
     }
 }

--- a/Src/TestTypeFoundation/InternalGetterPropertyHolder.cs
+++ b/Src/TestTypeFoundation/InternalGetterPropertyHolder.cs
@@ -4,7 +4,7 @@ public class InternalGetterPropertyHolder<T>
 {
     public InternalGetterPropertyHolder(T property)
     {
-        this.Property = property;
+        Property = property;
     }
 
     public T Property { internal get; set; }

--- a/Src/TestTypeFoundation/ItemContainer.cs
+++ b/Src/TestTypeFoundation/ItemContainer.cs
@@ -7,7 +7,7 @@ public class ItemContainer<T>
 {
     public ItemContainer(params T[] items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public ItemContainer(IEnumerable<T> items)

--- a/Src/TestTypeFoundation/ItemHolder.cs
+++ b/Src/TestTypeFoundation/ItemHolder.cs
@@ -20,8 +20,8 @@ public class ItemHolder<T1, T2>
 
     private ItemHolder(T1[] t1s, T2[] t2s)
     {
-        this.Item1s = t1s;
-        this.Item2s = t2s;
+        Item1s = t1s;
+        Item2s = t2s;
     }
 
     public IEnumerable<T1> Item1s { get; }
@@ -55,7 +55,7 @@ public class ItemHolder<T>
 
     private ItemHolder(T[] items)
     {
-        this.Items = items;
+        Items = items;
     }
 
     public IEnumerable<T> Items { get; }

--- a/Src/TestTypeFoundation/MultiUnorderedConstructorType.cs
+++ b/Src/TestTypeFoundation/MultiUnorderedConstructorType.cs
@@ -21,8 +21,8 @@ public class MultiUnorderedConstructorType
             throw new ArgumentNullException(nameof(text));
         }
 
-        this.Text = text;
-        this.Number = number;
+        Text = text;
+        Number = number;
     }
 
     public string Text { get; }
@@ -38,8 +38,8 @@ public class MultiUnorderedConstructorType
                 throw new ArgumentNullException(nameof(text));
             }
 
-            this.Text = text;
-            this.Number = number;
+            Text = text;
+            Number = number;
         }
 
         public string Text { get; }

--- a/Src/TestTypeFoundation/MutableValueType.cs
+++ b/Src/TestTypeFoundation/MutableValueType.cs
@@ -5,9 +5,9 @@ public struct MutableValueType
     public MutableValueType(object property1, object property2, object property3)
         : this()
     {
-        this.Property1 = property1;
-        this.Property2 = property2;
-        this.Property3 = property3;
+        Property1 = property1;
+        Property2 = property2;
+        Property3 = property3;
     }
 
     public object Property1 { get; set; }

--- a/Src/TestTypeFoundation/NonCompliantCollectionHolder.cs
+++ b/Src/TestTypeFoundation/NonCompliantCollectionHolder.cs
@@ -6,7 +6,7 @@ public class NonCompliantCollectionHolder<T>
 {
     public NonCompliantCollectionHolder()
     {
-        this.Collection = new List<T>();
+        Collection = new List<T>();
     }
 
     public ICollection<T> Collection { get; set; }

--- a/Src/TestTypeFoundation/PropertyHolder.cs
+++ b/Src/TestTypeFoundation/PropertyHolder.cs
@@ -8,7 +8,7 @@ public class PropertyHolder<T>
 
     public void SetProperty(T value)
     {
-        this.Property = value;
+        Property = value;
     }
 
     public static PropertyInfo GetProperty()

--- a/Src/TestTypeFoundation/QuadrupleParameterType.cs
+++ b/Src/TestTypeFoundation/QuadrupleParameterType.cs
@@ -4,10 +4,10 @@ public class QuadrupleParameterType<T1, T2, T3, T4>
 {
     public QuadrupleParameterType(T1 parameter1, T2 parameter2, T3 parameter3, T4 parameter4)
     {
-        this.Parameter1 = parameter1;
-        this.Parameter2 = parameter2;
-        this.Parameter3 = parameter3;
-        this.Parameter4 = parameter4;
+        Parameter1 = parameter1;
+        Parameter2 = parameter2;
+        Parameter3 = parameter3;
+        Parameter4 = parameter4;
     }
 
     public T1 Parameter1 { get; private set; }

--- a/Src/TestTypeFoundation/RecordType.cs
+++ b/Src/TestTypeFoundation/RecordType.cs
@@ -7,7 +7,7 @@ public class RecordType<T> : IEquatable<RecordType<T>>
 {
     public RecordType(T value)
     {
-        this.Value = value;
+        Value = value;
     }
 
     public T Value { get; }
@@ -16,16 +16,16 @@ public class RecordType<T> : IEquatable<RecordType<T>>
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
-        return EqualityComparer<T>.Default.Equals(this.Value, other.Value);
+        return EqualityComparer<T>.Default.Equals(Value, other.Value);
     }
 
     public override bool Equals(object obj)
     {
-        return this.Equals(obj as RecordType<T>);
+        return Equals(obj as RecordType<T>);
     }
 
     public override int GetHashCode()
     {
-        return EqualityComparer<T>.Default.GetHashCode(this.Value);
+        return EqualityComparer<T>.Default.GetHashCode(Value);
     }
 }

--- a/Src/TestTypeFoundation/SingleParameterType.cs
+++ b/Src/TestTypeFoundation/SingleParameterType.cs
@@ -4,7 +4,7 @@ public class SingleParameterType<T>
 {
     public SingleParameterType(T parameter)
     {
-        this.Parameter = parameter;
+        Parameter = parameter;
     }
 
     public T Parameter { get; private set; }

--- a/Src/TestTypeFoundation/TripleParameterType.cs
+++ b/Src/TestTypeFoundation/TripleParameterType.cs
@@ -4,9 +4,9 @@ public class TripleParameterType<T1, T2, T3>
 {
     public TripleParameterType(T1 parameter1, T2 parameter2, T3 parameter3)
     {
-        this.Parameter1 = parameter1;
-        this.Parameter2 = parameter2;
-        this.Parameter3 = parameter3;
+        Parameter1 = parameter1;
+        Parameter2 = parameter2;
+        Parameter3 = parameter3;
     }
 
     public T1 Parameter1 { get; private set; }

--- a/Src/TestTypeFoundation/TypeWithIndexer.cs
+++ b/Src/TestTypeFoundation/TypeWithIndexer.cs
@@ -4,22 +4,22 @@ namespace TestTypeFoundation;
 
 public class TypeWithIndexer
 {
-    private readonly Dictionary<string, string> dict;
+    private readonly Dictionary<string, string> _dict;
 
     public TypeWithIndexer()
     {
-        this.dict = new Dictionary<string, string>();
+        _dict = new Dictionary<string, string>();
     }
 
     public string this[string index]
     {
         get
         {
-            return this.dict[index];
+            return _dict[index];
         }
         set
         {
-            this.dict[index] = value;
+            _dict[index] = value;
         }
     }
 }

--- a/Src/TestTypeFoundation/UnguardedConstructorHost.cs
+++ b/Src/TestTypeFoundation/UnguardedConstructorHost.cs
@@ -7,7 +7,7 @@ public class UnguardedConstructorHost<T>
 {
     public UnguardedConstructorHost(T item)
     {
-        this.Item = item;
+        Item = item;
     }
 
     public T Item { get; }


### PR DESCRIPTION
### Description
Avoid usage of `this` keyword to modernize the look and feel of the solution.

Additionally added rules to the `editorconfig`, so now naming is checked on build

