### PR TITLE
Update unit tests to xUnit 3

### DIFF
--- a/tests/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
+++ b/tests/AutoFakeItEasyUnitTest/AutoFakeItEasyUnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsXUnit2>true</IsXUnit2>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <IsXUnit3>true</IsXUnit3>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>AutoFakeItEasy.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoFakeItEasy.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoFakeItEasy.UnitTest</RootNamespace>

--- a/tests/AutoFixture.NUnit4.UnitTest/AutoFixture.NUnit4.UnitTest.csproj
+++ b/tests/AutoFixture.NUnit4.UnitTest/AutoFixture.NUnit4.UnitTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>AutoFixture.NUnit4.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.NUnit4.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.NUnit4.UnitTest</RootNamespace>

--- a/tests/AutoFixture.SeedExtensions.UnitTest/AutoFixture.SeedExtensions.UnitTest.csproj
+++ b/tests/AutoFixture.SeedExtensions.UnitTest/AutoFixture.SeedExtensions.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsXUnit2>true</IsXUnit2>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <IsXUnit3>true</IsXUnit3>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>AutoFixture.SeedExtensions.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.SeedExtensions.UnitTest</AssemblyName>
   </PropertyGroup>

--- a/tests/AutoFixture.xUnit3.UnitTest/AutoFixture.xUnit3.UnitTest.csproj
+++ b/tests/AutoFixture.xUnit3.UnitTest/AutoFixture.xUnit3.UnitTest.csproj
@@ -5,7 +5,6 @@
     <AssemblyTitle>AutoFixture.xUnit.net3.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.Xunit3.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.Xunit3.UnitTest</RootNamespace>
-    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'net48'">win-x86</RuntimeIdentifiers>
   </PropertyGroup>
   
   <ItemGroup>

--- a/tests/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
+++ b/tests/AutoFixtureDocumentationTest/AutoFixtureDocumentationTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsXUnit2>true</IsXUnit2>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <IsXUnit3>true</IsXUnit3>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>AutoFixtureDocumentationTest</AssemblyTitle>
     <AssemblyName>AutoFixtureDocumentationTest</AssemblyName>
     <RootNamespace>AutoFixtureDocumentationTest</RootNamespace>

--- a/tests/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
+++ b/tests/AutoFixtureUnitTest/AutoFixtureUnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsXUnit2>true</IsXUnit2>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <IsXUnit3>true</IsXUnit3>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>AutoFixture.UnitTest</AssemblyTitle>
     <PackageId>AutoFixtureUnitTest</PackageId>
     <RootNamespace>AutoFixtureUnitTest</RootNamespace>

--- a/tests/AutoFixtureUnitTest/DataAnnotations/NumericRangedRequestRelayTest.cs
+++ b/tests/AutoFixtureUnitTest/DataAnnotations/NumericRangedRequestRelayTest.cs
@@ -47,14 +47,12 @@ public class NumericRangedRequestRelayTest
         Assert.IsType<NoSpecimen>(result);
     }
 
-    public static TheoryData<object> NonSupportedRequests => new TheoryData<object>
-    {
+    public static TheoryData<object> NonSupportedRequests => new TheoryData<object>(
         new object(),
         typeof(object),
         typeof(int),
         typeof(string),
-        new RangedNumberRequest(typeof(int), 0, 42)
-    };
+        new RangedNumberRequest(typeof(int), 0, 42));
 
     [Theory, MemberData(nameof(NonSupportedRequests))]
     public void ShouldReturnNoResultForNonSupportedRequests(object request)

--- a/tests/AutoFixtureUnitTest/Kernel/AsyncEnumerableRelayTest.cs
+++ b/tests/AutoFixtureUnitTest/Kernel/AsyncEnumerableRelayTest.cs
@@ -109,7 +109,7 @@ public class AsyncEnumerableRelayTest
 
         // Assert
         var actual = await Assert.IsAssignableFrom<IAsyncEnumerable<int>>(result)
-            .ToListAsync().ConfigureAwait(true);
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken).ConfigureAwait(true);
         Assert.Equal(enumerable, actual);
     }
 
@@ -157,7 +157,7 @@ public class AsyncEnumerableRelayTest
 
         // Assert
         var actual = await Assert.IsAssignableFrom<IAsyncEnumerable<int>>(result)
-            .ToListAsync().ConfigureAwait(true);
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken).ConfigureAwait(true);
         Assert.Equal(enumerable.OfType<int>(), actual);
     }
 }

--- a/tests/AutoFixtureUnitTest/UseCultureAttribute.cs
+++ b/tests/AutoFixtureUnitTest/UseCultureAttribute.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Reflection;
 using System.Threading;
-using Xunit.Sdk;
+using Xunit.v3;
 
 namespace AutoFixtureUnitTest;
 
@@ -26,7 +25,7 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
         _uiCulture = new CultureInfo(uiCulture);
     }
 
-    public override void Before(MethodInfo methodUnderTest)
+    public override void Before(MethodInfo methodUnderTest, IXunitTest test)
     {
         _originalCulture = CultureInfo.CurrentCulture;
         _originalUiCulture = CultureInfo.CurrentCulture;
@@ -34,7 +33,7 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
         SetCurrentCulture(_culture, _uiCulture);
     }
 
-    public override void After(MethodInfo methodUnderTest)
+    public override void After(MethodInfo methodUnderTest, IXunitTest test)
     {
         SetCurrentCulture(_originalCulture, _originalUiCulture);
     }

--- a/tests/AutoMoqUnitTest/AutoMoqUnitTest.csproj
+++ b/tests/AutoMoqUnitTest/AutoMoqUnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsXUnit2>true</IsXUnit2>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <IsXUnit3>true</IsXUnit3>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>AutoMoq.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoMoq.UnitTest</AssemblyName>
     <RootNamespace>AutoFixture.AutoMoq.UnitTest</RootNamespace>

--- a/tests/AutoMoqUnitTest/MockTypeTest.cs
+++ b/tests/AutoMoqUnitTest/MockTypeTest.cs
@@ -105,13 +105,11 @@ public class MockTypeTest
     }
 
     public static TheoryData<object> UnexpectedSpecimens =>
-        new TheoryData<object>
-        {
+        new TheoryData<object>(
             new OmitSpecimen(),
             NoSpecimen.Instance,
             new object(),
-            new StringBuilder()
-        };
+            new StringBuilder());
 
     [Theory]
     [MemberData(nameof(UnexpectedSpecimens))]

--- a/tests/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
+++ b/tests/AutoNSubstituteUnitTest/AutoNSubstituteUnitTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsXUnit2>true</IsXUnit2>
+    <IsXUnit3>true</IsXUnit3>
     <TargetFrameworks>$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>AutoNSubstitute.UnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.AutoNSubstitute.UnitTest</AssemblyName>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -26,6 +26,8 @@
       xUnit1003: Theory methods must have test data - xUnit does not support our custom data attributes
     -->
     <NoWarn>$(NoWarn);xUnit1003</NoWarn>
+
+    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'net48'">win-x86</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,12 +1,4 @@
 <Project>
-  <ItemGroup Condition="'$(IsXUnit2)' == 'true'">
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup  Condition="'$(IsXUnit3)' == 'true'">
     <PackageReference Include="xunit.v3" Version="1.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">

--- a/tests/IdiomsUnitTest/IdiomsUnitTest.csproj
+++ b/tests/IdiomsUnitTest/IdiomsUnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsXUnit2>true</IsXUnit2>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <IsXUnit3>true</IsXUnit3>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>IdiomsUnitTest</AssemblyTitle>
     <AssemblyName>AutoFixture.IdiomsUnitTest</AssemblyName>
     <RootNamespace>AutoFixture.IdiomsUnitTest</RootNamespace>

--- a/tests/TestTypeFoundation/TestTypeFoundation.csproj
+++ b/tests/TestTypeFoundation/TestTypeFoundation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;$(BaseTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net48;$(BaseTargetFrameworks)</TargetFrameworks>
     <AssemblyTitle>TestTypeFoundation</AssemblyTitle>
     <AssemblyName>TestTypeFoundation</AssemblyName>
 


### PR DESCRIPTION
### Description
<!-- Summarize your changes -->
Use xUnit 3 for all the unit tests. Also update target framework to net48, as that's the minimal supported version for xUnit 3
