### PR TITLE
Remove non-required ThreadStatic attribute

### DIFF
--- a/Src/AutoFixtureUnitTest/UseCultureAttribute.cs
+++ b/Src/AutoFixtureUnitTest/UseCultureAttribute.cs
@@ -8,11 +8,9 @@ namespace AutoFixtureUnitTest;
 
 public class UseCultureAttribute : BeforeAfterTestAttribute
 {
-    [ThreadStatic]
-    private static CultureInfo s_originalCulture_t;
+    private CultureInfo _originalCulture;
 
-    [ThreadStatic]
-    private static CultureInfo s_originalUiCulture_t;
+    private CultureInfo _originalUiCulture;
 
     private readonly CultureInfo _culture;
     private readonly CultureInfo _uiCulture;
@@ -30,15 +28,15 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
 
     public override void Before(MethodInfo methodUnderTest)
     {
-        s_originalCulture_t = CultureInfo.CurrentCulture;
-        s_originalUiCulture_t = CultureInfo.CurrentCulture;
+        _originalCulture = CultureInfo.CurrentCulture;
+        _originalUiCulture = CultureInfo.CurrentCulture;
 
         SetCurrentCulture(_culture, _uiCulture);
     }
 
     public override void After(MethodInfo methodUnderTest)
     {
-        SetCurrentCulture(s_originalCulture_t, s_originalUiCulture_t);
+        SetCurrentCulture(_originalCulture, _originalUiCulture);
     }
 
     private static void SetCurrentCulture(CultureInfo culture, CultureInfo uiCulture)
@@ -47,8 +45,8 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
         Thread.CurrentThread.CurrentCulture = culture;
         Thread.CurrentThread.CurrentUICulture = uiCulture;
 #elif SYSTEM_GLOBALIZATION_CULTUREINFO_CULTURESETTERS
-            CultureInfo.CurrentCulture = culture;
-            CultureInfo.CurrentUICulture = uiCulture;
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = uiCulture;
 #else
 #error No culture setter is defined.
 #endif


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
This attribute is not really needed, and tests pass happily without it. Clean it to simplify code and remove the single place in our codebase where we have `ThreadStatic`
