### PR TITLE
Suppress false-positive xUnit analyzer

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -21,6 +21,11 @@
 
     <!--Prevents failing cross target NuGet package restores-->
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+
+    <!--
+      xUnit1003: Theory methods must have test data - xUnit does not support our custom data attributes
+    -->
+    <NoWarn>$(NoWarn);xUnit1003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
xUnit analyzer doesn't recognize our data attributes, so just suppress the warning.
