### PR TITLE
Add devcontainer for VS Code

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+# Is needed for Claude to allow bypassing permissions
+ENV IS_SANDBOX 1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": ".NET SDK",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  	"build": { "dockerfile": "Dockerfile" },
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"JetBrains.resharper-code",
+				"Anthropic.claude-code"
+			],
+			"settings": {
+				"claudeCode.initialPermissionMode": "bypassPermissions",
+				"claudeCode.allowDangerouslySkipPermissions": true,
+				"claudeCode.hideOnboarding": true
+			}
+		}
+	},
+
+	"mounts": [
+		"source=${localEnv:USERPROFILE}/.claude,target=/root/.claude,type=bind,consistency=cached"
+	]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
Add VS Code Dev Container configuration. Is useful to run Claude in a sandboxed environment. I do mount local `.claude` folder into the container, so you don't have to configure it there.
