### PR TITLE
Re-enable publishing of xUnit3 and NUnit4

### DIFF
--- a/src/AutoFixture.NUnit4/AutoFixture.NUnit4.csproj
+++ b/src/AutoFixture.NUnit4/AutoFixture.NUnit4.csproj
@@ -9,7 +9,6 @@
     <PackageId>AutoFixture.NUnit4</PackageId>
     <Title>AutoFixture with NUnit4</Title>
     <Description>By leveraging some features of NUnit4, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AutoFixture.xUnit3/AutoFixture.xUnit3.csproj
+++ b/src/AutoFixture.xUnit3/AutoFixture.xUnit3.csproj
@@ -9,7 +9,6 @@
     <PackageId>AutoFixture.Xunit3</PackageId>
     <Title>AutoFixture with xUnit.net v3 data theories</Title>
     <Description>By leveraging the data theory feature of xUnit.net, this extension turns AutoFixture into a declarative framework for writing unit tests. In many ways it becomes a unit testing DSL (Domain Specific Language).</Description>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
Re-enable publishing for xUnit3 and NUnit4 packages, as they are going to be shipped a part of the mono-repo.

Once this PR is merged, I'll remove the following projects (they don't contain any new changes):
- https://github.com/AutoFixture/AutoFixture.xUnit3
- https://github.com/AutoFixture/AutoFixture.NUnit4

I've already made them non-visible. But I suggest to remove them to avoid confusion.

@aivascu Don't be sad that I remove it - I've re-used all your work when I migrated the rest to standalone projects. So it's not lost!